### PR TITLE
fix(runtime,compute): install process_diag from Engine::init + log the resolved dispatch (#1205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+- **A C-API embedding got different kernels than `imp-cli`/`imp-server` from the
+  same config** (#1205). `process_diag_install()` — the snapshot 28 kernel- and
+  dispatch-affecting flags are read from by leaf kernels that carry no
+  `RuntimeConfig` — ran only in the tool mains, so a library consumer's
+  `attention.*`, `moe.*`, `gdn.*` and `runtime.*` settings were honoured by
+  `exec/` and silently ignored by `compute/`. `attention.fa2_hd256` was the sharp
+  case: the executor decides whether to attempt FA2 (and whether to size the
+  384 MiB S-matrix workspace) from the engine's config while the kernel accepts
+  hd=256 from the process-wide snapshot, so the two could disagree and walk the
+  FMHA chain down to the #654 throw. `Engine::init()` now installs, before the
+  arch resolvers that promote `cublas_fp16_acc`/`deterministic_gemm`.
+
+### Added
+- **`Resolved dispatch:` log line — which attention and MoE kernels a model
+  actually ran** (#1205). Emitted once, after the first step that has seen both a
+  prefill and a decode, e.g.
+  `attn_prefill=fa2_fp16qk attn_decode=paged_fp8 moe_prefill=cutlass3x → device_args graphs=1`.
+  The six prefill tiers and five MoE branches all decline by returning `false`
+  with no log, so a model dropping to a slower or lower-quality path used to
+  leave no trace. Recorded from inside the real dispatch
+  (`compute/dispatch_record.h`), not predicted from a second copy of the routing
+  rules, so it cannot disagree with what ran.
+
 ## [0.20.2] - 2026-08-02
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ set(IMP_QUANT_SOURCES
 )
 
 set(IMP_COMPUTE_SOURCES
+    src/compute/dispatch_paths.cpp
     src/compute/gemm.cu
     src/compute/gemm_capture_fp16_sm120.cu
     src/compute/ffn_sparsity_probe.cu
@@ -610,6 +611,13 @@ if(IMP_BUILD_TESTS)
         tests/test_qwen3vl_vision_grid.cpp
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
+        # RuntimeConfig → process_diag snapshot (#1205). CPU-only by design:
+        # process_diag exists so leaf kernels can read config without carrying
+        # one, so the coupling is testable with no CUDA, Model or Engine.
+        tests/test_process_diag.cpp
+        # Resolved-dispatch recorder (#1205). CPU-only: plain POD + name tables,
+        # and it guards the "new tier prints '?' in the summary" gap.
+        tests/test_dispatch_record.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives
         # in the CPU lane on purpose: the FSM is CUDA-free without init(), and
         # every past grammar bug escaped CI because its tests need a GPU.

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -11,6 +11,7 @@
 #include "compute/attention_fmha_sm120.h"
 #include "compute/attention_fmha_mxfp4_sm120.h"
 #include "compute/attention_mxfp4_prefill.h"
+#include "compute/dispatch_record.h"
 
 namespace imp {
 
@@ -46,6 +47,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
         if (rcfg.attention.fmha_sm120 != "never" &&
             fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
                                attn_sinks)) {
+            dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FMHA_SM120);
             return;
         }
         char msg[160];
@@ -64,6 +66,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     if (attention_mxfp4_available()) {
         if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
                                      process_diag_mxfp4_blockscale(), q_offset)) {
+            dispatch_record::set_attn_prefill_tier(AttnPrefillPath::MXFP4);
             return;
         }
         // Fall through: head_dim not supported (e.g. < 32), use FP8/FP16 path
@@ -80,6 +83,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
             rcfg.attention.fa2_fp16qk == "never" && rcfg.attention.fp8_fmha == "on";
         if (fmha_sm120_fa2_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
                                    /*fp16_qk=*/!fa2_fp8_optin)) {
+            dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FA2);
             IMP_LOG_DEBUG("FMHA dispatch: using FA2 register-resident kernel (hd=%d)",
                           static_cast<int>(Q.shape[3]));
             return;
@@ -96,6 +100,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
         bool fp8_ok = fmha_sm120_fp8_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
                                               q_offset);
         if (fp8_ok) {
+            dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FP8);
             IMP_LOG_DEBUG("FMHA dispatch: using FP8 sm120 kernel (hd=%d)", static_cast<int>(Q.shape[3]));
             return;
         }
@@ -106,6 +111,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     const bool use_fmha_sm120 = rcfg.attention.fmha_sm120 != "never";
     if (use_fmha_sm120) {
         if (fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+            dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FMHA_SM120);
             return;
         }
     }
@@ -114,6 +120,7 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     // for unsupported configs — hd ∉ {64,96,128,256} or smem over the device
     // opt-in (hd=256 at Br=64 needs ~176 KB vs 99 KB on sm_120).
     if (flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+        dispatch_record::set_attn_prefill_tier(AttnPrefillPath::BLACKWELL);
         return;
     }
 

--- a/src/compute/attention_dispatch_decision.h
+++ b/src/compute/attention_dispatch_decision.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "compute/dispatch_paths.h"  // AttnPrefillPath
 #include "runtime/config.h"
 
 // Pure host-side model of the attention-prefill dispatch ordering in
