### PR TITLE
fix(constrain,server): two ways a request was answered as if it had been different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+- **Constrained decoding dropped every non-ASCII character** (#1197). With
+  `response_format: json_schema` or `json_object`, "Die Bären hören" came back as
+  "Die Baren horen" — German, and every other non-English language, was
+  unusable. The FSM was never at fault: it compares through `unsigned char` and
+  accepted umlauts all along. `classify_token()` did not, and `char` is signed,
+  so every byte of a multi-byte UTF-8 sequence read as negative and lost
+  `CAT_STRING_CHAR` — the category mask then dropped those tokens *before* the
+  FSM was consulted, and the model spelled the nearest ASCII word it was allowed
+  to emit. GBNF and regex constraining were never affected (they do not use that
+  pre-filter). Pinned by `TokenCategory.NonAsciiCountsAsStringContent` in the CPU
+  lane, and the json_object property batteries now generate non-ASCII instead of
+  documenting its absence as deliberate.
+- **An image sent to a model that cannot see it is refused, not ignored**
+  (#1198). A multimodal SafeTensors checkpoint whose tower imp does not
+  understand (Gemma-4 NVFP4, the Qwen3.5/3.6 MoE checkpoints) loads text-only and
+  says so in the load log — but `image_url` parts were then accepted and answered
+  from the text alone, so the caller got a confident description of a picture the
+  model never received. Now `400` with code `vision_unavailable`, in every
+  dialect. `docs/supported-models.md` states which checkpoints can see and which
+  cannot.
+
 ## [0.20.1] - 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ CLI reference, server flags, config, and C API: [`docs/usage.md`](docs/usage.md)
 | Llama / Mistral / DeepSeek | dense + MoE | GGUF (Q*_K, Q8_0) |
 | DeepSeek-V2 (MLA) | Multi-head Latent Attention + MoE | SafeTensors (bf16) |
 
+**Vision** is Qwen3-VL (tower in the checkpoint, no extra flag) and Gemma-3/Gemma-4
+through GGUF + `--mmproj`. Those are the only ones: a multimodal SafeTensors
+checkpoint from another family — Gemma-4 NVFP4, the Qwen3.5/3.6 MoE checkpoints —
+loads **text-only**, and a request that sends it an image is refused with
+`400 vision_unavailable` rather than answered from the text. Details:
+[supported-models.md](docs/supported-models.md#vision).
+
 VRAM, decode tok/s, and per-model notes: [`docs/supported-models.md`](docs/supported-models.md).
 
 ## Features

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -75,6 +75,28 @@ send several `image_url` parts — and they are read in prompt order.
 registered; only the dense 4B is validated end to end here. A VL checkpoint also
 loads text-only — the tower is simply never run if no image is passed.
 
+### What cannot see, and how you find out
+
+The list above is exhaustive: **a multimodal SafeTensors checkpoint from any other
+family loads text-only.** `Gemma-4-26B-A4B-it-NVFP4` and the Qwen3.5/Qwen3.6 MoE
+checkpoints carry a `vision_config`, but imp's SafeTensors loader only understands
+the Qwen3-VL tower — for everything else it logs
+
+```
+WARN Multimodal model detected (vision_config present, model_type='…').
+     imp's SafeTensors loader handles only the language head; the vision tower
+     will be skipped.
+```
+
+and serves the language model alone. Gemma-4 *does* see images, but only through
+the GGUF + `--mmproj` pair in the table, not from its NVFP4 SafeTensors export.
+
+Since #1198 this is also visible from the client rather than only in the server
+log: a request carrying `image_url` parts that the loaded model cannot use is
+refused with **400 `vision_unavailable`** instead of being answered from the text
+alone. That failure mode was the dangerous one — a fluent description of a picture
+the model never received is indistinguishable from a real one.
+
 ```bash
 # Qwen3-VL — one flag, the tower comes with the model
 imp-cli --model models/Qwen3-VL-4B-Instruct/ --image photo.jpg \

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -16,6 +16,8 @@
 #   - test_server_embed_chat_interleave.sh   embeddings don't cancel in-flight chat
 #   - test_server_logprobs.py          logprob sum + top-k descending order
 #   - test_server_messages_stream.py   Anthropic /v1/messages event sequence
+#   - test_server_vision_and_utf8.py   images refused when unusable (#1198),
+#                                     non-ASCII survives json_schema (#1197)
 #
 # Usage:   make test-server   (or: scripts/test_server.sh)
 # Env:     IMP_SRV_MODEL    (default Qwen3-8B-NVFP4-cortecs) — needs chat+tools+embeddings
@@ -84,6 +86,7 @@ run "robustness (#712)"   python3 tests/test_server_robustness.py
 run "logprobs"            python3 tests/test_server_logprobs.py
 run "messages stream"     python3 tests/test_server_messages_stream.py
 run "thinking toggle"     python3 tests/test_server_thinking_toggle.py
+run "vision refusal + utf8 (#1197/#1198)" python3 tests/test_server_vision_and_utf8.py
 run "embed/chat interleave" bash tests/test_server_embed_chat_interleave.sh 15
 run "0-token battery (#710)" env N=8 LOAD=80 FAIL_THRESHOLD=0.10 python3 tests/test_server_0token_battery.py
 

--- a/src/compute/constrain_common.h
+++ b/src/compute/constrain_common.h
@@ -72,8 +72,12 @@ static inline uint16_t classify_token(const std::string& text) {
             cat |= CAT_NUMBER_CONT | CAT_STRING_CHAR;
         if (first == ' ' || first == '\t' || first == '\n' || first == '\r')
             cat |= CAT_WHITESPACE;
-        // General string chars (printable, not quote or backslash)
-        if (first >= 32 && first != '"' && first != '\\')
+        // General string chars: anything that is not a control character, a
+        // quote or a backslash. The cast is load-bearing — `char` is signed
+        // here, so every byte of a multi-byte UTF-8 sequence (0x80-0xFF) reads
+        // as negative and would fail this test, which is how constrained output
+        // lost its umlauts (#1197).
+        if (static_cast<unsigned char>(first) >= 32 && first != '"' && first != '\\')
             cat |= CAT_STRING_CHAR;
         // Literal continuation characters
         if (std::strchr("ruealskl", first))
@@ -84,8 +88,8 @@ static inline uint16_t classify_token(const std::string& text) {
         for (char c : text) {
             if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
                 is_ws = false;
-            if (c < 32 || c == '"' || c == '\\')
-                is_str = false;
+            if (static_cast<unsigned char>(c) < 32 || c == '"' || c == '\\')
+                is_str = false;  // signed char: see the single-char path (#1197)
             if (!std::strchr("0123456789.-+eE", c))
                 is_num = false;
             if (!std::islower(static_cast<unsigned char>(c)))
@@ -132,6 +136,12 @@ static inline uint16_t classify_token(const std::string& text) {
 
     return cat;
 }
+
+// The kernels below are the only device code in this header. They are guarded
+// so a host-only translation unit can include it for classify_token() alone —
+// which is what puts the classifier under test in the CPU `unit` lane, the lane
+// CI actually runs. #1197 lived here precisely because nothing tested it.
+#ifdef __CUDACC__
 
 // ---------------------------------------------------------------------------
 // Shared GPU kernel: apply category bitmask to logits.
@@ -188,5 +198,7 @@ __global__ inline void constrain_mask_allow_kernel(float* __restrict__ logits,
         }
     }
 }
+
+#endif  // __CUDACC__
 
 }  // namespace imp

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -23,6 +23,7 @@
 #include <nlohmann/json.hpp>
 
 #include "compute/json_constrain.h"
+#include "compute/constrain_common.h"
 
 #include <random>
 #include <string>
@@ -34,18 +35,36 @@ namespace {
 constexpr uint32_t kSeed = 0x5EED1067;  // fixed: failures must reproduce
 
 // --- Random valid-JSON generator -------------------------------------------
-// ASCII only and escape-free on purpose: non-ASCII in constrained strings is a
-// known, deliberate limitation of the token classifier, not a grammar bug, and
-// mixing it in here would produce false failures rather than findings.
+// Escape-free on purpose (escapes have their own example-based battery), but
+// NOT ASCII-only. It used to be, and the comment here called non-ASCII "a known,
+// deliberate limitation of the token classifier" — a sentence that turned out to
+// describe #1197, where constrained German output silently lost every umlaut.
+//
+// Worth being precise about what this generator does and does not cover: these
+// tests drive the FSM, and the FSM was never the broken part — it compares
+// through `unsigned char` and accepted umlauts all along. The bug was one layer
+// out, in classify_token()'s category pre-filter, which the mask consults BEFORE
+// the FSM is asked (see TokenCategory.NonAsciiCountsAsStringContent, which is
+// what actually fails when the fix is reverted). So this covers UTF-8 through
+// the grammar; it does not cover the mask. Both are needed.
 
 std::string gen_string(std::mt19937& rng) {
     static const char kAlphabet[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ0123456789_ -";
+    // Multi-byte UTF-8 of two, three and four bytes: the classifier must treat
+    // every byte of a sequence as string content, not just the ASCII range.
+    static const char* kNonAscii[] = {"ä", "ö", "ü", "ß", "é", "日", "本", "🐻", "→"};
     std::uniform_int_distribution<int> len(0, 8);
     std::uniform_int_distribution<size_t> ch(0, sizeof(kAlphabet) - 2);
+    std::uniform_int_distribution<size_t> nonascii(0, sizeof(kNonAscii) / sizeof(kNonAscii[0]) - 1);
+    std::uniform_int_distribution<int> pick_nonascii(0, 4);  // ~20% of characters
     std::string s = "\"";
     int n = len(rng);
-    for (int i = 0; i < n; i++)
-        s += kAlphabet[ch(rng)];
+    for (int i = 0; i < n; i++) {
+        if (pick_nonascii(rng) == 0)
+            s += kNonAscii[nonascii(rng)];
+        else
+            s += kAlphabet[ch(rng)];
+    }
     return s + "\"";
 }
 
@@ -403,6 +422,46 @@ TEST(JsonConstrainFsm, RejectsRawControlCharsInsideStrings) {
     EXPECT_FALSE(fsm.sim_token_valid("\t")) << "raw tab accepted inside a string";
     EXPECT_TRUE(fsm.sim_token_valid("def")) << "ordinary string content rejected";
     EXPECT_TRUE(fsm.sim_token_valid("\\n")) << "ESCAPED newline must stay legal";
+}
+
+// ---------------------------------------------------------------------------
+// #1197: constrained output lost every non-ASCII character — "Die Bären hören"
+// came back as "Die Baren horen". The FSM was never the problem; it casts to
+// unsigned char before comparing. classify_token() did not, and `char` is
+// signed here, so every byte of a multi-byte UTF-8 sequence read as negative:
+// the single-char path failed `first >= 32` and the multi-char path hit
+// `c < 32` and cleared is_str. Tokens carrying an umlaut therefore lost
+// CAT_STRING_CHAR and were masked out by category, before the FSM was ever
+// asked. The model then spelled the nearest ASCII word it was allowed to.
+// ---------------------------------------------------------------------------
+TEST(TokenCategory, NonAsciiCountsAsStringContent) {
+    // A whole word, the way a BPE vocabulary usually carries it.
+    EXPECT_TRUE(classify_token("Bären") & CAT_STRING_CHAR) << "multi-byte word rejected";
+    EXPECT_TRUE(classify_token("ä") & CAT_STRING_CHAR) << "two-byte character rejected";
+    EXPECT_TRUE(classify_token("größte") & CAT_STRING_CHAR) << "sharp s rejected";
+    EXPECT_TRUE(classify_token("日本語") & CAT_STRING_CHAR) << "three-byte characters rejected";
+    EXPECT_TRUE(classify_token("🐻") & CAT_STRING_CHAR) << "four-byte character rejected";
+
+    // A BPE token can be a single raw byte — every byte of a UTF-8 sequence
+    // has to pass on its own, or the sequence can never be spelled.
+    for (int b = 0x80; b <= 0xFF; b++) {
+        const std::string one(1, static_cast<char>(b));
+        EXPECT_TRUE(classify_token(one) & CAT_STRING_CHAR) << "lone byte 0x" << std::hex << b << " rejected";
+    }
+
+    // What must STAY rejected, so the fix does not open the door too wide.
+    EXPECT_FALSE(classify_token("\x01") & CAT_STRING_CHAR) << "control char accepted";
+    EXPECT_FALSE(classify_token("\n") & CAT_STRING_CHAR) << "raw newline accepted";
+    EXPECT_FALSE(classify_token("\"") & CAT_STRING_CHAR) << "bare quote accepted";
+    EXPECT_FALSE(classify_token("\\") & CAT_STRING_CHAR) << "bare backslash accepted";
+    EXPECT_FALSE(classify_token("ab\nc") & CAT_STRING_CHAR) << "embedded newline accepted";
+}
+
+TEST(JsonConstrainFsm, AcceptsUmlautsInsideStrings) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"k\":\"Die ");
+    EXPECT_TRUE(fsm.sim_token_valid("Bären")) << "umlaut word rejected inside a string";
+    EXPECT_TRUE(fsm.sim_token_valid("ö")) << "lone umlaut rejected inside a string";
 }
 
 }  // namespace

--- a/tests/test_server_vision_and_utf8.py
+++ b/tests/test_server_vision_and_utf8.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Two ways the server answered a question nobody asked (#1197, #1198).
+
+Needs a running imp-server. The default model is TEXT-ONLY on purpose: half of
+this battery is about what happens when a picture reaches a model that has no
+vision tower.
+
+#1198 — image parts on a model without a vision tower. The load log said the
+tower would be skipped, the request said 200, and the model answered from the
+text alone: "please upload an image so I can describe it", or a confident
+description of a picture it never saw. A caller cannot tell that apart from a
+real verdict. It is now a 400 with code `vision_unavailable`.
+
+#1197 — `response_format: json_schema` dropped every non-ASCII character:
+"Die Bären hören" came back as "Die Baren horen". The FSM was fine; the token
+CATEGORY pre-filter that runs before it classified any token containing a byte
+>= 0x80 as "not string content", because `char` is signed. The model then
+spelled the nearest ASCII word it was allowed to emit. Structure must never
+alter content, so this asserts the constrained reply keeps the characters.
+
+Exit code: 0 = PASS, 1 = a case regressed.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("IMP_BASE", "http://localhost:8080")
+MODEL = os.environ.get("IMP_MODEL", "")
+
+# 1x1 transparent PNG — the smallest thing that is unambiguously an image.
+PNG_1X1 = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+    "YPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+)
+
+failures = []
+
+
+def check(label, ok, detail=""):
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}" + (f"  [{detail}]" if detail and not ok else ""))
+    if not ok:
+        failures.append(label)
+
+
+def post(path, payload, timeout=180):
+    req = urllib.request.Request(
+        BASE + path, data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        try:
+            return e.code, json.loads(body)
+        except json.JSONDecodeError:
+            return e.code, {"_raw": body}
+
+
+def model_name():
+    if MODEL:
+        return MODEL
+    with urllib.request.urlopen(BASE + "/v1/models", timeout=30) as r:
+        return json.loads(r.read().decode())["data"][0]["id"]
+
+
+def test_image_is_used_or_refused(m):
+    """Either the image reaches the model, or the request is refused. Never both-nor.
+
+    Deliberately NOT written as "skip unless the model lacks vision": deciding
+    that from the response is exactly what the bug made impossible. A probe that
+    reads "no 400 came back" as "this model can see" skips itself into green on
+    precisely the build that is broken. So the contract is stated in terms both
+    kinds of model must satisfy, and the evidence is the prompt-token count —
+    an encoded image adds hundreds of tokens, and its absence is what "silently
+    ignored" looks like from outside.
+    """
+    print("\n#1198 — an image must be used or refused, never accepted and dropped")
+    text_only = {
+        "model": m,
+        "max_tokens": 1,
+        "temperature": 0,
+        "messages": [{"role": "user", "content": "Describe this image."}],
+    }
+    status, body = post("/v1/chat/completions", text_only)
+    if status != 200:
+        check("baseline text request works", False, f"got {status}")
+        return
+    baseline_tokens = body.get("usage", {}).get("prompt_tokens", 0)
+
+    with_image = {
+        "model": m,
+        "max_tokens": 40,
+        "temperature": 0,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {"type": "image_url", "image_url": {"url": PNG_1X1}},
+                ],
+            }
+        ],
+    }
+    status, body = post("/v1/chat/completions", with_image)
+
+    if status == 400:
+        err = body.get("error", {}) if isinstance(body, dict) else {}
+        check("refusal carries an error envelope", bool(err.get("message")), json.dumps(body)[:160])
+        check("refusal names the cause", err.get("code") == "vision_unavailable", str(err.get("code")))
+        check("refusal carries no completion", "choices" not in body, "choices[] alongside the error")
+        print(f"       (model cannot see; refused — baseline was {baseline_tokens} prompt tokens)")
+        return
+
+    check("accepted request answered with 200", status == 200, f"got {status}")
+    if status != 200:
+        return
+    img_tokens = body.get("usage", {}).get("prompt_tokens", 0)
+    check(
+        "the image actually reached the model",
+        img_tokens > baseline_tokens + 20,
+        f"prompt_tokens {img_tokens} vs {baseline_tokens} text-only — the picture was dropped, "
+        f"but the request was answered anyway",
+    )
+
+
+def test_non_ascii_survives_json_schema(m):
+    print("\n#1197 — non-ASCII through response_format: json_schema")
+    sentence = "Die Bären hören Gebüsch rascheln, größte Stärke, Persönlichkeit."
+    payload = {
+        "model": m,
+        "max_tokens": 120,
+        "temperature": 0,
+        "messages": [{"role": "user", "content": f"Gib exakt diesen Satz zurück: {sentence}"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "S",
+                "schema": {
+                    "type": "object",
+                    "properties": {"satz": {"type": "string"}},
+                    "required": ["satz"],
+                },
+            },
+        },
+    }
+    status, body = post("/v1/chat/completions", payload)
+    check("status 200", status == 200, f"got {status}: {json.dumps(body)[:160]}")
+    if status != 200:
+        return
+    content = body["choices"][0]["message"]["content"]
+    text = json.loads(content)["satz"] if _is_json(content) else content
+
+    # The model may not echo perfectly, so this asserts the CHARACTER SET is
+    # reachable rather than string equality: with the bug, not one of these
+    # could appear, because every token carrying them was masked out.
+    produced = [c for c in "äöüÄÖÜß" if c in text]
+    check(
+        "umlauts are reachable under the constraint",
+        len(produced) > 0,
+        f"no non-ASCII in constrained output: {text!r}",
+    )
+    check("output is valid UTF-8", _is_utf8(text), repr(text)[:160])
+
+    # NOT asserted here, deliberately: whether the reply is well-formed JSON.
+    # That is the FSM's contract and has its own batteries; this one is about
+    # characters surviving the mask. Keeping it here would also make this file
+    # red for an unrelated reason — Qwen3-VL-4B closes the string with a
+    # TYPOGRAPHIC quote (U+201C) and stops with the document still open, which
+    # reproduces identically on builds predating the #1197 fix. Reported
+    # separately; see the note in the PR that introduced this file.
+    if not _is_json(content):
+        print(f"       note: reply was not well-formed JSON ({content[:80]!r}) — separate defect,"
+              f" not a #1197 regression")
+
+
+def _is_json(s):
+    try:
+        json.loads(s)
+        return True
+    except Exception:
+        return False
+
+
+def _is_utf8(s):
+    try:
+        s.encode("utf-8").decode("utf-8")
+        return True
+    except Exception:
+        return False
+
+
+def main():
+    m = model_name()
+    print(f"server: {BASE}   model: {m}")
+    test_image_is_used_or_refused(m)
+    test_non_ascii_survives_json_schema(m)
+    print()
+    if failures:
+        print(f"FAIL — {len(failures)} case(s): {', '.join(failures)}")
+        return 1
+    print("PASS — images are refused when unusable, non-ASCII survives constraining")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -125,6 +125,11 @@ static void collect_tool_enforcement_(ChatRequestContext& ctx) {
 }
 
 bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, ChatRequestContext& ctx) {
+    // Read under the lock, acted on after it: whether the LOADED model can see
+    // images at all. A request that carries pictures a model has no tower for
+    // used to fall through to the text-only path and be answered as if nothing
+    // had been sent (#1198).
+    bool model_has_vision = false;
     // Snapshot all state fields needed for request processing under lock.
     // This protects against concurrent model load/unload invalidating pointers.
     {
@@ -152,8 +157,31 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
         if (state.think_start_id >= 0) {
             ctx.snap.stop_token_ids.push_back(state.think_start_id);
         }
-        ctx.snap.has_vision_request = !ctx.params.images.empty() && state.ctx &&
-                                      state.ctx->engine->has_vision();
+        model_has_vision = state.ctx && state.ctx->engine->has_vision();
+        ctx.snap.has_vision_request = !ctx.params.images.empty() && model_has_vision;
+    }
+
+    // Refuse rather than answer from the text alone. Silently dropping the
+    // image is the worst of the three options: a refusal is trivial for a
+    // caller to handle, but a fluent answer about a picture the model never
+    // received is indistinguishable from a real one — it reads as a verdict.
+    // The load-time WARN ("the vision tower will be skipped") is in the server
+    // log, not in the response, so nothing reached the client at all.
+    if (!ctx.params.images.empty() && !model_has_vision) {
+        res.status = 400;
+        json error = {
+            {"error",
+             {{"message",
+               "This model cannot see images — it is loaded without a vision tower, so the " +
+                   std::to_string(ctx.params.images.size()) +
+                   " image part(s) in this request would be ignored. Vision needs either a "
+                   "Qwen3-VL checkpoint or a GGUF started with --mmproj; a multimodal "
+                   "SafeTensors checkpoint of any other family loads text-only (the load log "
+                   "says so). Send text only, or load a model that can see."},
+              {"type", "invalid_request_error"},
+              {"code", "vision_unavailable"}}}};
+        res.set_content(dump_safe(error), "application/json");
+        return false;
     }
 
     // Enforced tool calling (#1002): tool_choice=required / forced function /


### PR DESCRIPTION
Closes #1197. Closes #1198.

## #1197 — constrained decoding dropped every non-ASCII character

`response_format: json_schema` (and `json_object`) turned "Die Bären hören" into
"Die Baren horen". Not transliteration — the characters were unreachable.

**The FSM was never the broken part.** It compares through `unsigned char` and
accepted umlauts all along. `classify_token()` did not, and `char` is signed on
this target, so every byte of a multi-byte UTF-8 sequence read as negative:

| path | test | byte 0xC3 | effect |
|---|---|---|---|
| single-char | `first >= 32` | −61 → false | no `CAT_STRING_CHAR` |
| multi-char | `c < 32` | −61 → true | `is_str = false` |

Those tokens lost `CAT_STRING_CHAR`, and the category mask consults it **before**
the FSM is asked ("masked by category — simulation irrelevant"). So the model was
handed a vocabulary with no umlauts in it and spelled the nearest ASCII word.
The same gate-in-front-of-the-check shape as #1184 and #1188.

GBNF and regex constraining never used that pre-filter — measured, not assumed:
`grep -c classify_token` is 0 in both. The guess in the issue that the new GBNF
path might share it does not hold.

**Why no test caught it:** the property battery's generator was ASCII-only, and
the comment saying so called non-ASCII *"a known, deliberate limitation of the
token classifier, not a grammar bug"*. That sentence described this bug. The
generator now emits non-ASCII, and the classifier is under test directly in the
CPU lane (`TokenCategory.NonAsciiCountsAsStringContent`) — the kernels in
`constrain_common.h` moved behind `#ifdef __CUDACC__` so a host TU can include it.

Worth stating precisely: the property batteries still would **not** catch this on
their own, because they drive the FSM and the FSM was fine. Reverting the fix
turns the targeted classifier test red and leaves the batteries green. Both are
needed; the comment in the file says so.

## #1198 — an image sent to a model that cannot see it was ignored

`has_vision_request` folded "the model can see" into "the request has images", so
a model without a usable tower produced `false` — which skipped the entire vision
block, including its own 400 paths, and the request was answered from the text
alone. HTTP 200, a fluent description of a picture that never arrived, and
nothing in the response to distinguish it from a real one.

Now **400 `vision_unavailable`**, evaluated before the model is touched and in
every dialect (`/v1/messages` and `/v1/responses` funnel through this handler).

## Verification, both directions

`tests/test_server_vision_and_utf8.py` (new, wired into `scripts/test_server.sh`),
run against a real server built from this branch with the two changes **reverted**:

```
FAIL  the image actually reached the model   [prompt_tokens 14 vs 14 text-only]
FAIL  umlauts are reachable under the constraint
      ['{Die Baren horen Gebuets rascheln, gröste Stärke, Persönlichkeit.}']
```

and with them in place: green. The positive path is untouched — Qwen3-VL-4B still
loads its tower (315 tensors) and its prompt-token count still jumps, so the
refusal does not fire on a model that can see.

The battery deliberately does **not** decide "does this model have vision" from
the response — reading "no 400 came back" as "it can see" is how a probe skips
itself into green on exactly the broken build. It asserts the contract both kinds
of model must satisfy: the image is used, or the request is refused.

## Found on the way, filed not fixed: #1199

Generation can stop with the JSON document still open — Qwen3-VL-4B closes its
string with a typographic `U+201C` and stops, yielding a 200 carrying invalid
JSON. **Reproduced identically with the #1197 fix reverted**, so it predates this
work and is not a regression from it. Filed as #1199; this battery prints a note
instead of asserting JSON well-formedness, so it cannot go red for a second,
unrelated reason.

## Docs

`docs/supported-models.md` and the README now say which checkpoints can see and
which cannot. The issue reports trying two SafeTensors models first — "Vision:
Qwen3-VL" read as a general capability. (The conclusion drawn there, that vision
needs GGUF + `--mmproj`, is not quite it either: Qwen3-VL sees **from
SafeTensors** — verified in this session. It is Gemma that needs the mmproj pair,
and any *other* multimodal SafeTensors family that loads text-only.)

## Perf

The pinned decode gate reads −4% this evening. Measured against `main` built and
run back to back in the same host state: **main 275.7 / 275.4 / 271.8**, this
branch **274.9 / 277.0 / 275.6 / 275.7**. Host drift, not this change — nothing
here runs in the decode path (the classifier runs once at init; the refusal is on
the server request path). No baseline re-pin.