### PR TITLE
fix(runtime,compute,tests): the resolved-dispatch line never fired; F-8/F-12/F-14/F-18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ endif()
 set(IMP_RUNTIME_SOURCES
     src/runtime/config.cpp
     src/runtime/process_diag.cpp
+    src/runtime/graph_eligibility.cpp
     src/runtime/green_ctx.cu
     src/runtime/scheduler.cpp
     src/runtime/request.cpp
@@ -622,6 +623,10 @@ if(IMP_BUILD_TESTS)
         # Resolved-dispatch recorder (#1205). CPU-only: plain POD + name tables,
         # and it guards the "new tier prints '?' in the summary" gap.
         tests/test_dispatch_record.cpp
+        # Graph-demotion reason enum (F-14). CPU-only: the enum↔name binding is
+        # what makes "graphs=0(reason)" readable, and a new reason without a
+        # name would silently print "?".
+        tests/test_graph_eligibility.cpp
         # Public C enums vs their internal counterparts (#1206). A test file may
         # include both sides, which is the only place the two hand-maintained
         # copies of the arch/dtype numbering can be tied together.

--- a/src/compute/constrain_device_buffers.h
+++ b/src/compute/constrain_device_buffers.h
@@ -1,0 +1,125 @@
+#pragma once
+
+// The device buffers all four constrainers need (audit finding F-18).
+//
+// Deliberately separate from constrain_common.h: that header carries the JSON
+// category classifier and only compiles when the includer has already pulled in
+// the CAT_* flags, so grammar/ and regex/ — which have no categories — could not
+// include it. Buffers are not category logic.
+
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <utility>
+
+#include "core/logging.h"
+
+namespace imp {
+
+//
+// GrammarConstrainer, JsonConstrainer, RegexConstrainer and SchemaConstrainer
+// each declared their own `d_token_allow_` (and two of them their own
+// `d_token_categories_` / `d_allowed_mask_`), each with its own cudaMalloc, its
+// own cudaFree and its own failure convention — four lifetimes to get right for
+// one set of buffers, and four entries on the I1 allocation allowlist.
+//
+// The differences between the four were not design. Three nulled the pointer on
+// a failed allocation and one did not; one allocated the allow list lazily
+// inside apply_mask() until #1104, where a failure mid-decode returned without
+// masking and the request answered prose where JSON was promised.
+//
+// What is shared is the *storage*. The mask logic stays in the four classes —
+// they are genuinely different grammars, and merging them was rejected.
+//
+// Allocation happens at init and fails loudly, which is the invariant #1104
+// established: a constrainer that cannot mask must never look initialised.
+class ConstrainDeviceBuffers {
+public:
+    ConstrainDeviceBuffers() = default;
+    ~ConstrainDeviceBuffers() { free(); }
+
+    ConstrainDeviceBuffers(const ConstrainDeviceBuffers&) = delete;
+    ConstrainDeviceBuffers& operator=(const ConstrainDeviceBuffers&) = delete;
+
+    ConstrainDeviceBuffers(ConstrainDeviceBuffers&& o) noexcept { swap(o); }
+    ConstrainDeviceBuffers& operator=(ConstrainDeviceBuffers&& o) noexcept {
+        if (this != &o) {
+            free();
+            swap(o);
+        }
+        return *this;
+    }
+
+    // Per-token allow list, one byte per vocabulary entry.
+    [[nodiscard]] bool alloc_token_allow(const char* owner, int vocab_size) {
+        cudaError_t err = cudaMalloc(&d_token_allow_, static_cast<size_t>(vocab_size));
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("%s: failed to allocate the %d-token allow list: %s", owner, vocab_size,
+                          cudaGetErrorString(err));
+            d_token_allow_ = nullptr;  // three of the four did this; the fourth did not
+            return false;
+        }
+        return true;
+    }
+
+    // Per-token category bitmask, uploaded once and never mutated.
+    [[nodiscard]] bool alloc_categories(const char* owner, const uint16_t* host, int vocab_size) {
+        const size_t bytes = static_cast<size_t>(vocab_size) * sizeof(uint16_t);
+        cudaError_t err = cudaMalloc(&d_token_categories_, bytes);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("%s: failed to allocate device categories: %s", owner, cudaGetErrorString(err));
+            d_token_categories_ = nullptr;
+            return false;
+        }
+        err = cudaMemcpy(d_token_categories_, host, bytes, cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("%s: failed to copy categories to device: %s", owner, cudaGetErrorString(err));
+            return false;
+        }
+        return true;
+    }
+
+    // Single-word "which categories are allowed right now", rewritten per step.
+    [[nodiscard]] bool alloc_allowed_mask(const char* owner) {
+        cudaError_t err = cudaMalloc(&d_allowed_mask_, sizeof(uint16_t));
+        if (err != cudaSuccess) {
+            IMP_LOG_ERROR("%s: failed to allocate mask buffer: %s", owner, cudaGetErrorString(err));
+            d_allowed_mask_ = nullptr;
+            return false;
+        }
+        return true;
+    }
+
+    void free() {
+        if (d_token_categories_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(d_token_categories_));
+            d_token_categories_ = nullptr;
+        }
+        if (d_token_allow_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
+            d_token_allow_ = nullptr;
+        }
+        if (d_allowed_mask_) {
+            IMP_CUDA_CHECK_LOG(cudaFree(d_allowed_mask_));
+            d_allowed_mask_ = nullptr;
+        }
+    }
+
+    uint8_t* token_allow() const { return d_token_allow_; }
+    uint16_t* categories() const { return d_token_categories_; }
+    uint16_t* allowed_mask() const { return d_allowed_mask_; }
+
+    bool has_token_allow() const { return d_token_allow_ != nullptr; }
+
+private:
+    void swap(ConstrainDeviceBuffers& o) noexcept {
+        std::swap(d_token_allow_, o.d_token_allow_);
+        std::swap(d_token_categories_, o.d_token_categories_);
+        std::swap(d_allowed_mask_, o.d_allowed_mask_);
+    }
+
+    uint8_t* d_token_allow_ = nullptr;
+    uint16_t* d_token_categories_ = nullptr;
+    uint16_t* d_allowed_mask_ = nullptr;
+};
+
+}  // namespace imp

--- a/src/compute/grammar_constrain.cu
+++ b/src/compute/grammar_constrain.cu
@@ -21,12 +21,7 @@ __global__ void grammar_mask_kernel(float* __restrict__ logits, const uint8_t* _
 
 }  // namespace
 
