### PR TITLE
docs: correct three statements the audit found wrong (#1208)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # imp — Project Instructions
 
-From-scratch C++23/CUDA LLM inference engine targeting **exactly one chip: NVIDIA Blackwell `sm_120a`** (RTX 5090 / GB202, 32 GB GDDR7, 1792 GB/s, native FP4 tensor cores). No portability layer, no FP16 dequant fallback in the hot path. ~100k LOC (src/ + include/). See [`docs/architecture.md`](docs/architecture.md) (canonical narrative) and [`docs/sm120.md`](docs/sm120.md).
+From-scratch C++23/CUDA LLM inference engine targeting **exactly one chip: NVIDIA Blackwell `sm_120a`** (RTX 5090 / GB202, 32 GB GDDR7, 1792 GB/s, native FP4 tensor cores). No portability layer, no FP16 dequant fallback in the hot path. ~135k LOC (src/ + include/; ~220k with tests/). See [`docs/architecture.md`](docs/architecture.md) (canonical narrative) and [`docs/sm120.md`](docs/sm120.md).
 
 **This file is the router, not the manual.** It holds what applies to every task; the playbooks live in the skills below and are loaded on demand. If something here is also in a skill, the skill is the copy that gets maintained.
 
@@ -67,7 +67,9 @@ make verify-fast           # ~90 s pre-push gate    make verify   # ~5 min full
   5% prefill). Refresh via `scripts/gen_perf_baseline.sh` only when a change
   intentionally moves perf, and say so in the PR.
 - Runtime config is `RuntimeConfig` in `src/runtime/config.h` (`imp.conf` +
-  `--config` + `--set`). The only env vars still seeded are `IMP_DETERMINISTIC`
+  `--config` + `--set`). The env vars seeded are `IMP_DETERMINISTIC`, `IMP_FMHA_FA2`, and the three
+  trace knobs promoted to config keys in #1207 (`IMP_SPEC_TRACE`, `IMP_JUMP_TRACE`,
+  `IMP_PPL_DUMP` → `diagnostics.spec_trace` / `.jump_trace` / `.ppl_dump`)
   and `IMP_FMHA_FA2`; don't reintroduce ad-hoc env reads.
 - Internal errors throw and are translated to `ImpError` at the
   `src/api/imp_api.cpp` boundary — intentional, don't convert them to status returns.

