### PR TITLE
fix(compute,memory,ci,tests): F-3 coupling + tier precedence, residual reporting, GPU lane schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,19 @@ on:
   # squashed), but the branch's reported status is stale, and this makes it
   # refreshable without a PAT or a merge queue.
   workflow_dispatch:
+  # Nightly, 03:17 UTC. Two jobs at once:
+  #
+  #  1. The GPU lane (`test`, below) is the only lane that runs the full ctest,
+  #     compute-sanitizer and the perf gate. It is gated on a self-hosted runner,
+  #     and a runner that only ever sees push/pull_request events tests whatever
+  #     someone happened to open a PR for — never `main` on its own schedule.
+  #  2. It refreshes `main`'s reported status, which the workflow_dispatch note
+  #     above exists to work around by hand: an auto-merge squash does not start
+  #     a run, so main's newest result can be many commits stale.
+  #
+  # Costs nothing while HAS_GPU_RUNNER is unset beyond one nightly CPU build.
+  schedule:
+    - cron: "17 3 * * *"
 
 jobs:
   build:
@@ -394,9 +407,19 @@ jobs:
   test:
     name: Test
     needs: build
-    # GPU tests need a self-hosted runner with NVIDIA GPU. Set the repo variable
-    # HAS_GPU_RUNNER=true (Settings → Secrets and variables → Actions → Variables)
-    # once a runner labeled [self-hosted, gpu, cuda] is registered. Until then,
+    # GPU tests need a self-hosted runner with NVIDIA GPU. To turn this lane on:
+    #
+    #   1. On the GPU box: Settings → Actions → Runners → New self-hosted runner,
+    #      and give it the labels  self-hosted, gpu, cuda  (all three; the
+    #      runs-on below requires the full set).
+    #   2. Settings → Secrets and variables → Actions → Variables → new variable
+    #      HAS_GPU_RUNNER = true.
+    #   3. Optional: set IMP_MODELS_DIR on the runner to the directory holding
+    #      the baseline GGUF, or the perf gate below skips instead of running.
+    #
+    # This is the only lane that runs the full ctest, compute-sanitizer and the
+    # perf gate — everything else in CI is CPU-only. Until step 2, the job is
+    # skipped rather than failing. Until then,
     # this job is skipped — same effective behavior as the prior `if: false`,
     # but flips automatically when a runner appears. Also skipped on docs-only
     # changes (build uploads no artifact then — nothing to download/test).

--- a/src/compute/attention_dispatch.cu
+++ b/src/compute/attention_dispatch.cu
@@ -12,6 +12,7 @@
 #include "compute/attention_fmha_mxfp4_sm120.h"
 #include "compute/attention_mxfp4_prefill.h"
 #include "compute/dispatch_record.h"