-GrammarConstrainer::~GrammarConstrainer() {
-    if (d_token_allow_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
-        d_token_allow_ = nullptr;
-    }
-}
+GrammarConstrainer::~GrammarConstrainer() = default;
 
 bool GrammarConstrainer::init_grammar_only(const std::string& gbnf) {
     // The manager is pooled and reused across requests, so a new grammar lands
@@ -57,9 +52,7 @@ bool GrammarConstrainer::init(const std::string& gbnf, Tokenizer* tokenizer, int
         token_texts_[static_cast<size_t>(i)] = tokenizer->decode_token(static_cast<int32_t>(i));
     eos_ids_ = tokenizer->eos_ids();
 
-    if (cudaMalloc(&d_token_allow_, static_cast<size_t>(vocab_size)) != cudaSuccess) {
-        IMP_LOG_ERROR("GrammarConstrainer: failed to allocate the device allow mask");
-        d_token_allow_ = nullptr;
+    if (!dev_.alloc_token_allow("GrammarConstrainer", vocab_size)) {
         initialized_ = false;
         return false;
     }
@@ -141,18 +134,18 @@ const std::vector<uint8_t>& GrammarConstrainer::allow_for_current_state(int voca
 }
 
 void GrammarConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
-    if (!initialized_ || !d_token_allow_)
+    if (!initialized_ || !dev_.has_token_allow())
         return;
     if (preamble_.active())
         return;
 
     const std::vector<uint8_t>& allow = allow_for_current_state(vocab_size);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, allow.data(), static_cast<size_t>(vocab_size),
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(vocab_size),
                                        cudaMemcpyHostToDevice, stream));
 
     const int threads = 256;
     const int blocks = (vocab_size + threads - 1) / threads;
-    grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_allow_, vocab_size,
+    grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.token_allow(), vocab_size,
                                                         std::min(vocab_size, vocab_size_));
     IMP_CUDA_CHECK_LAUNCH();
 }

--- a/src/compute/grammar_constrain.h
+++ b/src/compute/grammar_constrain.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "compute/constrain_device_buffers.h"
+
 #include "compute/gbnf_grammar.h"
 #include "compute/preamble_gate.h"
 #include "model/tokenizer.h"
@@ -91,7 +93,7 @@ private:
 
     std::map<std::vector<int32_t>, std::vector<uint8_t>> mask_cache_;
 
-    uint8_t* d_token_allow_ = nullptr;
+    ConstrainDeviceBuffers dev_;
     PreambleGate preamble_;
 };
 

--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -15,20 +15,7 @@ namespace imp {
 // JsonConstrainer implementation
 // ============================================================================
 
-JsonConstrainer::~JsonConstrainer() {
-    if (d_token_categories_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_categories_));
-        d_token_categories_ = nullptr;
-    }
-    if (d_token_allow_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
-        d_token_allow_ = nullptr;
-    }
-    if (d_allowed_mask_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_allowed_mask_));
-        d_allowed_mask_ = nullptr;
-    }
-}
+JsonConstrainer::~JsonConstrainer() = default;
 
 bool JsonConstrainer::init(const Tokenizer& tok) {
     vocab_size_ = tok.vocab_size();
@@ -55,24 +42,11 @@ bool JsonConstrainer::init(const Tokenizer& tok) {
     }
 
     // Upload to device
-    cudaError_t err = cudaMalloc(&d_token_categories_, vocab_size_ * sizeof(uint16_t));
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("JsonConstrainer: failed to allocate device categories: %s", cudaGetErrorString(err));
+    if (!dev_.alloc_categories("JsonConstrainer", token_categories_.data(), vocab_size_))
         return false;
-    }
-    err = cudaMemcpy(d_token_categories_, token_categories_.data(), vocab_size_ * sizeof(uint16_t),
-                     cudaMemcpyHostToDevice);
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("JsonConstrainer: failed to copy categories to device: %s", cudaGetErrorString(err));
-        return false;
-    }
 
-    // Allocate mask buffer
-    err = cudaMalloc(&d_allowed_mask_, sizeof(uint16_t));
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("JsonConstrainer: failed to allocate mask buffer: %s", cudaGetErrorString(err));
+    if (!dev_.alloc_allowed_mask("JsonConstrainer"))
         return false;
-    }
 
     // Per-token allow list. Allocated HERE, not on first use (issue #1104).
     // The lazy version allocated it inside apply_mask() — i.e. mid-decode, on
@@ -84,13 +58,8 @@ bool JsonConstrainer::init(const Tokenizer& tok) {
     // fallback was taken. The three sibling constrainers (regex, grammar,
     // schema) have always allocated this at init and failed the load loudly;
     // this one was the outlier.
-    err = cudaMalloc(&d_token_allow_, static_cast<size_t>(vocab_size_));
-    if (err != cudaSuccess) {
-        IMP_LOG_ERROR("JsonConstrainer: failed to allocate the %d-token allow list: %s", vocab_size_,
-                      cudaGetErrorString(err));
-        d_token_allow_ = nullptr;
+    if (!dev_.alloc_token_allow("JsonConstrainer", vocab_size_))
         return false;
-    }
 
     reset();
     initialized_ = true;
@@ -587,7 +556,7 @@ static bool string_token_needs_simulation(const std::string& text) {
 }
 
 void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
-    if (!initialized_ || !d_token_categories_ || !d_allowed_mask_)
+    if (!initialized_ || !dev_.categories() || !dev_.allowed_mask())
         return;
 
     if (preamble_.active())
@@ -670,7 +639,7 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
                      std::to_underlying(current_state_));
     }
 
-    if (!d_token_allow_) {
+    if (!dev_.has_token_allow()) {
         // Unreachable after a successful initialize(), which is the point: a
         // constrainer that cannot mask must SAY so rather than let the request
         // decode unconstrained and look like a model that ignored the schema
@@ -690,16 +659,17 @@ void JsonConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t s
     // enough and copying the model width would run off the end of it.
     const size_t allow_bytes = std::min(static_cast<size_t>(vocab_size), static_cast<size_t>(vocab_size_));
     IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(d_token_allow_, token_allow_.data(), allow_bytes, cudaMemcpyHostToDevice, stream));
+        cudaMemcpyAsync(dev_.token_allow(), token_allow_.data(), allow_bytes, cudaMemcpyHostToDevice, stream));
 
     uint16_t any_mask = 0xFFFF;  // per-token allow already encodes the category mask
     IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(d_allowed_mask_, &any_mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+        cudaMemcpyAsync(dev_.allowed_mask(), &any_mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
 
     int threads = 256;
     int blocks = (vocab_size + threads - 1) / threads;
-    constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_,
-                                                                d_token_allow_, d_allowed_mask_, vocab_size,
+    constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.categories(),
+                                                                dev_.token_allow(), dev_.allowed_mask(),
+                                                                vocab_size,
                                                                 n_classified, /*use_token_allow=*/true);
     IMP_CUDA_CHECK_LAUNCH();
 }

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "compute/constrain_device_buffers.h"
+
 #include "compute/preamble_gate.h"
 #include "compute/json_schema.h"  // SchemaNode / RegexNfa
 #include "model/tokenizer.h"
@@ -138,7 +140,7 @@ public:
     // initialize() and never false again — the point of issue #1104, where it
     // was allocated lazily inside apply_mask() and a failure there produced a
     // silently UNCONSTRAINED reply instead of a refused one.
-    bool has_device_allow_list() const { return d_token_allow_ != nullptr; }
+    bool has_device_allow_list() const { return dev_.has_token_allow(); }
 
 private:
     bool initialized_ = false;
@@ -146,7 +148,6 @@ private:
 
     // Per-token category bitmask (host, copied to device at init)
     std::vector<uint16_t> token_categories_;
-    uint16_t* d_token_categories_ = nullptr;
 
     // Per-token decoded text (for FSM update)
     std::vector<std::string> token_texts_;
@@ -171,11 +172,10 @@ private:
     std::string partial_literal_;  // for tracking partial "true"/"false"/"null"
     std::string target_literal_;   // full expected literal
 
