### PR TITLE
fix(quantize): refuse stacked-expert checkpoints instead of copying them through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,14 @@ there instead of retelling it.
   referenced.** The multi-turn path branched on the mmproj tower alone, so on
   Qwen3-VL it rendered a prompt with no image tokens: "Image loaded", then an
   answer given as if there were no image.
+- **`imp-quantize` wrote a "quantized" checkpoint whose experts were untouched.**
+  The 3-D refusal sat behind a `.weight` name test, and no real stacked
+  checkpoint names its experts that way (`experts.gate_up_proj`,
+  `..._blocks`), so they were copied through as BF16 with no message, no
+  counter and no exclusion entry — while `hf_quant_config.json` announced
+  NVFP4. Such a checkpoint is now refused before anything is written. The
+  selection rule moved to `tools/imp-quantize/tensor_policy.cpp` and is covered
+  by `tests/test_quantize_policy.cpp` in the CPU lane.
 - **`imp-quantize` silently produced a broken MoE checkpoint.** "MoE is left
   unquantized" only ever applied to 3-D stacked tensors; the HF-standard
   per-expert 2-D layout was quantized and produced a model that loaded and then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ if(IMP_BUILD_TOOLS)
     # imp-quantize — offline BF16/FP16 -> NVFP4 checkpoint conversion
     add_executable(imp-quantize
         tools/imp-quantize/main.cpp
+        tools/imp-quantize/tensor_policy.cpp
         tools/imp-quantize/awq_plan.cpp
         tools/imp-quantize/awq.cu
     )
@@ -654,6 +655,11 @@ if(IMP_BUILD_TESTS)
         tests/test_vision_preprocess.cpp
         tests/test_mrope_positions.cpp
         tests/test_mla.cpp
+        # imp-quantize's tensor-selection rule. The tool is not otherwise
+        # covered, and this is the part of it that has already shipped a broken
+        # checkpoint (#1159), so it is compiled into the CPU lane directly.
+        tools/imp-quantize/tensor_policy.cpp
+        tests/test_quantize_policy.cpp
     )
     if(IMP_BUILD_SERVER)
         # Anthropic /v1/messages transform tests reuse the server's