+#include "compute/attention_dispatch_decision.h"
 
 namespace imp {
 
@@ -30,24 +31,64 @@ int get_device_sm_version() {
     return cached_sm_version;
 }
 
-// NOTE: the path-selection ORDER + config gates below are mirrored as a pure
-// host function `select_attn_prefill_path` in attention_dispatch_decision.h and
-// pinned by test_routing_decision.cpp (R2 / P1.4). The kernels are
-// called lazily here (each launches on accept, falls through on decline), so
-// this can't simply delegate to the pure function — but any reorder or gate
-// change MUST be reflected in that header or the unit test will diverge.
+// The path-selection ORDER + config gates below are mirrored as a pure host
+// function `select_attn_prefill_path` in attention_dispatch_decision.h.
+//
+// That mirror used to be TEST-ONLY: test_routing_decision.cpp was its sole
+// includer, so a reorder here left the test green and its stated purpose ("any
+// reorder or gate change shows up as a diff") unmet — audit finding F-3.
+//
+// This function now CONSULTS it. Each tier records the two booleans it already
+// discovers — did the config gate pass, did the kernel accept — and once a tier
+// wins, the model is replayed against those observations and must name the same
+// winner. A gate that drifts apart, a tier added here and not there, or a
+// reorder that moves a NON-accepting tier earlier now fires a loud one-shot
+// divergence log instead of nothing.
+//
+// KNOWN LIMIT, stated rather than implied: a tier reordered ahead of the winner
+// that WOULD have accepted is still invisible, because the dispatch short-
+// circuits and never asks it. Closing that needs a real `*_supports()` predicate
+// per kernel that the launcher itself consults — the kernels signal acceptance
+// by executing, and two of FA2's seven decline points depend on the tile
+// selection, so a predicate written beside them would be a THIRD copy of the
+// rules. That is a five-TU refactor of the hottest prefill kernel and is not
+// done here.
+// One-shot so a divergence cannot flood a serving log; the first occurrence is
+// the one that matters and it names both answers.
+static void verify_against_routing_model(const RuntimeConfig& rcfg, const AttnKernelSupport& sup,
+                                         bool has_sinks, AttnPrefillPath chosen) {
+    const AttnPrefillPath modeled = select_attn_prefill_path(rcfg, sup, has_sinks);
+    if (modeled == chosen)
+        return;
+    static bool warned = false;
+    if (warned)
+        return;
+    warned = true;
+    IMP_LOG_ERROR(
+        "attention routing model disagrees with the dispatch: dispatch ran %s, "
+        "select_attn_prefill_path() says %s. attention_dispatch.cu and "
+        "attention_dispatch_decision.h have drifted apart (F-3) — the routing unit "
+        "test is now describing a dispatch that does not exist.",
+        attn_prefill_path_name(chosen), attn_prefill_path_name(modeled));
+}
+
 void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& V, Tensor& O, float scale,
                                 bool causal, int sliding_window, float softcap, cudaStream_t stream,
                                 const RuntimeConfig& rcfg, int q_offset, const half* attn_sinks) {
+    // Observations, filled in as the chain is walked. A tier the chain never
+    // reaches keeps its `false` — see the KNOWN LIMIT above.
+    AttnKernelSupport sup{};
+    const bool has_sinks = (attn_sinks != nullptr);
     // Learned attention sinks (gpt-oss #547/#992): only the FP16 WMMA FMHA
     // tier folds them into its online softmax. Route straight there and fail
     // loudly on decline — falling through to a sink-blind kernel produces
     // silently wrong output (the pre-#992 executor WARN case).
-    if (attn_sinks != nullptr) {
+    if (has_sinks) {
         if (rcfg.attention.fmha_sm120 != "never" &&
-            fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
-                               attn_sinks)) {
+            (sup.fmha_sm120_accepts = fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window,
+                                                         softcap, stream, q_offset, attn_sinks))) {
             dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FMHA_SM120);
+            verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::FMHA_SM120);
             return;
         }
         char msg[160];
@@ -63,10 +104,13 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     // Enabled with [attention] mxfp4 = "always". Blockscale/ksmooth/pv_fp4
     // (#846 SageAttention3-recipe spike) are read from process_diag inside
     // the launcher.
