### PR TITLE
fix(gate): median the perf gate over independent processes, and print the spread

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@ on:
   # squashed), but the branch's reported status is stale, and this makes it
   # refreshable without a PAT or a merge queue.
   workflow_dispatch:
-  # Nightly, 03:17 UTC. Two jobs at once:
+  # Nightly, 03:17 UTC.
+  #
+  # NOTE (2026-08-03): the repo owner has decided against a self-hosted GPU
+  # runner for now, so the `test` job below stays skipped and this schedule
+  # currently buys only reason 2. Reason 1 is kept because the job is written
+  # and the decision is reversible — if a runner is ever registered, the lane
+  # starts covering `main` on its own cadence with no further change here.
   #
   #  1. The GPU lane (`test`, below) is the only lane that runs the full ctest,
   #     compute-sanitizer and the perf gate. It is gated on a self-hosted runner,

--- a/docs/audit/AUDIT_ARCH_2026_07_29.md
+++ b/docs/audit/AUDIT_ARCH_2026_07_29.md
@@ -1217,7 +1217,7 @@ blast = files touched by the fix; confidence in the finding itself.
 | # | Finding | Why it is still open |
 |---|---|---|
 | F-3 (rest) | routing replica | A tier reordered *ahead* of the winner that would have accepted stays invisible. Needs per-kernel `*_supports()` predicates; two of FA2's seven decline points depend on the computed tile selection, so predicates written beside them would be a **third** copy of the rules. Five-TU refactor of the hottest prefill kernel. |
-| F-5 (rest) | GPU CI lane | Schedule and enablement steps landed; registering a `[self-hosted, gpu, cuda]` runner is a repo-settings action. |
+| F-5 (rest) | GPU CI lane | **Declined by the repo owner, 2026-08-03: there will be no GPU runner for now.** The job and its nightly trigger stay in `ci.yml`, dormant. The consequence is load-bearing and stated below. |
 | F-6 (rest) | 20-39 % VRAM unattributed | The reporting bug is fixed; the attribution needs a per-consumer measurement loop, not a formatting change. |
 | F-9 | cuBLASLt algo unpinned | Needs a cache-file format with invalidation on driver/CUDA version — a feature, not a cleanup. |
 | F-10 | `config.h` in 22 `exec/` files | The `DispatchPolicy` extraction (~30 files) changes what dispatch reads. The perf gate currently passes with **0.06 percentage points** of margin and the GPU test lane does not run in CI; this is the wrong week to land it unmeasured. |
@@ -1345,7 +1345,19 @@ same guarantee the gate gives.
 
 ---
 
-**F-5 — No CI job verifies that any kernel produces the right numbers — but the job exists and is one repo variable away from running** — ⚠️ schedule + enablement steps landed in #1211; registering the runner is a repo-settings action
+**F-5 — No CI job verifies that any kernel produces the right numbers — but the job exists and is one repo variable away from running** — ⛔ WON'T FIX (owner decision 2026-08-03: no GPU runner). Schedule + enablement steps landed in #1211 and the job stays dormant in `ci.yml`.
+
+> **The consequence, since it constrains every other decision in this report.** With no GPU
+> runner, `make verify-fast` on the developer's box is the *only* thing that ever executes a
+> CUDA kernel against a correctness or perf bar. Nothing in GitHub-hosted CI can — the runners
+> have no GPU. So:
+>
+> - The full `ctest`, compute-sanitizer and the perf gate run only when someone runs them.
+> - A change that alters what dispatch or allocation reads at runtime (F-10, F-12) has no
+>   automated net beneath it. That is why those two are deferred rather than shipped.
+> - The local gate therefore has to be trustworthy. #1214 medians it over three independent
+>   processes and prints the spread, because a single-shot 3.00 % threshold on a host with
+>   4.01 % run-to-run spread was reporting its own noise.
 `HIGH` · effort **`S`** · blast infra · confidence **HIGH**
 
 *Evidence:* the `Build` job runs `ctest -L unit` and is the only required check. The **`Test` job

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -22,6 +22,9 @@
 #   IMP_VERIFY_SKIP_PERF=1    skip perf-baseline regression check (use when the
 #                             baseline is known-stale; refresh with
 #                             scripts/gen_perf_baseline.sh)
+#   IMP_VERIFY_TRIALS=3       independent PROCESSES the perf gate medians over.
+#                             1 restores the old single-shot behaviour (fast,
+#                             but see the note at the gate itself).
 #   IMP_VERIFY_IN_DOCKER=1    sentinel set by the auto-re-exec block; do not set manually
 #
 # Auto-Docker fallback: if cmake is not on PATH (Clean-Host workflow), the