@@ -25,14 +26,9 @@
 
 namespace imp {
 
-enum class AttnPrefillPath {
-    MXFP4,        // fmha_sm120_mxfp4_prefill
-    FA2,          // fmha_sm120_fa2_prefill (register-resident)
-    FP8,          // fmha_sm120_fp8_prefill
-    FMHA_SM120,   // fmha_sm120_prefill (WMMA)
-    BLACKWELL,    // flash_attention_blackwell (final tier; declines unsupported configs)
-    NONE,         // chain exhausted → attention_prefill_dispatch throws (#654)
-};
+// AttnPrefillPath now lives in compute/dispatch_paths.h so the runtime recorder
+// (compute/dispatch_record.h) names the tiers with the same vocabulary this
+// model does — see #1205. Renaming a tier breaks both sides together.
 
 // Per-kernel "would this kernel accept the config" flags, mirroring the bool
 // each `fmha_..._prefill(...)` collapses to in the .cu (mxfp4 also has an outer

--- a/src/compute/dispatch_paths.cpp
+++ b/src/compute/dispatch_paths.cpp
@@ -1,0 +1,97 @@
+#include "compute/dispatch_paths.h"
+
+namespace imp {
+
+const char* attn_prefill_path_name(AttnPrefillPath p) {
+    switch (p) {
+        case AttnPrefillPath::MXFP4:
+            return "fmha_mxfp4";
+        case AttnPrefillPath::FA2:
+            return "fmha_fa2";
+        case AttnPrefillPath::FP8:
+            return "fmha_fp8";
+        case AttnPrefillPath::FMHA_SM120:
+            return "fmha_sm120_wmma";
+        case AttnPrefillPath::BLACKWELL:
+            return "flash_blackwell";
+        case AttnPrefillPath::NONE:
+            return "none";
+    }
+    return "?";
+}
+
+const char* attn_prefill_outer_name(AttnPrefillOuter p) {
+    switch (p) {
+        case AttnPrefillOuter::UNSET:
+            return "unset";
+        case AttnPrefillOuter::FA2_FP16QK:
+            return "fa2_fp16qk";
+        case AttnPrefillOuter::CUBLAS:
+            return "cublas_materialized";
+        case AttnPrefillOuter::CUBLAS_SLICED:
+            return "cublas_sliced";
+        case AttnPrefillOuter::FMHA_CHAIN:
+            return "fmha_chain";
+    }
+    return "?";
+}
+
+const char* attn_decode_path_name(AttnDecodePath p) {
+    switch (p) {
+        case AttnDecodePath::UNSET:
+            return "unset";
+        case AttnDecodePath::FP16:
+            return "paged_fp16";
+        case AttnDecodePath::FP8:
+            return "paged_fp8";
+        case AttnDecodePath::INT8:
+            return "paged_int8";
+        case AttnDecodePath::INT4:
+            return "paged_int4";
+        case AttnDecodePath::NVFP4:
+            return "paged_nvfp4";
+        case AttnDecodePath::NVFP4_TC:
+            return "paged_nvfp4_tc";
+        case AttnDecodePath::MXFP4_KV:
+            return "paged_mxfp4_kv";
+    }
+    return "?";
+}
+
+const char* moe_prefill_outer_name(MoePrefillOuter p) {
+    switch (p) {
+        case MoePrefillOuter::UNSET:
+            return "unset";
+        case MoePrefillOuter::NONE:
+            return "n/a (dense)";
+        case MoePrefillOuter::FP16_BATCH:
+            return "fp16_batch";
+        case MoePrefillOuter::FP8_BATCH:
+            return "fp8_batch";
+        case MoePrefillOuter::CUTLASS3X:
+            return "cutlass3x";
+        case MoePrefillOuter::NVFP4_DEQUANT:
+            return "nvfp4_dequant_batch";
+        case MoePrefillOuter::LEGACY:
+            return "legacy_fallback";
+        case MoePrefillOuter::FUSED_Q6K:
+            return "fused_q6k";
+    }
+    return "?";
+}
+
+const char* moe_prefill_path_name(MoePrefillPath p) {
+    switch (p) {
+        case MoePrefillPath::DEVICE_ARGS:
+            return "device_args";
+        case MoePrefillPath::SMALL_M:
+            return "small_m";
+        case MoePrefillPath::GROUPED:
+            return "grouped";
+        case MoePrefillPath::LEGACY:
+            return "legacy";
+    }
+    return "?";
+}
+
+}  // namespace imp

--- a/src/compute/dispatch_paths.h
+++ b/src/compute/dispatch_paths.h
@@ -1,0 +1,78 @@
+#pragma once
+
+// The identities of the kernel paths imp can resolve to, as plain enums.
+//
+// Deliberately free of RuntimeConfig, CUDA and Tensor so that BOTH consumers
+// can include it without dragging a layer with them:
+//   - the pure routing models (attention_dispatch_decision.h,
+//     exec/moe_prefill_decision.h), which pull in runtime/config.h,
+//   - the dispatch recorder (dispatch_record.h), which is included from the
+//     hot path and must stay weightless.
+//
+// Splitting the enums out is what keeps the recorded path and the modelled
+// path expressed in ONE vocabulary: a tier renamed here breaks both sides.
+
+namespace imp {
+
+// Tiers inside the FMHA chain (compute/attention_dispatch.cu), tried in order.
+enum class AttnPrefillPath {
+    MXFP4,       // fmha_sm120_mxfp4_prefill
+    FA2,         // fmha_sm120_fa2_prefill (register-resident)
+    FP8,         // fmha_sm120_fp8_prefill
+    FMHA_SM120,  // fmha_sm120_prefill (WMMA)
+    BLACKWELL,   // flash_attention_blackwell (final tier; declines unsupported configs)
+    NONE,        // chain exhausted → attention_prefill_dispatch throws (#654)
+};
+
+// The branch taken by the executor BEFORE the FMHA chain is even reached
+// (exec/executor_attention_prefill.cu). Only FMHA_CHAIN continues into
+// AttnPrefillPath above; the other three are terminal.
+enum class AttnPrefillOuter {
+    UNSET,
+    FA2_FP16QK,     // try_fa2_fp16qk_prefill — the primary hd=128/256 path
+    CUBLAS,         // attention_cublas_prefill — materialized S-matrix
+    CUBLAS_SLICED,  // attention_cublas_prefill_sliced — hd=512 S-matrix overflow (#1036)
+    FMHA_CHAIN,     // attention_prefill_dispatch → AttnPrefillPath
+};
+
+// Paged-decode kernel family, selected by the KV cache dtype
+// (exec/executor_attention_decode.cu).
+enum class AttnDecodePath {
+    UNSET,
+    FP16,
+    FP8,
+    INT8,
+    INT4,
+    NVFP4,
+    NVFP4_TC,
+    MXFP4_KV,
+};
+
+// MoE prefill: the outer 5-way chain in exec/executor_forward_moe.cu.
+enum class MoePrefillOuter {
+    UNSET,
+    NONE,           // dense model — no MoE layers
+    FP16_BATCH,     // try_run_moe_fp16_batch_prefill
+    FP8_BATCH,      // try_run_moe_fp8_batch_prefill
+    CUTLASS3X,      // try_run_moe_cutlass3x_nvfp4_prefill_ → MoePrefillPath
+    NVFP4_DEQUANT,  // try_run_moe_nvfp4_dequant_batch_prefill_
+    LEGACY,         // run_moe_legacy_fallback_
+    FUSED_Q6K,      // fused Q6_K path (taken before the chain)
+};
+
+// Tiers inside try_run_moe_cutlass3x_nvfp4_prefill_
+// (exec/executor_forward_moe_cutlass.cu).
+enum class MoePrefillPath {
+    DEVICE_ARGS,  // CUTLASS 3.x NVFP4 device-args full path (fast)
+    SMALL_M,      // gemm_grouped_nvfp4_smallM (small token counts)
+    GROUPED,      // host-args CUTLASS 3.x grouped GEMM (+ gpt-oss bias seams)
+    LEGACY,       // per-expert legacy fallback (gather + serial GEMM)
+};
+
+const char* attn_prefill_path_name(AttnPrefillPath p);
+const char* attn_prefill_outer_name(AttnPrefillOuter p);
+const char* attn_decode_path_name(AttnDecodePath p);
+const char* moe_prefill_outer_name(MoePrefillOuter p);
+const char* moe_prefill_path_name(MoePrefillPath p);
+
+}  // namespace imp

--- a/src/compute/dispatch_record.h
+++ b/src/compute/dispatch_record.h
@@ -1,0 +1,72 @@
+#pragma once
+
+// Which kernels a request ACTUALLY ran (#1205).
+//
+// imp resolves a model to a specific set of kernels through several chains —
+// six attention-prefill tiers, five MoE-prefill branches, a KV-dtype decode
+// switch — and every one of them declines by returning `false` with no log.
+// The result was that a model silently taking a slower or lower-quality path
+// was invisible: the audit's "no resolved-path dump exists, so every future
+// routing regression is invisible" finding.
+//
+// This records the branch that WON, at the point it wins, from inside the real
+// dispatch. That is the whole design constraint: a *predicted* path (running
+// the pure routing models from select_attn_prefill_path() at init) would be a
+// third copy of the routing rules and could be wrong exactly when it matters.
+// What is recorded here cannot disagree with what ran, because it is set by the
+// code that ran.
+//
+// Cost: one thread_local store per branch taken, on paths that are already
+// doing a kernel launch. No allocation, no logging, no synchronisation. Under
+// CUDA-graph capture the store happens at capture time — which is the correct
+// moment, since replay repeats exactly the captured path.
+//
+// Threading: thread_local, following the graph_diag::g_phase precedent. The
+// BatchingEngine worker thread is the sole caller of Engine::step()/forward, so
+// per-thread state is per-engine state here; a second inference thread simply
+// gets its own record rather than corrupting a shared one.
+
+#include "compute/dispatch_paths.h"
+
+namespace imp::dispatch_record {
+
+struct Record {
+    AttnPrefillOuter attn_prefill_outer = AttnPrefillOuter::UNSET;
+    // Only meaningful when attn_prefill_outer == FMHA_CHAIN.
+    AttnPrefillPath attn_prefill_tier = AttnPrefillPath::NONE;
+    bool attn_prefill_tier_set = false;
+
+    AttnDecodePath attn_decode = AttnDecodePath::UNSET;
+
+    MoePrefillOuter moe_prefill_outer = MoePrefillOuter::UNSET;
+    // Only meaningful when moe_prefill_outer == CUTLASS3X.
+    MoePrefillPath moe_prefill_tier = MoePrefillPath::LEGACY;
+    bool moe_prefill_tier_set = false;
+
+    bool has_prefill() const { return attn_prefill_outer != AttnPrefillOuter::UNSET; }
+    bool has_decode() const { return attn_decode != AttnDecodePath::UNSET; }
+};
+
+inline thread_local Record g_record;
+
+inline Record& current() { return g_record; }
+
+inline void set_attn_prefill_outer(AttnPrefillOuter p) { g_record.attn_prefill_outer = p; }
+
+inline void set_attn_prefill_tier(AttnPrefillPath p) {
+    g_record.attn_prefill_tier = p;
+    g_record.attn_prefill_tier_set = true;
+}
+
+inline void set_attn_decode(AttnDecodePath p) { g_record.attn_decode = p; }
+
+inline void set_moe_prefill_outer(MoePrefillOuter p) { g_record.moe_prefill_outer = p; }
+
+inline void set_moe_prefill_tier(MoePrefillPath p) {
+    g_record.moe_prefill_tier = p;
+    g_record.moe_prefill_tier_set = true;
+}
+
+inline void reset() { g_record = Record{}; }
+
+}  // namespace imp::dispatch_record

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -22,6 +22,7 @@
 #include "compute/attention_fmha_sm120.h"
 #include "compute/attention_fmha_mxfp4_sm120.h"
 #include "compute/attention_paged.h"
+#include "compute/dispatch_record.h"  // resolved-path recording (#1205)
 #include "compute/kv_gather.h"
 #include "compute/moe_routing.h"
 #include "compute/sampling.h"

--- a/src/exec/executor_attention_decode.cu
+++ b/src/exec/executor_attention_decode.cu
@@ -160,6 +160,7 @@
         set_l2_persist_kv(stream, k_c.data, k_c.nbytes() + v_c.nbytes());
 
         if (cache_dtype == QType::INT4) {
+            dispatch_record::set_attn_decode(AttnDecodePath::INT4);
             // INT4 paged attention with per-head scales and INT4 unpack (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_int4(q4, k_c, v_c, o4,
@@ -169,6 +170,8 @@
                                         state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
                                         stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::NVFP4) {
+            // TC vs non-TC is decided per shape below.
+            dispatch_record::set_attn_decode(AttnDecodePath::NVFP4);
             // NVFP4 paged attention: packed FP4 + UE4M3 per-group_of_16 scales (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             // BitDecoding TC dispatch opt-in: kv_cache.bitdecoding_qk routes to the WMMA-Q.K variant; default
@@ -184,6 +187,7 @@
                 const uint8_t* k_scales = static_cast<const uint8_t*>(cache->k_scale_ptr(kv_layer, 0));
                 const uint8_t* v_scales = static_cast<const uint8_t*>(cache->v_scale_ptr(kv_layer, 0));
                 if (!residual_on) {
+                    dispatch_record::set_attn_decode(AttnDecodePath::NVFP4_TC);
                     paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, layer_block_tables,
                                                     state.context_lens, kv_bs, scale, state.max_context_len,
                                                     layer_sliding_window, cfg.attn_logit_softcap, stream,
@@ -222,6 +226,7 @@
                         res_count = rs.fill_count;
                         res_widx = rs.write_idx;
                     }
+                    dispatch_record::set_attn_decode(AttnDecodePath::NVFP4_TC);
                     paged_attention_decode_nvfp4_tc(q4, k_c, v_c, o4, k_scales, v_scales, layer_block_tables,
                                                     state.context_lens, kv_bs, scale, state.max_context_len,
                                                     layer_sliding_window, cfg.attn_logit_softcap, stream,
@@ -241,6 +246,7 @@
                                              cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
             }
         } else if (cache_dtype == QType::MXFP4_KV) {
+            dispatch_record::set_attn_decode(AttnDecodePath::MXFP4_KV);
             // MXFP4-KV paged attention: same kernel as NVFP4 but with UE8M0 scale decode.
             // BitDecoding TC path not supported for MXFP4_KV in Slice 2 — always scalar.
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
@@ -251,6 +257,7 @@
                                             state.max_context_len, layer_sliding_window,
                                             cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::INT8) {
+            dispatch_record::set_attn_decode(AttnDecodePath::INT8);
             // INT8 dp4a paged attention with per-head scales (Split-K enabled)
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode_int8(q4, k_c, v_c, o4,
@@ -260,6 +267,7 @@
                                         state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,
                                         stream, state.max_blocks_per_seq);
         } else if (cache_dtype == QType::FP8_E4M3) {
+            dispatch_record::set_attn_decode(AttnDecodePath::FP8);
             // FP8 paged attention with on-the-fly dequant (Split-K enabled)
             float kv_scale = (!kv_scales_.empty() && kv_layer < static_cast<int>(kv_scales_.size()))
                                  ? kv_scales_[kv_layer]
@@ -269,6 +277,7 @@
                                        kv_scale, state.max_context_len, layer_sliding_window,
                                        cfg.attn_logit_softcap, stream, state.max_blocks_per_seq);
         } else {
+            dispatch_record::set_attn_decode(AttnDecodePath::FP16);
             paged_attention_set_splitk_scratch(qscratch_.splitk, qscratch_.splitk_size);
             paged_attention_decode(q4, k_c, v_c, o4, layer_block_tables, state.context_lens, kv_bs, scale,
                                    state.max_context_len, layer_sliding_window, cfg.attn_logit_softcap,

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -298,17 +298,20 @@
                                             stream, state.context_lens)) {
                     throw std::runtime_error("chunked_prefill: FA2 declined a capture-replay chunk");
                 }
