### PR TITLE
fix(model): refuse a MoE checkpoint whose experts were all skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ there instead of retelling it.
   violation.
 
 ### Fixed
+- **A MoE checkpoint whose experts imp cannot read now fails to load** instead
+  of routing through null experts and generating garbage. Measured on
+  `gpt-oss-20b` in BF16, whose experts are 3-D stacks only the MXFP4
+  `_blocks`/`_scales` matcher looks for: every layer logged "unrecognised layer
+  weight", the load succeeded, and generation produced `:!!!!!!!!!!`. The check
+  fires only when the config declares experts and not one layer carries any
+  expert representation, so a partially mapped MoE stays a warning.
 - **An image that spanned a prefill chunk boundary got the wrong half of
   itself.** Both vision kernels find "the k-th image token" by scanning the span
   they are handed, which under chunked prefill is one chunk — so a second chunk

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -1343,6 +1343,46 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
         }
     }
 
+    // A MoE model whose experts were all skipped loads, runs, and answers with
+    // garbage — the routing picks experts that are null tensors. Measured on
+    // gpt-oss-20b in BF16, whose experts are 3-D stacks (`experts.gate_up_proj`)
+    // that only the MXFP4 `_blocks`/`_scales` matcher looks for: every layer
+    // logged "unrecognised layer weight", the load succeeded, and generation
+    // produced ":!!!!!!!!!!".
+    //
+    // Deliberately narrow: it fires only when the config declares experts and
+    // NOT ONE layer carries any expert representation — per-expert 2-D, the
+    // Gemma-4 packed pair, or the gpt-oss packed blocks. A partially mapped MoE
+    // is a different question and stays a warning.
+    if (model.config_.n_experts > 0) {
+        // The per-expert vectors are RESIZED by `ensure_expert` as soon as any
+        // expert-shaped name is seen, so a non-empty vector says nothing — the
+        // entries can all be default Tensors. Only a non-null `data` means a
+        // weight actually arrived.
+        bool any_experts = false;
+        for (const auto& layer : model.layers_) {
+            for (const auto& w : layer.expert_w_gate) {
+                if (w.data) {
+                    any_experts = true;
+                    break;
+                }
+            }
+            if (any_experts || layer.expert_gate_packed.data || layer.expert_gate_up_packed_blocks.data ||
+                layer.expert_down_packed.data || layer.expert_down_packed_blocks.data) {
+                any_experts = true;
+                break;
+            }
+        }
+        if (!any_experts) {
+            IMP_LOG_ERROR(
+                "WeightMap: the config declares %d experts per layer but not one expert tensor was "
+                "recognised (%d tensors skipped). This checkpoint stores its experts in a layout imp "
+                "does not read — loading it would route through null experts and generate garbage.",
+                model.config_.n_experts, skipped);
+            return false;
+        }
+    }
+
     if (assigned == 0) {
         IMP_LOG_ERROR("WeightMap: no tensors were assigned -- check weight names");
         return false;


### PR DESCRIPTION
A checkpoint whose expert tensors match no branch of the weight mapper **loads successfully, routes through null experts, and generates garbage.**

Measured on `gpt-oss-20b` in BF16 — its experts are 3-D stacks (`experts.gate_up_proj`, `experts.down_proj`) that only the MXFP4 `_blocks`/`_scales` matcher looks for, so all 48 expert tensors fell through:

```
WARN  WeightMap: unrecognised layer weight: model.layers.23.mlp.experts.gate_up_proj
...                                          (once per layer, 48 total)
INFO  WeightMap (GPT_OSS): assigned … skipped 48
→ load succeeds → "What is 2+2?" → ":!!!!!!!!!!"
```

The warnings were already there. They are one WARN among many in a long init log, and the model that follows them looks like it works — the same shape of failure as #1186 and #1159.

### Scope

Deliberately narrow: it fires only when the config declares experts **and** not one layer carries any expert representation — per-expert 2-D, the Gemma-4 packed pair, or the gpt-oss packed blocks. A partially mapped MoE stays a warning; a dense model is untouched.

### One trap worth recording

The first cut of this check did not fire. `ensure_expert` **resizes** `expert_w_gate` as soon as any expert-shaped name is seen, so `!expert_w_gate.empty()` is true even when every entry is a default `Tensor`. The vector size says nothing — only a non-null `data` means a weight actually arrived. Same class of mistake as the bug being fixed: a guard that reads the wrong property.

### Verified against a freshly built image, not the incremental tree

| Checkpoint | Expected | Result |
|---|---|---|
| `gpt-oss-20b-BF16` | refused | refused with the message |
| `gpt-oss-20b` (native MXFP4) | loads | loads, answers normally |
| `Qwen3-Coder-30B-A3B-FP4` | loads | answers "4" |
| `Gemma-4-26B-A4B-NVFP4` | loads | answers "4" |

The image matters here: `build-dev` produced garbage for native gpt-oss **with and without this change**, so the incremental tree had a stale object. Testing the change against it would have shown a regression that does not exist.

`make verify-fast` green (decode +0.34%), `make dev-test` green.

This came out of downloading a BF16 MoE checkpoint to evaluate gap 1 (3-D expert stacks in the quantizer). That evaluation produced a separate, negative result — see the follow-up roadmap change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B