--- a/docs/attention-dispatch.md
+++ b/docs/attention-dispatch.md
@@ -8,38 +8,45 @@ If this doc and the code disagree, the code wins. Source of truth is `src/exec/e
 > on hd=128 models (Qwen3 dense/MoE — Q8_0, Q4_K_M, NVFP4) the legacy
 > materialized cuBLAS+softmax path is **0.0% of prefill time** at pp512–pp4096
 > — FP16-QK FA2 (#525) covers the short range, FA2/FP8-FMHA the long range.
-> At the time of that measurement hd≠128 models (gemma-3-12b, hd=256) still hit
-> it (3.6–6.9% of prefill time); since #930/#932 hd=256 rides the FA2 port too
-> (`attention.fa2_hd256`, default on), so the cuBLAS path now serves only
-> heterogeneous-shape / sinks / opted-out configs.
+> Since #930/#932 hd=256 rides the FA2 port too (`attention.fa2_hd256`, default on).
+>
+> **This does NOT generalise to Gemma-4** (2026-08-02 audit, F-16). Its global
+> layers are hd=512 and take `attention_cublas_prefill` — or, when the S-matrix
+> overflows, `attention_cublas_prefill_sliced` (#1036) — *by design and by
+> measurement*: both beat the SMEM-capped fused hd=512 kernel
+> ([`docs/audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md`](audit/gemma4_attn_routing_2026_07_16/PERF_LOG.md)).
+> So on an advertised model the "legacy" path is the *default* prefill path for
+> half the layer stack, and the 384 MiB `attn_scores` workspace is retained for it.
 
-## Prefill — gate (post #525/#932: FA2 f16-QK first at hd 128 and 256, cuBLAS as fallback)
+## Prefill — the gate
 
-The prefill dispatch in `src/exec/executor_attention_prefill.cu` (~line 338) tries
-the FP16-QK FA2 drop-in before the materialized cuBLAS path:
+**Read the code, not a snippet.** This section used to inline the dispatch
+source; the variables it named (`force_cublas_attn`, `s_matrix_fits`,
+`prefer_fmha`) no longer all exist, and the quoted logic was wrong about
+Gemma-4 for six weeks. Source of truth:
+`src/exec/executor_attention_prefill.cu` for the outer gate (two blocks —
+chunked and non-chunked) and `src/compute/attention_dispatch.cu` for the FMHA
+chain.
 
-```cpp
-// Uniform per-layer shapes (GDN/Mamba2 hybrids: zeros on non-attention layers)
-// are FA2-servable since #932 — only truly heterogeneous shapes (gemma-4 dual
-// head_dim) and learned sinks (gpt-oss) force cuBLAS.
-const bool force_cublas_attn = (per_layer_shapes && !attn_shapes_uniform()) ||
-                               attn_sinks != nullptr;
-const bool s_matrix_fits     = attn_scores_buf_ != nullptr &&
-                               n <= attn_scores_.shape[1];
-const bool prefer_fmha       = !force_cublas_attn &&
-                               (n >= attention.fmha_prefill_threshold);
+The outer gate is decided **per layer**, not per model — that is the part the
+old snippet got wrong. A Gemma-4 request takes FA2 on its hd=256 SWA layers and
+cuBLAS on its hd=512 global layers, in the same forward pass:
 
-if (!force_cublas_attn && try_fa2_fp16qk_prefill(...)) { /* FA2 f16-QK */ }
-else if (s_matrix_fits && !prefer_fmha) attention_cublas_prefill(...); // legacy materialized
-else attention_prefill_dispatch(...);                                  // FMHA chain
-```
+| Condition (per layer) | Path |
+|---|---|
+| no learned sinks, and `hd == 128` or (`hd == 256` and `attention.fa2_hd256`), and `fa2_fp16qk != "never"` | `try_fa2_fp16qk_prefill` — FP16-QK FA2, O(n) memory, primary path |
+| S-matrix fits and below the FMHA threshold | `attention_cublas_prefill` — materialized `[nh, n, ctx]` FP16 S-matrix |
+| `hd == 512`, S-matrix too small for the whole chunk | `attention_cublas_prefill_sliced` (#1036) — cuBLAS in workspace-sized q-row slices; 3.4–3.9x faster than the fused hd=512 FMHA at Skv 8k/16k |
+| otherwise | `attention_prefill_dispatch` → the FMHA chain below |
 
-| Condition | Path | Why |
-|---|---|---|
-| **hd=128, or hd=256 with `fa2_hd256` (default on)**, uniform shapes, no sinks, `fa2_fp16qk != "never"` | `fmha_sm120_fa2_kernel<…,FP16QK=1>` | FP16-QK FA2 (#525, hd=256 since #930/#932): cuBLAS-FP16-quality without the materialized S-matrix, at every length. |
-| short seq, FA2 declined (heterogeneous shapes, `attn_sinks`, hd ∉ {128, 256}, or `fa2_hd256=false`) | `attention_cublas_prefill` | Legacy materialized path: cuBLAS QK^T → [nh, n, n] FP16 S-matrix (`attn_scores_mib`, default 384 MiB; skipped entirely at init when FA2 serves all prefill, #932) → causal softmax → cuBLAS PV. |
-| long seq (n ≥ threshold), FA2 declined | FMHA chain below | Tiled O(n) memory; no materialized S. |
-| chunked continuation (`q_offset > 0`) with cumulative ctx < threshold | `attention_cublas_prefill` | FA2 f16-QK still declines `q_offset > 0` (conservative blanket gate post-#548); the FMHA chain needs ctx ≥ threshold. |
+Learned sinks (gpt-oss) are pre-gated at `attention_dispatch.cu:45`: they route
+straight to the FP16 WMMA FMHA — the only sink-capable tier — and **throw** on
+decline rather than falling through to a sink-blind kernel (#992).
+
+Since #1205 the resolved path is also **observable at runtime**: the engine logs
+one `Resolved dispatch: attn_prefill=… attn_decode=… moe_prefill=…` line after
+the first step that has seen both a prefill and a decode, recorded from inside
+the real dispatch rather than predicted.
 
 ### FMHA chain (`src/compute/attention_dispatch.cu`, host model: `attention_dispatch_decision.h`)
 
@@ -74,6 +81,16 @@ The decode dispatch (further down in `executor_attention.cu`) is a single `switc
 ### BitDecoding residual cache
 
 When `kv_cache.bitdecoding_qk` is true AND `kv_cache.dtype = nvfp4`, the newest `kv_cache.bitdecoding_residual_tokens` tokens are kept in a residual FP16 buffer and combined with the quantized older blocks at attention time. Used by NVFP4-decode for higher fidelity on the recent context. See `src/compute/attention_paged_nvfp4_tc.cu`.