+                dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FA2_FP16QK);
             } else if (chunk_fa2_serves &&
                 try_fa2_fp16qk_prefill(runtime_config(), qv, k_full_t, v_full_t, ao, n, ctx_len, nh,
                                        nkv, hd, scale, layer_sliding_window, cfg.attn_logit_softcap,
                                        q_offset, stream)) {
                 // chunked prefill: FP16-QK FA2 (no S-matrix, no e4m3 noise)
+                dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FA2_FP16QK);
             } else if (smatrix_fits && !prefer_fmha) {
                 // cuBLAS: below-threshold reference for uniform models, learned
                 // sinks, AND the hd=512 Gemma-4 global layers whenever their
                 // S-matrix fits (measured faster than the SMEM-capped fused
                 // hd=512 kernel — docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). The hd=256 SWA layers took FA2
                 // above; only the hd=512 layers land here.
+                dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::CUBLAS);
                 attention_cublas_prefill(qv, k_full_t, v_full_t, ao, attn_scores_, nh, nkv, hd, scale,
                                          /*causal=*/true, cfg.attn_logit_softcap, q_offset, stream,
                                          layer_sliding_window, attn_sinks);
@@ -317,6 +320,7 @@
                                                        hd, scale, /*causal=*/true, cfg.attn_logit_softcap,
                                                        q_offset, stream, layer_sliding_window,
                                                        attn_sinks)) {
+                dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::CUBLAS_SLICED);
                 // hd=512 S-matrix overflow (long ctx): cuBLAS in workspace-sized
                 // q-row slices — 3.4-3.9× faster than the whole-chunk FMHA hd=512
                 // fallback at Skv 8k/16k (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 4; the FMHA's Bq=16