@@ -56,6 +59,7 @@ if ! command -v cmake >/dev/null 2>&1 && [ "${IMP_VERIFY_IN_DOCKER:-0}" != "1" ]
         -e IMP_VERIFY_SKIP_PERF="${IMP_VERIFY_SKIP_PERF:-0}" \
         -e IMP_VERIFY_BASELINE="${IMP_VERIFY_BASELINE:-tests/perf_baseline.json}" \
         -e IMP_VERIFY_CHUNK_SIZE="${IMP_VERIFY_CHUNK_SIZE:-0}" \
+        -e IMP_VERIFY_TRIALS="${IMP_VERIFY_TRIALS:-3}" \
         --entrypoint bash imp:test scripts/verify.sh "$@"
 fi
 
@@ -354,17 +358,48 @@ else
             # (~99.9% draft accept), so with speculation ON tg measures the
             # batched spec-verify GEMMs — restart-volatile like cuBLAS prefill
             # (observed 11% swing across healthy-clock restarts, 2026-07-15).
-            # The gate guards the decode GEMV hot path, which is stable (<1%).
+            #
+            # MEDIAN OVER INDEPENDENT PROCESSES, not one shot. --bench-reps
+            # averages WITHIN a process; it cannot see the variance that lives
+            # BETWEEN them (cuBLASLt heuristic re-selection, allocator layout,
+            # clock/host state at load). Measured 2026-08-03 on an idle host,
+            # six runs of near-identical code: 278.59 … 289.77 tok/s — a 4.01 %
+            # spread against a 3.00 % threshold. A single-shot gate that tight
+            # reports its own noise: the same tree failed at -3.25 % and passed
+            # at +0.90 % on the same day.
+            #
+            # The line this replaces claimed "the decode GEMV hot path ... is
+            # stable (<1%)". That is true within a process and false across
+            # them, which is the number the gate actually compares.
+            #
+            # What the median does and does not buy: it drops single-run
+            # outliers, which is the failure that produced the -3.25 % scare.
+            # It does NOT flatten the hours-scale host drift — three runs taken
+            # back to back spread 0.09 %, the same binary hours apart spread
+            # 4.01 %. That is why the spread is PRINTED: a tight spread means
+            # the median is worth believing, a wide one means the host moved
+            # mid-gate and the verdict is about the box, not the diff.
+            TRIALS="${IMP_VERIFY_TRIALS:-3}"
+            TG_ALL=""; PP_ALL=""
             gpu_sample_start