-    // Device buffer for allowed mask (1 uint16_t, stable address)
-    uint16_t* d_allowed_mask_ = nullptr;
-    // Per-token whole-token-validated allow list (host + device)
+    // Per-token whole-token-validated allow list (host side)
     std::vector<uint8_t> token_allow_;
-    uint8_t* d_token_allow_ = nullptr;
+    // categories + allowed-mask + token-allow, one lifetime (F-18)
+    ConstrainDeviceBuffers dev_;
     std::vector<int32_t> eos_ids_;
 
     // Preamble pass-through (reasoning models emit <think>...</think> first)

--- a/src/compute/regex_constrain.cu
+++ b/src/compute/regex_constrain.cu
@@ -23,12 +23,7 @@ __global__ void regex_mask_kernel(float* __restrict__ logits, const uint8_t* __r
 
 }  // namespace
 
-RegexConstrainer::~RegexConstrainer() {
-    if (d_token_allow_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
-        d_token_allow_ = nullptr;
-    }
-}
+RegexConstrainer::~RegexConstrainer() = default;
 
 // The shared engine is permissive about syntax it cannot honour: `(?=x)` parses
 // as an ordinary group and `^`/`$`/`\b` as literals, so a pattern using them
@@ -147,9 +142,7 @@ bool RegexConstrainer::init(const std::string& pattern, Tokenizer* tokenizer, in
         token_texts_[i] = tokenizer->decode_token(static_cast<int32_t>(i));
     eos_ids_ = tokenizer->eos_ids();
 
-    if (cudaMalloc(&d_token_allow_, vocab_size) != cudaSuccess) {
-        IMP_LOG_ERROR("RegexConstrainer: failed to allocate the device allow mask");
-        d_token_allow_ = nullptr;
+    if (!dev_.alloc_token_allow("RegexConstrainer", vocab_size)) {
         initialized_ = false;
         return false;
     }
@@ -250,18 +243,18 @@ const std::vector<uint8_t>& RegexConstrainer::allow_for_current_state(int vocab_
 }
 
 void RegexConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t stream) {
-    if (!initialized_ || !d_token_allow_)
+    if (!initialized_ || !dev_.has_token_allow())
         return;
     if (preamble_.active())
         return;
 
     const std::vector<uint8_t>& allow = allow_for_current_state(vocab_size);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, allow.data(), static_cast<size_t>(vocab_size),
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(vocab_size),
                                        cudaMemcpyHostToDevice, stream));
 
     const int threads = 256;
     const int blocks = (vocab_size + threads - 1) / threads;
-    regex_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_allow_, vocab_size,
+    regex_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.token_allow(), vocab_size,
                                                       std::min(vocab_size, vocab_size_));
     IMP_CUDA_CHECK_LAUNCH();
 }

--- a/src/compute/regex_constrain.h
+++ b/src/compute/regex_constrain.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "compute/constrain_device_buffers.h"
+
 #include "compute/json_schema.h"  // RegexNfa
 #include "compute/preamble_gate.h"
 #include "model/tokenizer.h"
@@ -98,7 +100,7 @@ private:
 
     std::map<std::vector<int>, std::vector<uint8_t>> mask_cache_;
 
-    uint8_t* d_token_allow_ = nullptr;
+    ConstrainDeviceBuffers dev_;
     PreambleGate preamble_;
 };
 

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -81,14 +81,7 @@ static const SchemaNode* xml_tool_params(const SchemaNode* root, const std::stri
 // Initialization
 // ---------------------------------------------------------------------------
 
-SchemaConstrainer::~SchemaConstrainer() {
-    if (d_token_categories_)
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_categories_));
-    if (d_token_allow_)
-        IMP_CUDA_CHECK_LOG(cudaFree(d_token_allow_));
-    if (d_allowed_mask_)
-        IMP_CUDA_CHECK_LOG(cudaFree(d_allowed_mask_));
-}
+SchemaConstrainer::~SchemaConstrainer() = default;
 
 bool SchemaConstrainer::init_grammar_for_test(std::unique_ptr<SchemaNode> schema) {
     schema_ = std::move(schema);
@@ -132,12 +125,12 @@ bool SchemaConstrainer::init(const Tokenizer& tok, std::unique_ptr<SchemaNode> s
     }
 
     // Upload to GPU
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_token_categories_, vocab_size_ * sizeof(uint16_t)));
-    IMP_CUDA_CHECK_LOG(cudaMemcpy(d_token_categories_, token_categories_.data(),
-                                  vocab_size_ * sizeof(uint16_t), cudaMemcpyHostToDevice));
-
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_token_allow_, vocab_size_ * sizeof(uint8_t)));
-    IMP_CUDA_CHECK_LOG(cudaMalloc(&d_allowed_mask_, sizeof(uint16_t)));
+    if (!dev_.alloc_categories("SchemaConstrainer", token_categories_.data(), vocab_size_))
+        return false;
+    if (!dev_.alloc_token_allow("SchemaConstrainer", vocab_size_))
+        return false;
+    if (!dev_.alloc_allowed_mask("SchemaConstrainer"))
+        return false;
 
     reset();
     initialized_ = true;
@@ -623,12 +616,12 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
                 token_allow_[e] = 1;
         uint16_t all_cats = 0xFFFF;
         IMP_CUDA_CHECK_LOG(
-            cudaMemcpyAsync(d_allowed_mask_, &all_cats, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size_ * sizeof(uint8_t),
+            cudaMemcpyAsync(dev_.allowed_mask(), &all_cats, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), token_allow_.data(), vocab_size_ * sizeof(uint8_t),
                                            cudaMemcpyHostToDevice, stream));
         int t = 256, b = (vocab_size + t - 1) / t;
-        constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
-                                                         d_allowed_mask_, vocab_size,
+        constrain_mask_allow_kernel<<<b, t, 0, stream>>>(d_logits, dev_.categories(), dev_.token_allow(),
+                                                         dev_.allowed_mask(), vocab_size,
                                                          /*n_classified=*/vocab_size_, /*use_allow=*/true);
         IMP_CUDA_CHECK_LAUNCH();
         return;
@@ -665,11 +658,11 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
 
     // Upload category mask
     IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(d_allowed_mask_, &cat_mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
+        cudaMemcpyAsync(dev_.allowed_mask(), &cat_mask, sizeof(uint16_t), cudaMemcpyHostToDevice, stream));
 
     // Upload token allow mask if needed
     if (need_token_allow_) {
-        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_token_allow_, token_allow_.data(), vocab_size_ * sizeof(uint8_t),
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), token_allow_.data(), vocab_size_ * sizeof(uint8_t),
                                            cudaMemcpyHostToDevice, stream));
     }
 
@@ -678,8 +671,9 @@ void SchemaConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t
     // vocab_size is the LOGITS width (model vocab); the category/allow buffers
     // only cover the tokenizer vocab — padding logits are masked via
     // n_classified (SafeTensors lm_head padding, see json_constrain.cu).
-    constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, d_token_categories_, d_token_allow_,
-                                                                d_allowed_mask_, vocab_size,
+    constrain_mask_allow_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.categories(),
+                                                                dev_.token_allow(), dev_.allowed_mask(),
+                                                                vocab_size,
                                                                 /*n_classified=*/vocab_size_,
                                                                 need_token_allow_);
     IMP_CUDA_CHECK_LAUNCH();