@@ -336,6 +340,7 @@
                 Tensor k4 = k_full_t.reshape(4, kv4s);
                 Tensor v4 = v_full_t.reshape(4, kv4s);
                 Tensor o4 = ao.reshape(4, o4s);
+                dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FMHA_CHAIN);
                 attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
                                            cfg.attn_logit_softcap, stream, runtime_config(), q_offset,
                                            static_cast<const half*>(attn_sinks));
@@ -414,11 +419,13 @@
                                    layer_sliding_window, cfg.attn_logit_softcap, /*q_offset=*/0,
                                    stream)) {
             // handled by FA2 f16 — no S-matrix needed (hd 128/256, incl. Gemma-4 SWA)
+            dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FA2_FP16QK);
         } else if (s_matrix_fits && !prefer_fmha) {
             // Materialized cuBLAS: below-threshold reference for uniform models
             // and learned sinks, AND the hd=512 Gemma-4 global layers whenever
             // the S-matrix fits (faster than the SMEM-capped fused hd=512 kernel
             // — docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md). The hd=256 SWA layers took FA2 above.
+            dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::CUBLAS);
             attention_cublas_prefill(qv, kk, vv, ao, attn_scores_, nh, nkv, hd, scale,
                                      /*causal=*/true, cfg.attn_logit_softcap,
                                      /*q_offset=*/0, stream, layer_sliding_window, attn_sinks);
@@ -427,6 +434,7 @@
                                                    /*causal=*/true, cfg.attn_logit_softcap,
                                                    /*q_offset=*/0, stream, layer_sliding_window,
                                                    attn_sinks)) {
+            dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::CUBLAS_SLICED);
             // hd=512 S-matrix overflow: cuBLAS in workspace-sized q-row slices —
             // 3.4-3.9× faster than the whole-prompt FMHA hd=512 fallback
             // (docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md entry 4). False only when even a 16-row slice
@@ -444,6 +452,7 @@
             Tensor k4 = kk.reshape(4, kv4s);
             Tensor v4 = vv.reshape(4, kv4s);
             Tensor o4 = ao.reshape(4, o4s);
+            dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FMHA_CHAIN);
             attention_prefill_dispatch(q4, k4, v4, o4, scale, /*causal=*/true, layer_sliding_window,
                                        cfg.attn_logit_softcap, stream, runtime_config(), /*q_offset=*/0,
                                        static_cast<const half*>(attn_sinks));

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -29,6 +29,7 @@
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_grouped_3x.h"
 #include "compute/gemm_grouped_nvfp4_smallM.h"
+#include "compute/dispatch_record.h"  // resolved-path recording (#1205)
 #include "compute/quantize_fp16_nvfp4_moe_native.h"
 #include "compute/activation.h"
 #include "compute/attention.h"
@@ -575,22 +576,27 @@ void GraphExecutor::run_moe_ffn(int layer, cudaStream_t stream) {
                     debug_tensor_stats("L0_moe_norm_out_no", no, stream);
                 }
                 if (can_fp16_batch_nosync) {
+                    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::FP16_BATCH);
                     try_run_moe_fp16_batch_prefill(layer, stream, n, d, eff, ne, expanded,
                                                    non_gated_experts, up_qtype, routing,
                                                    fp32_down_active, fp32_down_buf);
                 } else if (can_fp8_batch) {
+                    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::FP8_BATCH);
                     try_run_moe_fp8_batch_prefill(layer, stream, n, d, eff, ne, expanded,
                                                   non_gated_experts, up_qtype, routing);
 
                     // Falls through to scatter (step 7)
 
                 } else if (try_run_moe_cutlass3x_nvfp4_prefill_(layer, stream, ctx)) {
+                    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::CUTLASS3X);
                     // Falls through to scatter (step 7)
 
                 } else if (try_run_moe_nvfp4_dequant_batch_prefill_(layer, stream, ctx)) {
+                    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::NVFP4_DEQUANT);
                     // Falls through to scatter (step 7)
 
                 } else {
+                    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::LEGACY);
                     run_moe_legacy_fallback_(layer, stream, ctx);
                 }
             }  // else of can_fp16/fp8_batch/legacy

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -11,6 +11,7 @@
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_grouped_3x.h"
 #include "compute/gemm_grouped_nvfp4_smallM.h"
+#include "compute/dispatch_record.h"  // resolved-path recording (#1205)
 #include "compute/quantize_fp16_nvfp4_moe_native.h"
 #include "compute/activation.h"
 #include "compute/moe_routing.h"
@@ -294,6 +295,7 @@ bool device_args_done = false;
         }
         if (ok) {
             device_args_done = true;
+            dispatch_record::set_moe_prefill_tier(MoePrefillPath::DEVICE_ARGS);
         } else {
             IMP_LOG_ERROR(
                 "device-args full path failed; falling back to legacy");
@@ -625,6 +627,7 @@ bool smallM_done = false;
                         cudaFreeAsync(d_act_tscales_dn, stream));
                     if (ok_down) {
                         smallM_done = true;
+                        dispatch_record::set_moe_prefill_tier(MoePrefillPath::SMALL_M);
                     } else {
                         IMP_LOG_ERROR(
                             "smallM down dispatch failed; falling back to "
@@ -645,9 +648,11 @@ bool smallM_done = false;
     }
 }
 