-            "$BIN" --model "$MODEL_PATH" --bench --bench-pp 512 --bench-reps $REPS \
-                  --prefill-chunk-size "${CHUNK_SIZE}" --max-tokens 128 --temperature 0 \
-                  --set speculative.ngram=false >/dev/null 2>"$ERR"
+            for _t in $(seq 1 "$TRIALS"); do
+                "$BIN" --model "$MODEL_PATH" --bench --bench-pp 512 --bench-reps $REPS \
+                      --prefill-chunk-size "${CHUNK_SIZE}" --max-tokens 128 --temperature 0 \
+                      --set speculative.ngram=false >/dev/null 2>"$ERR"
+                _tg=$(grep -oP '^tg\s+128\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
+                _pp=$(grep -oP '^pp\s+512\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
+                [ -n "$_tg" ] && TG_ALL="$TG_ALL$_tg\n"
+                [ -n "$_pp" ] && PP_ALL="$PP_ALL$_pp\n"
+            done
             gpu_sample_stop
+            median() { printf "$1" | grep -v '^$' | sort -n | awk '{a[NR]=$1} END{if(NR==0)exit 1; print (NR%2)?a[(NR+1)/2]:(a[NR/2]+a[NR/2+1])/2}'; }
+            spread() { printf "$1" | grep -v '^$' | sort -n | awk '{a[NR]=$1} END{if(NR<2)exit 0; printf "%.2f", (a[NR]-a[1])/a[1]*100}'; }
             # Bench lines (stderr) have variable spacing inside parens for short numbers:
             #   "pp   512 tokens  avg    38.47 ms  (13310.12 tok/s)  [3 reps]"
             #   "tg   128 tokens  avg   861.50 ms  ( 148.58 tok/s)  [3 reps]"
-            PP=$(grep -oP '^pp\s+512\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
-            TG=$(grep -oP '^tg\s+128\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' "$ERR" | head -1)
+            PP=$(median "$PP_ALL" || true)
+            TG=$(median "$TG_ALL" || true)
+            TG_SPREAD=$(spread "$TG_ALL")
             if [ -z "$PP" ] || [ -z "$TG" ]; then
                 fail "could not parse bench output (see $ERR)"
                 tail -15 "$ERR"
@@ -375,6 +410,10 @@ else
                 DEC_REG=$(awk -v d="$DEC_DELTA" -v t="$DEC_THR" 'BEGIN{print (-d > t) ? 1 : 0}')
                 PRE_REG=$(awk -v d="$PRE_DELTA" -v t="$PRE_THR" 'BEGIN{print (-d > t) ? 1 : 0}')
 
+                if [ "$TRIALS" -gt 1 ]; then
+                    printf "  perf gate: median of %s independent runs (spread %s%%)\n" "$TRIALS" \
+                           "${TG_SPREAD:-n/a}"
+                fi
                 printf "  decode  tg128 = %7.2f tok/s  (baseline %7.2f, delta %+s%%)\n" "$TG" "$BL_TG" "$DEC_DELTA"
                 printf "  prefill pp512 = %7.2f tok/s  (baseline %7.2f, delta %+s%%)\n" "$PP" "$BL_PP" "$PRE_DELTA"
                 [ -n "${GPU_DRIFT_DESC:-}" ] && echo "  GPU during bench: $GPU_DRIFT_DESC"


### PR DESCRIPTION
With no GPU CI runner, `make verify-fast` is the **only** thing that ever checks whether a kernel still produces the right numbers at the right speed. So it should not report its own noise as a verdict.

## The problem

The decode gate compared **one** run against a **3.00 %** threshold. Measured today, six runs of near-identical code on an idle box:

```
278.75  279.91  278.59  278.78  279.47  289.77   →  spread 4.01 %
```

The host's own run-to-run spread is **larger than the threshold**. Concretely: the same tree failed at **−3.25 %** and passed at **+0.90 %** on the same day, and I initially read the red run as a stale baseline pin. It was not — it was one sample.

`--bench-reps 3` does not help here. It averages **within** a process; the variance lives **between** them — cuBLASLt heuristic re-selection, allocator layout, clock and host state at load. That between-process number is exactly what the gate compares to the pin.

## The change

The gate medians over `IMP_VERIFY_TRIALS=3` independent processes and prints the spread:

```
  perf gate: median of 3 independent runs (spread 0.09%)
  decode  tg128 =  285.69 tok/s  (baseline  287.19, delta -0.52%)
  GPU during bench: sm=2902MHz(med) mem=13801MHz(med) power=501W(max) n=11
```

**What the median buys, and what it does not.** It drops single-run outliers — the failure that produced the −3.25 % scare. It does **not** flatten hours-scale host drift: three back-to-back runs spread 0.09 %, the same binary hours apart spread 4.01 %. That is why the spread is printed rather than swallowed. A tight spread means the median is worth believing; a wide one means the host moved mid-gate and the verdict is about the box, not the diff.

`IMP_VERIFY_TRIALS=1` restores the old single-shot behaviour.

## Also corrected

The comment at that gate asserted the decode path *"is stable (<1%)"*. That is true within a process and false across them — and across is what it measures.

## Cost

Three model loads instead of one for the perf section. `verify-fast` goes from ~90 s to ~3 min. That is the price of a gate whose verdict means something; `IMP_VERIFY_TRIALS=1` is there for tight iteration loops.

## Verification

- `IMP_VERIFY_TRIALS=1 make verify-fast`: green, no median line (correct — only shown when TRIALS>1), decode 285.52.
- `make verify-fast` (default 3): green, `median of 3 independent runs (spread 0.09%)`, decode 285.69.
- `bash -n scripts/verify.sh`: clean.
- `IMP_VERIFY_TRIALS` is threaded through the container re-exec, or setting it on the host would have been silently ignored.

The `median`/`spread` helpers unit-checked against hand-computed answers, including the case that motivates a median at all:

| input | result | expected |
|---|---|---|
| 300 100 200 | 200 | 200 (odd) |
| 400 100 200 300 | 250 | 250 (even) |
| 123.5 | 123.5 | single value |
| **285 286 100** | **285** | outlier dropped — the mean would be 223.7 |
| 278.59 289.77 280 | 4.01 % | spread |
| 285 | *(empty)* | no spread from one sample |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B