--- a/src/compute/schema_constrain.h
+++ b/src/compute/schema_constrain.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "compute/constrain_device_buffers.h"
+
 #include "compute/json_schema.h"
 #include "compute/preamble_gate.h"
 #include "model/tokenizer.h"
@@ -207,13 +209,12 @@ private:
 
     // Per-token classification (shared pattern with JsonConstrainer)
     std::vector<uint16_t> token_categories_;
-    uint16_t* d_token_categories_ = nullptr;
     std::vector<std::string> token_texts_;
 
     // Per-token allow mask for fine-grained control (key names, enum values)
     std::vector<uint8_t> token_allow_;
-    uint8_t* d_token_allow_ = nullptr;
-    uint16_t* d_allowed_mask_ = nullptr;
+    // categories + allowed-mask + token-allow, one lifetime (F-18)
+    ConstrainDeviceBuffers dev_;
     bool need_token_allow_ = false;
 
     // Schema FSM state

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -11,6 +11,7 @@
 #include "vision/qwen3vl_pipeline.h"
 #include "runtime/constraint_manager.h"
 #include "runtime/config.h"
+#include "runtime/graph_eligibility.h"
 #include "runtime/suffix_draft.h"
 #include "runtime/token_recycle_draft.h"
 #include "runtime/vram_budget.h"
@@ -572,6 +573,10 @@ private:
     bool dequant_done_ = false;
     // One-shot guard for the resolved-dispatch summary (#1205).
     bool dispatch_dump_done_ = false;
+    // Why CUDA graphs were turned off, if they were. First reason wins: a model
+    // demoted for pure-SSM layers that later also hits KV pressure was never
+    // graph-eligible in the first place, and that is the answer worth keeping.
+    GraphDemotionReason graph_demotion_ = GraphDemotionReason::None;
     // Balloon reservation for the mandatory native-NVFP4 decode caches
     // (CUTLASS SfAtom slab + nvfp4_moe). Held from right after weight
     // upload (before workspaces/KV consume the headroom) until just before
@@ -1100,6 +1105,18 @@ private:
     void finish_request(std::shared_ptr<Request>& req);
 
     // ── step() sub-phases ─────────────────────────────────────────────
+    // The real step body. step() is a thin wrapper so the resolved-dispatch
+    // summary runs on EVERY exit — the body has five early returns, and the
+    // graphs-ON decode path leaves through the first of them (#1205 placed the
+    // call before the final return, where decode almost never arrives).
+    [[nodiscard]] bool step_impl_();
+
+    // The single answer site for "are CUDA graphs off, and why" (F-14). Turns
+    // them off if they are still on, records the FIRST reason, and logs it in
+    // one format. Idempotent: calling it once graphs are already off keeps the
+    // original reason and logs nothing further.
+    void demote_graphs_(GraphDemotionReason reason);
+
     // Returns: 0 = no async graph active, 1 = still running (step returns true),
     //         -1 = graph exhausted/generation done (check scheduler for more work)
     int step_async_graph_resume();

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -578,10 +578,8 @@ void Engine::init_resolve_quant_flags_() {
         }
         // Gemma 4: CUDA graphs are fully enabled by default. The user can opt
         // out via [gemma4] no_graphs = true for bisecting regressions.