-if (!smallM_done && layer == 0)
-    IMP_LOG_INFO("MoE prefill: CUTLASS 3.x NVFP4 grouped (n=%d, expanded=%d)",
-                 n, expanded);
+if (!smallM_done) {
+    dispatch_record::set_moe_prefill_tier(MoePrefillPath::GROUPED);
+    if (layer == 0)
+        IMP_LOG_INFO("MoE prefill: CUTLASS 3.x NVFP4 grouped (n=%d, expanded=%d)", n, expanded);
+}
 
 if (!smallM_done) {
 

--- a/src/exec/moe_prefill_decision.h
+++ b/src/exec/moe_prefill_decision.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "compute/dispatch_paths.h"  // MoePrefillPath
 #include "model/model_arch.h"
 #include "runtime/config.h"
 
@@ -18,12 +19,9 @@
 
 namespace imp {
 
-enum class MoePrefillPath {
-    DEVICE_ARGS,   // CUTLASS 3.x NVFP4 device-args full path (fast)
-    SMALL_M,       // gemm_grouped_nvfp4_smallM (small token counts)
-    GROUPED,       // host-args CUTLASS 3.x grouped GEMM (+ gpt-oss bias seams)
-    LEGACY,        // per-expert legacy fallback (gather + serial GEMM)
-};
+// MoePrefillPath now lives in compute/dispatch_paths.h so the runtime recorder
+// (compute/dispatch_record.h) names the tiers with the same vocabulary this
+// model does — see #1205.
 
 // Workspace-readiness flags, mirroring the device-pointer / packed-tensor
 // conjunctions in the .cu. When false, that tier's preconditions are not met

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -780,12 +780,30 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // budgets, KV clamp, workspaces) reads through vram_budget_mem_get_info.
     vram_budget_install(config_.vram_budget_mb);
 
-    // The deterministic kernel gate lives in process_diag (compute kernels
-    // read process_diag_deterministic_gemm()), but process_diag_install()
-    // only runs in tool mains. Promote the gate here so library/test
-    // embeddings (C API without a tool main) honor [runtime] deterministic /
-    // IMP_DETERMINISTIC too. True-promotion only — arch resolvers and tool
-    // installs may already have set it.
+    // Publish THIS engine's RuntimeConfig to the process_diag snapshot that the
+    // leaf kernels read. Until #1205 this only ever ran in the tool mains
+    // (imp-cli / imp-server), so a C-API embedding got the *default* value for
+    // all 28 mirrored flags while exec/ read the engine's own RuntimeConfig —
+    // same config, different kernels. attention.fa2_hd256 was the sharp case:
+    // exec/ decides whether to attempt FA2 (and whether to size the S-matrix
+    // workspace) from runtime_config_, while the kernel accepts hd=256 based on
+    // process_diag_fa2_hd256(); with the two disagreeing, the FMHA chain can walk
+    // down to the #654 throw.
+    //
+    // Ordering matters twice over:
+    //   - BEFORE the arch resolvers below. install() writes gemm.cublas_fp16_acc
+    //     ("auto" → off) and runtime.deterministic_gemm verbatim; the resolvers
+    //     then promote both via their setters. Installing after them would undo
+    //     the arch-specific decisions.
+    //   - BEFORE the true-promotion of the deterministic gate, which must stay
+    //     after install() so [runtime] deterministic still implies
+    //     deterministic_gemm (install copies only the latter field).
+    process_diag_install(runtime_config_);
+
+    // The deterministic kernel gate lives in process_diag (compute kernels read
+    // process_diag_deterministic_gemm()). [runtime] deterministic implies it,
+    // but install() above copies only [runtime] deterministic_gemm, so promote
+    // here. True-promotion only — arch resolvers may already have set it.
     if (runtime_config_.runtime.deterministic || runtime_config_.runtime.deterministic_gemm)
         process_diag_set_deterministic_gemm(true);
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -570,6 +570,8 @@ private:
     std::unique_ptr<LayerOffloadManager> offload_mgr_;
     bool experts_on_host_ = false;
     bool dequant_done_ = false;
+    // One-shot guard for the resolved-dispatch summary (#1205).
+    bool dispatch_dump_done_ = false;
     // Balloon reservation for the mandatory native-NVFP4 decode caches
     // (CUTLASS SfAtom slab + nvfp4_moe). Held from right after weight
     // upload (before workspaces/KV consume the headroom) until just before
@@ -973,6 +975,11 @@ private:
     // call sequence in init() for which flag each one resolves.
     void init_apply_debug_raw_overrides_();
     void init_apply_rope_override_();
+    // One-shot "which kernels did this model actually resolve to" summary,
+    // read back from compute/dispatch_record.h after the first step that has
+    // seen both a prefill and a decode (#1205).
+    void log_resolved_dispatch_once_();
+
     void init_resolve_kv_dtype_policy_();
     void init_resolve_ssm_dtype_();
     void init_resolve_fp8_prefill_();

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -26,6 +26,7 @@
 #include "runtime/batch.h"
 #include "runtime/think_stop_logic.h"
 #include "compute/mtp_forward.h"
+#include "compute/dispatch_record.h"  // resolved-path summary (#1205)
 #include "model/image_placeholders.h"
 #include "memory/kv_cache.h"
 #include "compute/sampling.h"
@@ -33,6 +34,7 @@
 #include "core/logging.h"
 
 #include <climits>
+#include <cstdio>
 #include <cmath>
 #include <cstring>
 #include <algorithm>
@@ -102,7 +104,53 @@ bool Engine::step() {
         ensure_prefill_workspace(executor_.get());
     }
 
+    log_resolved_dispatch_once_();
+
     return scheduler_->has_pending() || scheduler_->active_count() > 0;
+}
+
+// One-shot summary of the kernels this model ACTUALLY resolved to (#1205).
+//
+// Emitted after the first step that has seen both a prefill and a decode, so
+// every chain has had a chance to record. Everything here is read back from
+// compute/dispatch_record.h — i.e. from the branches that ran, not from a
+// prediction — so it cannot drift away from the dispatch the way a second copy
+// of the routing rules would.
+//
+// Why this exists: the prefill chain has six tiers and the MoE chain five, and
+// every one of them declines by returning `false` with no log. Before this,
+// a model silently taking a slower or lower-quality path left no trace, which
+// made every future routing regression invisible.
+void Engine::log_resolved_dispatch_once_() {
+    if (dispatch_dump_done_)
+        return;
+    const auto& r = dispatch_record::current();
+    if (!r.has_prefill() || !r.has_decode())
+        return;
+    dispatch_dump_done_ = true;
+
+    const bool is_moe = model_ && model_->profile().is_moe;
+
+    char prefill[96];
+    if (r.attn_prefill_outer == AttnPrefillOuter::FMHA_CHAIN && r.attn_prefill_tier_set) {
+        snprintf(prefill, sizeof(prefill), "%s → %s", attn_prefill_outer_name(r.attn_prefill_outer),
+                 attn_prefill_path_name(r.attn_prefill_tier));
+    } else {
+        snprintf(prefill, sizeof(prefill), "%s", attn_prefill_outer_name(r.attn_prefill_outer));
+    }
+
+    char moe[96];
+    if (!is_moe) {
+        snprintf(moe, sizeof(moe), "%s", moe_prefill_outer_name(MoePrefillOuter::NONE));
+    } else if (r.moe_prefill_outer == MoePrefillOuter::CUTLASS3X && r.moe_prefill_tier_set) {
+        snprintf(moe, sizeof(moe), "%s → %s", moe_prefill_outer_name(r.moe_prefill_outer),
+                 moe_prefill_path_name(r.moe_prefill_tier));
+    } else {
+        snprintf(moe, sizeof(moe), "%s", moe_prefill_outer_name(r.moe_prefill_outer));
+    }
+
+    IMP_LOG_INFO("Resolved dispatch: attn_prefill=%s attn_decode=%s moe_prefill=%s graphs=%d", prefill,
+                 attn_decode_path_name(r.attn_decode), moe, (int)config_.use_cuda_graphs);
 }
 
 // =====================================================================

--- a/tests/test_dispatch_record.cpp
+++ b/tests/test_dispatch_record.cpp
@@ -1,0 +1,139 @@
+// Resolved-dispatch recording (#1205).
+//
+// The recorder in compute/dispatch_record.h is what makes "which kernels did
+// this model actually run" answerable. Two properties keep it honest and both
+// are checked here:
+//
+//   1. Every enumerator has a name. The summary is built by concatenating
+//      *_name() results, so a tier added to compute/dispatch_paths.h without a
+//      matching switch arm would silently print "?" in production — the exact
+//      class of silent gap the recorder exists to close.
+//   2. has_prefill()/has_decode() only go true once a branch has actually
+//      recorded. Engine::log_resolved_dispatch_once_() gates the one-shot dump
+//      on them, so a false positive there would emit a summary full of
+//      "unset" on the very first step.
+//
+// CPU-only: the recorder is plain thread_local POD with no CUDA in it.
+
+#include "compute/dispatch_paths.h"
+#include "compute/dispatch_record.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+using namespace imp;
+
+namespace {
+
+// Keep in lock-step with compute/dispatch_paths.h. A new enumerator that is not
+// listed here is not covered — but a new enumerator with no switch arm IS
+// caught, which is the failure that reaches production.
+const AttnPrefillPath kAllPrefillTiers[] = {
+    AttnPrefillPath::MXFP4,      AttnPrefillPath::FA2,       AttnPrefillPath::FP8,
+    AttnPrefillPath::FMHA_SM120, AttnPrefillPath::BLACKWELL, AttnPrefillPath::NONE,
+};
+const AttnPrefillOuter kAllPrefillOuter[] = {
+    AttnPrefillOuter::UNSET,         AttnPrefillOuter::FA2_FP16QK, AttnPrefillOuter::CUBLAS,
+    AttnPrefillOuter::CUBLAS_SLICED, AttnPrefillOuter::FMHA_CHAIN,
+};
+const AttnDecodePath kAllDecode[] = {
+    AttnDecodePath::UNSET, AttnDecodePath::FP16,  AttnDecodePath::FP8,      AttnDecodePath::INT8,
+    AttnDecodePath::INT4,  AttnDecodePath::NVFP4, AttnDecodePath::NVFP4_TC, AttnDecodePath::MXFP4_KV,
+};
+const MoePrefillOuter kAllMoeOuter[] = {
+    MoePrefillOuter::UNSET,     MoePrefillOuter::NONE,      MoePrefillOuter::FP16_BATCH,
+    MoePrefillOuter::FP8_BATCH, MoePrefillOuter::CUTLASS3X, MoePrefillOuter::NVFP4_DEQUANT,
+    MoePrefillOuter::LEGACY,    MoePrefillOuter::FUSED_Q6K,
+};
+const MoePrefillPath kAllMoeTiers[] = {
+    MoePrefillPath::DEVICE_ARGS,
+    MoePrefillPath::SMALL_M,
+    MoePrefillPath::GROUPED,
+    MoePrefillPath::LEGACY,
+};
+
+void expect_named(const char* name) {
+    ASSERT_NE(name, nullptr);
+    EXPECT_STRNE(name, "?") << "enumerator has no switch arm in dispatch_paths.cpp — the "
+                               "resolved-dispatch summary would print '?' for it";
+    EXPECT_GT(std::string(name).size(), 0u);
+}
+
+}  // namespace
+
+TEST(DispatchPaths, EveryEnumeratorHasAName) {
+    for (auto p : kAllPrefillTiers)
+        expect_named(attn_prefill_path_name(p));
+    for (auto p : kAllPrefillOuter)
+        expect_named(attn_prefill_outer_name(p));
+    for (auto p : kAllDecode)
+        expect_named(attn_decode_path_name(p));
+    for (auto p : kAllMoeOuter)
+        expect_named(moe_prefill_outer_name(p));
+    for (auto p : kAllMoeTiers)
+        expect_named(moe_prefill_path_name(p));
+}
+
+// Names are what an operator greps for, so they must be distinguishable.
+TEST(DispatchPaths, NamesAreDistinctWithinEachFamily) {
+    auto distinct = [](const auto& range, auto fn) {
+        std::vector<std::string> seen;
+        for (auto p : range) {
+            std::string n = fn(p);
+            for (const auto& s : seen)
+                EXPECT_NE(s, n) << "duplicate path name: " << n;
+            seen.push_back(n);
+        }
+    };
+    distinct(kAllPrefillTiers, attn_prefill_path_name);
+    distinct(kAllPrefillOuter, attn_prefill_outer_name);
+    distinct(kAllDecode, attn_decode_path_name);
+    distinct(kAllMoeOuter, moe_prefill_outer_name);
+    distinct(kAllMoeTiers, moe_prefill_path_name);
+}
+
+TEST(DispatchRecord, StartsUnsetAndGatesTheDump) {
+    dispatch_record::reset();
+    const auto& r = dispatch_record::current();
+
+    EXPECT_FALSE(r.has_prefill());
+    EXPECT_FALSE(r.has_decode());
+    EXPECT_FALSE(r.attn_prefill_tier_set);
+    EXPECT_FALSE(r.moe_prefill_tier_set);
+
+    // A prefill alone must not unlock the dump — the summary reports both.
+    dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FA2_FP16QK);
+    EXPECT_TRUE(r.has_prefill());
+    EXPECT_FALSE(r.has_decode());
+
+    dispatch_record::set_attn_decode(AttnDecodePath::FP8);
+    EXPECT_TRUE(r.has_decode());
+
+    dispatch_record::reset();
+    EXPECT_FALSE(dispatch_record::current().has_prefill());
+    EXPECT_FALSE(dispatch_record::current().has_decode());
+}
+
+// The two-level paths (outer → tier) must report the tier only once it was
+// really recorded, otherwise the summary would claim a CUTLASS tier for a
+// model that never reached the CUTLASS branch.
+TEST(DispatchRecord, TierFlagsTrackTheirSetters) {
+    dispatch_record::reset();
+    const auto& r = dispatch_record::current();
+
+    dispatch_record::set_attn_prefill_outer(AttnPrefillOuter::FMHA_CHAIN);
+    EXPECT_FALSE(r.attn_prefill_tier_set) << "outer must not imply a tier";
+    dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FA2);
+    EXPECT_TRUE(r.attn_prefill_tier_set);
+    EXPECT_EQ(r.attn_prefill_tier, AttnPrefillPath::FA2);
+
+    dispatch_record::set_moe_prefill_outer(MoePrefillOuter::CUTLASS3X);
+    EXPECT_FALSE(r.moe_prefill_tier_set);
+    dispatch_record::set_moe_prefill_tier(MoePrefillPath::DEVICE_ARGS);
+    EXPECT_TRUE(r.moe_prefill_tier_set);
+    EXPECT_EQ(r.moe_prefill_tier, MoePrefillPath::DEVICE_ARGS);
+
+    dispatch_record::reset();
+}

