### PR TITLE
fix(build): the five warnings that had accumulated since the last zero-warning claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Fixed
+- **The build is warning-free again.** Five had accumulated: `tmpnam` in a
+  test fixture (which then fed `system("rm -rf " + dir)` — replaced with
+  `mkdtemp` + `std::filesystem::remove_all`, so no shell parses the path), a
+  non-literal format string reaching `snprintf` with no arguments
+  (`-Wformat-security`), and three unbraced `if` branches around GTest macros
+  that expand to an `if`/`else` of their own (`-Wdangling-else`). Only the
+  first two show in an incremental build; the other three need the full image.
 - **Constrained decoding dropped every non-ASCII character** (#1197). With
   `response_format: json_schema` or `json_object`, "Die Bären hören" came back as
   "Die Baren horen" — German, and every other non-English language, was

--- a/src/runtime/plan_shadow.cpp
+++ b/src/runtime/plan_shadow.cpp
@@ -55,7 +55,13 @@ std::string shadow_plan_report(const ShadowPlanProbe& probe, const PlanResult& s
     std::string out;
     char line[320];
     auto emit = [&](const char* fmt, auto... args) {
-        std::snprintf(line, sizeof(line), fmt, args...);
+        // Without arguments `fmt` is still a runtime pointer as far as the
+        // compiler can tell, so a stray '%' in it would read operands that were
+        // never passed (-Wformat-security). Print it as data in that case.
+        if constexpr (sizeof...(args) == 0)
+            std::snprintf(line, sizeof(line), "%s", fmt);
+        else
+            std::snprintf(line, sizeof(line), fmt, args...);
         out += line;
         out += '\n';
     };

--- a/tests/test_gbnf_grammar.cpp
+++ b/tests/test_gbnf_grammar.cpp
@@ -305,8 +305,9 @@ TEST(GbnfGrammar, LeadByteFilterAgreesWithTheSimulator) {
     m.lead_bytes(lead);
     for (int b = 0; b < 256; b++) {
         const std::string s(1, static_cast<char>(b));
-        if (m.would_accept(s))
+        if (m.would_accept(s)) {
             EXPECT_TRUE(lead[b]) << "byte " << b << " is legal but the prefilter drops it";
+        }
     }
     EXPECT_TRUE(lead[static_cast<unsigned char>('5')]);
     EXPECT_FALSE(lead[static_cast<unsigned char>('a')]);

--- a/tests/test_memory_backend.cpp
+++ b/tests/test_memory_backend.cpp
@@ -161,8 +161,11 @@ TEST_F(PhaseFixture, JournalRecordsThePhaseOfEveryEvent) {
 
     // The I2 assertion a soak makes: no acquire event carries phase == Serving.
     for (const auto& e : be.journal()) {
-        if (e.op == AllocEvent::Op::Acquire)
+        if (e.op == AllocEvent::Op::Acquire) {
+            // Braced: the GTest macro expands to an if/else of its own, so an
+            // unbraced branch here is a dangling-else the compiler warns about.
             EXPECT_NE(e.phase, AllocPhase::Serving);
+        }
     }
 }
 

--- a/tests/test_memory_plan.cpp
+++ b/tests/test_memory_plan.cpp
@@ -152,8 +152,9 @@ TEST(MemoryPlan, IsDeterministicAcrossRandomisedConfigs) {
         ASSERT_EQ(a.plan.total(), b.plan.total()) << "i=" << i;
         ASSERT_EQ(a.plan.kv.blocks, b.plan.kv.blocks) << "i=" << i;
         ASSERT_EQ(a.plan.model_resident, b.plan.model_resident) << "i=" << i;
-        if (!a.ok)
+        if (!a.ok) {
             ASSERT_EQ(a.failure.over_by, b.failure.over_by) << "i=" << i;
+        }
     }
 }
 

--- a/tests/test_mrope_config.cpp
+++ b/tests/test_mrope_config.cpp
@@ -12,8 +12,11 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 namespace imp {
 namespace {
@@ -22,10 +25,19 @@ namespace {
 class MRopeConfig : public ::testing::Test {
 protected:
     void SetUp() override {
-        dir_ = std::string(std::tmpnam(nullptr)) + "_mrope";
-        ::system(("mkdir -p " + dir_).c_str());
+        // mkdtemp creates the directory atomically and reports the name it
+        // actually used. tmpnam only guesses one — which is what the linker
+        // warns about — and that guess then went into `system("rm -rf " + dir)`
+        // on teardown: a shell taking apart a path nobody had validated.
+        const std::string tmpl = (std::filesystem::temp_directory_path() / "imp_mrope_XXXXXX").string();
+        std::vector<char> buf(tmpl.c_str(), tmpl.c_str() + tmpl.size() + 1);
+        ASSERT_NE(::mkdtemp(buf.data()), nullptr) << "could not create a temp directory";
+        dir_ = buf.data();
     }
-    void TearDown() override { ::system(("rm -rf " + dir_).c_str()); }
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(dir_, ec);  // no shell involved
+    }
 
     ModelConfig load(const std::string& json) {
         std::ofstream f(dir_ + "/config.json");


### PR DESCRIPTION
The `tmpnam` linker warning, and the four others that came out with it.

## The one that was reported

```
test_mrope_config.cpp:(.text+0x7cb): warning: the use of `tmpnam' is dangerous,
                                     better use `mkstemp'
```

`tmpnam` only *guesses* a name — that is the race the warning is about. Worse,
the guess then went into

```cpp
::system(("mkdir -p " + dir_).c_str());
::system(("rm -rf " + dir_).c_str());   // teardown
```

so a shell was taking apart a path nobody had validated, with `rm -rf` on the
end of it. Now `mkdtemp` (creates the directory atomically, reports the name it
actually used) plus `std::filesystem::remove_all` — no shell in the picture.

## The four the incremental build never showed

`make dev` does not recompile far enough to surface these; only a full
`make build` does:

- **`plan_shadow.cpp` (-Wformat-security)** — the `emit` lambda passed a runtime
  `const char*` to `snprintf` with no varargs. A stray `%` would have read
  operands that were never passed. No call site contains one (checked: `grep -nE
  'emit\("[^"]*%[^"]*"\);'` finds nothing), so output is byte-identical; the
  no-argument case now prints the string as data.
- **Three `-Wdangling-else`** in `test_memory_backend.cpp`,
  `test_memory_plan.cpp` and `test_gbnf_grammar.cpp` — an unbraced `if` branch
  wrapping a GTest macro, which expands to an `if`/`else` of its own. Braces, as
  the warning asks.

## Verification

- Full `make build` from a clean tree: **no warning** (`grep -i 'warning:'` on
  the build log is empty apart from the container's driver notice).
- `test-core`: 839 tests, **0 failures**; `MRopeConfig.*` green and leaving no
  `/tmp/imp_mrope_*` behind.

## Perf

The pinned decode gate is red, and it cannot attribute that to this diff — four
test files and one `if constexpr` in a diagnostic report path. Measured
alongside, rebuilt from `main` in the same host state:

| build | run 1 | run 2 |
|---|---:|---:|
| `main` | 278.82 | 259.72 |
| this branch | 272.84 | 272.66 |

`main` alone spans 7.4% across two consecutive runs and this branch sits inside
that range. Host instability, not a regression — the same conclusion the earlier
A/B in #1200 reached at a different drift level. No baseline re-pin.