### PR TITLE
refactor(core,runtime,server): self-registering reset hooks, config-ify stray env vars, gate /metrics (#1207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Added
+- **`--metrics-require-auth`** (#1207): fold `/metrics` back under the
+  `--api-key` check. Off by default so a stock Prometheus scrape keeps working,
+  but the endpoint discloses the loaded model name, `d_model` and cumulative
+  token counts to anyone who can reach the port.
 - **CI gate: every CUDA kernel launch must carry a post-launch error check**
   (#1206, `tools/check_launch_guards.py`, job `Launch guards`). An unguarded
   launch turns a launch-time failure — bad configuration, shared memory over the
@@ -23,6 +27,31 @@ there instead of retelling it.
   image embeddings. Now 407/407 in-scope launches are guarded; the 25 launches
   written inside `#define` bodies are reported as out of scope rather than
   guessed at, since deciding those needs the enclosing function.
+- **`Resolved dispatch:` log line — which attention and MoE kernels a model
+  actually ran** (#1205). Emitted once, after the first step that has seen both a
+  prefill and a decode, e.g.
+  `attn_prefill=fa2_fp16qk attn_decode=paged_fp8 moe_prefill=cutlass3x → device_args graphs=1`.
+  The six prefill tiers and five MoE branches all decline by returning `false`
+  with no log, so a model dropping to a slower or lower-quality path used to
+  leave no trace. Recorded from inside the real dispatch
+  (`compute/dispatch_record.h`), not predicted from a second copy of the routing
+  rules, so it cannot disagree with what ran.
+
+### Changed
+- **Pre-`cudaDeviceReset` hooks register themselves** (#1207). The eleven module
+  hooks that free lazily-created CUDA statics (cuBLAS handles, CUTLASS
+  workspaces, device scratch) were listed by hand in `cuda_static_reset.cpp`, so
+  a twelfth lazy static added without an entry dangled behind an armed guard —
+  the exact bug the file exists to prevent, with nothing to catch it. Each
+  owning TU now uses `IMP_REGISTER_CUDA_STATIC_RESET`. Side effect: `core/` no
+  longer includes a `compute/` header, removing the one `core → compute`
+  backward edge in the layer graph.
+- **`IMP_SPEC_TRACE`, `IMP_JUMP_TRACE` and `IMP_PPL_DUMP` are config keys**
+  (#1207). All three had crept back as raw `getenv()` calls at their use sites,
+  against the rule that only `IMP_DETERMINISTIC` and `IMP_FMHA_FA2` are seeded.
+  They are now `diagnostics.spec_trace` / `.jump_trace` / `.ppl_dump`, reachable
+  from `imp.conf` and `--set`; the env names still work (seeded at load) so
+  existing shell habits are unaffected.
 
 ### Fixed
 - **An unrecognised architecture string loaded silently as GENERIC** (#1206).
@@ -57,17 +86,6 @@ there instead of retelling it.
   hd=256 from the process-wide snapshot, so the two could disagree and walk the
   FMHA chain down to the #654 throw. `Engine::init()` now installs, before the
   arch resolvers that promote `cublas_fp16_acc`/`deterministic_gemm`.
-
-### Added
-- **`Resolved dispatch:` log line — which attention and MoE kernels a model
-  actually ran** (#1205). Emitted once, after the first step that has seen both a
-  prefill and a decode, e.g.
-  `attn_prefill=fa2_fp16qk attn_decode=paged_fp8 moe_prefill=cutlass3x → device_args graphs=1`.
-  The six prefill tiers and five MoE branches all decline by returning `false`
-  with no log, so a model dropping to a slower or lower-quality path used to
-  leave no trace. Recorded from inside the real dispatch
-  (`compute/dispatch_record.h`), not predicted from a second copy of the routing
-  rules, so it cannot disagree with what ran.
 
 ## [0.20.2] - 2026-08-02
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,9 @@ if(IMP_BUILD_TESTS)
         # include both sides, which is the only place the two hand-maintained
         # copies of the arch/dtype numbering can be tied together.
         tests/test_c_api_enum_binding.cpp
+        # Pre-cudaDeviceReset hook registry (#1207): self-registration replaced a
+        # hand-maintained call list, so the new failure mode is an EMPTY registry.
+        tests/test_cuda_static_reset.cpp
         # Generative FSM battery for the schema-less json_object grammar. Lives
         # in the CPU lane on purpose: the FSM is CUDA-free without init(), and
         # every past grammar bug escaped CI because its tests need a GPU.

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -360,6 +360,11 @@ void attention_cublas_reset_static_cuda_state() {
     s_attn_d_ptrs_capacity = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(attention_cublas_reset_static_cuda_state);
+}  // namespace
+
 // Fill s_attn_d_ptrs device-side so the GQA cuBLAS batched path is
 // graph-capturable. The previous implementation built host stack arrays and
 // issued cudaMemcpyAsync — host pointers have no stable identity across

--- a/src/compute/attention_fmha_mxfp4_sm120.cu
+++ b/src/compute/attention_fmha_mxfp4_sm120.cu
@@ -1632,6 +1632,11 @@ void fmha_mxfp4_reset_static_cuda_state() {
     s_promote_paged_cap = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(fmha_mxfp4_reset_static_cuda_state);
+}  // namespace
+
 bool fmha_sm120_mxfp4_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                               bool causal, int sliding_window, float softcap, cudaStream_t stream,
                               bool use_blockscale, int q_offset) {

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -1873,6 +1873,11 @@ void fmha_sm120_reset_static_cuda_state() {
     }
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(fmha_sm120_reset_static_cuda_state);
+}  // namespace
+
 bool fmha_sm120_fa2_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                             bool causal, int sliding_window, float softcap, cudaStream_t stream, int q_offset,
                             bool fp16_qk, const int* d_kv_len) {

--- a/src/compute/attention_mxfp4_prefill.cu
+++ b/src/compute/attention_mxfp4_prefill.cu
@@ -368,6 +368,11 @@ void attention_mxfp4_prefill_reset_static_cuda_state() {
     }
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(attention_mxfp4_prefill_reset_static_cuda_state);
+}  // namespace
+
 // =============================================================================
 // Main entry point
 // =============================================================================

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -562,6 +562,11 @@ void gemm_reset_static_cuda_state() {
     s_bench_scratch_size = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(gemm_reset_static_cuda_state);
+}  // namespace
+
 // ---------------------------------------------------------------------------
 // gemm:  C = alpha * A @ B^T + beta * C
 //   A [M, K]  B [N, K]  C [M, N]   -- all row-major

--- a/src/compute/gemm_cutlass_grouped_3x.cu
+++ b/src/compute/gemm_cutlass_grouped_3x.cu
@@ -6,6 +6,7 @@
 // which CUTLASS then indexes directly for its GroupProblemShape scheduler.
 
 #include "compute/gemm_cutlass_grouped_3x.h"
+#include "core/cuda_static_reset.h"
 #include "core/logging.h"
 #include "memory/engine_arena.h"
 
@@ -390,6 +391,11 @@ void gemm_grouped_3x_nvfp4_cleanup() {
     s_can_impl_N = -1;
     s_can_impl_K = -1;
 }
+
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(gemm_grouped_3x_nvfp4_cleanup);
+}  // namespace
 
 // Compile-time verification: kernel type instantiates on SM120.
 static_assert(sizeof(GrpGemm) > 0, "GrpGemm type must instantiate");

--- a/src/compute/gemm_grouped.cu
+++ b/src/compute/gemm_grouped.cu
@@ -43,6 +43,11 @@ void gemm_grouped_reset_static_cuda_state() {
     }
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(gemm_grouped_reset_static_cuda_state);
+}  // namespace
+
 // ---------------------------------------------------------------------------
 // Helper: map QType -> cudaDataType
 // ---------------------------------------------------------------------------

--- a/src/compute/gemm_grouped_nvfp4_smallM.cu
+++ b/src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -770,6 +770,11 @@ void gemm_grouped_nvfp4_smallM_reset_static_cuda_state() {
     s_dummy_ready = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(gemm_grouped_nvfp4_smallM_reset_static_cuda_state);
+}  // namespace
+
 bool gemm_grouped_nvfp4_smallM(
     int n_experts, const int* host_M, int N, int K,
     const void* const* host_ptr_A,   const void* const* host_ptr_SFA,

--- a/src/core/cuda_static_reset.cpp
+++ b/src/core/cuda_static_reset.cpp
@@ -1,28 +1,42 @@
 #include "core/cuda_static_reset.h"
 
-#include "compute/gemm_cutlass_grouped_3x.h"  // gemm_grouped_3x_nvfp4_cleanup()
-
 #include <cuda_runtime.h>
+
+#include <vector>
 
 namespace imp {
 
-void reset_static_cuda_state() {
-    gemm_reset_static_cuda_state();
-    gemm_grouped_reset_static_cuda_state();
-    gemm_grouped_nvfp4_smallM_reset_static_cuda_state();
-    attention_cublas_reset_static_cuda_state();
-    attention_mxfp4_prefill_reset_static_cuda_state();
-    vision_encoder_reset_static_cuda_state();
-    qwen3vl_encoder_reset_static_cuda_state();
-    // gemm_cutlass_sm120 / gemm_cutlass_mxfp4 have no hook: A7 step 8 deleted
-    // the lazily-grown CUTLASS workspaces they existed to re-arm.
-    fmha_sm120_reset_static_cuda_state();
-    fmha_mxfp4_reset_static_cuda_state();
-    moe_batch_reset_static_cuda_state();
-    nvfp4_gemm_reset_static_cuda_state();
+namespace {
 
-    // Persistent CUTLASS 3x grouped-GEMM staging/workspace + gemm instance.
-    gemm_grouped_3x_nvfp4_cleanup();
+// Function-local static so a registrar in another TU cannot run before this
+// container is constructed (static-init order fiasco). Registration happens
+// during static init from arbitrary TUs, so the container has to be created
+// on first use, not at namespace scope.
+std::vector<void (*)()>& hooks() {
+    static std::vector<void (*)()> v;
+    return v;
+}
+
+}  // namespace
+
+namespace detail {
+
+CudaStaticResetRegistrar::CudaStaticResetRegistrar(void (*fn)()) {
+    if (fn)
+        hooks().push_back(fn);
+}
+
+}  // namespace detail
+
+int cuda_static_reset_hook_count() { return static_cast<int>(hooks().size()); }
+
+void reset_static_cuda_state() {
+    // Registration order is link order, which is arbitrary — every hook is
+    // independent and idempotent by contract, so that is fine. What is NOT
+    // fine is a hook missing entirely, which is what the old hand-maintained
+    // call list allowed; see the header.
+    for (auto* fn : hooks())
+        fn();
 
     // Best-effort teardown: clear any sticky error left by the frees above.
     (void)cudaGetLastError();

--- a/src/core/cuda_static_reset.h
+++ b/src/core/cuda_static_reset.h
@@ -14,25 +14,49 @@
 // This is NOT part of normal engine teardown (~Engine's gemm_cleanup() etc.
 // stay untouched). All hooks are idempotent and safe to call when the
 // corresponding module was never used (its statics are still null).
+//
+// REGISTRATION IS AUTOMATIC (#1207). This header used to declare each owning
+// module's hook by name, and cuda_static_reset.cpp called all eleven from a
+// hand-maintained list. That cost two things: a twelfth lazy static added
+// without an entry dangled behind an armed guard — exactly the bug this file
+// exists to prevent, with nothing to catch it — and the aggregator had to
+// include a compute/ header to reach one of them, inverting the layer graph
+// (core -> compute).
+//
+// Each owning TU now registers itself at static-init time:
+//
+//     namespace {
+//     void my_module_reset() { ... }
+//     IMP_REGISTER_CUDA_STATIC_RESET(my_module_reset);
+//     }
+//
+// No declaration here, no call site to forget, and core/ no longer includes
+// anything above it.
 
 namespace imp {
 
-// Aggregator: calls every per-module hook below, then clears any sticky
-// CUDA error.
+// Runs every registered hook, then clears any sticky CUDA error.
 void reset_static_cuda_state();
 
-// Per-module hooks, each defined in the translation unit that owns the
-// statics it resets.
-void gemm_reset_static_cuda_state();                        // compute/gemm.cu
-void gemm_grouped_reset_static_cuda_state();                // compute/gemm_grouped.cu
-void gemm_grouped_nvfp4_smallM_reset_static_cuda_state();   // compute/gemm_grouped_nvfp4_smallM.cu
-void attention_cublas_reset_static_cuda_state();            // compute/attention_cublas.cu
-void attention_mxfp4_prefill_reset_static_cuda_state();     // compute/attention_mxfp4_prefill.cu
-void vision_encoder_reset_static_cuda_state();              // vision/vision_encoder.cu
-void qwen3vl_encoder_reset_static_cuda_state();             // vision/qwen3vl_encoder.cu
-void fmha_sm120_reset_static_cuda_state();                  // compute/attention_fmha_sm120.cu
-void fmha_mxfp4_reset_static_cuda_state();                  // compute/attention_fmha_mxfp4_sm120.cu
-void moe_batch_reset_static_cuda_state();                   // exec/executor_forward_moe_batch.cu
-void nvfp4_gemm_reset_static_cuda_state();                  // quant/nvfp4_gemm.cu
+// Number of registered hooks. Lets a test assert the registry is populated
+// rather than silently empty — a link-order or --gc-sections accident would
+// otherwise turn the whole mechanism into a no-op that still "passes".
+int cuda_static_reset_hook_count();
+
+namespace detail {
+
+// Appends `fn` to the hook list when constructed. File-scope instances run
+// before main(), so every TU linked into the binary is registered by the time
+// imp_gpu_release() can be called.
+struct CudaStaticResetRegistrar {
+    explicit CudaStaticResetRegistrar(void (*fn)());
+};
+
+}  // namespace detail
 
 }  // namespace imp
+
+// Registers `fn` (a `void()` in the current TU) as a pre-cudaDeviceReset hook.
+// Place at file scope, inside an anonymous namespace.
+#define IMP_REGISTER_CUDA_STATIC_RESET(fn) \
+    const ::imp::detail::CudaStaticResetRegistrar imp_cuda_reset_registrar_##fn { &fn }

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -542,6 +542,15 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         // `is_prefill` is part of the condition, not an optimisation: image
         // tokens only ever exist in the prompt, and a decode graph captured
         // with this branch taken would bake the add into every replay.
+        //
+        // Speculative decoding depends on this too (#1207). The spec gate in
+        // engine_spec_ngram.cpp rejects constrained decode, SSM state and
+        // non-NVFP4 MoE explicitly, but says nothing about vision — because it
+        // does not have to: the verify chunk forwards with is_prefill=false, so
+        // it never re-injects, and the image is already in the KV cache from the
+        // prompt. Extending this branch to decode would silently break
+        // speculation (verify and target would inject differently) — so if that
+        // ever becomes necessary, add a vision reject to the spec gate first.
         if (state.is_prefill && i < state.n_deepstack && state.deepstack_embeddings[i] &&
             state.n_vision_tokens > 0 && state.vision_token_id >= 0 && h.qtype == QType::F16) {
             launch_add_vision_embeddings(static_cast<half*>(h.data), state.token_ids,

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -536,6 +536,11 @@ void moe_batch_reset_static_cuda_state() {
     s_norm_fp32_d = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(moe_batch_reset_static_cuda_state);
+}  // namespace
+
 bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stream, int n, int d,
                                                     int eff, int top_k, QType up_qtype, float eps,
                                                     const MoeRoutingResult& routing,

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -125,6 +125,11 @@ void nvfp4_gemm_reset_static_cuda_state() {
     s_nvfp4_dequant_buf_size = 0;
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(nvfp4_gemm_reset_static_cuda_state);
+}  // namespace
+
 // FP32 -> FP16 copy for the small-M batched-GEMV path (the batched kernel
 // accumulates and writes FP32; gemm_nvfp4's contract is an FP16 C).
 __global__ void nvfp4_fp32_to_fp16_kernel(const float* __restrict__ in, __half* __restrict__ out,

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -173,6 +173,9 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("attention.force_cublas_decode", cfg.attention.force_cublas_decode);
     B("attention.mla_absorb", cfg.attention.mla_absorb);
     B("attention.no_qknorm_fused", cfg.attention.no_qknorm_fused);
+    B("diagnostics.spec_trace", cfg.diagnostics.spec_trace);
+    B("diagnostics.jump_trace", cfg.diagnostics.jump_trace);
+    S("diagnostics.ppl_dump", cfg.diagnostics.ppl_dump);
     B("attention.splitk_pipe", cfg.attention.splitk_pipe);
     B("attention.fp8_tile", cfg.attention.fp8_tile);
     B("attention.fp8_tile_gqa", cfg.attention.fp8_tile_gqa);
@@ -354,6 +357,10 @@ std::string home_dir() {
 //     inject determinism through the public API without a config file.
 //   IMP_FMHA_FA2 — set by the roofline A/B harness (tools/roofline/roofline.py)
 //     to toggle the FA2 prefill kernel per subprocess.
+// Three trace vars are seeded here as of #1207 (IMP_SPEC_TRACE, IMP_JUMP_TRACE,
+// IMP_PPL_DUMP). They had crept back as raw getenv() calls at their use sites —
+// unreachable from imp.conf/--set and undocumented. Seeding keeps the shell
+// habit working while making the keys first-class.
 void seed_from_env(RuntimeConfig& cfg) {
     // runtime.deterministic — IMP_DETERMINISTIC: '1'/'true' enables full
     // reproducibility (also implies deterministic_gemm).
@@ -367,6 +374,16 @@ void seed_from_env(RuntimeConfig& cfg) {
     // prefill kernel (A/B vs the legacy FP8 FMHA), '0' forces it off.
     if (const char* e = std::getenv("IMP_FMHA_FA2"))
         cfg.attention.fmha_fa2 = (std::atoi(e) != 0) ? "on" : "never";
+
+    // diagnostics.spec_trace / jump_trace / ppl_dump — presence-is-truth for the
+    // two booleans (the old getenv() call sites tested `if (getenv(...))`, so an
+    // empty value counted as ON; keep that so existing shell habits behave).
+    if (std::getenv("IMP_SPEC_TRACE"))
+        cfg.diagnostics.spec_trace = true;
+    if (std::getenv("IMP_JUMP_TRACE"))
+        cfg.diagnostics.jump_trace = true;
+    if (const char* e = std::getenv("IMP_PPL_DUMP"))
+        cfg.diagnostics.ppl_dump = e;
 }
 
 }  // anonymous namespace

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -1031,6 +1031,16 @@ struct RuntimeConfig {
         int exit_layer = -1;
         bool profile = false;
         bool graph_diag = false;
+        // Trace knobs that used to be raw getenv() reads in the hot path
+        // (#1207). CLAUDE.md's rule is that IMP_DETERMINISTIC and IMP_FMHA_FA2
+        // are the only seeded env vars; IMP_SPEC_TRACE / IMP_JUMP_TRACE /
+        // IMP_PPL_DUMP had crept back in. The env names still work — they are
+        // debug aids people have in their shell history — but they are seeded
+        // into these keys at load, so `--set` and imp.conf reach them too and
+        // `imp-cli --help`/imp.conf.example can document them.
+        bool spec_trace = false;  // per-step speculative draft/verify trace
+        bool jump_trace = false;  // conditional-graph jump trace
+        std::string ppl_dump;     // path: dump per-token NLL from --perplexity
         std::string graph_dump_dir;
         // Force NVFP4 dispatch through dequant->FP16 GEMV (M=1 bisection
         // tool — see Mistral-Small-3.2-NVFP4 long-form repetition loops).

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -276,7 +276,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
                 think_limit = std::max(
                     1, static_cast<int>(req->max_tokens * req->think_budget) - used);
             }
-            if (getenv("IMP_SPEC_TRACE"))
+            if (runtime_config_.diagnostics.spec_trace)
                 IMP_LOG_INFO("[burst-launch] REARM seed=%d pos=%d ctx=%d limit=%d", (int)first_token,
                              ctx - 1, ctx, step_limit);
             if (async_graph_runner_.rearm(first_token, /*position=*/ctx - 1, /*context_len=*/ctx,
@@ -345,7 +345,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         state_template.n_d_banned_tokens = static_cast<int>(banned_token_ids_.size());
     }
 
-    if (getenv("IMP_SPEC_TRACE"))
+    if (runtime_config_.diagnostics.spec_trace)
         IMP_LOG_INFO("[burst-launch] FRESH seed=%d ctx=%d limit=%d remaining=%d", (int)first_token,
                      req->context_len(), step_limit, remaining);
     auto gcfg = build_graph_config(*req, remaining);
@@ -603,7 +603,7 @@ int Engine::step_constrained_pipeline() {
             p.fnext++;
             return 1;
         }
-        if (getenv("IMP_JUMP_TRACE")) {
+        if (runtime_config_.diagnostics.jump_trace) {
             Tokenizer* tk = model_->tokenizer();
             const int32_t want = p.fnext <= p.frows ? p.fdraft[p.fnext - 1] : -1;
             IMP_LOG_INFO("[jump] exit at %d/%d: sampled %d [%s] draft %d [%s]", p.fnext, p.frows,
@@ -645,7 +645,7 @@ int Engine::step_constrained_pipeline() {
             }
             return 1;
         }
-        if (getenv("IMP_JUMP_TRACE")) {
+        if (runtime_config_.diagnostics.jump_trace) {
             Tokenizer* tk = model_->tokenizer();
             IMP_LOG_INFO("[jump] pending dropped at %d: sampled %d [%s] draft %d [%s]",
                          p.fpend_cursor, token,
@@ -698,7 +698,7 @@ void Engine::constrained_jump_probe_(std::shared_ptr<Request>& req) {
         return;
     p.fpending = std::move(draft);
     p.fpend_cursor = 0;
-    if (getenv("IMP_JUMP_TRACE"))
+    if (runtime_config_.diagnostics.jump_trace)
         IMP_LOG_INFO("[jump] pended %d tokens for forced span \"%s\"",
                      static_cast<int>(p.fpending.size()), text.c_str());
 }
@@ -804,7 +804,7 @@ void Engine::constrained_jump_commit_(std::shared_ptr<Request>& req, cudaStream_
     p.fbase_pos = pos1 + 1;
     p.frows = K;
     p.jumps++;
-    if (getenv("IMP_JUMP_TRACE")) {
+    if (runtime_config_.diagnostics.jump_trace) {
         std::string ids;
         for (int32_t t : p.fdraft) ids += std::to_string(t) + " ";
         IMP_LOG_INFO("[jump] committed %d-token chunk after free first-token match (ids: %s)", K,

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -446,7 +446,8 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     // IMP_PPL_DUMP=full: every position — needed for cross-mode forensics;
     // the sparse form hid that per-position values diverge between chunked
     // and single-shot runs (#655).
-    if (const char* dump = getenv("IMP_PPL_DUMP")) {
+    if (!runtime_config_.diagnostics.ppl_dump.empty()) {
+        const char* dump = runtime_config_.diagnostics.ppl_dump.c_str();
         const bool full = (strcmp(dump, "full") == 0);
         fprintf(stderr, "[PPL-DUMP] per-pos nll:");
         for (int i = 0; i < n - 1; ++i) {

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -228,7 +228,7 @@ bool Engine::spec_burst_launch_ok_(const Request& req) const {
     // IMP_SPEC_TRACE: dump every term — the launch decision decides WHICH
     // kernel mix (loop vs pooled/eager) serves the next tokens, so an
     // asymmetric term here shows up as a greedy flip between requests.
-    if (getenv("IMP_SPEC_TRACE")) {
+    if (runtime_config_.diagnostics.spec_trace) {
         IMP_LOG_INFO("[burst-ok?] req=%d out=%zu pool_avail=%d offload=%d graphs=%d setup=%d parked=%d "
                      "think=%d think_end=%d status=%d",
                      req.id, req.output_tokens.size(),
@@ -881,7 +881,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         return false;
     }
 
-    if (getenv("IMP_SPEC_TRACE")) {
+    if (runtime_config_.diagnostics.spec_trace) {
         std::string s = "[verify] p0=" + std::to_string(p0) + " t0=" + std::to_string(t0) +
                         (mc_on ? " mc_cands=" + std::to_string(mc.size()) : "") + " draft=[";
         const auto& dref = mc_on ? mc[0] : draft;

--- a/src/vision/qwen3vl_encoder.cu
+++ b/src/vision/qwen3vl_encoder.cu
@@ -1,4 +1,5 @@
 #include "vision/qwen3vl_encoder.h"
+#include "core/cuda_static_reset.h"
 
 #include "core/logging.h"
 #include "memory/vram_allocator.h"
@@ -50,6 +51,11 @@ void qwen3vl_encoder_reset_static_cuda_state() {
         s_handle = nullptr;
     }
 }
+
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(qwen3vl_encoder_reset_static_cuda_state);
+}  // namespace
 
 Qwen3VLEncoder::~Qwen3VLEncoder() { free_buffers(); }
 

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -35,6 +35,11 @@ void vision_encoder_reset_static_cuda_state() {
     }
 }
 
+// Registered as a pre-cudaDeviceReset hook (#1207); see core/cuda_static_reset.h.
+namespace {
+IMP_REGISTER_CUDA_STATIC_RESET(vision_encoder_reset_static_cuda_state);
+}  // namespace
+
 // ---- Helper: cuBLAS GEMM  C = alpha * A @ B^T ----
 // A: [M, K], B: [N, K], C: [M, N]  (row-major)
 static void vision_gemm(const half* A, const half* B, half* C, int M, int N, int K, float alpha, float beta,

--- a/tests/test_cuda_static_reset.cpp
+++ b/tests/test_cuda_static_reset.cpp
@@ -1,0 +1,26 @@
+// The pre-cudaDeviceReset hook registry must not be silently empty (#1207).
+//
+// reset_static_cuda_state() frees the lazily-created module statics (cuBLAS
+// handles, CUTLASS workspaces, device scratch) before cudaDeviceReset(), so
+// their `if (!ptr)` guards re-arm. Before #1207 the hooks were listed by hand
+// in cuda_static_reset.cpp; each owning TU now registers itself at static-init
+// time, which removes the "added a static, forgot the list entry" failure —
+// and introduces a new one worth pinning: if the registrars are stripped
+// (--gc-sections, a link-order accident, a TU dropped from a target), the
+// registry is EMPTY and reset_static_cuda_state() becomes a no-op that still
+// returns cleanly. That failure is invisible until an in-process model reload
+// touches freed device memory.
+//
+// So: assert the registry is populated. The exact count is link-dependent —
+// a test binary does not link every .cu the full engine does — hence a floor
+// rather than an equality.
+
+#include "core/cuda_static_reset.h"
+
+#include <gtest/gtest.h>
+
+TEST(CudaStaticReset, HookRegistryIsPopulated) {
+    EXPECT_GT(imp::cuda_static_reset_hook_count(), 0)
+        << "no pre-cudaDeviceReset hooks registered — reset_static_cuda_state() is a no-op, "
+           "so module statics will dangle after an in-process reload";
+}

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -20,7 +20,8 @@ void print_server_usage(const char* prog) {
             "  --gpu-layers <n>      Layers on GPU, -1 = all (default: -1)\n"
             "  --device <n>          CUDA device ID (default: 0)\n"
             "  --chat-template <t>   auto, none, chatml, llama2, llama3, nemotron, gemma\n"
-            "  --lora NAME=PATH      Load a PEFT LoRA adapter (repeatable); select per request via \"lora\" field\n"
+            "  --lora NAME=PATH      Load a PEFT LoRA adapter (repeatable); select per request via \"lora\" "
+            "field\n"
             "  --no-cuda-graphs      Disable CUDA Graph capture for decode\n"
             "  --ssm-fp16            Use FP16 for SSM h_state\n"
             "  --kv-fp8              Use FP8 E4M3 KV cache (halves KV memory)\n"
@@ -39,6 +40,7 @@ void print_server_usage(const char* prog) {
             "  --mmproj <path>       Path to vision encoder GGUF (mmproj) for multimodal\n"
             "  --models-dir <path>   Directory to scan for .gguf models (auto-load on select)\n"
             "  --api-key <key>       Require Bearer token authentication\n"
+            "  --metrics-require-auth  Also gate /metrics behind --api-key\n"
             "  --reasoning-format <f> deepseek (default) or none\n"
             "  --mem-report          Print the full VRAM attribution table at init\n"
             "  --vram-budget <mb>    Hard per-process VRAM cap in MiB — size everything as if\n"
@@ -126,6 +128,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.models_dir = argv[++i];
         } else if (std::strcmp(arg, "--api-key") == 0 && i + 1 < argc) {
             args.api_key = argv[++i];
+        } else if (std::strcmp(arg, "--metrics-require-auth") == 0) {
+            args.metrics_require_auth = true;
         } else if (std::strcmp(arg, "--reasoning-format") == 0 && i + 1 < argc) {
             args.reasoning_format = argv[++i];
         } else if (std::strcmp(arg, "--mem-report") == 0) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -36,6 +36,11 @@ struct ServerArgs {
     std::string mmproj_path;                    // --mmproj: vision encoder GGUF
     std::string models_dir;                     // --models-dir: scan for .gguf files
     std::string api_key;                        // --api-key: require Bearer token auth
+    // --metrics-require-auth: also gate /metrics behind --api-key. Off by
+    // default because the standard Prometheus scrape (monitoring/) is
+    // unauthenticated; on, because /metrics discloses the loaded model name,
+    // d_model and cumulative token counts to anyone who can reach the port.
+    bool metrics_require_auth = false;
     std::string reasoning_format = "deepseek";  // --reasoning-format: deepseek or none
     bool mem_report = false;  // --mem-report: full VRAM attribution table at init
     int vram_budget_mb = 0;  // --vram-budget: hard per-process VRAM cap in MiB (0 = uncapped)

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -134,6 +134,10 @@ struct ServerState {
     ServerArgs default_args;
     std::string models_dir;       // directory to scan for available .gguf files
     std::string api_key;          // if non-empty, require Bearer token auth
+    // --metrics-require-auth: gate /metrics behind api_key too (#1207). Default
+    // off — the Prometheus scrape in monitoring/ is unauthenticated — but the
+    // endpoint discloses model name, d_model and cumulative token counts.
+    bool metrics_require_auth = false;
     bool is_think_model = false;  // model has <think> token (DeepSeek R1 etc.)
     int32_t think_start_id = -1;  // <think> token ID (-1 if not present)
     int32_t think_end_id = -1;    // </think> token ID (-1 if not present)

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char** argv) {
 
     // Store API key and limits in state
     state.api_key = args.api_key;
+    state.metrics_require_auth = args.metrics_require_auth;
     state.max_concurrent = args.max_concurrent;
     state.request_timeout = args.request_timeout;
     state.rate_limit = args.rate_limit;
@@ -144,8 +145,12 @@ int main(int argc, char** argv) {
         res.set_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
         res.set_header("Access-Control-Allow-Headers", "Content-Type, Authorization");
 
-        // Skip auth/limits for health checks and CORS preflight
-        if (req.path == "/health" || req.path == "/metrics" || req.method == "OPTIONS")
+        // Skip auth/limits for health checks and CORS preflight. /metrics is
+        // exempt by default so a stock Prometheus scrape works, but it leaks the
+        // loaded model name, d_model and cumulative token counts — so
+        // --metrics-require-auth folds it back under the api_key check (#1207).
+        const bool metrics_exempt = (req.path == "/metrics" && !state.metrics_require_auth);
+        if (req.path == "/health" || metrics_exempt || req.method == "OPTIONS")
             return httplib::Server::HandlerResponse::Unhandled;
 
         // Rate limiting (per-IP, inference endpoints only)


### PR DESCRIPTION
Three more audit findings closed, plus one resolved as a non-issue.

## F-11 — the reset-hook registry was hand-maintained

`reset_static_cuda_state()` frees the lazily-created module statics (cuBLAS handles, CUTLASS workspaces, device scratch) before `cudaDeviceReset()` so their `if (!ptr)` guards re-arm. The eleven hooks were listed by hand in `cuda_static_reset.cpp` — so a **twelfth lazy static added without an entry dangles behind an armed guard** after an in-process reload. That is precisely the bug the file exists to prevent, and nothing caught it.

Each owning TU now registers itself:

```cpp
namespace {
IMP_REGISTER_CUDA_STATIC_RESET(gemm_reset_static_cuda_state);
}
```

**Side effect worth having:** `core/cuda_static_reset.cpp` no longer includes `compute/gemm_cutlass_grouped_3x.h`. That was the one `core → compute` backward edge in the layer graph (§11 of the audit) — the aggregator had to reach up into `compute/` to call one cleanup by name.

**This trades one failure mode for another, so the new one is pinned.** An *empty* registry (registrars stripped by `--gc-sections`, a link-order accident, a TU dropped from a target) would make `reset_static_cuda_state()` a silent no-op that still returns cleanly. `cuda_static_reset_hook_count()` + `tests/test_cuda_static_reset.cpp` assert it is populated; the exact count is link-dependent (a test binary does not link every `.cu`), so the test asserts a floor rather than an equality.

## F-23 — three env vars had crept back

`CLAUDE.md`: *"The only env vars still seeded are `IMP_DETERMINISTIC` and `IMP_FMHA_FA2`; don't reintroduce ad-hoc env reads."* `IMP_SPEC_TRACE`, `IMP_JUMP_TRACE` and `IMP_PPL_DUMP` were raw `getenv()` calls at their use sites — unreachable from `imp.conf`/`--set` and undocumented.

Now `diagnostics.spec_trace` / `.jump_trace` / `.ppl_dump`. The env names still work (seeded at load in `seed_from_env`), **including the presence-is-truth semantics** the old sites had — they tested `if (getenv(...))`, so an empty value counted as ON, and shell habits keep working.

## F-25 — `/metrics` was unauthenticated by design

`--metrics-require-auth` folds it back under the `--api-key` check. Off by default so a stock Prometheus scrape (`monitoring/`) keeps working, but the endpoint discloses the loaded model name, `d_model` and cumulative token counts to anyone who can reach the port. Now a choice rather than a default.

## F-20 — RESOLVED, no code change

The audit could not find a decision site for **speculative decoding × vision** and recorded `UNKNOWN` — the one unresolved cell in the routing matrix, flagged on the grounds that "nobody decided, so nobody knows".

There is no decision site because none is required: DeepStack injection is gated on `state.is_prefill` (`executor_forward.cu:545`), the verify chunk forwards with `is_prefill=false`, and the image is already in the KV cache from the prompt. The pairing is safe.

That is load-bearing and was invisible, so the coupling is now stated at the injection site: extending the branch to decode would silently break speculation (verify and target would inject differently), and would need a vision reject in the spec gate first.

## Verification

- `make dev-test` (CI's `ctest -L unit`): green, 4/4.
- Gates: `check_launch_guards` 407/407 · `check_filesize` violations=0 · `check_alloc_sites` no new sites.
- Build warning-free. clang-format on changed lines: clean.
- **Mutation-validated:** neutering `CudaStaticResetRegistrar` (`(void)fn;` instead of `push_back`) makes the registry test fail with *"no pre-cudaDeviceReset hooks registered — reset_static_cuda_state() is a no-op"*.

**`make verify-fast` did NOT run** — GPU busy (`mmm-imp-vision`). No perf gate, no degeneration smoke. This batch is mostly link-time and host-side, but `IMP_REGISTER_CUDA_STATIC_RESET` touches 12 kernel TUs and the reset path itself is only exercised by an in-process model reload.

## Deliberately NOT done: F-15 (27 duplicated CLI flags)

Both sane fixes are worse than the finding. A shared arg table has to reconcile **deliberately different defaults** (`max_tokens` is 256 in `imp-cli`, 8192 in `imp-server`) and would touch every use site in both binaries — an invasive, purely mechanical change with no GPU gate available to catch a regression. A static parity checker, meanwhile, cannot distinguish "flag missing from the other binary by mistake" from the 35 flags that are legitimately CLI-only. Left open and stated rather than papered over.

Follows #1205, #1206. Closes F-11, F-20, F-23, F-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B