--- a/tests/test_process_diag.cpp
+++ b/tests/test_process_diag.cpp
@@ -1,0 +1,180 @@
+// process_diag ↔ RuntimeConfig coupling (#1205).
+//
+// process_diag is a process-wide snapshot of the flags that leaf kernels read
+// when they have no RuntimeConfig to hand. Until #1205 process_diag_install()
+// ran ONLY in the tool mains, so a C-API embedding got the built-in defaults
+// for all mirrored flags while exec/ read the engine's own RuntimeConfig — the
+// same config producing different kernels depending on who started the engine.
+// Engine::init() now installs, which makes these two properties load-bearing:
+//
+//   1. install() must transfer EVERY mirrored field. A field added to
+//      ProcessDiag but forgotten in install() silently keeps its default
+//      forever; this test fails when that happens for any field it covers.
+//   2. The built-in defaults must equal the RuntimeConfig defaults, so the
+//      engine-less paths that still read process_diag before any install
+//      (standalone tools, unit tests) behave like a default engine.
+//
+// CPU-only: no CUDA, no Model, no Engine — this is the whole point of the
+// process_diag indirection and it keeps the check in the CI unit lane.
+
+#include "runtime/config.h"
+#include "runtime/process_diag.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace imp;
+
+namespace {
+
+// Every mirrored field flipped away from its default. Keep in lock-step with
+// process_diag_install(); a field added there and not here is not covered.
+RuntimeConfig make_non_default() {
+    RuntimeConfig c;
+    c.diagnostics.debug_forward = true;
+    c.diagnostics.debug_template = true;
+    c.diagnostics.graph_diag = true;
+    c.diagnostics.nvfp4_force_dequant = true;
+    c.diagnostics.log_gemm_algo = true;
+    c.diagnostics.audit_nvfp4_scales = true;
+    c.diagnostics.dump_hidden_dir = "/var/tmp/imp-hidden";
+    c.diagnostics.graph_dump_dir = "/var/tmp/imp-graphs";
+
+    c.runtime.no_pdl = true;
+    c.runtime.no_vision_graph = true;
+    c.runtime.graph_capture_mode = "global";
+    c.runtime.prefill_graph = false;
+    c.runtime.deterministic_gemm = true;
+
+    c.gemm.cublas_fp16_acc = "on";
+
+    c.attention.splitk_pipe = false;
+    c.attention.fp8_tile = false;
+    c.attention.fp8_tile_gqa = false;
+    c.attention.fa2_f16acc = false;
+    c.attention.fa2_pv_f16acc = false;
+    c.attention.fa2_hd256 = false;
+    c.attention.fp8_qk_scaled = true;
+    c.attention.mxfp4 = "always";
+    c.attention.mxfp4_blockscale = true;
+    c.attention.mxfp4_ksmooth = true;
+    c.attention.mxfp4_pv_fp4 = true;
+    c.attention.mxfp4_promote_budget = 0.25f;
+
+    c.ffn.sparsity_probe = true;
+
+    c.moe.mr_nr = 32;
+    c.moe.expert_overhead_pct = 42;
+    c.moe.force_host_experts = 7;
+
+    c.gdn.layout_override = "blocked";
+    return c;
+}
+
+// Restores the process-wide slot so test ordering inside the binary cannot
+// leak a non-default snapshot into an unrelated test.
+struct ProcessDiagGuard {
+    ~ProcessDiagGuard() { process_diag_install(RuntimeConfig{}); }
+};
+
+}  // namespace
+
+// Every mirrored field survives the RuntimeConfig → ProcessDiag transfer.
+// This is the regression guard for "added a flag, forgot the install() line".
+TEST(ProcessDiag, InstallTransfersEveryMirroredField) {
+    ProcessDiagGuard restore;
+    const RuntimeConfig c = make_non_default();
+    process_diag_install(c);
+
+    EXPECT_TRUE(process_diag_debug_forward());
+    EXPECT_TRUE(process_diag_debug_template());
+    EXPECT_TRUE(process_diag_graph_diag());
+    EXPECT_TRUE(process_diag_nvfp4_force_dequant());
+    EXPECT_TRUE(process_diag_log_gemm_algo());
+    EXPECT_TRUE(process_diag_audit_nvfp4_scales());
+    ASSERT_NE(process_diag_dump_hidden_dir(), nullptr);
+    EXPECT_EQ(std::string(process_diag_dump_hidden_dir()), "/var/tmp/imp-hidden");
+    ASSERT_NE(process_diag_graph_dump_dir(), nullptr);
+    EXPECT_EQ(std::string(process_diag_graph_dump_dir()), "/var/tmp/imp-graphs");
+
+    EXPECT_TRUE(process_diag_no_pdl());
+    EXPECT_TRUE(process_diag_no_vision_graph());
+    EXPECT_EQ(process_diag_graph_capture_mode(), "global");
+    EXPECT_FALSE(process_diag_prefill_graph_enabled());
+
+    EXPECT_TRUE(process_diag_deterministic_gemm());
+    EXPECT_TRUE(process_diag_cublas_fp16_acc());
+
+    EXPECT_FALSE(process_diag_attention_splitk_pipe());
+    EXPECT_FALSE(process_diag_attention_fp8_tile());
+    EXPECT_FALSE(process_diag_attention_fp8_tile_gqa());
+    EXPECT_FALSE(process_diag_fa2_f16acc());
+    EXPECT_FALSE(process_diag_fa2_pv_f16acc());
+    EXPECT_FALSE(process_diag_fa2_hd256());
+    EXPECT_TRUE(process_diag_fp8_qk_scaled());
+    EXPECT_EQ(process_diag_attention_mxfp4_mode(), "always");
+    EXPECT_TRUE(process_diag_mxfp4_blockscale());
+    EXPECT_TRUE(process_diag_mxfp4_ksmooth());
+    EXPECT_TRUE(process_diag_mxfp4_pv_fp4());
+    EXPECT_FLOAT_EQ(process_diag_mxfp4_promote_budget(), 0.25f);
+
+    EXPECT_TRUE(process_diag_ffn_sparsity_probe());
+
+    EXPECT_EQ(process_diag_moe_mr_nr(), 32);
+    EXPECT_EQ(process_diag_moe_expert_overhead_pct(), 42);
+    EXPECT_EQ(process_diag_moe_force_host_experts(), 7);
+
+    EXPECT_EQ(process_diag_gdn_layout_override(), "blocked");
+}
+
+// Installing a default RuntimeConfig must reproduce the built-in defaults.
+// If these drift apart, an engine-less reader (standalone tool, unit test)
+// sees different kernel behaviour than a default engine does.
+TEST(ProcessDiag, DefaultConfigMatchesBuiltInDefaults) {
+    ProcessDiagGuard restore;
+    // Dirty the slot first so a no-op install() cannot pass this by accident.
+    process_diag_install(make_non_default());
+    process_diag_install(RuntimeConfig{});
+
+    const RuntimeConfig d;
+    EXPECT_EQ(process_diag_debug_forward(), d.diagnostics.debug_forward);
+    EXPECT_EQ(process_diag_graph_diag(), d.diagnostics.graph_diag);
+    EXPECT_EQ(process_diag_no_pdl(), d.runtime.no_pdl);
+    EXPECT_EQ(process_diag_no_vision_graph(), d.runtime.no_vision_graph);
+    EXPECT_EQ(process_diag_graph_capture_mode(), d.runtime.graph_capture_mode);
+    EXPECT_EQ(process_diag_prefill_graph_enabled(), d.runtime.prefill_graph);
+    EXPECT_EQ(process_diag_deterministic_gemm(), d.runtime.deterministic_gemm);
+    EXPECT_EQ(process_diag_attention_splitk_pipe(), d.attention.splitk_pipe);
+    EXPECT_EQ(process_diag_attention_fp8_tile(), d.attention.fp8_tile);
+    EXPECT_EQ(process_diag_attention_fp8_tile_gqa(), d.attention.fp8_tile_gqa);
+    EXPECT_EQ(process_diag_fa2_f16acc(), d.attention.fa2_f16acc);
+    EXPECT_EQ(process_diag_fa2_pv_f16acc(), d.attention.fa2_pv_f16acc);
+    EXPECT_EQ(process_diag_fa2_hd256(), d.attention.fa2_hd256);
+    EXPECT_EQ(process_diag_fp8_qk_scaled(), d.attention.fp8_qk_scaled);
+    EXPECT_EQ(process_diag_attention_mxfp4_mode(), d.attention.mxfp4);
+    EXPECT_EQ(process_diag_ffn_sparsity_probe(), d.ffn.sparsity_probe);
+    EXPECT_EQ(process_diag_moe_mr_nr(), d.moe.mr_nr);
+    EXPECT_EQ(process_diag_moe_expert_overhead_pct(), d.moe.expert_overhead_pct);
+    EXPECT_EQ(process_diag_moe_force_host_experts(), d.moe.force_host_experts);
+    EXPECT_EQ(process_diag_gdn_layout_override(), d.gdn.layout_override);
+
+    // "auto" (the default) maps to OFF — the arch resolvers promote it later.
+    EXPECT_EQ(d.gemm.cublas_fp16_acc, "auto");
+    EXPECT_FALSE(process_diag_cublas_fp16_acc());
+}
+
+// dump_hidden_dir carries a documented shorthand: "1"/"all" resolve to /tmp.
+TEST(ProcessDiag, DumpHiddenDirShorthandResolves) {
+    ProcessDiagGuard restore;
+    RuntimeConfig c;
+    c.diagnostics.dump_hidden_dir = "1";
+    process_diag_install(c);
+    ASSERT_NE(process_diag_dump_hidden_dir(), nullptr);
+    EXPECT_EQ(std::string(process_diag_dump_hidden_dir()), "/tmp");
+
+    c.diagnostics.dump_hidden_dir = "all";
+    process_diag_install(c);
+    ASSERT_NE(process_diag_dump_hidden_dir(), nullptr);
+    EXPECT_EQ(std::string(process_diag_dump_hidden_dir()), "/tmp");
+}