-    if (attention_mxfp4_available()) {
-        if (fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
-                                     process_diag_mxfp4_blockscale(), q_offset)) {
+    sup.mxfp4_available = attention_mxfp4_available();
+    if (sup.mxfp4_available) {
+        if ((sup.mxfp4_accepts = fmha_sm120_mxfp4_prefill(Q, K, V, O, scale, causal, sliding_window,
+                                                          softcap, stream,
+                                                          process_diag_mxfp4_blockscale(), q_offset))) {
             dispatch_record::set_attn_prefill_tier(AttnPrefillPath::MXFP4);
+            verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::MXFP4);
             return;
         }
         // Fall through: head_dim not supported (e.g. < 32), use FP8/FP16 path
@@ -81,9 +125,11 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     if (rcfg.attention.fmha_fa2 == "on") {
         const bool fa2_fp8_optin =
             rcfg.attention.fa2_fp16qk == "never" && rcfg.attention.fp8_fmha == "on";
-        if (fmha_sm120_fa2_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset,
-                                   /*fp16_qk=*/!fa2_fp8_optin)) {
+        if ((sup.fa2_accepts = fmha_sm120_fa2_prefill(Q, K, V, O, scale, causal, sliding_window, softcap,
+                                                     stream, q_offset,
+                                                     /*fp16_qk=*/!fa2_fp8_optin))) {
             dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FA2);
+            verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::FA2);
             IMP_LOG_DEBUG("FMHA dispatch: using FA2 register-resident kernel (hd=%d)",
                           static_cast<int>(Q.shape[3]));
             return;
@@ -97,10 +143,11 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     // gemma-3-12b 16.6 -> 549 / Qwen3-8B 40.5 -> 4506 when this kernel actually
     // serves prefill. Strictly opt-in: [attention] fp8_fmha = "on".
     if (rcfg.attention.fp8_fmha == "on") {
-        bool fp8_ok = fmha_sm120_fp8_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream,
-                                              q_offset);
-        if (fp8_ok) {
+        sup.fp8_accepts = fmha_sm120_fp8_prefill(Q, K, V, O, scale, causal, sliding_window, softcap,
+                                                 stream, q_offset);
+        if (sup.fp8_accepts) {
             dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FP8);
+            verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::FP8);
             IMP_LOG_DEBUG("FMHA dispatch: using FP8 sm120 kernel (hd=%d)", static_cast<int>(Q.shape[3]));
             return;
         }
@@ -110,8 +157,10 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     // Fallback when FP8 is disabled or unsupported config.
     const bool use_fmha_sm120 = rcfg.attention.fmha_sm120 != "never";
     if (use_fmha_sm120) {
-        if (fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+        if ((sup.fmha_sm120_accepts =
+                 fmha_sm120_prefill(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset))) {
             dispatch_record::set_attn_prefill_tier(AttnPrefillPath::FMHA_SM120);
+            verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::FMHA_SM120);
             return;
         }
     }