--- a/tests/test_quantize_policy.cpp
+++ b/tests/test_quantize_policy.cpp
@@ -1,0 +1,127 @@
+// Which tensors imp-quantize touches, and which checkpoints it refuses.
+//
+// This rule has already been wrong in the direction that ships a working-looking
+// model: #1159 quantized MLA latent projections and MoE routers because they are
+// 2-D and K-aligned, producing a checkpoint that loaded and then emitted
+// garbage. Nothing here is a shape assertion for its own sake — each case is a
+// tensor role that must or must not survive.
+
+#include "../tools/imp-quantize/tensor_policy.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace imp::quantize {
+namespace {
+
+RawTensor tensor(const std::string& name, std::vector<int64_t> shape, const std::string& dtype = "BF16") {
+    RawTensor t;
+    t.name = name;
+    t.dtype = dtype;
+    t.shape = std::move(shape);
+    return t;
+}
+
+bool quantizes(const RawTensor& t, bool lm_head = false) {
+    std::string why;
+    return should_quantize(t, lm_head, why);
+}
+
+std::string reason(const RawTensor& t, bool lm_head = false) {
+    std::string why;
+    should_quantize(t, lm_head, why);
+    return why;
+}
+
+TEST(QuantizePolicy, TakesOrdinaryLinearWeights) {
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.self_attn.q_proj.weight", {4096, 4096})));
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.mlp.down_proj.weight", {4096, 11008})));
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.mlp.experts.7.gate_proj.weight", {1408, 2048})))
+        << "per-expert 2-D is the supported MoE layout";
+}
+
+// The two roles from #1159. Both are 2-D and K-aligned, so only the name
+// distinguishes them from a weight that must be quantized.
+TEST(QuantizePolicy, RefusesMlaLatentProjectionsAndTheRouter) {
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.self_attn.kv_a_proj_with_mqa.weight", {576, 2048})));
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.self_attn.kv_b_proj.weight", {4096, 512})));
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.mlp.gate.weight", {64, 2048})));
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.mlp.router.weight", {64, 2048})));
+}
+
+// `gate_proj` is an expert projection, `gate` is the router. A substring test
+// instead of a suffix test would silently stop quantizing every expert.
+TEST(QuantizePolicy, GateProjIsNotTheRouter) {
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.mlp.experts.0.gate_proj.weight", {1408, 2048})));
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.mlp.gate_proj.weight", {11008, 4096})));
+}
+
+TEST(QuantizePolicy, LeavesEmbeddingsNormsAndBiasesAlone) {
+    EXPECT_FALSE(quantizes(tensor("model.embed_tokens.weight", {151936, 4096})));
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.input_layernorm.weight", {4096})));
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.self_attn.q_proj.bias", {4096})));
+}
+
+TEST(QuantizePolicy, LmHeadNeedsTheFlag) {
+    const auto t = tensor("lm_head.weight", {151936, 4096});
+    EXPECT_FALSE(quantizes(t, /*lm_head=*/false));
+    EXPECT_TRUE(quantizes(t, /*lm_head=*/true));
+}
+
+TEST(QuantizePolicy, RefusesMisalignedKAndNonFloatDtypes) {
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.mlp.up_proj.weight", {4096, 100})))
+        << "K must be a multiple of the 16-value micro-block";
+    EXPECT_FALSE(quantizes(tensor("model.layers.0.mlp.up_proj.weight", {4096, 4096}, "U8")));
+}
+
+// The rank check has to come BEFORE the name check. With the other order a
+// stacked tensor was diagnosed as "not a .weight tensor" — which produced no
+// SKIP line, no counter and no exclusion entry, so it was copied through in
+// silence. Real stacked checkpoints never use the `.weight` suffix.
+TEST(QuantizePolicy, DiagnosesAStackWhateverItIsNamed) {
+    EXPECT_NE(reason(tensor("model.layers.0.mlp.experts.gate_up_proj", {128, 1408, 2048})).find("3-D"),
+              std::string::npos);
+    EXPECT_NE(reason(tensor("model.layers.0.mlp.experts.gate_up_proj_blocks", {32, 5760, 90})).find("3-D"),
+              std::string::npos);
+    EXPECT_NE(reason(tensor("model.layers.0.mlp.experts.down_proj.weight", {128, 2048, 1408})).find("3-D"),
+              std::string::npos)
+        << "and still a stack when it does end in .weight";
+}
+
+TEST(StackedExperts, FindsThemUnderEveryRealNamingConvention) {
+    const std::vector<RawTensor> tensors = {
+        tensor("model.layers.0.mlp.experts.gate_up_proj", {128, 1408, 2048}),   // Gemma-4 style
+        tensor("model.layers.0.mlp.experts.down_proj_blocks", {32, 5760, 90}),  // gpt-oss style
+        tensor("model.layers.0.self_attn.q_proj.weight", {4096, 4096}),         // ordinary 2-D
+        tensor("model.embed_tokens.weight", {151936, 4096}),
+    };
+    const auto found = find_stacked_expert_tensors(tensors);
+    ASSERT_EQ(found.size(), 2u);
+    EXPECT_EQ(found[0]->name, "model.layers.0.mlp.experts.gate_up_proj");
+    EXPECT_EQ(found[1]->name, "model.layers.0.mlp.experts.down_proj_blocks");
+}
+
+// Rank 3 on its own is not a reason to refuse a checkpoint — a vision tower has
+// plenty of 3-D tensors that have nothing to do with MoE.
+TEST(StackedExperts, IgnoresThreeDTensorsThatAreNotExperts) {
+    const std::vector<RawTensor> tensors = {
+        tensor("model.vision.patch_embed.proj.weight", {1024, 3, 16}),
+        tensor("model.layers.0.conv1d.weight", {4096, 1, 4}),
+        tensor("model.vision.pos_embed", {1, 2304, 1024}),
+    };
+    EXPECT_TRUE(find_stacked_expert_tensors(tensors).empty());
+}
+
+// Already-quantized stacks are somebody else's export, not an input this tool
+// would have mangled — it refuses them on dtype long before rank matters.
+TEST(StackedExperts, IgnoresNonFloatStacks) {
+    const std::vector<RawTensor> tensors = {
+        tensor("model.layers.0.mlp.experts.gate_up_proj_blocks", {32, 5760, 90}, "U8"),
+    };
+    EXPECT_TRUE(find_stacked_expert_tensors(tensors).empty());
+}
+
+}  // namespace
+}  // namespace imp::quantize

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -27,7 +27,8 @@
 // are quantized like any other matrix; measured on DeepSeek-V2-Lite, 4992
 // expert tensors quantize and the result generates correctly. Expert weights
 // stored as a single 3-D [n_experts, N, K] STACK (gpt-oss-style) are still
