### PR TITLE
fix(kv): persist the KV scales with the prefix cache, not just K and V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ there instead of retelling it.
   violation.
 
 ### Fixed
+- **The persisted prefix cache dropped the KV scales**, so a restored block
+  decoded against whatever scales were in the pool — wrong attention, no error.
+  Only on a KV dtype with a separate scale pool (NVFP4, INT8, INT4, MXFP4_KV),
+  which is why the FP16/FP8 defaults never showed it; `--prefix-cache` plus
+  `--kv-nvfp4` was enough. The file format now carries the scales
+  (`kPrefixCacheVersion` 3, older files are discarded as before). Pinned by
+  `PrefixPersistTest.QuantizedKvRestoresItsScales`.
 - **An image that spanned a prefill chunk boundary got the wrong half of
   itself.** Both vision kernels find "the k-th image token" by scanning the span
   they are handed, which under chunked prefill is one chunk — so a second chunk

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -1221,7 +1221,8 @@ int KVCacheManager::total_allocated_blocks() const {
 // Rejecting on fingerprint mismatch degrades to a clean recompute.
 
 static constexpr uint32_t kPrefixCacheMagic = 0x494D5043;  // "IMPC"
-static constexpr uint32_t kPrefixCacheVersion = 2;
+// v3 carries the KV scale blocks alongside K/V.
+static constexpr uint32_t kPrefixCacheVersion = 3;
 
 struct PrefixCacheHeader {
     uint32_t magic;
@@ -1232,6 +1233,10 @@ struct PrefixCacheHeader {
     uint32_t head_dim;
     uint32_t dtype;
     uint64_t block_bytes;
+    // Bytes of scale per block per layer, 0 for dtypes that carry none (FP16,
+    // FP8_E4M3). A quantized KV block is meaningless without its scales, so
+    // this is part of the format rather than something to infer at load.
+    uint64_t scale_block_bytes;
     uint64_t model_fingerprint;
 };
 
@@ -1255,6 +1260,7 @@ int KVCacheManager::save_prefix_cache(const std::string& path, uint64_t model_fi
 
     int n_blocks = static_cast<int>(cached_blocks_lru_.size());
     size_t bb = cache_->block_bytes();
+    size_t sbb = cache_->scale_block_bytes();
     int nl = cache_->n_layers();
 
     PrefixCacheHeader hdr = {};
@@ -1266,6 +1272,7 @@ int KVCacheManager::save_prefix_cache(const std::string& path, uint64_t model_fi
     hdr.head_dim = static_cast<uint32_t>(cache_->head_dim());
     hdr.dtype = std::to_underlying(cache_->qtype());
     hdr.block_bytes = bb;
+    hdr.scale_block_bytes = sbb;
     hdr.model_fingerprint = model_fingerprint;
 
     if (fwrite(&hdr, sizeof(hdr), 1, f) != 1) {
@@ -1276,7 +1283,10 @@ int KVCacheManager::save_prefix_cache(const std::string& path, uint64_t model_fi
 
     // Allocate host buffer for ALL blocks' KV data so we can pipeline
     // all D2H transfers with cudaMemcpyAsync and sync once.
-    size_t per_block_total = static_cast<size_t>(nl) * 2 * bb;
+    // K + V + their scales, per layer. Persisting the KV bytes without the
+    // scales produced a block that loads and then decodes against whatever
+    // scales happened to be in the pool — wrong attention, no error.
+    size_t per_block_total = static_cast<size_t>(nl) * 2 * (bb + sbb);
 
     // First pass: collect valid block IDs and their hashes.
     struct BlockEntry {
@@ -1326,6 +1336,22 @@ int KVCacheManager::save_prefix_cache(const std::string& path, uint64_t model_fi
                 break;
             }
             offset += bb;
+            if (sbb == 0)
+                continue;
+            err = cudaMemcpyAsync(host_buf.data() + buf_offset + offset, cache_->k_scale_ptr(l, block_id),
+                                  sbb, cudaMemcpyDeviceToHost, stream);
+            if (err == cudaSuccess) {
+                offset += sbb;
+                err = cudaMemcpyAsync(host_buf.data() + buf_offset + offset, cache_->v_scale_ptr(l, block_id),
+                                      sbb, cudaMemcpyDeviceToHost, stream);
+            }
+            if (err != cudaSuccess) {
+                IMP_LOG_ERROR("cudaMemcpyAsync failed for block %d layer %d scales: %s", block_id, l,
+                              cudaGetErrorString(err));
+                block_ok[bi] = false;
+                break;
+            }
+            offset += sbb;
         }
     }
 
@@ -1412,7 +1438,16 @@ int KVCacheManager::load_prefix_cache(const std::string& path, uint64_t model_fi
     int n_blocks = static_cast<int>(hdr.n_blocks);
     int nl = cache_->n_layers();
     size_t bb = cache_->block_bytes();
-    size_t per_block_total = static_cast<size_t>(nl) * 2 * bb;
+    size_t sbb = cache_->scale_block_bytes();
+    // Same reasoning as the dtype/geometry gate above: a file whose scale
+    // geometry differs describes blocks this cache cannot interpret.
+    if (hdr.scale_block_bytes != sbb) {
+        IMP_LOG_WARN("Prefix cache: scale geometry mismatch (cache=%llu, current=%zu) — discarding",
+                     static_cast<unsigned long long>(hdr.scale_block_bytes), sbb);
+        fclose(f);
+        return -1;
+    }
+    size_t per_block_total = static_cast<size_t>(nl) * 2 * (bb + sbb);
 
     int loaded = 0;
     int skipped = 0;
@@ -1488,6 +1523,24 @@ int KVCacheManager::load_prefix_cache(const std::string& path, uint64_t model_fi
                 break;
             }
             offset += bb;
+            if (sbb == 0)
+                continue;
+            err = cudaMemcpyAsync(cache_->k_scale_ptr(l, entry.block_id),
+                                  all_host_buf.data() + entry.buf_offset + offset, sbb,
+                                  cudaMemcpyHostToDevice, stream);
+            if (err == cudaSuccess) {
+                offset += sbb;
+                err = cudaMemcpyAsync(cache_->v_scale_ptr(l, entry.block_id),
+                                      all_host_buf.data() + entry.buf_offset + offset, sbb,
+                                      cudaMemcpyHostToDevice, stream);
+            }
+            if (err != cudaSuccess) {
+                IMP_LOG_ERROR("cudaMemcpyAsync failed loading block %d layer %d scales: %s", entry.block_id,
+                              l, cudaGetErrorString(err));
+                entry.copy_ok = false;
+                break;
+            }
+            offset += sbb;
         }
     }
 

--- a/tests/test_prefix_cache_equiv.cpp
+++ b/tests/test_prefix_cache_equiv.cpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <cstdio>
 #include <numeric>
 #include <vector>
 
@@ -410,6 +411,83 @@ TEST(PrefixEquivTest, LongestCachedPrefixProbe) {
     // Break the chain at block 0 → probe reports 0 despite block 1 cached.
     ASSERT_TRUE(mgr->evict_cached_block());
     EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, hashes), 0);
+}
+
+// ── (N) Persistence carries the KV SCALES, not just the KV bytes ──────────
+// A quantized KV block is meaningless without its scales: the values are
+// indices into a scale, so restoring the bytes alone yields a block that loads
+// and then decodes against whatever scales happen to sit in the pool. Nothing
+// errors — the attention is simply wrong.
+//
+// NVFP4 (like INT8/INT4/MXFP4_KV) allocates a SEPARATE scale pool, so the
+// scales are not covered by copying k_ptr/v_ptr. FP16 and FP8_E4M3 carry no
+// scale pool, which is why the gap stayed invisible on the default KV dtype.
+TEST(PrefixPersistTest, QuantizedKvRestoresItsScales) {
+    SKIP_IF_NO_CUDA();
+    // head_dim must be a multiple of 16 for the NVFP4 scale geometry.
+    auto cache = std::make_unique<KVCache>(2, /*n_kv_heads=*/2, /*head_dim=*/32, QType::NVFP4,
+                                           /*max_blocks=*/16);
+    ASSERT_GT(cache->scale_block_bytes(), 0u) << "NVFP4 must have a scale pool, or this proves nothing";
+    const size_t sbb = cache->scale_block_bytes();
+    auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
+    mgr->set_prefix_caching_enabled(true);
+    KVCache* c = mgr->kv_cache();
+
+    std::vector<int32_t> tokens(32);
+    std::iota(tokens.begin(), tokens.end(), 4000);
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens), 0);
+    const std::vector<int> table = mgr->block_table(0);
+    ASSERT_GE(table.size(), 2u);
+
+    // A pattern the zero-initialized pool cannot reproduce by accident.
+    std::vector<uint8_t> scale_pattern(sbb);
+    for (size_t i = 0; i < sbb; ++i)
+        scale_pattern[i] = static_cast<uint8_t>(0xA0 + (i & 0x1F));
+    for (int bi = 0; bi < 2; ++bi) {
+        WriteBlockPattern(c, table[bi], static_cast<uint8_t>(11 + bi));
+        for (int l = 0; l < c->n_layers(); ++l) {
+            ASSERT_EQ(cudaMemcpy(c->k_scale_ptr(l, table[bi]), scale_pattern.data(), sbb,
+                                 cudaMemcpyHostToDevice),
+                      cudaSuccess);
+            ASSERT_EQ(cudaMemcpy(c->v_scale_ptr(l, table[bi]), scale_pattern.data(), sbb,
+                                 cudaMemcpyHostToDevice),
+                      cudaSuccess);
+        }
+    }
+    mgr->register_block_hashes(0, tokens);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 2);
+
+    const std::string path = "/tmp/imp_prefix_scale_roundtrip.bin";
+    ::remove(path.c_str());
+    ASSERT_GT(mgr->save_prefix_cache(path, /*fingerprint=*/0xABCDEF, nullptr), 0);
+
+    // A FRESH pool: zero-initialized, so anything the restore does not write
+    // reads back as zero rather than as the previous manager's leftovers.
+    auto cache2 = std::make_unique<KVCache>(2, 2, 32, QType::NVFP4, 16);
+    auto mgr2 = std::make_unique<KVCacheManager>(std::move(cache2));
+    mgr2->set_prefix_caching_enabled(true);
+    ASSERT_EQ(mgr2->load_prefix_cache(path, 0xABCDEF, nullptr), 2);
+    KVCache* c2 = mgr2->kv_cache();
+
+    // The restored blocks are the ones a matching prefix now hits.
+    ASSERT_EQ(mgr2->allocate_blocks_with_prefix(1, tokens), 2);
+    const std::vector<int> table2 = mgr2->block_table(1);
+    ASSERT_GE(table2.size(), 2u);
+
+    std::vector<uint8_t> got(sbb);
+    for (int bi = 0; bi < 2; ++bi) {
+        for (int l = 0; l < c2->n_layers(); ++l) {
+            ASSERT_EQ(cudaMemcpy(got.data(), c2->k_scale_ptr(l, table2[bi]), sbb, cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_EQ(got, scale_pattern) << "K scales lost for block " << bi << " layer " << l;
+            ASSERT_EQ(cudaMemcpy(got.data(), c2->v_scale_ptr(l, table2[bi]), sbb, cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_EQ(got, scale_pattern) << "V scales lost for block " << bi << " layer " << l;
+        }
+    }
+    mgr2->free_sequence(1);
+    ::remove(path.c_str());
 }
 
 }  // namespace


### PR DESCRIPTION
`save_prefix_cache` copies `k_ptr`/`v_ptr` per block per layer **and nothing else**. On a KV dtype with a separate scale pool — NVFP4, INT8, INT4, MXFP4_KV — that is half the block: the stored values are indices into a scale, so a restored block decodes against whatever scales happen to sit in the pool at that block id.

Nothing errors. The attention is simply wrong, and the reply reads like a normal reply.

### Why it stayed invisible

FP16 and FP8_E4M3 allocate no scale pool (`kv_cache.cu:65`, `needs_scales`), and FP8_E4M3 is the auto default. Reaching the bug takes `--prefix-cache <path>` **together with** a quantized KV dtype such as `--kv-nvfp4` — both documented features. `save_prefix_cache` is gated on the path and on prefix caching being enabled, never on the dtype.

### Fix

The file now carries `sbb` bytes of K scale and V scale after each layer's K and V, plus `scale_block_bytes` in the header so a file written under a different KV dtype is discarded rather than misread. Version 2 → 3; older files were already rejected on version mismatch, so nothing needs migrating. **Where there is no scale pool the layout is byte-identical to v2.**

### Test

`PrefixPersistTest.QuantizedKvRestoresItsScales` writes a pattern into an NVFP4 pool's scales, saves, and loads into a **fresh** pool — zero-initialized, so anything the restore does not write reads back as zero rather than as the previous manager's leftovers — then reads the scales back through the block table that a matching prefix actually hits.

**Mutation-validated:** skipping both scale copies while keeping the format fails it. The mutation was asserted present in the file before measuring.

`make verify-fast` green: decode +0.52%.

### Note on how this was found

It came out of scoping gap 6 (host spill), not from using the feature. The same scoping produced two other results worth recording separately:

- The `-1`-sentinel guard that #963 added exists **only** in the FP16 paged kernel; `attention_paged_nvfp4.cu` and `attention_paged_int8.cu` dereference `bt[blk]` unguarded at four sites. This is currently **not reachable** — `engine_weight_upload.cpp:59` disables StreamingLLM for non-FP16 KV, and `init_resolve_kv_dtype_policy_()` runs before that check, so the guard sees the resolved dtype. Latent, not a bug; noting it so the next person does not have to re-derive it.
- Gap 6 itself looks unwarranted on measured numbers rather than merely large — see the roadmap change in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B