### PR DESCRIPTION
Two findings from the architecture audit, both about decisions the engine makes and does not record.

## 1. A C-API embedding got different kernels than the tools, from the same config

`process_diag` is a process-wide snapshot of the **28** kernel- and dispatch-affecting flags that leaf kernels read when they carry no `RuntimeConfig`. `process_diag_install()` ran **only in the tool mains** (`tools/imp-cli/main.cpp:134`, `tools/imp-server/main.cpp:64`), so a library consumer's `attention.*`, `moe.*`, `gdn.*` and `runtime.*` settings were honoured by `exec/` and silently ignored by `compute/`. `Engine::init()` promoted exactly one of the 28 (`deterministic_gemm`) and said so in a comment.

The sharp case is `attention.fa2_hd256`, which is read from **two different places** for the same question:

| reader | source |
|---|---|
| `exec/executor_attention_prefill.cu:51`, `executor_workspace_buffers.cu:1489,1579`, `executor_attention_internal.h:41` | `runtime_config()` — per engine |
| `compute/attention_fmha_sm120.cu:1900` | `process_diag_fa2_hd256()` — process-global |

The executor decides whether to attempt FA2 *and* whether to size the 384 MiB S-matrix workspace; the kernel decides whether to accept hd=256. With the two disagreeing, the FMHA chain can walk down to the #654 `throw`.