-// unsupported: they are reported and left unquantized rather than mangled.
+// unsupported, and such a checkpoint is now REFUSED outright rather than
+// written with its experts copied through — see tensor_policy.h.
 //
 // Two roles are deliberately excluded even though they are 2-D and K-aligned:
 // the MLA latent projections and the MoE router (see should_quantize for the
@@ -63,6 +64,7 @@
 // performance work where the weights only need to be the right shape.
 
 #include "awq.h"
+#include "tensor_policy.h"
 
 #include "core/tensor.h"
 #include "model/safetensors_raw.h"
@@ -136,74 +138,6 @@ std::vector<unsigned char> folded_copy(const RawTensor& t, const std::vector<flo
     std::memcpy(out.data(), t.data, t.nbytes);
     ok = awq_apply_vector_div(out.data(), static_cast<size_t>(t.numel()), t.dtype, div);
     return out;
-}
-
-// A weight qualifies when it is a 2-D linear matrix the runtime reads through
-// the NVFP4 GEMM path. Everything else is copied through untouched: norms and
-// biases are 1-D, embeddings stay full precision (quantizing them costs quality
-// for no bandwidth win on the decode hot path), and K must be a multiple of 16
-// because that is the micro-block size.
-bool should_quantize(const RawTensor& t, const Options& opt, std::string& why_not) {
-    if (!ends_with(t.name, ".weight")) {
-        why_not = "not a .weight tensor";
-        return false;
-    }
-    if (t.dtype != "BF16" && t.dtype != "F16") {
-        why_not = "dtype " + t.dtype + " (already quantized or unsupported)";
-        return false;
-    }
-    if (t.shape.size() == 3) {
-        why_not = "3-D MoE expert stack — needs the per-expert path, not supported yet";
-        return false;
-    }
-    if (t.shape.size() != 2) {
-        why_not = std::to_string(t.shape.size()) + "-D";
-        return false;
-    }
-    if (contains(t.name, "embed_tokens") || contains(t.name, "embed_positions")) {
-        why_not = "embedding";
-        return false;
-    }
-    if (contains(t.name, "norm")) {
-        why_not = "norm";
-        return false;
-    }
-    if (contains(t.name, "lm_head") && !opt.quantize_lm_head) {
-        why_not = "lm_head (use --lm-head to include)";
-        return false;
-    }
-    // Two weight roles that are 2-D and K-aligned — so every shape check waves
-    // them through — but that must NOT be quantized. Both were found by
-    // bisection on DeepSeek-V2-Lite (MLA + 64-expert MoE), where quantizing
-    // everything produced a checkpoint that loaded and then emitted
-    // cross-script repetition garbage while the BF16 source answered normally.
-    // Excluding them costs almost nothing: a handful of small matrices per
-    // layer against 4992 expert tensors that quantize fine.
-    //
-    // 1. MLA latent projections. `kv_a_proj_with_mqa` packs latent+RoPE into one
-    //    output and `kv_b_proj` up-projects the latent into per-head nope/v
-    //    halves; the runtime slices and reshapes both. Leaving only these two in
-    //    full precision made the same checkpoint coherent again.
-    if (contains(t.name, "kv_a_proj") || contains(t.name, "kv_b_proj")) {
-        why_not = "MLA latent projection (runtime slices it — must stay full precision)";
-        return false;
-    }
-    // 2. MoE router. It decides WHICH experts run, and FP4 across 16
-    //    shared-scale values is enough to change the top-k pick. Measured
-    //    independently: with the MLA pair already excluded, quantizing the
-    //    router alone still produced garbage. Published exports (Modelopt,
-    //    llm-compressor) keep routers full precision for the same reason.
-    //    `.gate.weight` is the router; expert projections are `gate_proj.weight`
-    //    and are unaffected by this suffix test.
-    if (ends_with(t.name, ".gate.weight") || ends_with(t.name, ".router.weight")) {
-        why_not = "MoE router (FP4 changes expert selection)";
-        return false;
-    }
-    if (t.shape[1] % 16 != 0) {
-        why_not = "K=" + std::to_string(t.shape[1]) + " is not a multiple of 16";
-        return false;
-    }
-    return true;
 }
 
 // Quantize one host FP16 matrix, returning host-side packed data + scales.