@@ -119,8 +168,10 @@ void attention_prefill_dispatch(const Tensor& Q, const Tensor& K, const Tensor& 
     // Final tier: WMMA 128x64 tiles for Blackwell. Declines (returns false)
     // for unsupported configs — hd ∉ {64,96,128,256} or smem over the device
     // opt-in (hd=256 at Br=64 needs ~176 KB vs 99 KB on sm_120).
-    if (flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window, softcap, stream, q_offset)) {
+    if ((sup.blackwell_accepts = flash_attention_blackwell(Q, K, V, O, scale, causal, sliding_window,
+                                                           softcap, stream, q_offset))) {
         dispatch_record::set_attn_prefill_tier(AttnPrefillPath::BLACKWELL);
+        verify_against_routing_model(rcfg, sup, has_sinks, AttnPrefillPath::BLACKWELL);
         return;
     }
 

--- a/src/memory/mem_account.cu
+++ b/src/memory/mem_account.cu
@@ -301,11 +301,28 @@ void MemAccount::report(const char* phase_label) {
             named += static_cast<int64_t>(named_arena_);
         }
 
+        // The headline number of the whole attribution campaign, so it has to
+        // say what it is labelled. It did not: the percentage printed on the
+        // RESIDUAL line was 100*(1 - residual/used) — the ACCOUNTED share — so
+        // an over-count rendered as "RESIDUAL (unattributed) -38246.8 MiB,
+        // 230.3% of device used". Both halves now belong to their own line.
+        //
+        // `cur_sum` can exceed `used` legitimately: pools report their own live
+        // bytes, and a pool that suballocates from an arena is counted by both.
+        // When that happens the residual goes negative, which is a real signal
+        // (double-counting) and not a rounding artifact — so it is named rather
+        // than clamped to zero.
         const double accounted = double(cur_sum) + double(named);
         const double residual = double(used) - accounted;
-        emit("%-26s %12.1f", "ACCOUNTED (tracked+named)", accounted / kMiB);
+        const double used_d = double(used);
+        emit("%-26s %12.1f    %.1f%% of device used", "ACCOUNTED (tracked+named)", accounted / kMiB,
+             used ? (100.0 * accounted / used_d) : 0.0);
         emit("%-26s %12.1f    %.1f%% of device used", "RESIDUAL (unattributed)", residual / kMiB,
-             used ? (100.0 * (1.0 - residual / double(used))) : 0.0);
+             used ? (100.0 * residual / used_d) : 0.0);
+        if (residual < 0.0)
+            emit("%-26s %s", "  NOTE",
+                 "residual < 0 — pools sum above device usage, i.e. at least one "
+                 "region is counted twice (suballocation reported by both owner and pool).");
     }
     emit("===== END VRAM AUDIT [%s] =====", phase_label ? phase_label : "?");
 

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -177,23 +177,20 @@ TEST(MoePrefillTable, GptOssSkipsDeviceArgsTakesGrouped) {
 TEST(MoePrefillTable, DeviceArgsDisabledFallsToGrouped) {
     auto cfg = default_cfg();
     cfg.moe.nvfp4_device_args = false;
-    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
-              MoePrefillPath::GROUPED);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()), MoePrefillPath::GROUPED);
 }
 
 TEST(MoePrefillTable, DeviceArgsWorkspaceNotReadyFallsToGrouped) {
     auto ws = all_ready();
     ws.device_args_ready = false;
-    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, default_cfg(), ws),
-              MoePrefillPath::GROUPED);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, default_cfg(), ws), MoePrefillPath::GROUPED);
 }
 
 TEST(MoePrefillTable, SmallMWhenOptedInAndUnderThreshold) {
     auto cfg = default_cfg();
     cfg.moe.nvfp4_device_args = false;  // so device-args doesn't win first
     cfg.moe.nvfp4_smallM = true;
-    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
-              MoePrefillPath::SMALL_M);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()), MoePrefillPath::SMALL_M);
 }
 
 TEST(MoePrefillTable, SmallMOverThresholdFallsToGrouped) {
@@ -208,8 +205,7 @@ TEST(MoePrefillTable, SmallMOverThresholdFallsToGrouped) {
 TEST(MoePrefillTable, NoCutlass3xFallsToLegacy) {
     auto cfg = default_cfg();
     cfg.moe.no_cutlass3x = true;
-    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()),
-              MoePrefillPath::LEGACY);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, all_ready()), MoePrefillPath::LEGACY);
 }
 
 TEST(MoePrefillTable, GroupedUnavailableFallsToLegacy) {
@@ -232,8 +228,7 @@ TEST(MoePrefillTable, GptOssNoCutlass3xFallsToLegacy) {
     // Even gpt-oss drops to legacy when the grouped kernel is unavailable.
     auto cfg = default_cfg();
     cfg.moe.no_cutlass3x = true;
-    EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, all_ready()),
-              MoePrefillPath::LEGACY);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, all_ready()), MoePrefillPath::LEGACY);
 }
 
 // ---- #992: learned-sink pre-gate ------------------------------------------