`Engine::init()` now installs, ordered **before** the arch resolvers that promote `cublas_fp16_acc` / `deterministic_gemm` through their setters (installing after them would undo the arch-specific decisions), and the existing true-promotion of the deterministic gate stays after it.

## 2. `Resolved dispatch:` — which kernels a model actually ran

The six attention-prefill tiers and five MoE-prefill branches all decline by returning `false` with no log, so a model dropping to a slower or lower-quality path left no trace. One line, once, after the first step that has seen both a prefill and a decode:

```
Resolved dispatch: attn_prefill=fa2_fp16qk attn_decode=paged_fp8 moe_prefill=cutlass3x → device_args graphs=1
```

**Recorded, not predicted.** `compute/dispatch_record.h` is set by the branch that wins, at the point it wins. Running the existing pure routing models (`select_attn_prefill_path()`) at init was the obvious alternative and was rejected: the kernels expose no "would you accept this" predicate — they signal acceptance by *executing* — so a prediction would have meant a third copy of the routing rules, wrong exactly when it matters.

The path enums move to `compute/dispatch_paths.h` so the recorder and the existing routing models (`attention_dispatch_decision.h`, `moe_prefill_decision.h`) name the tiers with one vocabulary.

Cost: one `thread_local` store per branch taken, on paths already doing a kernel launch. Under graph capture the store happens at capture time, which is the correct moment.

## Tests (CPU lane, `test-core`, runs in CI)

- `test_process_diag.cpp` — every mirrored field survives `install()`; defaults match `RuntimeConfig`; the `"1"`/`"all"` → `/tmp` shorthand resolves.
- `test_dispatch_record.cpp` — every enumerator has a name (a new tier cannot print `?` in the summary); names are distinct; the tier flags do not go true without their setter.

**Mutation-validated**, since a green test proves nothing here:

| mutation | result |
|---|---|
| drop `d.attention_fa2_hd256 = cfg.attention.fa2_hd256;` | RED |
| drop `d.moe_mr_nr = cfg.moe.mr_nr;` | RED |
| drop the `AttnDecodePath::MXFP4_KV` switch arm | RED ("would print '?' for it") |

## Verification status — read this

- `make dev-test` (= CI's `ctest -L unit`): **green**, 4/4.
- `tools/check_filesize.py`: violations=0. `tools/check_alloc_sites.py`: no new sites.
- clang-format on changed lines only (what the Lint job checks): clean.
- **`make verify-fast` did NOT run** — the GPU was busy with another workload for the whole session (29 207 / 32 607 MiB at the start, 20 607 MiB at push time). So **no perf gate, no peak-VRAM gate and no degeneration smoke ran against this change**, and the `Resolved dispatch:` line has never been observed against a real model. This touches the attention and MoE dispatch paths; it is worth running `make build && make verify-fast` before relying on it.

Closes the two highest-value items from the architecture audit (`AUDIT_ARCH_2026_07_29.md`, findings F-1 CRITICAL and F-2/F-3 HIGH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B