+
+## MLA (Multi-head Latent Attention)
+
+DeepSeek-V2/V3 checkpoints take a different route entirely and were missing from
+this doc until the 2026-08-02 audit. `ModelProfile::AttnVariant::MLA` marks them;
+the compressed KV latent is expanded by `src/compute/mla_kv_assemble.cu` before
+the assembled K/V reach the gate above, so from the dispatch's point of view an
+MLA layer looks like a normal attention layer with the assembled shapes. There is
+no standard RoPE on the latent path — the YaRN `mscale` ratio bug fixed
+2026-07-07 lived here.
 
 ## Sliding-window mask
 

--- a/docs/audit/ARCHMAP.md
+++ b/docs/audit/ARCHMAP.md
@@ -17,8 +17,14 @@ vision ──▶ compute/model        lora ──▶ runtime/model
 - **core** — `Buffer`, `Tensor`, `cuda_raii.h` (`CudaStream`/`CudaEvent`, move-only),
   logging + `IMP_CUDA_CHECK*` macros, `ModelProfile` (centralized arch facts).
 - **memory** — three layers since #1106 (design doc: `docs/MEMORY_ARCHITECTURE.md`,
-  findings log: root `AUDIT.md`). `backend.{h,cpp}` is the **only** code that talks
-  to the driver about memory (invariant I1, gated by `tools/check_alloc_sites.py`);
+  findings log: root `AUDIT.md`). `backend.{h,cpp}` is the code that *should* be the
+  only thing talking to the driver about memory (invariant I1). In practice I1 is
+  a **ratchet, not an absolute**: `tools/check_alloc_sites.py` gates against
+  `tools/alloc_allowlist.txt`, which grandfathers **74 files / 492 direct
+  allocation sites** outside `src/memory/` (28 in `exec/`, 25 in `compute/`, 9 in
+  `runtime/`). The list only shrinks and the gate fails in both directions — a new
+  allocating file AND a listed file that stopped allocating — so the mechanism is
+  sound; the absolute phrasing was not (2026-08-02 audit, F-13);
   above it the tier allocators `arena` (T2 engine-persistent), `block_pool` (T3
   fixed-block, now backs `KVCache`), `scratch_stack` (T4 forward-scratch) and
   `graph_slots` (T2 slot pool for the conditional-graph loop); `span.h` encodes in
@@ -40,8 +46,15 @@ vision ──▶ compute/model        lora ──▶ runtime/model
 - **tools/imp-server** — httplib server, `handlers.cpp` (~4600 LOC, OpenAI +
   Anthropic), `BatchingEngine` (the HTTP→GPU bridge).
 