@@ -250,13 +245,146 @@ TEST(AttnDispatchTable, SinksWithFMHADeclineIsNoneNotBlackwell) {
     // dispatcher throws (NONE), it must NOT fall through to Blackwell.
     auto sup = all_accept();
     sup.fmha_sm120_accepts = false;
-    EXPECT_EQ(select_attn_prefill_path(default_cfg(), sup, /*has_sinks=*/true),
-              AttnPrefillPath::NONE);
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), sup, /*has_sinks=*/true), AttnPrefillPath::NONE);
 }
 
 TEST(AttnDispatchTable, SinksWithFMHANeverIsNone) {
     auto cfg = default_cfg();
     cfg.attention.fmha_sm120 = "never";
-    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept(), /*has_sinks=*/true),
-              AttnPrefillPath::NONE);
+    EXPECT_EQ(select_attn_prefill_path(cfg, all_accept(), /*has_sinks=*/true), AttnPrefillPath::NONE);
+}
+
+// --------------------------------------------------------------------------
+// The coupling that makes this file mean something (audit finding F-3)
+// --------------------------------------------------------------------------
+//
+// Until #1210 this model was TEST-ONLY: attention_dispatch.cu mentioned
+// select_attn_prefill_path() in a comment and never called it, so a reorder in
+// the dispatch left every test above green while the header described a routing
+// order that no longer existed.
+//
+// The dispatch now replays the model at the moment a tier wins, against the
+// booleans it observed on the way down, and logs a divergence. These tests pin
+// the invariant that replay depends on: for each tier, the observation pattern
+// the dispatch can actually produce when THAT tier wins must make the model
+// name the same tier. If it did not, the production check would cry wolf on a
+// correct dispatch and get muted.
+namespace {
+
+// What attention_dispatch.cu has filled in by the time `winner` commits: every
+// tier it walked past declined (false), the winner accepted, and tiers below
+// the winner were never evaluated so they stay false.
+AttnKernelSupport observed_when(AttnPrefillPath winner) {
+    AttnKernelSupport s;  // all false — the dispatch's starting state
+    switch (winner) {
+        case AttnPrefillPath::MXFP4:
+            s.mxfp4_available = true;
+            s.mxfp4_accepts = true;
+            break;
+        case AttnPrefillPath::FA2:
+            s.fa2_accepts = true;
+            break;
+        case AttnPrefillPath::FP8:
+            s.fp8_accepts = true;
+            break;
+        case AttnPrefillPath::FMHA_SM120:
+            s.fmha_sm120_accepts = true;
+            break;
+        case AttnPrefillPath::BLACKWELL:
+            s.blackwell_accepts = true;
+            break;
+        case AttnPrefillPath::NONE:
+            break;
+    }
+    return s;
+}
+
+}  // namespace
+
+TEST(AttnRoutingModelCoupling, EveryTierReplaysToItself) {
+    auto cfg = default_cfg();
+    cfg.attention.fp8_fmha = "on";  // so the FP8 tier is reachable at all
+
+    const AttnPrefillPath tiers[] = {AttnPrefillPath::FA2, AttnPrefillPath::FP8, AttnPrefillPath::FMHA_SM120,
+                                     AttnPrefillPath::BLACKWELL};
+    for (AttnPrefillPath t : tiers) {
+        EXPECT_EQ(select_attn_prefill_path(cfg, observed_when(t)), t)
+            << "the dispatch would run " << attn_prefill_path_name(t) << " but the model replays to "
+            << attn_prefill_path_name(select_attn_prefill_path(cfg, observed_when(t)))
+            << " — verify_against_routing_model() would fire on a correct dispatch";
+    }
+}
+
+TEST(AttnRoutingModelCoupling, Mxfp4ReplaysToItselfWhenAvailable) {
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), observed_when(AttnPrefillPath::MXFP4)),
+              AttnPrefillPath::MXFP4);
+}
+
+// The sinks pre-gate (#992) is a separate entry point in the dispatch: it either
+// runs the FP16 WMMA tier or throws. Both arms must replay.
+TEST(AttnRoutingModelCoupling, SinksReplayToFmhaOrNone) {
+    auto sup = observed_when(AttnPrefillPath::FMHA_SM120);
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), sup, /*has_sinks=*/true), AttnPrefillPath::FMHA_SM120);
+
+    AttnKernelSupport declined;  // sink-capable tier said no -> dispatch throws
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), declined, /*has_sinks=*/true), AttnPrefillPath::NONE);
+}
+
+// The chain-exhausted case: nothing accepted, so the dispatch throws (#654) and
+// the model must agree rather than naming a tier that never ran.
+TEST(AttnRoutingModelCoupling, NothingAcceptsReplaysToNone) {
+    EXPECT_EQ(select_attn_prefill_path(default_cfg(), AttnKernelSupport{}), AttnPrefillPath::NONE);
+}
+
+// --------------------------------------------------------------------------
+// Tier PRECEDENCE — the tests that actually catch a reorder
+// --------------------------------------------------------------------------
+//
+// The replay tests above cannot: each of their support patterns has exactly ONE
+// accepting tier, so swapping two tiers in the chain leaves every answer
+// unchanged. Verified by mutation — reordering FP8 ahead of FA2 in
+// select_attn_prefill_path() left all of them green.
+//
+// Neither could the sixteen AttnDispatchTable cases, for a different reason:
+// every one that involves FP8 sets fmha_fa2="never" first, so FA2 and FP8 are
+// never both live. The relative order of the chain — the thing a reorder breaks
+// and the thing attention_dispatch.cu is now checked against at runtime — was
+// not asserted anywhere.
+//
+// These pin it: both gates on, both kernels accepting, earlier tier must win.
+TEST(AttnTierPrecedence, Mxfp4BeatsFA2) {
+    auto cfg = default_cfg();
+    auto sup = all_accept();
+    sup.mxfp4_available = true;
+    ASSERT_TRUE(sup.mxfp4_accepts && sup.fa2_accepts);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::MXFP4);
+}
+
+TEST(AttnTierPrecedence, FA2BeatsFP8WhenBothOnAndBothAccept) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "on";
+    cfg.attention.fp8_fmha = "on";
+    auto sup = all_accept();
+    ASSERT_TRUE(sup.fa2_accepts && sup.fp8_accepts);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FA2)
+        << "FA2 must precede FP8: the raw-e4m3 FP8 tier compounds ~10% score error "
+           "per layer (#511) and must never win a tie";
+}
+
+TEST(AttnTierPrecedence, FP8BeatsFmhaSm120WhenBothAccept) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "on";
+    auto sup = all_accept();
+    ASSERT_TRUE(sup.fp8_accepts && sup.fmha_sm120_accepts);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FP8);
+}
+
+TEST(AttnTierPrecedence, FmhaSm120BeatsBlackwellWhenBothAccept) {
+    auto cfg = default_cfg();
+    cfg.attention.fmha_fa2 = "never";
+    cfg.attention.fp8_fmha = "never";
+    auto sup = all_accept();
+    ASSERT_TRUE(sup.fmha_sm120_accepts && sup.blackwell_accepts);
+    EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FMHA_SM120);
 }


