### PR TITLE
fix(vision,model,runtime): close four gaps where a check did not fire (#1206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,22 @@ jobs:
       - name: I1 allowlist gate (blocking)
         run: python3 tools/check_alloc_sites.py
 
+  # Post-launch error checks after every CUDA kernel launch. Blocking: an
+  # unguarded launch turns a launch-time failure (bad config, smem over the
+  # opt-in, missing kernel image) into silently wrong output instead of an
+  # error. The convention was ~99% adopted and 0% enforced until the 2026-08-02
+  # audit found the whole Qwen3-VL tower at 9 launches / 0 checks.
+  launchguards:
+    name: Launch guards
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Post-launch check gate (blocking)
+        run: python3 tools/check_launch_guards.py
+
   test:
     name: Test
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,41 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+- **CI gate: every CUDA kernel launch must carry a post-launch error check**
+  (#1206, `tools/check_launch_guards.py`, job `Launch guards`). An unguarded
+  launch turns a launch-time failure — bad configuration, shared memory over the
+  99 KB opt-in, missing kernel image — into silently wrong output instead of an
+  error, because the sticky error only surfaces at the next synchronizing call,
+  or not at all. The convention was ~99 % adopted and 0 % enforced: the whole
+  Qwen3-VL vision tower (`src/vision/qwen3vl_encoder_kernels.cu`) sat at 9
+  launches / 0 checks, where a launch failure would have produced silently wrong
+  image embeddings. Now 407/407 in-scope launches are guarded; the 25 launches
+  written inside `#define` bodies are reported as out of scope rather than
+  guessed at, since deciding those needs the enclosing function.
+
 ### Fixed
+- **An unrecognised architecture string loaded silently as GENERIC** (#1206).
+  `parse_model_arch()` falls back to a Llama-shaped decoder for any unknown
+  `general.architecture` / `architectures[]` value — deliberate, and it is how 30
+  mapped strings work — but the fallback said nothing, so a genuinely unsupported
+  checkpoint looked supported and produced plausible wrong output. It now names
+  the string it did not recognise. (`is_encoder_only_arch()` already covered the
+  one family that failed loudly, #818.)
+- **A failed chat-template init was discarded** (#1206). `ChatTemplate::init()`'s
+  result was ignored at `engine_workspace_warmup.cpp:72`; on failure the template
+  stays inert and every `/v1/chat/completions` request silently falls back to raw
+  prompt concatenation with no role markers — which reads as a model-quality
+  problem, not a load problem. Found by marking the 14 remaining two-phase
+  `init()`/`setup()` methods `[[nodiscard]]`.
+- **Nothing bound the public C enums to their internal counterparts** (#1206).
+  `src/model/model.cpp` re-declares all 16 `IMP_ARCH_*` values as `kApi*`
+  constants to keep the public header out of the model layer; no `static_assert`
+  and no test tied the two lists, so a wrong or forgotten id made
+  `imp_model_architecture()` report the wrong architecture to every C-API
+  consumer with a green build. `tests/test_c_api_enum_binding.cpp` now closes the
+  loop for arch ids, names, uniqueness and the `ImpDType` wire values (including
+  that the retired TurboQuant values 9/10 stay retired).
 - **A C-API embedding got different kernels than `imp-cli`/`imp-server` from the
   same config** (#1205). `process_diag_install()` — the snapshot 28 kernel- and
   dispatch-affecting flags are read from by leaf kernels that carry no

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,10 @@ if(IMP_BUILD_TESTS)
         # Resolved-dispatch recorder (#1205). CPU-only: plain POD + name tables,
         # and it guards the "new tier prints '?' in the summary" gap.
         tests/test_dispatch_record.cpp
+        # Public C enums vs their internal counterparts (#1206). A test file may
+        # include both sides, which is the only place the two hand-maintained
+        # copies of the arch/dtype numbering can be tied together.
+        tests/test_c_api_enum_binding.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives
         # in the CPU lane on purpose: the FSM is CUDA-free without init(), and
         # every past grammar bug escaped CI because its tests need a GPU.

--- a/src/compute/grammar_constrain.h
+++ b/src/compute/grammar_constrain.h
@@ -35,7 +35,7 @@ public:
     // Compiles `gbnf` and classifies the tokenizer vocabulary. Returns false on
     // a grammar that does not compile — the caller then declines constrained
     // decoding rather than enforcing something nobody wrote.
-    bool init(const std::string& gbnf, Tokenizer* tokenizer, int vocab_size);
+    [[nodiscard]] bool init(const std::string& gbnf, Tokenizer* tokenizer, int vocab_size);
 
     // Grammar-only init for unit tests: no tokenizer, no device buffers. Only
     // update_text/is_done/would_accept work afterwards.

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -67,7 +67,7 @@ public:
 
     // Initialize: classify all tokens in the vocabulary.
     // Must be called once before use.
-    bool init(const Tokenizer& tok);
+    [[nodiscard]] bool init(const Tokenizer& tok);
 
     // Apply logit mask: set logits of invalid tokens to -inf.
     // Called after penalties, before sampling.

--- a/src/compute/regex_constrain.h
+++ b/src/compute/regex_constrain.h
@@ -38,7 +38,7 @@ public:
     // Compiles `pattern` and classifies the tokenizer vocabulary. Returns false
     // on an unsupported/malformed pattern — the caller then declines
     // constrained decoding rather than enforcing a wrong grammar.
-    bool init(const std::string& pattern, Tokenizer* tokenizer, int vocab_size);
+    [[nodiscard]] bool init(const std::string& pattern, Tokenizer* tokenizer, int vocab_size);
 
     // Pattern-only init for unit tests: no tokenizer, no device buffers. Only
     // update_text/is_done/would_accept work afterwards.

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -113,7 +113,7 @@ public:
     ~SchemaConstrainer();
 
     // Initialize with tokenizer (classifies all tokens) and schema.
-    bool init(const Tokenizer& tok, std::unique_ptr<SchemaNode> schema);
+    [[nodiscard]] bool init(const Tokenizer& tok, std::unique_ptr<SchemaNode> schema);
 
     // Grammar-only init for the CPU FSM tests: installs the schema and the
     // frame stack, skipping the tokenizer classification and the device

--- a/src/exec/expert_cache.h
+++ b/src/exec/expert_cache.h
@@ -153,8 +153,8 @@ struct ExpertLRUCache {
     // Initialize: allocate the slot pool (partitioned per-layer) + the
     // device mirror + the host source-pointer table. Returns false if GPU
     // allocation fails (cache disabled).
-    bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc,
-              int n_layers, int n_experts, bool debug_parity = false);
+    [[nodiscard]] bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc, int n_layers,
+                            int n_experts, bool debug_parity = false);
 
     // Lookup or insert an expert. Returns GPU pointer to cached expert data.
     // If cache miss: copies from host, evicts LRU entry within the layer's

--- a/src/memory/layer_offload.h
+++ b/src/memory/layer_offload.h
@@ -28,7 +28,7 @@ public:
     // gpu_layers: number of layers to keep on GPU (0 = all offloaded,
     //             -1 = all on GPU i.e. disabled).
     // Priority: attention layers first, then SSM, then MoE-only.
-    bool init(Model* model, int gpu_layers);
+    [[nodiscard]] bool init(Model* model, int gpu_layers);
 
     // Ensure layer's weights are accessible on GPU. If the layer is resident
     // (not offloaded), this is a no-op. Otherwise, waits for the prefetch

--- a/src/memory/ssm_state.h
+++ b/src/memory/ssm_state.h
@@ -22,8 +22,9 @@ public:
 
     // Allocate state for the given configuration.
     // h_dtype: QType::F32 (default) or QType::F16 for h_state storage.
-    bool init(int n_ssm_layers, int max_sequences, int conv_channels, int conv_kernel, int n_heads,
-              int head_dim_ssm, int state_size, QType h_dtype = QType::F32, VRAMAllocator* alloc = nullptr);
+    [[nodiscard]] bool init(int n_ssm_layers, int max_sequences, int conv_channels, int conv_kernel,
+                            int n_heads, int head_dim_ssm, int state_size, QType h_dtype = QType::F32,
+                            VRAMAllocator* alloc = nullptr);
 
     // Get pointers into the state pool for a given sequence and SSM layer index.
     void* conv_state(int seq_id, int ssm_layer_idx);

--- a/src/memory/vram_allocator.h
+++ b/src/memory/vram_allocator.h
@@ -33,7 +33,7 @@ public:
 
     // Initialize: query total VRAM and set headroom fraction.
     // Must be called before any allocations.
-    bool init(float headroom_fraction = 0.10f);
+    [[nodiscard]] bool init(float headroom_fraction = 0.10f);
 
     // Allocate device memory. Returns nullptr if:
     //  - allocation would violate headroom (unless bypass_headroom=true)

--- a/src/model/chat_template.h
+++ b/src/model/chat_template.h
@@ -52,7 +52,8 @@ public:
     // Initialize: resolve special token IDs via tokenizer.
     // jinja_str: raw Jinja2 template from GGUF (optional). When provided and
     // parseable, the engine renders via Jinja2 instead of hardcoded families.
-    bool init(ChatTemplateFamily family, const Tokenizer& tokenizer, const std::string& jinja_str = "");
+    [[nodiscard]] bool init(ChatTemplateFamily family, const Tokenizer& tokenizer,
+                            const std::string& jinja_str = "");
 
     // Build token ID vector: special tokens as raw IDs, text segments encoded.
     // suppress_thinking: inject /no_think + stamp enable_thinking=false so the

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -347,7 +347,23 @@ ModelArch parse_model_arch(const std::string& s) {
         {"CohereForCausalLM", ModelArch::LLAMA},
     };
     auto it = registry.find(s);
-    return (it != registry.end()) ? it->second : ModelArch::GENERIC;
+    if (it != registry.end())
+        return it->second;
+
+    // Unrecognised architecture → GENERIC, which loads and produces
+    // plausible-looking output rather than an error (#1206). That fallback is
+    // deliberate — the registry above maps 30 strings onto known archs and a
+    // Llama-shaped checkpoint usually works through it — but it used to be
+    // completely silent, so a genuinely unsupported model looked supported.
+    // is_encoder_only_arch() guards the one family where the failure was loud
+    // (BERT encoders: IMA on the first request, #818); everything else just
+    // ran. Say which string was not recognised, once, at parse time.
+    if (!s.empty())
+        IMP_LOG_WARN(
+            "Unrecognised architecture '%s' — loading as GENERIC (Llama-shaped decoder). "
+            "Output may be wrong if the checkpoint needs arch-specific handling.",
+            s.c_str());
+    return ModelArch::GENERIC;
 }
 
 bool is_encoder_only_arch(const std::string& s) {

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -222,8 +222,8 @@ public:
     //   - d_position[0] and d_context_len[0] will be set by setup.
     //   - block_tables must cover the full generation (pre-allocated).
     //   - max_context_len should be set to initial_ctx + max_steps.
-    bool setup(GraphExecutor* executor, const InferenceState& state_template, int32_t first_token,
-               Config config, cudaStream_t stream);
+    [[nodiscard]] bool setup(GraphExecutor* executor, const InferenceState& state_template,
+                             int32_t first_token, Config config, cudaStream_t stream);
 
     // Launch the graph. Returns immediately.
     bool launch(cudaStream_t stream);

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -69,8 +69,16 @@ bool Engine::init_features() {
                 IMP_LOG_INFO("No chat template in metadata, using %s default for %s",
                              chat_template_family_name(family), model_arch_name(mcfg.arch));
         }
-        if (family != ChatTemplateFamily::RAW)
-            chat_template_.init(family, *tok, tok->chat_template_str());
+        if (family != ChatTemplateFamily::RAW && !chat_template_.init(family, *tok, tok->chat_template_str()))
+            // Was silently discarded until #1206 marked init() [[nodiscard]]. A
+            // failed template init leaves chat_template_ inert, so every
+            // /v1/chat/completions request falls back to raw concatenation —
+            // the model sees no role markers and answers as if continuing text.
+            // That looks like a model-quality problem, not a load problem.
+            IMP_LOG_WARN(
+                "Chat template init failed for family %s — requests will use raw "
+                "prompt concatenation (no role markers)",
+                chat_template_family_name(family));
     }
 
     build_banned_token_list();

--- a/src/runtime/green_ctx.h
+++ b/src/runtime/green_ctx.h
@@ -17,7 +17,7 @@ public:
 
     // Initialize with SM partitioning: prefill gets prefill_sm_ratio of SMs,
     // decode gets the remainder. device is the CUDA device ordinal.
-    bool init(int device, float prefill_sm_ratio = 0.8f);
+    [[nodiscard]] bool init(int device, float prefill_sm_ratio = 0.8f);
     void destroy();
 
     // Reconfigure SM split at runtime (requires destroy + reinit under the hood)

--- a/src/vision/qwen3vl_encoder.h
+++ b/src/vision/qwen3vl_encoder.h
@@ -29,7 +29,7 @@ public:
 
     // `model` must already be uploaded (qwen3vl_upload_vision_tower). Its
     // lifetime must outlast this encoder — only the pointer is kept.
-    bool init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens);
+    [[nodiscard]] bool init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens);
     void free_buffers();
 
     int max_tokens() const { return max_tokens_; }

--- a/src/vision/qwen3vl_encoder_kernels.cu
+++ b/src/vision/qwen3vl_encoder_kernels.cu
@@ -1,5 +1,7 @@
 #include "vision/qwen3vl_encoder_kernels.h"
 
+#include "core/logging.h"  // IMP_CUDA_CHECK_LAUNCH
+
 #include <cmath>
 
 namespace imp {
@@ -200,29 +202,35 @@ int reduce_threads(int dim) {
 void launch_qwen3vl_pos_embed_add(half* hidden, const half* table, const int32_t* taps, const float* weights,
                                   int tokens, int dim, int taps_per_token, cudaStream_t stream) {
     pos_embed_add_kernel<<<tokens, kBlock, 0, stream>>>(hidden, table, taps, weights, dim, taps_per_token);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_layernorm(const half* x, const half* weight, const half* bias, half* out, int rows,
                               int dim, float eps, cudaStream_t stream) {
     const int threads = reduce_threads(dim);
     layernorm_kernel<<<rows, threads, threads * sizeof(float), stream>>>(x, weight, bias, out, dim, eps);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_add_bias(half* x, const half* bias, int rows, int dim, cudaStream_t stream) {
     const int64_t n = static_cast<int64_t>(rows) * dim;
     add_bias_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, bias, n, dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_residual_add(half* dst, const half* src, int64_t n, cudaStream_t stream) {
     residual_add_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(dst, src, n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_gelu_tanh(half* x, int64_t n, cudaStream_t stream) {
     gelu_tanh_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_gelu_erf(half* x, int64_t n, cudaStream_t stream) {
     gelu_erf_kernel<<<static_cast<int>((n + kBlock - 1) / kBlock), kBlock, 0, stream>>>(x, n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_split_qkv_rope(const half* qkv, const int32_t* row, const int32_t* col, half* q, half* k,
@@ -230,16 +238,19 @@ void launch_qwen3vl_split_qkv_rope(const half* qkv, const int32_t* row, const in
                                    cudaStream_t stream) {
     dim3 grid(tokens, heads);
     split_qkv_rope_kernel<<<grid, 64, 0, stream>>>(qkv, row, col, q, k, v, tokens, heads, head_dim, theta);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_softmax_rows(half* scores, int rows, int cols, cudaStream_t stream) {
     const int threads = reduce_threads(cols);
     softmax_rows_kernel<<<rows, threads, threads * sizeof(float), stream>>>(scores, cols);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 void launch_qwen3vl_merge_heads(const half* per_head, half* out, int tokens, int heads, int head_dim,
                                 cudaStream_t stream) {
     merge_heads_kernel<<<tokens, kBlock, 0, stream>>>(per_head, out, tokens, heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 }  // namespace imp

--- a/src/vision/qwen3vl_pipeline.h
+++ b/src/vision/qwen3vl_pipeline.h
@@ -49,7 +49,7 @@ public:
     // device here if it is still host-resident. `max_patches` bounds the image
     // size this pipeline will accept — it sizes every workspace, so it is also
     // what an oversized image is rejected against.
-    bool init(VisionModel& tower, VRAMAllocator& alloc, int max_patches);
+    [[nodiscard]] bool init(VisionModel& tower, VRAMAllocator& alloc, int max_patches);
 
     bool is_ready() const { return encoder_ != nullptr; }
     int max_patches() const { return max_patches_; }

--- a/src/vision/vision_encoder.h
+++ b/src/vision/vision_encoder.h
@@ -15,7 +15,8 @@ public:
     ~VisionEncoder();
 
     // Initialize workspace buffers. lm_d_model = LLM hidden dim.
-    bool init(const VisionModel& model, int lm_d_model, cudaStream_t stream, VRAMAllocator* alloc = nullptr);
+    [[nodiscard]] bool init(const VisionModel& model, int lm_d_model, cudaStream_t stream,
+                            VRAMAllocator* alloc = nullptr);
 
     // Encode a preprocessed image.
     // d_pixels: [3, image_size, image_size] FP16 on device

--- a/tests/test_c_api_enum_binding.cpp
+++ b/tests/test_c_api_enum_binding.cpp
@@ -1,0 +1,138 @@
+// The public C enums and their internal counterparts are two hand-maintained
+// copies of one numbering. Nothing bound them (#1206).
+//
+// src/model/model.cpp:148 re-declares every IMP_ARCH_* value as a kApi*
+// constant with the comment "IMP_ARCH_* values from include/imp/types.h (avoid
+// header dependency)" — a deliberate choice to keep the public C header out of
+// the model layer, and a correct one. But grepping tests/ for kApi or IMP_ARCH_
+// returned nothing before this file: a wrong or forgotten id made
+// imp_model_architecture() report the wrong architecture to every C-API
+// consumer, silently, with a green build and a green test suite.
+//
+// A test file may include both sides, so this is where the two copies get tied
+// together. Same for the ImpDType ↔ QType pair.
+//
+// CPU-only: pure enum arithmetic, no CUDA, no Model.
+
+#include "imp/types.h"
+#include "model/model_arch.h"
+#include "core/qtype.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace imp;
+
+namespace {
+
+struct ArchBinding {
+    ModelArch arch;
+    int c_api_id;
+    const char* name;  // the registry's own name string, for a readable failure
+};
+
+// Every enumerator of ModelArch, paired with the IMP_ARCH_* value the C API
+// promises for it. Adding an architecture means adding a row here — which is
+// the point: the compiler cannot see the coupling, so the test has to.
+const ArchBinding kBindings[] = {
+    {ModelArch::LLAMA, IMP_ARCH_LLAMA, "llama"},
+    {ModelArch::MISTRAL, IMP_ARCH_MISTRAL, "mistral"},
+    {ModelArch::MIXTRAL, IMP_ARCH_MIXTRAL, "mixtral"},
+    {ModelArch::DEEPSEEK, IMP_ARCH_DEEPSEEK, "deepseek"},
+    {ModelArch::NEMOTRON_H_MOE, IMP_ARCH_NEMOTRON_H_MOE, "nemotron_h_moe"},
+    {ModelArch::QWEN3, IMP_ARCH_QWEN3, "qwen3"},
+    {ModelArch::QWEN3_MOE, IMP_ARCH_QWEN3_MOE, "qwen3moe"},
+    {ModelArch::QWEN35, IMP_ARCH_QWEN35, "qwen35"},
+    {ModelArch::QWEN35_MOE, IMP_ARCH_QWEN35_MOE, "qwen35moe"},
+    {ModelArch::QWEN36_MOE, IMP_ARCH_QWEN36_MOE, "qwen36moe"},
+    {ModelArch::GPT_OSS, IMP_ARCH_GPT_OSS, "gpt_oss"},
+    {ModelArch::GEMMA3, IMP_ARCH_GEMMA3, "gemma3"},
+    {ModelArch::GEMMA4, IMP_ARCH_GEMMA4, "gemma4"},
+    {ModelArch::LLAMA4, IMP_ARCH_LLAMA4, "llama4"},
+    {ModelArch::NOMIC_BERT, IMP_ARCH_NOMIC_BERT, "nomic-bert"},
+    {ModelArch::GENERIC, IMP_ARCH_GENERIC, "generic"},
+};
+
+}  // namespace
+
+// The registry's c_api_id must be the value the public header promises.
+TEST(CApiEnumBinding, ArchIdsMatchThePublicHeader) {
+    for (const auto& b : kBindings) {
+        EXPECT_EQ(model_arch_c_api_id(b.arch), b.c_api_id)
+            << "arch '" << b.name << "': model.cpp's kApi* table disagrees with IMP_ARCH_* in "
+            << "include/imp/types.h — imp_model_architecture() would report the wrong architecture";
+    }
+}
+
+// Two architectures sharing a C-API id makes them indistinguishable to a
+// consumer; the copy in model.cpp is exactly where that typo would live.
+TEST(CApiEnumBinding, ArchIdsAreUnique) {
+    std::set<int> seen;
+    for (const auto& b : kBindings) {
+        const int id = model_arch_c_api_id(b.arch);
+        EXPECT_TRUE(seen.insert(id).second) << "duplicate C-API arch id " << id << " (at '" << b.name << "')";
+    }
+}
+
+// Coverage guard: kBindings must list every ModelArch enumerator. GENERIC is
+// the last one, so its id doubles as the count. A new architecture added to
+// model_arch.h without a row here leaves the binding untested.
+TEST(CApiEnumBinding, EveryArchEnumeratorIsCovered) {
+    const size_t n = sizeof(kBindings) / sizeof(kBindings[0]);
+    EXPECT_EQ(n, 16u) << "ModelArch gained or lost an enumerator — add/remove the row in "
+                         "kBindings so the C-API id stays bound";
+    // Every listed arch must round-trip through the registry's name table too,
+    // which is what catches a row pointing at the wrong enumerator.
+    for (const auto& b : kBindings)
+        EXPECT_STREQ(model_arch_name(b.arch), b.name);
+}
+
+// The name string is what parse_model_arch() consumes, so name → arch → id must
+// be a closed loop. A row copy-pasted with the wrong enumerator survives the
+// id check when two archs happen to share an id range; this closes that gap.
+TEST(CApiEnumBinding, ArchNamesRoundTripThroughParse) {
+    for (const auto& b : kBindings) {
+        if (b.arch == ModelArch::GENERIC)
+            continue;  // "generic" is the fallback, not a parseable input
+        EXPECT_EQ(parse_model_arch(b.name), b.arch)
+            << "name '" << b.name << "' does not parse back to its own enumerator";
+    }
+}
+
+// An unrecognised architecture string resolves to GENERIC and LOADS — it does
+// not error. That is deliberate (the registry maps 30 strings onto known archs
+// and a Llama-shaped checkpoint usually works through it), but it means an
+// unsupported model looks supported, so parse_model_arch() warns since #1206.
+// Pinning the behaviour here so the fallback cannot be turned into a silent
+// hard error or a silent success again without a test saying so.
+TEST(CApiEnumBinding, UnknownArchFallsBackToGeneric) {
+    EXPECT_EQ(parse_model_arch("definitely-not-an-architecture"), ModelArch::GENERIC);
+    EXPECT_EQ(parse_model_arch(""), ModelArch::GENERIC);
+    // A known one must still resolve — guards against the fallback swallowing
+    // everything if the registry lookup ever breaks.
+    EXPECT_EQ(parse_model_arch("qwen3"), ModelArch::QWEN3);
+}
+
+// ImpDType is a second enum for the concept QType already names, kept separate
+// so the public header stays C and CUDA-free. imp_api.cpp maps between them by
+// hand; these are the pairs that mapping must honour.
+TEST(CApiEnumBinding, DTypeValuesAreStableAndDistinct) {
+    const std::vector<std::pair<int, const char*>> dtypes = {
+        {IMP_DTYPE_FP32, "fp32"},         {IMP_DTYPE_FP16, "fp16"},         {IMP_DTYPE_BF16, "bf16"},
+        {IMP_DTYPE_FP8_E4M3, "fp8_e4m3"}, {IMP_DTYPE_FP8_E5M2, "fp8_e5m2"}, {IMP_DTYPE_INT8, "int8"},
+        {IMP_DTYPE_INT4, "int4"},         {IMP_DTYPE_INT32, "int32"},       {IMP_DTYPE_FP4_E2M1, "fp4_e2m1"},
+        {IMP_DTYPE_NVFP4, "nvfp4"},       {IMP_DTYPE_MXFP4_KV, "mxfp4_kv"},
+    };
+    std::set<int> seen;
+    for (const auto& [v, name] : dtypes)
+        EXPECT_TRUE(seen.insert(v).second) << "duplicate ImpDType value for " << name;
+
+    // 9 and 10 were TURBOQUANT aliases, removed 2026-07-07. They must stay
+    // retired: reusing a wire value silently reinterprets an old caller's KV
+    // dtype request.
+    EXPECT_EQ(seen.count(9), 0u) << "IMP_DTYPE value 9 was a retired TurboQuant alias — do not reuse";
+    EXPECT_EQ(seen.count(10), 0u) << "IMP_DTYPE value 10 was a retired TurboQuant alias — do not reuse";
+}

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -375,7 +375,7 @@ TEST(ChatTemplateInitTest, PhiSuccess) {
 TEST(ChatTemplateApplyTest, ChatMLBasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -410,7 +410,7 @@ TEST(ChatTemplateApplyTest, UseDefaultSystemPromptFalseInjectsSystem) {
     tok.set_use_default_system_prompt(false);
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -427,7 +427,7 @@ TEST(ChatTemplateApplyTest, UseDefaultSystemPromptTrueDoesNotInject) {
     EXPECT_TRUE(tok.use_default_system_prompt());
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -444,7 +444,7 @@ TEST(ChatTemplateApplyTest, UseDefaultSystemPromptFalseRespectsExplicitSystem) {
     tok.set_use_default_system_prompt(false);
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"system", "Be brief."}, {"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -460,7 +460,7 @@ TEST(ChatTemplateApplyTest, ChatMLNoBOSWhenDisabled) {
     tok.set_add_bos(false);
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -473,7 +473,7 @@ TEST(ChatTemplateApplyTest, ChatMLNoBOSWhenDisabled) {
 TEST(ChatTemplateApplyTest, ChatMLMultiTurn) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {
         {"system", "You help."},
@@ -496,7 +496,7 @@ TEST(ChatTemplateApplyTest, ChatMLMultiTurn) {
 TEST(ChatTemplateApplyTest, Llama3BasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::LLAMA3, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::LLAMA3, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -516,7 +516,7 @@ TEST(ChatTemplateApplyTest, Llama3BasicStructure) {
 TEST(ChatTemplateApplyTest, Llama2BasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::LLAMA2, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::LLAMA2, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -530,7 +530,7 @@ TEST(ChatTemplateApplyTest, Llama2BasicStructure) {
 TEST(ChatTemplateApplyTest, Llama2SystemMessage) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::LLAMA2, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::LLAMA2, tok));
 
     std::vector<ChatMessage> msgs = {
         {"system", "Be helpful."},
@@ -549,7 +549,7 @@ TEST(ChatTemplateApplyTest, Llama2SystemMessage) {
 TEST(ChatTemplateApplyTest, NemotronBasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::NEMOTRON, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::NEMOTRON, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -570,7 +570,7 @@ TEST(ChatTemplateApplyTest, NemotronBasicStructure) {
 TEST(ChatTemplateApplyTest, GemmaBasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::GEMMA, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -588,7 +588,7 @@ TEST(ChatTemplateApplyTest, GemmaBasicStructure) {
 TEST(ChatTemplateApplyTest, GemmaAssistantRoleMappedToModel) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::GEMMA, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
 
     std::vector<ChatMessage> msgs = {
         {"user", "Hi"},
@@ -604,7 +604,7 @@ TEST(ChatTemplateApplyTest, GemmaAssistantRoleMappedToModel) {
 TEST(ChatTemplateApplyTest, DeepSeekR1BasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::DEEPSEEK_R1, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::DEEPSEEK_R1, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -622,7 +622,7 @@ TEST(ChatTemplateApplyTest, DeepSeekR1BasicStructure) {
 TEST(ChatTemplateApplyTest, PhiBasicStructure) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::PHI, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::PHI, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -640,7 +640,7 @@ TEST(ChatTemplateApplyTest, PhiBasicStructure) {
 TEST(ChatTemplateApplyTest, RawReturnsEmpty) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::RAW, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::RAW, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs);
@@ -659,7 +659,7 @@ TEST(ChatTemplateDefaultSysTest, ExtractFromJinja) {
         "{% endfor %}");
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
     EXPECT_EQ(tpl.default_system_message(), "You are a helpful assistant.");
 }
 
@@ -669,7 +669,7 @@ TEST(ChatTemplateDefaultSysTest, SkipsJinjaVariables) {
     tok.set_chat_template_str("<|im_start|>system\n{{ messages[0].content }}<|im_end|>\n");
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
     EXPECT_TRUE(tpl.default_system_message().empty());
 }
 
@@ -678,7 +678,7 @@ TEST(ChatTemplateDefaultSysTest, NoTemplateNoDefault) {
     // No chat_template_str set
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
     EXPECT_TRUE(tpl.default_system_message().empty());
 }
 
@@ -687,7 +687,7 @@ TEST(ChatTemplateDefaultSysTest, InjectDefaultWhenNoUserSystem) {
     tok.set_chat_template_str("<|im_start|>system\nDefault system.<|im_end|>\n");
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
     EXPECT_EQ(tpl.default_system_message(), "Default system.");
 
     // Apply without system message -> default system should be injected
@@ -704,7 +704,7 @@ TEST(ChatTemplateDefaultSysTest, NoInjectionWhenUserProvidesSystem) {
     tok.set_chat_template_str("<|im_start|>system\nDefault system.<|im_end|>\n");
 
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     // Apply with explicit system message -> no double injection
     std::vector<ChatMessage> msgs = {
@@ -723,7 +723,7 @@ TEST(ChatTemplateDefaultSysTest, NoInjectionWhenUserProvidesSystem) {
 TEST(ChatTemplateVisionTest, GemmaImageTokens) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::GEMMA, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "What is this?"}};
     auto ids = tpl.apply_with_image(tok, msgs, /*n_image_tokens=*/4);
@@ -744,7 +744,7 @@ TEST(ChatTemplateVisionTest, GemmaImageTokens) {
 TEST(ChatTemplateVisionTest, NonGemmaFallsBackToTextOnly) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto with_image = tpl.apply_with_image(tok, msgs, 4);
@@ -759,7 +759,7 @@ TEST(ChatTemplateVisionTest, NonGemmaFallsBackToTextOnly) {
 TEST(ChatTemplateApplyTest, ChatMLSuppressThinking) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids_suppress = tpl.apply(tok, msgs, /*suppress_thinking=*/true);
@@ -776,7 +776,7 @@ TEST(ChatTemplateApplyTest, ChatMLSuppressThinking) {
 TEST(ChatTemplateApplyTest, ChatMLNoSuppressThinking) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", "Hi"}};
     auto ids = tpl.apply(tok, msgs, /*suppress_thinking=*/false);
@@ -796,7 +796,7 @@ TEST(ChatTemplateApplyTest, ChatMLNoSuppressThinking) {
 TEST(ChatTemplateApplyTest, EmptyUserMessage) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {{"user", ""}};
     auto ids = tpl.apply(tok, msgs);
@@ -810,7 +810,7 @@ TEST(ChatTemplateApplyTest, EmptyUserMessage) {
 TEST(ChatTemplateApplyTest, VeryLongSystemMessage) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::string long_sys(10000, 'A');
     std::vector<ChatMessage> msgs = {{"system", long_sys}, {"user", "Hi"}};
@@ -824,7 +824,7 @@ TEST(ChatTemplateApplyTest, VeryLongSystemMessage) {
 TEST(ChatTemplateApplyTest, MultipleSystemMessages) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;
-    tpl.init(ChatTemplateFamily::CHATML, tok);
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok));
 
     std::vector<ChatMessage> msgs = {
         {"system", "First system."},

--- a/tools/check_launch_guards.py
+++ b/tools/check_launch_guards.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Every CUDA kernel launch in src/ must be followed by a post-launch error check.
+
+WHY THIS EXISTS
+---------------
+A kernel launch that fails at launch time (invalid configuration, too much
+shared memory, missing kernel image) does NOT raise where it happens — the
+error goes sticky and surfaces at the next synchronizing call, arbitrarily far
+away, or is swallowed entirely and the kernel simply never runs. The output is
+then silently wrong rather than obviously broken. `IMP_CUDA_CHECK_LAUNCH()`
+(core/logging.h) reports it at the launch site via `cudaPeekAtLastError()`
+without clearing the sticky error, so downstream handling still sees it.
+
+The convention was ~99% adopted and 0% enforced, which is exactly what erosion
+looks like from the outside: uniform adherence in mature code and a clean miss
+in the newest file. The 2026-08-02 architecture audit found
+src/vision/qwen3vl_encoder_kernels.cu at 9 launches / 0 checks — the whole
+Qwen3-VL tower — where a launch failure would have produced silently wrong
+image embeddings.
+
+WHAT COUNTS
+-----------
+A launch is a `<<<` outside a comment/string. It is guarded when one of
+IMP_CUDA_CHECK_LAUNCH / cudaPeekAtLastError / cudaGetLastError appears within
+LOOKAHEAD lines after the statement the launch belongs to (launches spanning
+several lines are followed to their terminating `;`).
+
+Launches written inside a `#define` body are OUT OF SCOPE and are reported as
+such rather than guessed at. There the `<<<` is not the launch *site* — the
+macro's call sites are, typically a `switch` over head_dim expanding it 5x with
+a single shared check after the switch (paged_attention_splitk in
+compute/attention_paged.cu guards both its macros with one cudaGetLastError 67
+lines below, and falls back to the single-split path on failure). Deciding
+guardedness for those needs the enclosing function, not a line window; a
+line-distance heuristic would either flag working code or silently stop
+catching real misses once someone's switch grows. The gate covers what it can
+decide and prints the count it cannot, so the blind spot is visible instead of
+implied.
+
+Exit 0 when clean, 1 when a launch is unguarded and not allowlisted.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAN_DIRS = ["src"]
+LOOKAHEAD = 4  # lines after the launch statement ends
+
+GUARD = re.compile(r"IMP_CUDA_CHECK_LAUNCH|cudaPeekAtLastError|cudaGetLastError")
+
+# Launch sites that are deliberately unguarded, each with a reason.
+# THIS LIST ONLY SHRINKS — an entry that no longer matches is an error too, so
+# it cannot go stale silently.
+ALLOWLIST: dict[str, str] = {}
+
+
+def strip_comments_and_strings(src: str) -> str:
+    """Blank out comments and string/char literals, preserving line structure."""
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "/" and i + 1 < n and src[i + 1] == "/":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            out.append(" " * (j - i))
+            i = j
+        elif c == "/" and i + 1 < n and src[i + 1] == "*":
+            j = src.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            out.append("".join(ch if ch == "\n" else " " for ch in src[i:j]))
+            i = j
+        elif c in "\"'":
+            q, j = c, i + 1
+            while j < n and src[j] != q:
+                j += 2 if src[j] == "\\" else 1
+            j = min(j + 1, n)
+            out.append("".join(ch if ch == "\n" else " " for ch in src[i:j]))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def scan(path: Path) -> tuple[list[tuple[int, str]], int]:
+    """Return ([(line_no, source_line)] unguarded, count of macro-body launches)."""
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    clean = strip_comments_and_strings(raw).split("\n")
+    raw_lines = raw.split("\n")
+
+    # Line indices that belong to a #define body (the directive line and every
+    # backslash-continued line after it).
+    in_macro = set()
+    cont = False
+    for i, line in enumerate(clean):
+        stripped = line.strip()
+        if cont or stripped.startswith("#define"):
+            in_macro.add(i)
+        cont = line.rstrip().endswith("\\")
+
+    bad = []
+    macro_launches = 0
+    for idx, line in enumerate(clean):
+        if "<<<" not in line:
+            continue
+        if idx in in_macro:
+            macro_launches += 1
+            continue  # out of scope — see the module docstring
+        # Follow the statement to its terminating ';' (launches wrap often).
+        end = idx
+        while end < len(clean) and ";" not in clean[end]:
+            end += 1
+        window = "\n".join(clean[idx : min(end + 1 + LOOKAHEAD, len(clean))])
+        if not GUARD.search(window):
+            bad.append((idx + 1, raw_lines[idx].strip()))
+    return bad, macro_launches
+
+
+def main() -> int:
+    total_launches = 0
+    macro_total = 0
+    findings: list[tuple[str, int, str]] = []
+    files = []
+    for d in SCAN_DIRS:
+        files.extend(sorted((ROOT / d).rglob("*.cu")))
+
+    for f in files:
+        rel = f.relative_to(ROOT).as_posix()
+        clean = strip_comments_and_strings(f.read_text(encoding="utf-8", errors="replace"))
+        total_launches += clean.count("<<<")
+        unguarded, in_macro = scan(f)
+        macro_total += in_macro
+        for line_no, text in unguarded:
+            findings.append((rel, line_no, text))
+
+    unexpected = [(f, l, t) for f, l, t in findings if f not in ALLOWLIST]
+    stale = [f for f in ALLOWLIST if not any(f == g for g, _, _ in findings)]
+
+    in_scope = total_launches - macro_total
+    guarded = in_scope - len(findings)
+    print(f"launch guards: {guarded}/{in_scope} in-scope kernel launches carry a post-launch check "
+          f"({macro_total} in #define bodies — guarded at their call sites, not checked here)")
+
+    if unexpected:
+        print(f"\nFAIL — {len(unexpected)} unguarded kernel launch(es):\n")
+        for f, l, t in unexpected:
+            print(f"  {f}:{l}\n      {t[:100]}")
+        print(
+            "\nAdd IMP_CUDA_CHECK_LAUNCH(); after the launch (core/logging.h).\n"
+            "A launch-time failure otherwise surfaces at the next sync, or not at all,\n"
+            "and the kernel's output is silently wrong."
+        )
+        return 1
+
+    if stale:
+        print(f"\nFAIL — {len(stale)} stale allowlist entry/entries (now guarded — remove them):")
+        for f in stale:
+            print(f"  {f}")
+        return 1
+
+    print("OK — every kernel launch is guarded.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Four findings from the architecture audit, all the same shape: a guard exists somewhere and does not cover the case that matters, so the failure is silent instead of loud.

## 1. Post-launch checks: 99 % adopted, 0 % enforced

An unguarded kernel launch turns a launch-time failure (bad config, smem over the 99 KB opt-in, missing kernel image) into **silently wrong output** — the sticky error only surfaces at the next synchronizing call, or not at all.

The whole **Qwen3-VL vision tower** (`src/vision/qwen3vl_encoder_kernels.cu`) was at **9 launches / 0 checks**. A launch failure there produces wrong image embeddings with no signal. Guarded, plus `tools/check_launch_guards.py` as a blocking CI job (`Launch guards`).

```
launch guards: 407/407 in-scope kernel launches carry a post-launch check
               (25 in #define bodies — guarded at their call sites, not checked here)
```

**On the 25 out-of-scope launches:** `paged_attention_splitk` guards both its head_dim macros with a single `cudaGetLastError` **67 lines** below, and falls back to the single-split path on failure. That is correct code. Deciding guardedness for a macro body needs the enclosing function, not a line window — a line-distance heuristic would either flag that working code or silently stop catching real misses once someone's `switch` grows. The gate covers what it can decide and prints the count it cannot, so the blind spot is visible instead of implied.

> This also corrects the audit's own F-4. It listed three files with deficits; the real count from a proper per-launch scan is **one** (`qwen3vl_encoder_kernels.cu`). `executor_elementwise.cu` and `sampling_topk_topp.cu` were artifacts of comparing per-file `grep -c` totals.

## 2. An unrecognised architecture loaded silently as GENERIC

`parse_model_arch()` falls back to a Llama-shaped decoder for any unknown `general.architecture` / `architectures[]`. That is deliberate — 30 mapped strings ride it — but it said nothing, so a genuinely unsupported checkpoint looked supported and produced plausible wrong output. `is_encoder_only_arch()` already covered the one family that failed loudly (#818); everything else just ran. It now names the string it did not recognise.

## 3. A failed chat-template init was discarded

`ChatTemplate::init()`'s result was ignored at `engine_workspace_warmup.cpp:72`. On failure the template stays inert and **every `/v1/chat/completions` request falls back to raw prompt concatenation** — no role markers, so the model answers as if continuing text. That reads as a model-quality problem, not a load problem.

Found by marking the **14** remaining two-phase `init()`/`setup()` methods `[[nodiscard]]`. This was the only production site that ignored one — the other 27 hits were in `test_chat_template.cpp`, which now asserts instead of discarding.

## 4. Nothing bound the public C enums to their internal copies

`src/model/model.cpp:148` re-declares all 16 `IMP_ARCH_*` values as `kApi*` constants, with the comment *"avoid header dependency"* — a correct choice to keep the public C header out of the model layer. But `grep 'kApi\|IMP_ARCH_' tests/` returned **nothing**: a wrong or forgotten id made `imp_model_architecture()` report the wrong architecture to every C-API consumer, silently, with a green build.

`tests/test_c_api_enum_binding.cpp` ties them together — ids, names, uniqueness, enumerator coverage, the GENERIC fallback, and the `ImpDType` wire values (including that the retired TurboQuant slots 9/10 stay retired, since reusing a wire value reinterprets an old caller's KV dtype request).

## Verification

- `make dev-test` (= CI's `ctest -L unit`): green, 4/4. New: 6 `CApiEnumBinding` tests.
- `check_launch_guards.py` 407/407 · `check_filesize.py` violations=0 · `check_alloc_sites.py` no new sites.
- Build is **warning-free** — the `[[nodiscard]]` additions surfaced 28 sites, all addressed.
- clang-format on changed lines only: clean.

**Mutation-validated:**

| mutation | result |
|---|---|
| give `GEMMA4` the `kApiGemma3` id | RED (2 tests: "disagrees with IMP_ARCH_*", "duplicate C-API arch id 7") |
| drop one `IMP_CUDA_CHECK_LAUNCH()` | RED (gate names the file:line) |

**`make verify-fast` did NOT run** — the GPU was occupied by `mmm-imp-vision` (31820 / 32607 MiB) at push time. So no perf gate, no peak-VRAM gate and no degeneration smoke ran. The vision-tower launches and the chat-template warning are compile- and gate-checked only. Worth a `make build && make verify-fast` when the card is free.

Follows #1205. Closes audit findings F-4, F-7, F-19, F-21, F-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B