-        if (model_->config().overrides.gemma4.no_graphs) {
-            IMP_LOG_INFO("Gemma 4: disabling all CUDA graphs (gemma4.no_graphs=true)");
-            config_.use_cuda_graphs = false;
-        }
+        if (model_->config().overrides.gemma4.no_graphs)
+            demote_graphs_(GraphDemotionReason::Gemma4NoGraphs);
         // Enable MMVQ for all weight GEMMs — quantized matmul matching llama.cpp's
         // accumulation behavior, critical for 128-expert MoE precision.
         if (!model_->config().overrides.gemma4.force_mmvq) {

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -343,11 +343,8 @@ bool Engine::init_kv_cache() {
     // GDN-only models (Qwen3.5) are graph-compatible; pure SSM (Nemotron-H) is not yet.
     {
         has_pure_ssm_layers_ = model_->profile().has_pure_ssm;
-        if (has_pure_ssm_layers_ && config_.use_cuda_graphs) {
-            config_.use_cuda_graphs = false;
-            IMP_LOG_INFO("Mamba2 SSM layers detected: disabling CUDA graphs "
-                         "(recurrent state not yet graph-safe)");
-        }
+        if (has_pure_ssm_layers_)
+            demote_graphs_(GraphDemotionReason::PureSsmLayers);
     }
 
     // Dequant weights → FP16/FP8/NVFP4 caches

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -59,7 +59,23 @@ using engine_internal::free_prefill_buffers;
 // step() — main inference loop
 // =====================================================================
 
+// The resolved-dispatch summary must survive EVERY exit from the step body,
+// which is why the body is wrapped instead of ending with the call.
+//
+// #1205 put log_resolved_dispatch_once_() before the final `return` of step().
+// That is the one exit the decode path almost never takes: once the async
+// conditional graph loop is armed — the normal graphs-ON decode route — every
+// subsequent step() returns from the `async_result == 1` fast path below, so the
+// recorded decode tier was set and then never read. A full prefill+decode E2E run
+// on Qwen3.6-35B-A3B-NVFP4 printed no summary line at all. The feature built to
+// make silent routing visible was itself silent.
 bool Engine::step() {
+    const bool more = step_impl_();
+    log_resolved_dispatch_once_();
+    return more;
+}
+
+bool Engine::step_impl_() {
     // Fast path: async conditional graph loop completed on GPU.
     int async_result = step_async_graph_resume();
     if (async_result == 1)
@@ -104,9 +120,26 @@ bool Engine::step() {
         ensure_prefill_workspace(executor_.get());
     }
 
-    log_resolved_dispatch_once_();
-
     return scheduler_->has_pending() || scheduler_->active_count() > 0;
+}
+
+// The one answer site for graph eligibility (F-14).
+//
+// Eight sites across four TUs can turn graphs off. They stay where they are —
+// two of them depend on state that does not exist until weight upload and
+// warmup respectively — but they all route the *decision* through here, so the
+// reason survives the call and prints in the resolved-dispatch summary instead
+// of scrolling past in an init transcript.
+void Engine::demote_graphs_(GraphDemotionReason reason) {
+    if (!config_.use_cuda_graphs) {
+        // Already off. Keep the first reason: it is the one that describes the
+        // model, and a later demotion could not have taken effect anyway.
+        return;
+    }
+    config_.use_cuda_graphs = false;
+    graph_demotion_ = reason;
+    IMP_LOG_INFO("CUDA graphs disabled: %s%s", graph_demotion_reason_name(reason),
+                 graph_demotion_is_mid_run(reason) ? " (mid-run, one-way)" : "");
 }
 
 // One-shot summary of the kernels this model ACTUALLY resolved to (#1205).
@@ -149,8 +182,16 @@ void Engine::log_resolved_dispatch_once_() {
         snprintf(moe, sizeof(moe), "%s", moe_prefill_outer_name(r.moe_prefill_outer));
     }
 
-    IMP_LOG_INFO("Resolved dispatch: attn_prefill=%s attn_decode=%s moe_prefill=%s graphs=%d", prefill,
-                 attn_decode_path_name(r.attn_decode), moe, (int)config_.use_cuda_graphs);
+    // graphs=0 alone made the interesting case unreadable — "off" and "off
+    // because this model can never capture" are different facts (F-14).
+    char graphs[64];
+    if (config_.use_cuda_graphs)
+        snprintf(graphs, sizeof(graphs), "1");
+    else
+        snprintf(graphs, sizeof(graphs), "0(%s)", graph_demotion_reason_name(graph_demotion_));
+
+    IMP_LOG_INFO("Resolved dispatch: attn_prefill=%s attn_decode=%s moe_prefill=%s graphs=%s", prefill,
+                 attn_decode_path_name(r.attn_decode), moe, graphs);
 }
 
 // =====================================================================
@@ -1509,11 +1550,7 @@ void Engine::step_decode(cudaStream_t dec_stream) {
                         "KV cache >90%% full (%d/%d blocks free) — auto-enabling "
                         "StreamingLLM (sinks=%d, window=%d)",
                         st.free_blocks, st.total_blocks, n_sinks, win);
-                    if (config_.use_cuda_graphs) {
-                        IMP_LOG_WARN(
-                            "Disabling CUDA Graphs (block table mutates with StreamingLLM).");
-                        config_.use_cuda_graphs = false;
-                    }
+                    demote_graphs_(GraphDemotionReason::StreamingKvKvPressure);
                 }
             }
         }

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -45,10 +45,7 @@ bool Engine::init_weights() {
             IMP_LOG_INFO("Activation calibration ON — collecting per-channel activation magnitudes.");
             // The collector allocates an accumulator the first time it sees a
             // weight, which a graph capture rejects outright.
-            if (config_.use_cuda_graphs) {
-                IMP_LOG_INFO("Disabling CUDA Graphs while calibration is active.");
-                config_.use_cuda_graphs = false;
-            }
+            demote_graphs_(GraphDemotionReason::CalibrationActive);
         }
 
         if (config_.streaming_kv_enabled) {
@@ -74,12 +71,7 @@ bool Engine::init_weights() {
                     // begins; a CUDA graph captured against an old table
                     // would replay stale pointers. Re-capturing per step
                     // negates the graph's win, so disable graphs entirely.
-                    if (config_.use_cuda_graphs) {
-                        IMP_LOG_INFO(
-                            "Disabling CUDA Graphs while StreamingLLM is active "
-                            "(block table mutates per decode step).");
-                        config_.use_cuda_graphs = false;
-                    }
+                    demote_graphs_(GraphDemotionReason::StreamingKvConfigured);
                 } else {
                     IMP_LOG_WARN(
                         "StreamingLLM enabled but no sliding window configured "
@@ -263,7 +255,7 @@ bool Engine::init_weights() {
                     "selection. Set moe.prefetch_top_k high enough that the "
                     "captured top-K covers the router's hot set.");
             } else {
-                IMP_LOG_INFO("Disabling CUDA graphs: expert weights on host");
+                demote_graphs_(GraphDemotionReason::ExpertsOnHost);
                 IMP_LOG_INFO(
                     "  Tip: if model+KV fits in VRAM, set IMP_EXPERT_OVERHEAD_PCT=10 "
                     "(default 30) to upload ALL experts and re-enable CUDA graphs "
@@ -271,13 +263,10 @@ bool Engine::init_weights() {
                 IMP_LOG_INFO(
                     "  Or set moe.allow_graphs_under_offload=true (experimental) "
                     "to opt into captured decode under host-offload.");
-                config_.use_cuda_graphs = false;
             }
         }
-        if (runtime_config_.runtime.cuda_graphs == "never" && config_.use_cuda_graphs) {
-            IMP_LOG_INFO("Disabling CUDA graphs: runtime.cuda_graphs=never");
-            config_.use_cuda_graphs = false;
-        }
+        if (runtime_config_.runtime.cuda_graphs == "never")
+            demote_graphs_(GraphDemotionReason::ConfigNever);
         // MoE decode fast path is fully device-side (no D2H memcpy) — graph-safe.
         // Only MoE prefill paths use D2H sync for expert_offsets, but prefill is
         // never captured in CUDA graphs.

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -182,11 +182,8 @@ bool Engine::init_features() {
     // Pinned sample buffer for CUDA graphs
     if (!h_sample_pinned_) {
         h_sample_pinned_ = PinnedBuffer::acquire(cuda_host_pinned_allocator(), sizeof(int32_t));
-        if (h_sample_pinned_.empty()) {
-            IMP_LOG_WARN("pinned sample buffer unavailable — disabling CUDA graphs");
-            if (config_.use_cuda_graphs)
-                config_.use_cuda_graphs = false;
-        }
+        if (h_sample_pinned_.empty())
+            demote_graphs_(GraphDemotionReason::PinnedSampleBufUnavailable);
     }
     if (!decode_done_)
         (void)decode_done_.create(cudaEventDisableTiming);

--- a/src/runtime/graph_eligibility.cpp
+++ b/src/runtime/graph_eligibility.cpp
@@ -1,0 +1,33 @@
+#include "runtime/graph_eligibility.h"
+
+namespace imp {
+
+const char* graph_demotion_reason_name(GraphDemotionReason r) {
+    switch (r) {
+        case GraphDemotionReason::None:
+            return "none";
+        case GraphDemotionReason::ConfigNever:
+            return "runtime.cuda_graphs=never";
+        case GraphDemotionReason::Gemma4NoGraphs:
+            return "gemma4.no_graphs=true";
+        case GraphDemotionReason::PureSsmLayers:
+            return "mamba2_ssm_layers";
+        case GraphDemotionReason::CalibrationActive:
+            return "calibration_active";
+        case GraphDemotionReason::StreamingKvConfigured:
+            return "streaming_kv_configured";
+        case GraphDemotionReason::ExpertsOnHost:
+            return "experts_on_host";
+        case GraphDemotionReason::PinnedSampleBufUnavailable:
+            return "pinned_sample_buf_unavailable";
+        case GraphDemotionReason::StreamingKvKvPressure:
+            return "streaming_kv_kv_pressure";
+    }
+    return "?";
+}
+
+bool graph_demotion_is_mid_run(GraphDemotionReason r) {
+    return r == GraphDemotionReason::StreamingKvKvPressure;
+}
+
+}  // namespace imp

--- a/src/runtime/graph_eligibility.h
+++ b/src/runtime/graph_eligibility.h
@@ -1,0 +1,54 @@
+#pragma once
+
+// Why CUDA graphs are off for this engine (architecture audit, finding F-14).
+//
+// `config_.use_cuda_graphs` is a mutable bool that eight sites across four
+// translation units can turn off. All eight logged, so the demotion was
+// observable in a transcript — but "is this model graph-eligible, and why not"
+// had no single answer site, and the reason was gone by the time anything
+// downstream (the resolved-dispatch summary, a bug report, a benchmark) wanted
+// it.
+//
+// The audit proposed hoisting the seven init-time demotions into one resolver.
+// That is not implementable as stated: two of the seven inputs do not exist at
+// resolver time — the expert-offload decision is made during weight upload, and
+// the pinned-buffer demotion is the result of an allocation that failed at
+// warmup. Hoisting the other five would leave three answer sites instead of one,
+// which is the condition the finding is about.
+//
+// So the decision sites stay where their inputs are, and what is centralised is
+// the *answer*: every site calls Engine::demote_graphs_(reason), which records
+// the first reason, logs uniformly, and makes the reason readable afterwards.
+//
+// Deliberately header-only and dependency-free (no CUDA, no RuntimeConfig) so
+// the CPU test lane can cover the enum↔name binding without a GPU.
+
+namespace imp {
+
+enum class GraphDemotionReason {
+    None,  // graphs still enabled
+
+    // ── init-time ────────────────────────────────────────────────────
+    ConfigNever,                 // runtime.cuda_graphs = "never"
+    Gemma4NoGraphs,              // [gemma4] no_graphs = true (regression bisect knob)
+    PureSsmLayers,               // Mamba2 recurrent state is not graph-safe yet
+    CalibrationActive,           // the collector allocates on first sight of a weight
+    StreamingKvConfigured,       // block table mutates per decode step
+    ExpertsOnHost,               // MoE host-offload; captured decode would replay stale pointers
+    PinnedSampleBufUnavailable,  // pinned host buffer allocation failed at warmup
+
+    // ── mid-run ──────────────────────────────────────────────────────
+    // A one-way demotion taken while requests are in flight, not an init
+    // property of the model. Kept distinct precisely so it cannot be confused
+    // with a model that was never eligible.
+    StreamingKvKvPressure,  // KV cache >90% full → StreamingLLM auto-enabled
+};
+
+// Every enumerator has a name; a new reason that forgets one prints "?" and the
+// unit test fails rather than the summary line quietly degrading.
+const char* graph_demotion_reason_name(GraphDemotionReason r);
+
+// True for the reasons that are decided while requests are already running.
+bool graph_demotion_is_mid_run(GraphDemotionReason r);
+
+}  // namespace imp

--- a/tests/test_attention_paged_oracle.cu
+++ b/tests/test_attention_paged_oracle.cu
@@ -194,6 +194,17 @@ float ue4m3_to_f(uint8_t b) {
     return (float)v;
 }
 
+// UE8M0 (MXFP4-KV block scale): pure exponent, byte b means 2^(b-127), no
+// mantissa. Round the required scale UP to the next power of two — rounding
+// down would push the largest element of the group past E2M1's +-6 and clip it.
+uint8_t f_to_ue8m0(float s) {
+    if (!(s > 0.0f))
+        return 127;  // 2^0
+    int e = (int)std::ceil(std::log2(s)) + 127;
+    return (uint8_t)std::clamp(e, 0, 255);
+}
+float ue8m0_to_f(uint8_t b) { return std::ldexp(1.0f, (int)b - 127); }
+
 // ---------------------------------------------------------------------------
 // Build the F16 paged cache: [num_blocks, block_size, n_kv_heads, head_dim].
 // Identity block table. Returns flat half buffer.
@@ -476,8 +487,12 @@ struct PathINT4 {
 // Shared NVFP4 host quantize (scalar + TC use the same cache). per-(token,
 // kv_head, group-of-16) UE4M3 micro-scale + E2M1 nibble [head_dim/2]. A CORRECT
 // host quantize is mandatory — random-byte NVFP4 drives the scalar kernel NaN.
+// `ue8m0` switches the group-scale byte from UE4M3 (NVFP4) to UE8M0 (MXFP4-KV).
+// Everything else — group of 16, E2M1 nibble pairs, buffer layout — is shared;
+// per attention_paged.h the two caches are structurally identical and differ
+// only in scale-byte semantics.
 static std::vector<uint8_t> nvfp4_quant_kv(const PathCtx& c, const std::vector<half>& kv,
-                                           std::vector<uint8_t>& scales) {
+                                           std::vector<uint8_t>& scales, bool ue8m0 = false) {
     const int half_hd = c.head_dim / 2;
     const int sc_groups = c.head_dim / 16;
     const int sc_elems = c.num_blocks * BLOCK_SIZE * c.n_kv_heads * sc_groups;
@@ -496,8 +511,8 @@ static std::vector<uint8_t> nvfp4_quant_kv(const PathCtx& c, const std::vector<h
                 for (int d = 0; d < 16; d++)
                     amax = std::max(amax, std::fabs(__half2float(kv[src + g * 16 + d])));
                 float sc = amax > 0 ? amax / 6.0f : 1.0f;  // E2M1 max magnitude = 6
-                uint8_t sc_byte = f_to_ue4m3(sc);
-                float sc_q = ue4m3_to_f(sc_byte);
+                uint8_t sc_byte = ue8m0 ? f_to_ue8m0(sc) : f_to_ue4m3(sc);
+                float sc_q = ue8m0 ? ue8m0_to_f(sc_byte) : ue4m3_to_f(sc_byte);
                 if (sc_q <= 0.0f)
                     sc_q = 1.0f;
                 scales[sdst + g] = sc_byte;
@@ -573,6 +588,44 @@ struct PathNVFP4TC {
     }
 };
 
+// MXFP4-KV: reachable from both binaries via --kv-mxfp4 and kv_cache.dtype=mxfp4,
+// dispatched at exec/executor_attention_decode.cu, and until now the only
+// user-selectable KV dtype with no correctness oracle (audit finding F-8).
+//
+// The envelope is looser than NVFP4's on purpose: UE8M0 carries no mantissa, so
+// the group scale is rounded up to a power of two and up to half the E2M1 range
+// can go unused. That is a property of the format, not of the kernel.
+struct PathMXFP4KV {
+    static const char* name() { return "MXFP4-KV"; }
+    static bool strict() { return false; }
+    static float envelope() { return 0.12f; }
+    static ErrStats run(const PathCtx& c) {
+        std::vector<uint8_t> ks, vs;
+        auto Kq = nvfp4_quant_kv(c, *c.Kh, ks, /*ue8m0=*/true);
+        auto Vq = nvfp4_quant_kv(c, *c.Vh, vs, /*ue8m0=*/true);
+        const int half_hd = c.head_dim / 2;
+        void* d_k = up(Kq.data(), Kq.size());
+        void* d_v = up(Vq.data(), Vq.size());
+        void* d_ks = up(ks.data(), ks.size());
+        void* d_vs = up(vs.data(), vs.size());
+        Tensor K = raw_tensor(d_k, QType::MXFP4_KV, {c.num_blocks, BLOCK_SIZE, c.n_kv_heads, half_hd});
+        Tensor V = raw_tensor(d_v, QType::MXFP4_KV, {c.num_blocks, BLOCK_SIZE, c.n_kv_heads, half_hd});
+        Tensor O = c.O();
+        c.clear_o();
+        paged_attention_decode_mxfp4_kv(c.Q, K, V, O, (const uint8_t*)d_ks, (const uint8_t*)d_vs, c.d_bt,
+                                        c.d_ctx, BLOCK_SIZE, c.scale, c.kv_len, 0, 0.0f, c.stream,
+                                        c.num_blocks);
+        cudaStreamSynchronize(c.stream);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess) << "MXFP4-KV paged launch";
+        ErrStats e = err_stats(read_o(c.d_o, c.q_elems), *c.ref);
+        cudaFree(d_k);
+        cudaFree(d_v);
+        cudaFree(d_ks);
+        cudaFree(d_vs);
+        return e;
+    }
+};
+
 // ===========================================================================
 // TYPED_TEST over KV dtypes (R8 / audit Phase-2 R8: "TYPED_TEST over KV dtypes
 // in the paged oracle"). One typed fixture, one body; each KV dtype is a policy
@@ -639,7 +692,8 @@ protected:
     }
 };
 
-using KVDtypes = ::testing::Types<PathF16, PathFP8, PathINT8, PathINT4, PathNVFP4, PathNVFP4TC>;
+using KVDtypes =
+    ::testing::Types<PathF16, PathFP8, PathINT8, PathINT4, PathNVFP4, PathNVFP4TC, PathMXFP4KV>;
 TYPED_TEST_SUITE(PagedOracle, KVDtypes);
 
 // ===========================================================================
@@ -658,6 +712,7 @@ TYPED_TEST_SUITE(PagedOracle, KVDtypes);
 //   INT4       0.0609    0.0474    0.0193    0.0096    0.10
 //   NVFP4      0.0670    0.0251    0.0134    0.0072    0.11
 //   NVFP4-TC   0.0670    0.0251    0.0133    0.0072    0.11  (tracks scalar)
+//   MXFP4-KV   0.0801    0.0362    0.0251    0.0163    0.12  (MEASURED 2026-08-03)
 //
 // Findings (real):
 //   * Monotone improvement with kv_len — confirms the #512 mechanism in the
@@ -671,6 +726,11 @@ TYPED_TEST_SUITE(PagedOracle, KVDtypes);
 //     documented trap). The no-NaN guard is the load-bearing decode assert.
 //   * NVFP4 scalar and NVFP4-TC agree to <2e-4 — the tensor-core Q.K dot is
 //     numerically equivalent to the scalar dot on this data.
+//   * MXFP4-KV sits ~20% above NVFP4 at every kv_len (0.0801 vs 0.0670 at 16)
+//     and follows the same monotone dilution. That gap is the format, not the
+//     kernel: UE8M0 has no mantissa, so the group scale rounds up to a power of
+//     two and up to half of E2M1's range can go unused. Same layout, same
+//     kernel structure, one coarser scale byte.
 //   * F16 paged tracks fp64 at <2.5e-4, four orders under its 1e-2 budget —
 //     the decode F16 path has no hidden score-precision tax.
 // ===========================================================================

--- a/tests/test_graph_eligibility.cpp
+++ b/tests/test_graph_eligibility.cpp
@@ -1,0 +1,78 @@
+// Graph-demotion reasons (audit finding F-14).
+//
+// Eight sites across four TUs can turn CUDA graphs off. They now route through
+// Engine::demote_graphs_(), which records the reason so the resolved-dispatch
+// summary can print `graphs=0(mamba2_ssm_layers)` instead of a bare `graphs=0`.
+//
+// That readback is only worth anything if every reason has a name: a new
+// enumerator without a switch arm prints "?" and turns the informative half of
+// the line back into noise. That is the failure this file catches.
+//
+// CPU-only by design — runtime/graph_eligibility.h is deliberately free of CUDA,
+// RuntimeConfig and Engine so this can run in the unit lane.
+
+#include "runtime/graph_eligibility.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace imp;
+
+namespace {
+
+// Keep in lock-step with runtime/graph_eligibility.h.
+const GraphDemotionReason kAll[] = {
+    GraphDemotionReason::None,
+    GraphDemotionReason::ConfigNever,
+    GraphDemotionReason::Gemma4NoGraphs,
+    GraphDemotionReason::PureSsmLayers,
+    GraphDemotionReason::CalibrationActive,
+    GraphDemotionReason::StreamingKvConfigured,
+    GraphDemotionReason::ExpertsOnHost,
+    GraphDemotionReason::PinnedSampleBufUnavailable,
+    GraphDemotionReason::StreamingKvKvPressure,
+};
+
+}  // namespace
+
+// A reason added without a switch arm would print "?" in the dispatch summary.
+TEST(GraphEligibility, EveryReasonHasAName) {
+    for (GraphDemotionReason r : kAll) {
+        const char* name = graph_demotion_reason_name(r);
+        ASSERT_NE(name, nullptr);
+        EXPECT_STRNE(name, "?") << "GraphDemotionReason value " << static_cast<int>(r)
+                                << " has no name — it would print '?' in 'Resolved dispatch: graphs=0(?)'";
+        EXPECT_GT(std::string(name).size(), 0u);
+    }
+}
+
+// Two reasons sharing a name make the summary ambiguous exactly when it matters
+// (telling "never eligible" apart from "demoted under pressure").
+TEST(GraphEligibility, NamesAreDistinct) {
+    std::set<std::string> seen;
+    for (GraphDemotionReason r : kAll) {
+        std::string name = graph_demotion_reason_name(r);
+        EXPECT_TRUE(seen.insert(name).second) << "duplicate reason name: " << name;
+    }
+}
+
+// The mid-run demotion is a one-way state change taken while requests are in
+// flight; the audit asked for it to stay distinguishable from the init-time
+// reasons, which describe the model itself.
+TEST(GraphEligibility, OnlyKvPressureIsMidRun) {
+    for (GraphDemotionReason r : kAll) {
+        const bool expected = (r == GraphDemotionReason::StreamingKvKvPressure);
+        EXPECT_EQ(graph_demotion_is_mid_run(r), expected)
+            << "mid-run classification wrong for " << graph_demotion_reason_name(r);
+    }
+}
+
+// `None` is the "graphs still on" sentinel — if it ever read as a demotion the
+// summary would claim a reason for an engine that never lost graphs.
+TEST(GraphEligibility, NoneIsNotMidRunAndNamesItself) {
+    EXPECT_FALSE(graph_demotion_is_mid_run(GraphDemotionReason::None));
+    EXPECT_STREQ(graph_demotion_reason_name(GraphDemotionReason::None), "none");
+}

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -5,11 +5,12 @@
 # be justified in review; the gate fails on any file that allocates and is
 # not listed, and equally on any listed file that no longer allocates.
 #
-# remaining: 74 files, 492 sites
+# remaining: 71 files, 482 sites
 
 src/compute/attention_cublas.cu  # 14
 src/compute/attention_fmha_sm120.cu  # 2
 src/compute/attention_mxfp4_prefill.cu  # 8
+src/compute/constrain_device_buffers.h  # 6
 src/compute/encoder_forward.cu  # 5
 src/compute/gdn.cu  # 2
 src/compute/gemm.cu  # 4
@@ -19,19 +20,15 @@ src/compute/gemm_cutlass_sm120.cu  # 2
 src/compute/gemm_grouped.cu  # 6
 src/compute/gemm_grouped_nvfp4_smallM.cu  # 24
 src/compute/gemm_moe_fused_tc.cu  # 1
-src/compute/grammar_constrain.cu  # 2
-src/compute/json_constrain.cu  # 6
 src/compute/mmq_q4k_imma_tile.cu  # 6
 src/compute/mmq_q8_imma.cu  # 3
 src/compute/mmq_q8_imma_scratch.cu  # 4
 src/compute/moe_routing.cu  # 12
 src/compute/mtp_forward.cu  # 12
 src/compute/quantize_fp16_nvfp4_moe_native.cu  # 6
-src/compute/regex_constrain.cu  # 2
 src/compute/sampling.cu  # 1
 src/compute/sampling_penalties.cu  # 2
 src/compute/sampling_topk_topp.cu  # 3
-src/compute/schema_constrain.cu  # 6
 src/core/buffer.cpp  # 2
 src/exec/executor.cu  # 2
 src/exec/executor_attention.cu  # 4


### PR DESCRIPTION
Four items off the audit roadmap — and the bug the first of them found in my own #1205.

## 0. The `Resolved dispatch:` line has never printed

#1205 added a one-shot summary of the kernels a model actually resolved to, and put the call **before the final `return` of `Engine::step()`**. That is the one exit the decode path almost never takes:

```
bool Engine::step() {
    int async_result = step_async_graph_resume();
    if (async_result == 1) return true;          // <-- graphs-ON decode leaves HERE, every step
    ...
    log_resolved_dispatch_once_();               // <-- five early returns above it
```

Once the async conditional graph loop is armed — the normal graphs-ON decode route — every subsequent `step()` returns from the first fast path. The prefill tier was recorded, the decode tier was recorded, and nothing ever read them.

Found by running a full prefill+decode E2E on Qwen3.6-35B-A3B-NVFP4 and grepping for the line: **zero hits**. The feature built to make silent routing visible was itself silent.

`step()` is now a thin wrapper around `step_impl_()`, so the summary cannot be bypassed by any exit. Confirmed on the same model:

```
Resolved dispatch: attn_prefill=fa2_fp16qk attn_decode=paged_fp16 moe_prefill=cutlass3x → device_args graphs=1
```

## 1. F-17 — measured, and it does not reproduce (no code change)

Open question #1 of the audit: *is the NVFP4 grouped-MoE CUTLASS GEMM actually non-deterministic?* It does not consult `process_diag_deterministic_gemm()` — that part of the finding is correct and unchanged.

`DetEvalE2ETest` on **Qwen3.6-35B-A3B-NVFP4** with `IMP_DETERMINISTIC=1`: **3/3 green**, greedy output and teacher-forced perplexity bit-identical.

The line above is what makes that evidence rather than assertion — it shows the run went through `moe_prefill=cutlass3x → device_args`, i.e. the exact kernel the finding names. Without the fix in §0 I could not have told whether the test had even reached that path.

**Scope of the claim:** same-context repeats, which is the server steady state. The across-fresh-contexts case is the pre-existing `DISABLED_` pair and is documented flaky on the GDN hybrid; this run says nothing new about it. So the high-stakes branch of the open question ("golden-output regression testing is impossible for the reference config") does not materialise, and the residual is a documentation item.

## 2. F-8 — MXFP4-KV had no oracle

Reachable from both binaries via `--kv-mxfp4` / `kv_cache.dtype=mxfp4`, dispatched at `executor_attention_decode.cu`, and the only user-selectable KV dtype with no correctness test. Added as a seventh policy type to the existing typed sweep.

Measured against the fp64 reference, worst across GQA 32x8 and MHA 8x8:

| kv_len | 16 | 64 | 333 | 1024 | envelope |
|---|---|---|---|---|---|
| NVFP4 | 0.0670 | 0.0251 | 0.0134 | 0.0072 | 0.11 |
| **MXFP4-KV** | **0.0801** | **0.0362** | **0.0251** | **0.0163** | **0.12** |

The kernel is correct. MXFP4-KV sits ~20 % above NVFP4 at every length and follows the same monotone dilution with context — that gap is the *format*: UE8M0 carries no mantissa, so the group scale rounds up to a power of two and part of E2M1's range goes unused. Envelope set by the file's own convention (worst observed + ~50 %).

## 3. F-14 — one answer site for "why are graphs off"

Eight sites across four TUs set `config_.use_cuda_graphs = false`. All eight logged, so it was observable in a transcript — but nothing could answer the question afterwards, and `graphs=0` in the dispatch summary could not distinguish "off" from "this model can never capture".

**The audit's proposal was to hoist the seven init-time demotions into one resolver. That is not implementable as stated** and I did not do it: two of the seven inputs do not exist at resolver time — the expert-offload decision is made during weight upload, and the pinned-buffer demotion is the *result* of an allocation that failed at warmup. Hoisting the other five would have left three answer sites instead of one, which is the condition the finding is about.

So the decision sites stay where their inputs are, and the **answer** is centralised: every site calls `demote_graphs_(reason)`, first reason wins, one log format, and the summary prints `graphs=0(mamba2_ssm_layers)`. The mid-run KV-pressure demotion stays a distinct enumerator, as the finding asked.

## 4. F-18 — four private copies of the same device buffers

`d_token_allow_` was declared in all four constrainer headers, `d_token_categories_` and `d_allowed_mask_` in two each — four cudaMalloc/cudaFree lifetimes for one set of buffers.

The differences between them were not design: three nulled the pointer on a failed allocation and one did not, and `SchemaConstrainer` logged a failed `cudaMalloc` and carried on with a null pointer. They now share `ConstrainDeviceBuffers`, which allocates at init and fails loudly — the invariant #1104 established after a lazy allocation failure produced a silently *unconstrained* reply.

The mask logic stays in the four classes; merging the FSMs was rejected and stays rejected.

It lives in its own header rather than `constrain_common.h`, because that header only compiles when the includer has already pulled in the `CAT_*` flags — grammar/ and regex/ have no categories and could not include it. Buffers are not category logic.

**I1 ratchet: 74 files / 492 sites → 71 / 482.** The gate caught both directions of the move (new file allocating, four listed files no longer allocating), which is exactly what it exists for.

## Verification

- `make dev-test` (CI's `ctest -L unit`): green, 4/4.
- `test-attention PagedOracle/*`: 7/7 green, MXFP4-KV included.
- `test-moe-gdn` 143 passed / 1 skipped, `test-core` 851/6 skipped, `test-text` 193/1 skipped — all skips model-gated, no failures.
- Gates: `check_alloc_sites` OK after the allowlist update · `check_launch_guards` 407/407 · `check_filesize` violations=0.
- clang-format on changed lines only: clean.

**Mutation-validated** (green proves nothing here):

| mutation | result |
|---|---|
| drop the `StreamingKvKvPressure` switch arm | RED — "would print '?' in graphs=0(?)" |
| `graph_demotion_is_mid_run` → always false | RED — `OnlyKvPressureIsMidRun` |
| MXFP4-KV host quantize uses UE4M3 instead of UE8M0 | RED — max_rel 0.2319 vs 0.12 envelope |

I also caught a filter that matched nothing: `*PagedOracle*MXFP4*` silently ran **0 tests** because TYPED_TESTs are named by index. The numbers above are from `PagedOracle/6.*`.

**`make verify-fast` did NOT run against this branch.** The perf gate is currently red on `main` for an unrelated reason — the 287.19 decode pin (26.07., #1079) is not reachable on this host: an alternating A/B against v0.20.2 built and measured in the same host state reads **266.13 vs 264.03 (−0.79 %)**, with both arms ~7-8 % under the pin. That is a stale pin, not a regression, and re-pinning belongs on a quiet host rather than in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B