### PR DESCRIPTION
Three more roadmap items. Follows #1210.

## 1. F-3 — the routing model was decorative, and the tests had a hole

`select_attn_prefill_path()` models the six-tier prefill chain. Nothing in production called it: `attention_dispatch.cu` named it in a comment, `test_routing_decision.cpp` was its only includer. So the header's own stated purpose — *"any reorder or gate change shows up as a diff"* — did not hold.

The dispatch now **consults** it. Each tier records the two booleans it already discovers on the way down (did the config gate pass, did the kernel accept), and when a tier wins the model is replayed against those observations. Disagreement logs once, naming both answers.

### The part worth reading: the tests did not test what they claimed

After adding coupling tests I mutated the header to put FP8 ahead of FA2. **All 20 tests stayed green.** Two independent blind spots:

- My new replay patterns each set exactly **one** accepting tier, so swapping two tiers cannot change any answer. The test faithfully mirrored the production check's limitation and asserted nothing beyond it.
- Every pre-existing FP8 case starts with `cfg.attention.fmha_fa2 = "never"`. FA2 and FP8 are **never both live** in the suite, so their relative order — the thing a reorder breaks — was asserted nowhere in 16 tests.

`AttnTierPrecedence` fixes that: both gates on, both kernels accepting, earlier tier must win. Four pairs, adjacent in the chain. The same mutation now fails:

```
FA2 must precede FP8: the raw-e4m3 FP8 tier compounds ~10% score error per layer (#511)
[  FAILED  ] AttnTierPrecedence.FA2BeatsFP8WhenBothOnAndBothAccept
```

**KNOWN LIMIT, written into the code rather than implied:** a tier reordered ahead of the winner that *would* have accepted is still invisible, because the dispatch short-circuits and never asks it. Closing that needs a real `*_supports()` predicate per kernel that the launcher itself consults. Two of FA2's seven decline points depend on the computed tile selection, so a predicate written beside them would be a **third** copy of the routing rules — the exact failure F-3's own note warns about. That is a five-TU refactor of the hottest prefill kernel and is deliberately not in this PR.

## 2. F-6 (reporting half) — the residual line contradicted itself

The VRAM audit's headline number printed the **accounted** share on the **residual** line: `100*(1 - residual/used)`, labelled "of device used". On a run where pools sum above device usage that rendered as

```
RESIDUAL (unattributed)        -38246.8    230.3% of device used
```

on a 32 GB card. Each line now carries its own percentage, and a negative residual is named as what it is — double counting (a suballocation reported by both owner and pool), not unexplained loss. Verified on a real run:

```
ACCOUNTED (tracked+named)       12847.6    100.0% of device used
RESIDUAL (unattributed)             0.0      0.0% of device used
```

The attribution work itself (tagging the prewarm block and the CUTLASS/cuBLAS workspaces so the 20-39 % gap actually shrinks) is not in this PR — that needs a measurement loop per consumer, not a formatting fix.

## 3. F-5 — the GPU lane gets its schedule

The job at `ci.yml` is fully written and dormant behind `vars.HAS_GPU_RUNNER`. It gains the `schedule:` trigger R-20 asks for (nightly 03:17 UTC) plus the three concrete steps to enable it. It is the only lane that runs the full `ctest`, compute-sanitizer and the perf gate.

The nightly also fixes something the workflow already complains about in its own comments: an auto-merge squash does not start a run, so `main`'s reported status can be many commits stale.

Registering the self-hosted runner is a repo-settings action and is not something this PR can do.

## Perf — the gate is green, and the earlier red was the host

Worth recording because I got this wrong first. `make verify-fast` failed on `main` earlier today at decode −3.25 %. It was **not** a regression and **not** a stale pin:

| condition | decode tg128 | vs pin 287.19 |
|---|---|---|
| 4-6 unrelated containers running (rust build, vite, chrome, freqtrade — none on the GPU) | 264-278 | −3 … −8 % |
| quiet host | **278.75** | **−2.94 % → PASS** |

Full `verify-fast` on the quiet host: decode PASS, prefill −1.89 % PASS, pp4096 −1.46 % PASS, peak VRAM +0.01 % PASS, graphs-ON 2.25x PASS, degeneration smoke PASS.

The pin holds — with **0.06 percentage points** of margin. CPU contention from non-GPU containers moves decode by ~5 %, i.e. far more than the gate's threshold, so host state decides red/green. Worth knowing before anyone re-pins on the strength of one red run. (Also: `nvidia-smi --query-compute-apps` is empty on WSL2 even with containers running — it is not a free-card check.)

## Verification

- `make dev-test` (CI's `ctest -L unit`): green, 4/4. 24 routing tests, of which 8 are new.
- `make verify-fast`: green (quiet host), see above.
- Gates: `check_alloc_sites` OK · `check_launch_guards` 407/407 · `check_filesize` OK.
- clang-format on changed lines: clean.

**Mutation-validated:**

| mutation | result |
|---|---|
| reorder FP8 ahead of FA2 in `select_attn_prefill_path()` | RED — `AttnTierPrecedence.FA2BeatsFP8WhenBothOnAndBothAccept` (and green before this PR — that is the finding) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B