@@ -386,6 +320,40 @@ int main(int argc, char** argv) {
         opened.push_back(std::move(src));
     }
 
+    // Refuse a stacked-expert checkpoint before writing anything. The experts
+    // are the bulk of the bytes and there is no NVFP4 layout the loader can
+    // read them back from, so "quantizing" one produced a checkpoint that was
+    // mostly still BF16 and said NVFP4 in its config — the failure being that
+    // it loads and runs, just without the size or bandwidth win it claims.
+    {
+        std::vector<const RawTensor*> stacked;
+        size_t stacked_bytes = 0, total_bytes = 0;
+        for (const auto& src : opened) {
+            for (const auto& t : src->tensors())
+                total_bytes += t.nbytes;
+            auto found = quantize::find_stacked_expert_tensors(src->tensors());
+            for (const RawTensor* t : found)
+                stacked_bytes += t->nbytes;
+            stacked.insert(stacked.end(), found.begin(), found.end());
+        }
+        if (!stacked.empty()) {
+            fprintf(stderr,
+                    "refusing: %zu tensor(s) store MoE experts as a 3-D stack — %.1f%% of this\n"
+                    "checkpoint — and imp has no NVFP4 layout to read stacked experts back from.\n"
+                    "Quantizing would copy them through unchanged and still label the result\n"
+                    "NVFP4, so the output would claim a size and bandwidth win it does not have.\n",
+                    stacked.size(), total_bytes ? 100.0 * double(stacked_bytes) / double(total_bytes) : 0.0);
+            for (size_t i = 0; i < stacked.size() && i < 3; ++i)
+                fprintf(stderr, "  %s\n", stacked[i]->name.c_str());
+            if (stacked.size() > 3)
+                fprintf(stderr, "  ... and %zu more\n", stacked.size() - 3);
+            fprintf(stderr,
+                    "Supported layout: one 2-D tensor per expert\n"
+                    "(`...mlp.experts.<e>.gate_proj.weight`), which is the HF standard.\n");
+            return 1;
+        }
+    }
+
     awq::Plan plan;
     // A dry run reports what would be quantized; the scale search costs a GPU
     // pass per layer and changes nothing it would report.