-Layer note (pass-1 D1): a few `compute/quant/memory → runtime` includes exist for
-diagnostics/PDL only (instrumentation, not algorithmic coupling).
+Layer note (revised 2026-08-02, audit F-10). The `compute/quant/memory → runtime`
+edges are mostly instrumentation as described (`pdl.h` 7 files, `process_diag.h`
+12). **`exec → runtime` is not**: 27 files, 22 of them `runtime/config.h` (1124
+LOC). `RuntimeConfig` is declared in the top layer and drives dispatch in the hot
+layer, which is *why* `process_diag` exists at all — see its header comment about
+leaf utilities that cannot carry a config. The durable fix is a small
+`DispatchPolicy` POD in `core/`, resolved once at init; until then this is the
+largest live layering inversion. (The one `core → compute` edge was removed in
+#1207 by making the cuda_static_reset hooks self-registering.)
 
 ## Concurrency / async model (HTTP → GPU bridge)
 


### PR DESCRIPTION
Docs-only. No source, no config, no build files.

## `docs/attention-dispatch.md` — the canonical routing doc quoted code that no longer exists

It inlined the prefill dispatch as a snippet. `force_cublas_attn` **does not exist** (`grep` returns nothing), and the quoted logic was **wrong about Gemma-4 for six weeks**: it said heterogeneous shapes force cuBLAS wholesale, when the gate is decided **per layer** — a Gemma-4 request takes FA2 on its hd=256 SWA layers and cuBLAS on its hd=512 global layers *in the same forward pass*.

Replaced the snippet with a table of the actual branches plus a pointer to the two source files. Quoted code rots; described behaviour does not. The doc's own line — *"If this doc and the code disagree, the code wins"* — was honest and also an admission that nothing kept them from disagreeing.

Three more corrections there:

- **The "0.0 % of prefill" measurement does not generalise.** It is real for hd=128/256. On Gemma-4 the "legacy" cuBLAS path is the **default** for half the layer stack, by design and by measurement (it beats the SMEM-capped fused hd=512 kernel), and the 384 MiB `attn_scores` workspace is retained for it. An advertised model was running the path the doc called dead.
- **Added the hd=512 sliced-cuBLAS tier** (#1036) — 3.4–3.9× faster than the fused hd=512 FMHA at Skv 8k/16k, and absent from the doc.
- **Added an MLA section.** DeepSeek-V2/V3 were missing entirely.
- Noted that since #1205 the resolved path is observable at runtime via the `Resolved dispatch:` line.

## `docs/audit/ARCHMAP.md` — two summaries overstated their mechanisms

- *"`backend.{h,cpp}` is the **only** code that talks to the driver about memory"*. I1 is a **ratchet**: `tools/alloc_allowlist.txt` grandfathers **74 files / 492 direct allocation sites**. The mechanism is genuinely good — the list only shrinks and the gate fails in *both* directions, on a new allocating file and on a listed file that stopped allocating — but the absolute phrasing was not true. Now states the number, the way `alloc_allowlist.txt`'s own header does.
- *"a few `compute/quant/memory → runtime` includes exist for diagnostics/PDL only (instrumentation, not algorithmic coupling)"*. True for `compute` (7 `pdl.h`, 12 `process_diag.h`). **`exec → runtime` is 27 files, 22 of them `runtime/config.h`** — `RuntimeConfig` is declared in the top layer and drives dispatch in the hot layer, which is *why* `process_diag` exists at all. Noted, with the `DispatchPolicy` POD as the durable fix, and that #1207 removed the one `core → compute` edge.

## `CLAUDE.md`

- `~100k LOC (src/ + include/)` → actual **~135k** (~220k with `tests/`).
- The env-var rule named two seeded vars; #1207 promoted `IMP_SPEC_TRACE` / `IMP_JUMP_TRACE` / `IMP_PPL_DUMP` to config keys, so the line now lists all five and where they land.

## Verification

`scripts/check-release.sh`: all gates pass, including the dead-`docs/…`-pointer check that would catch a broken cross-reference in the rewritten sections.

Stacked on nothing — touches only the three markdown files, none of which #1207 modifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B
