### PR TITLE
fix(constrain): stop offering EOS while the JSON document is still open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+- **Constrained generation could stop with the JSON document still open**
+  (#1199), returning 200 with a reply that does not parse. `<|im_end|>`
+  decodes to plain printable ASCII, so the token classifier gives it
+  `CAT_STRING_CHAR` and the free-string shortcut allowed it without
+  simulating — the category mask does not govern EOS inside a string. The
+  clear that exists for exactly this hazard was gated on the XML dialect;
+  it is unconditional now, which is correct because the mask is only
+  computed while the document is incomplete. Measured on Qwen3-VL-4B:
+  `<|im_end|>` sat at rank 2 on the last step and the model took it.
+
 ### Changed
 - **CI can be run against a ref on demand** (`gh workflow run CI --ref main`).
   A squash merge performed by auto-merge starts no workflow run — it is

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -583,11 +583,21 @@ void SchemaConstrainer::compute_token_allow_mask(uint16_t cat_mask) {
     // EOS must not stop generation mid-value: its rendered text ("<|im_end|>")
     // would pass the anything-goes value scan above. Post-loop so no shortcut
     // can re-allow it.
-    if (xml_raw) {
-        for (int32_t e : eos_tokens_)
-            if (e >= 0 && e < vocab_size_)
-                token_allow_[e] = 0;
-    }
+    //
+    // This used to be gated on `xml_raw` while the hazard it describes belongs
+    // just as much to the JSON free-string shortcut a few lines up (#1199).
+    // "<|im_end|>" is plain printable ASCII, so classify_token hands it
+    // CAT_STRING_CHAR and the category mask does NOT govern it inside a string
+    // — contrary to what the comment on compute_token_allow_mask assumes. A
+    // model that reached for EOS mid-string therefore ended the request with
+    // the document still open, and the caller got a 200 carrying invalid JSON.
+    //
+    // Unconditional is correct: reaching this function means the stack is
+    // non-empty, and apply_mask returns before it when the root value is
+    // complete — that is the one place EOS is legal, and there it is forced.
+    for (int32_t e : eos_tokens_)
+        if (e >= 0 && e < vocab_size_)
+            token_allow_[e] = 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/test_server_vision_and_utf8.py
+++ b/tests/test_server_vision_and_utf8.py
@@ -18,6 +18,11 @@ CATEGORY pre-filter that runs before it classified any token containing a byte
 spelled the nearest ASCII word it was allowed to emit. Structure must never
 alter content, so this asserts the constrained reply keeps the characters.
 
+#1199 — the constrainer offered EOS while the JSON document was still open, so a
+model that reached for it ended the request with a 200 carrying invalid JSON. The
+EOS clear in the allow mask was gated on the XML dialect while the hazard belongs
+to the JSON free-string shortcut just as much.
+
 Exit code: 0 = PASS, 1 = a case regressed.
 """
 import json
@@ -165,16 +170,70 @@ def test_non_ascii_survives_json_schema(m):
     )
     check("output is valid UTF-8", _is_utf8(text), repr(text)[:160])
 
-    # NOT asserted here, deliberately: whether the reply is well-formed JSON.
-    # That is the FSM's contract and has its own batteries; this one is about
-    # characters surviving the mask. Keeping it here would also make this file
-    # red for an unrelated reason — Qwen3-VL-4B closes the string with a
-    # TYPOGRAPHIC quote (U+201C) and stops with the document still open, which
-    # reproduces identically on builds predating the #1197 fix. Reported
-    # separately; see the note in the PR that introduced this file.
-    if not _is_json(content):
-        print(f"       note: reply was not well-formed JSON ({content[:80]!r}) — separate defect,"
-              f" not a #1197 regression")
+    check("reply is well-formed JSON", _is_json(content), content[:160])
+
+
+def test_eos_is_masked_while_the_document_is_open(m):
+    """#1199 — the model must not be *offered* EOS mid-document.
+
+    Asserting only that the reply parses would pass by luck on a model that
+    never reaches for EOS mid-string. This reads the alternatives the sampler
+    was given: while the JSON is incomplete, no end-of-turn token may be among
+    them. On the build that had the bug, `<|im_end|>` sat at rank 2 on the very
+    last step — the model took it, and the request returned 200 with the string
+    still open.
+    """
+    print("\n#1199 — EOS must not be offered while the document is incomplete")
+    status, body = post(
+        "/v1/chat/completions",
+        {
+            "model": m,
+            "max_tokens": 200,
+            "temperature": 0,
+            "logprobs": True,
+            "top_logprobs": 5,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Gib exakt diesen Satz zurück: Die Bären hören Gebüsch rascheln, "
+                    "größte Stärke, Persönlichkeit.",
+                }
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "S",
+                    "schema": {
+                        "type": "object",
+                        "properties": {"satz": {"type": "string"}},
+                        "required": ["satz"],
+                    },
+                },
+            },
+        },
+    )
+    if status != 200:
+        check("request succeeded", False, f"got {status}")
+        return
+    content = body["choices"][0]["message"]["content"]
+    check("constrained reply is well-formed JSON", _is_json(content), repr(content)[:160])
+
+    steps = (body["choices"][0].get("logprobs") or {}).get("content") or []
+    if not steps:
+        print("       note: server returned no logprobs — the offer check needs them")
+        return
+    # Every step except the last is unambiguously mid-document.
+    offered = []
+    for st in steps[:-1]:
+        for alt in st.get("top_logprobs") or []:
+            tokentext = alt.get("token") or ""
+            if "<|im_end|>" in tokentext or "<|endoftext|>" in tokentext:
+                offered.append(tokentext)
+    check(
+        "no end-of-turn token among the candidates mid-document",
+        not offered,
+        f"offered {sorted(set(offered))} while the JSON was still open",
+    )
 
 
 def _is_json(s):
@@ -198,6 +257,7 @@ def main():
     print(f"server: {BASE}   model: {m}")
     test_image_is_used_or_refused(m)
     test_non_ascii_survives_json_schema(m)
+    test_eos_is_masked_while_the_document_is_open(m)
     print()
     if failures:
         print(f"FAIL — {len(failures)} case(s): {', '.join(failures)}")


### PR DESCRIPTION
Closes #1199.

A `json_schema` request could return **200 with a reply that does not parse**:

```
finish_reason: stop      completion_tokens: 29      (not a max_tokens truncation)
content: {"satz":"} Die Bären hören Gebüsch rascheln, größte Stärke, Persönlichkeit.}
```

## Root cause

The EOS clear in `compute_token_allow_mask` was gated on `xml_raw`:

```cpp
// EOS must not stop generation mid-value: its rendered text ("<|im_end|>")
// would pass the anything-goes value scan above. …
if (xml_raw) { for (int32_t e : eos_tokens_) token_allow_[e] = 0; }
```

The comment describes the hazard in general terms, and the **JSON free-string
shortcut a few lines above has the same one**: `"<|im_end|>"` decodes to plain
printable ASCII, so `classify_token` gives it `CAT_STRING_CHAR`, and the shortcut
allows any "plain" token without simulating. The function's own comment claims
the category mask "governs EOS" — inside a string it does not. Nothing masked it.

Same shape as #1184, #1188 and #1197: a guard standing behind a condition
narrower than the hazard it was written for.

Unconditional is the correct scope. `compute_token_allow_mask` is only reached
with a non-empty stack — `apply_mask` returns before it when the root value is
complete, and that is the one place EOS belongs, where it is *forced* rather than
merely allowed.

## Evidence

`logprobs` on Qwen3-VL-4B, temperature 0, same request:

| | alternatives at the final step | result |
|---|---|---|
| before | `['}', '<\|im_end\|>', ' {']` | string left open, invalid JSON |
| after | `['}', ' {', '"}']` | `{"satz":"…"}`, parses |

The token the model took is simply no longer on the menu, so it closes the string
instead. Qwen3-8B-Q8_0 never reached for it, which is why the bug looked
model-specific — it was a matter of which model *wants* to stop there.

## Ruled out on the way

- The empty-allow guard ("no token satisfies the schema — allowing EOS"): its
  WARN never appears in the reproduction.
- The constrainer not being applied at all: an `integer` schema returns `{"n":3}`
  and an `enum` returns `{"x":"ZITRONE"}`, both well-formed.
- `<|im_end|>` missing from the tokenizer's EOS set: `add_eos_id` resolves it
  (`tokenizer_config.json: resolved eos_token '<|im_end|>' -> id 151645`), so the
  set was right and the gate was wrong.

## Test

`tests/test_server_vision_and_utf8.py` gains the #1199 case, and the
well-formedness assertion I had deliberately withheld there is now live.

The new check asserts **two** things: that the reply parses, and that no
end-of-turn token appears among the candidates while the document is incomplete.
The second exists because the first can pass by luck on a model that would not
have reached for EOS anyway — which is exactly how this went unnoticed.

Green on both a vision and a text-only model; `test-core` 779 pass; full image
build warning-free.