@@ -441,8 +409,8 @@ int main(int argc, char** argv) {
         for (const auto& t : src.tensors()) {
             bytes_in += t.nbytes;
             std::string why;
-            if (!should_quantize(t, opt, why)) {
-                if (contains(why, "3-D MoE")) {
+            if (!quantize::should_quantize(t, opt.quantize_lm_head, why)) {
+                if (contains(why, "3-D stacked")) {
                     n_moe_skipped++;
                     printf("  SKIP  %-58s %s\n", t.name.c_str(), why.c_str());
                 }

--- a/tools/imp-quantize/tensor_policy.cpp
+++ b/tools/imp-quantize/tensor_policy.cpp
@@ -1,0 +1,100 @@
+#include "tensor_policy.h"
+
+namespace imp::quantize {
+namespace {
+
+bool ends_with(const std::string& s, const std::string& suf) {
+    return s.size() >= suf.size() && s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
+}
+
+bool contains(const std::string& s, const char* what) { return s.find(what) != std::string::npos; }
+
+bool is_float_dtype(const std::string& dtype) { return dtype == "BF16" || dtype == "F16"; }
+
+}  // namespace
+
+// A weight qualifies when it is a 2-D linear matrix the runtime reads through
+// the NVFP4 GEMM path. Everything else is copied through untouched: norms and
+// biases are 1-D, embeddings stay full precision (quantizing them costs quality
+// for no bandwidth win on the decode hot path), and K must be a multiple of 16
+// because that is the micro-block size.
+bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why_not) {
+    if (!is_float_dtype(t.dtype)) {
+        why_not = "dtype " + t.dtype + " (already quantized or unsupported)";
+        return false;
+    }
+    // Rank is checked BEFORE the name, so a 3-D stack is diagnosed as a stack
+    // whatever it is called. The other order made this branch unreachable for
+    // every real stacked checkpoint, since none of them name the tensor
+    // `.weight` — see find_stacked_expert_tensors.
+    if (t.shape.size() == 3) {
+        why_not = "3-D stacked tensor — needs the per-expert 2-D layout, not supported yet";
+        return false;
+    }
+    if (!ends_with(t.name, ".weight")) {
+        why_not = "not a .weight tensor";
+        return false;
+    }
+    if (t.shape.size() != 2) {
+        why_not = std::to_string(t.shape.size()) + "-D";
+        return false;
+    }
+    if (contains(t.name, "embed_tokens") || contains(t.name, "embed_positions")) {
+        why_not = "embedding";
+        return false;
+    }
+    if (contains(t.name, "norm")) {
+        why_not = "norm";
+        return false;
+    }
+    if (contains(t.name, "lm_head") && !quantize_lm_head) {
+        why_not = "lm_head (use --lm-head to include)";
+        return false;
+    }
+    // Two weight roles that are 2-D and K-aligned — so every shape check waves
+    // them through — but that must NOT be quantized. Both were found by
+    // bisection on DeepSeek-V2-Lite (MLA + 64-expert MoE), where quantizing
+    // everything produced a checkpoint that loaded and then emitted
+    // cross-script repetition garbage while the BF16 source answered normally.
+    // Excluding them costs almost nothing: a handful of small matrices per
+    // layer against 4992 expert tensors that quantize fine.
+    //
+    // 1. MLA latent projections. `kv_a_proj_with_mqa` packs latent+RoPE into one
+    //    output and `kv_b_proj` up-projects the latent into per-head nope/v
+    //    halves; the runtime slices and reshapes both. Leaving only these two in
+    //    full precision made the same checkpoint coherent again.
+    if (contains(t.name, "kv_a_proj") || contains(t.name, "kv_b_proj")) {
+        why_not = "MLA latent projection (runtime slices it — must stay full precision)";
+        return false;
+    }
+    // 2. MoE router. It decides WHICH experts run, and FP4 across 16
+    //    shared-scale values is enough to change the top-k pick. Measured
+    //    independently: with the MLA pair already excluded, quantizing the
+    //    router alone still produced garbage. Published exports (Modelopt,
+    //    llm-compressor) keep routers full precision for the same reason.
+    //    `.gate.weight` is the router; expert projections are `gate_proj.weight`
+    //    and are unaffected by this suffix test.
+    if (ends_with(t.name, ".gate.weight") || ends_with(t.name, ".router.weight")) {
+        why_not = "MoE router (FP4 changes expert selection)";
+        return false;
+    }
+    if (t.shape[1] % 16 != 0) {
+        why_not = "K=" + std::to_string(t.shape[1]) + " is not a multiple of 16";
+        return false;
+    }
+    return true;
+}
+
+std::vector<const RawTensor*> find_stacked_expert_tensors(const std::vector<RawTensor>& tensors) {
+    std::vector<const RawTensor*> out;
+    for (const auto& t : tensors) {
+        // Rank 3 alone is not enough: conv1d kernels, patch embeddings and
+        // position tables are 3-D too, and none of them is a reason to refuse a
+        // checkpoint. "expert" in the name is what makes it the MoE bulk.
+        if (t.shape.size() == 3 && is_float_dtype(t.dtype) && contains(t.name, "expert"))
+            out.push_back(&t);
+    }
+    return out;
+}
+
+}  // namespace imp::quantize

--- a/tools/imp-quantize/tensor_policy.h
+++ b/tools/imp-quantize/tensor_policy.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Which tensors imp-quantize may touch, and which checkpoints it must refuse.
+//
+// This lives apart from main.cpp because it is the part that has already been
+// wrong in the dangerous direction. #1159: "MoE is left unquantized" described
+// 3-D stacks only, so the HF-standard per-expert 2-D layout was quantized into
+// a checkpoint that loaded and then emitted garbage. The fix was not a shape
+// check — it was learning WHICH roles must stay full precision. A rule with
+// that history belongs somewhere a test can reach it.
+
+#include "model/safetensors_raw.h"
+
+#include <string>
+#include <vector>
+
+namespace imp::quantize {
+
+// True when this tensor is a 2-D linear matrix the runtime reads through the
+// NVFP4 GEMM path. On false, `why_not` says why — the caller prints it and
+// copies the tensor through untouched.
+bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why_not);
+
+// MoE experts stored as one 3-D [n_experts, N, K] stack rather than a 2-D
+// tensor per expert.
+//
+// These have to be found by inspection rather than by the rank check in
+// `should_quantize`, because they are not named `.weight` — gpt-oss ships
+// `mlp.experts.gate_up_proj_blocks`, Gemma-4 `experts.gate_up_proj` — and the
+// name gate rejects them first, as "not a .weight tensor", with no counter and
+// no message. They were then copied through as BF16 while `hf_quant_config.json`
+// announced a quantized checkpoint: the experts are most of the bytes, so the
+// output was a model that had barely shrunk and claimed otherwise.
+//
+// Returns pointers into `tensors` so the caller can report both which they are
+// and how much of the checkpoint they represent — the share is the difference
+// between "the experts are the whole model" and "this is an MTP sidecar", and
+// the refusal should not guess which.
+std::vector<const RawTensor*> find_stacked_expert_tensors(const std::vector<RawTensor>& tensors);
+
+}  // namespace imp::quantize


### PR DESCRIPTION
Replaces #1186, which went stale against `main` and could not be updated (force-push is blocked on this repo). Same commit, cherry-picked onto current `main`.

---

`should_quantize` refuses 3-D tensors with *"3-D MoE expert stack — needs the per-expert path"*, and the summary reports how many it skipped. **Neither ever fired on a real checkpoint.**

The rank check sat *behind* a `.weight` name test, and no stacked checkpoint names its experts that way — gpt-oss ships `mlp.experts.gate_up_proj_blocks`, Gemma-4 `experts.gate_up_proj`. They were rejected one branch earlier as `not a .weight tensor`, which prints nothing, counts nothing, and adds no `excluded_modules` entry.

So the experts were **copied through as BF16 while `hf_quant_config.json` announced NVFP4**. The output loads and runs — it has simply not been quantized, which on a MoE checkpoint is most of the bytes. Same failure class as #1159 (a checkpoint that looks like a result), one branch further up.

### Changes

- The rank check moves in front of the name check, so a stack is diagnosed as a stack whatever it is called.
- A pre-pass over every shard **refuses the checkpoint before anything is written**, naming the tensors and the share of the checkpoint they hold.

The share is computed rather than asserted, and that turned out to matter: on `Qwen3.6-35B-A3B-NVFP4` the only stacks are the MTP head's — **6.4%** — so a refusal claiming "most of the checkpoint" would have been false.

```
refusing: 2 tensor(s) store MoE experts as a 3-D stack — 6.4% of this
checkpoint — and imp has no NVFP4 layout to read stacked experts back from.
Quantizing would copy them through unchanged and still label the result
NVFP4, so the output would claim a size and bandwidth win it does not have.
  mtp.layers.0.mlp.experts.down_proj
  mtp.layers.0.mlp.experts.gate_up_proj
```

### Testing

The tool had **no tests at all**, and this is the part of it with a history of shipping broken checkpoints, so the selection rule moved to `tools/imp-quantize/tensor_policy.{h,cpp}` where a test can reach it. `tests/test_quantize_policy.cpp` runs in the CPU lane and covers the roles #1159 established (MLA latent projections, the router, `gate` vs `gate_proj`) alongside the stack cases.

**Mutation-validated** — restoring the name-before-rank order fails `DiagnosesAStackWhateverItIsNamed`; dropping the `"expert"` name filter from the scanner fails `IgnoresThreeDTensorsThatAreNotExperts`. Both mutations were asserted present in the file before measuring.

**Against real checkpoints:** `Qwen3.6-35B-A3B-NVFP4` is refused as above; `Qwen3-VL-4B-Instruct` still dry-runs to 357 tensors quantized, so the vision tower's many 3-D tensors (patch embeddings, position tables) do not trip the scanner.

`make verify-fast` green against a rebuilt image: decode +0.35%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B