### PR TITLE
docs(audit): settled-priors ledger, read before hypotheses and gated in CI

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -5,14 +5,31 @@ description: Use when auditing the imp codebase for structural debt, dead code, 
 
 # Codebase audit & structural debt — imp
 
-## The one hard rule
+## The two hard rules
 
-**Never act on a raw finding. Verify every finding against the real code first.**
+**1. Never act on a raw finding. Verify every finding against the real code first.**
 Fan-out audits (Explore agents, grep sweeps) systematically **over-flag**. On the
 2026-06-09 pass, the big-ticket findings C1/C2/C4 were all REFUTED on inspection,
 and several "dead flags/files" were live. Treat a finding as a *candidate*, not a
 fact, until a targeted check confirms it. Most of an audit's value is in the
 verification, not the sweep.
+
+**2. Read [`docs/audit/SETTLED.md`](../../../docs/audit/SETTLED.md) before you generate
+hypotheses, not while you verify them.** Rule 1 puts the filter *after* unbounded
+generation, which makes the expensive stage pay for the cheap one. The 2026-07-29 audit
+is the cost of getting this backwards: eight of thirteen hypotheses came back REFUTED
+because they described duplication earlier campaigns had already collapsed (its §15), and
+five facts in its own brief were stale — 9 vs 16 architectures, C++20 vs C++23,
+`src/graph/` vs `src/exec/` (its §19). One of the refuted hypotheses contradicted a prior
+written *in this file*. So:
+
+- Generate hypotheses **against** the ledger. A candidate that contradicts an entry is not
+  reportable until you disprove that entry's **anchor** — "the code changed since then" is
+  the claim, show it.
+- **Verify the facts your brief rests on** before generating from them. `SETTLED.md` §F
+  lists the five that were wrong last time, each with a one-command counter-check.
+- Recording a refutation is part of finishing the audit. One you leave out of `SETTLED.md`
+  is one the next pass pays for again.
 
 ## Verification recipes (the load-bearing checks)
 
@@ -27,10 +44,17 @@ verification, not the sweep.
 
 ## Workflow
 
-1. **Fan out** — Explore agents / grep to surface candidates (breadth is fine here).
+0. **Read the ledger first** — `docs/audit/SETTLED.md`, plus the running log for the axis
+   you are about to sweep (root `AUDIT.md` for `src/memory/`). Re-derive any brief fact the
+   hypotheses depend on. This step is what makes step 1 cheap.
+1. **Fan out** — Explore agents / grep to surface candidates. Breadth is fine, but a
+   candidate that contradicts a `SETTLED.md` entry needs that entry's anchor disproven
+   before it is worth reporting.
 2. **Verify each** with the recipe above. Demote refuted ones immediately.
-3. **Write it up** — `docs/audit/structural_debt_YYYY_MM_DD.md`. Counts are evidence,
-   not estimates. Keep a **"Refuted (do not re-chase)"** section so the next pass
+3. **Write it up** — `docs/audit/structural_debt_YYYY_MM_DD.md`, **and append the
+   refutations to `docs/audit/SETTLED.md`** with their anchors — that is what stops the
+   next pass re-chasing them, and `scripts/check-release.sh` gates the anchors. Counts are
+   evidence, not estimates. Keep a **"Refuted (do not re-chase)"** section so the next pass
    doesn't re-flag the same false positives. Exception: the memory subsystem has a
    running findings log at repo root, **`AUDIT.md`** (CONFIRMED / REFUTED / OPEN per
    finding, negative results included) — append there rather than opening a parallel
@@ -49,13 +73,14 @@ verification, not the sweep.
 
 ## Priors — settled, do NOT re-flag
 
+**Canonical list: [`docs/audit/SETTLED.md`](../../../docs/audit/SETTLED.md)** — the
+collapsed-duplication entries (S-1…S-11), the deliberate specialisations that are the
+classic false positive, the hunted-and-absent negatives, and the findings that were
+themselves wrong. Read it at step 0, not here. What follows is only what has not moved
+into the ledger yet.
+
 From the structural-debt audit chain (D1–D4 / C1–C8, archived in `docs/archive/README.md`;
 current verdicts in `docs/audit/housekeeping_2026_06_13.md`):
-- **exec/ god-object** (`GraphExecutor`) is intrinsically forward-pass-coupled; the
-  D2 runner-extraction track ENDED (cosmetic friend-backdoor only). Header split done
-  (1188→584 lines). Don't re-attempt runner classes.
-- **ModelProfile (D1)** centralized arch facts — don't reintroduce scattered `cfg.arch==`.
-- `gdn.cu` is domain-cohesive ("don't touch"); the compute/ files are not god-files.
 - The two-config-systems split (`RuntimeConfig` global vs `ModelConfig::Overrides`) is
   known and deliberate; config keys use the typed-binder `B/I/F/S(...)` ladder (PR #626).
 - **Audit #5 (2026-07-07, `docs/audit/structural_debt_2026_07_07.md`)**: server layer is
@@ -75,6 +100,10 @@ current verdicts in `docs/audit/housekeeping_2026_06_13.md`):
 
 ## Red flags — you are about to over-flag
 
+- About to report a finding that contradicts a `SETTLED.md` entry → did you disprove its
+  anchor, or are you re-running a sweep someone already paid for?
+- Your hypotheses came from the brief rather than the tree → did you re-derive the facts
+  they rest on? Five of the 07-29 brief's were wrong.
 - About to delete code because a sweep said "no references" → did you grep `tools/`?
 - About to split a file because it's big → is it *conflated* or just one large domain?
 - About to rewrite a working ladder/loader for elegance → where's the concrete bug?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ compile-time isolation:
 ### auditor
 - **Scope:** whole repo, **read-only assessment**.
 - **Allowed tools:** read/search tools, read-only sub-agents.
-- **MUST:** verify each finding against source before reporting; write only a dated report under `docs/audit/`, or append to an existing running findings log where one owns the area (`AUDIT.md` for the memory subsystem, which records REFUTED results too); rank by severity+effort.
-- **MAY NOT:** edit any code or config; act on an unverified sweep result; propose multi-arch or speculative rewrites.
+- **MUST:** read `docs/audit/SETTLED.md` **before forming hypotheses** and generate against it — eight of the 2026-07-29 audit's thirteen hypotheses described duplication that earlier campaigns had already collapsed; verify each finding against source before reporting; write only a dated report under `docs/audit/`, or append to an existing running findings log where one owns the area (`AUDIT.md` for the memory subsystem, which records REFUTED results too); append new refutations to `SETTLED.md` with their anchors; rank by severity+effort.
+- **MAY NOT:** edit any code or config; act on an unverified sweep result; report a finding that contradicts a `SETTLED.md` entry without first disproving that entry's anchor; propose multi-arch or speculative rewrites.
 
 ### build-engineer
 - **Scope:** `CMakeLists.txt`, `cmake/`, `CMakePresets.json`, `Dockerfile`, `Makefile`, dependency pins, `.github/workflows/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ there instead of retelling it.
   existing `args.<field>` use site is unchanged.
 
 ### Added
+- **`docs/audit/SETTLED.md`** — the ledger an audit reads *before* forming
+  hypotheses, gated by a new `settled-prior anchors` section in
+  `scripts/check-release.sh` (CI job `Release hygiene`, 49 anchors). Eight of the
+  2026-07-29 audit's thirteen hypotheses were REFUTED because they described
+  duplication earlier campaigns had already collapsed, and five facts in its own
+  brief were stale; the ledger records both, and the gate fails when an anchor
+  stops resolving so an entry cannot quietly become the next stale prior.
 - **`--metrics-require-auth`** (#1207): fold `/metrics` back under the
   `--api-key` check. Off by default so a stock Prometheus scrape keeps working,
   but the endpoint discloses the loaded model name, `d_model` and cumulative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ there instead of retelling it.
   existing `args.<field>` use site is unchanged.
 
 ### Added
-- **`docs/audit/SETTLED.md`** — the ledger an audit reads *before* forming
+- **`docs/audit/SETTLED.md`** (#1215) — the ledger an audit reads *before* forming
   hypotheses, gated by a new `settled-prior anchors` section in
   `scripts/check-release.sh` (CI job `Release hygiene`, 49 anchors). Eight of the
   2026-07-29 audit's thirteen hypotheses were REFUTED because they described

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Match the task, invoke that skill first.
 | imp-server / OpenAI+Anthropic HTTP API | skill **server-api** |
 | Add a new model architecture | skill **add-model-arch** |
 | Open/merge a PR, cut a release | skill **shipping-prs** |
-| Structure audit / dead code / god-files | skill **codebase-audit** |
+| Structure audit / dead code / god-files | skill **codebase-audit** — read [`docs/audit/SETTLED.md`](docs/audit/SETTLED.md) **before** forming hypotheses |
 | Keep docs in sync after a change | skill **docs-sync** |
 | VRAM / ownership / lifetime / "where did the memory go" | read [`docs/MEMORY_ARCHITECTURE.md`](docs/MEMORY_ARCHITECTURE.md) **first** |
 

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -1,0 +1,164 @@
+# SETTLED.md — what previous passes already resolved
+
+**Read this before generating audit hypotheses, not while verifying them.**
+
+This file exists because the 2026-07-29 architecture audit spent most of its budget
+refuting its own hypotheses. Its §15 names the cause: *"Several of these are the reason
+hypotheses 1, 3, 4, 5, 7, 8, 9 and 11 came back REFUTED"* — eight of thirteen described
+duplication that earlier campaigns had already collapsed. §19 names the other half:
+*"Several dispatch priors were stale … 9 vs 16 architectures, C++20 vs C++23, `src/graph/`
+vs `src/exec/`, missing histograms that exist"* — the brief the hypotheses were generated
+from carried five verifiably wrong facts about the repo.
+
+Both are generation-stage failures. The verification stage worked; it was fed too much.
+
+## Convention
+
+Same as the memory subsystem's running log (root `AUDIT.md`), and for the same stated
+reason: *a suspected problem that turns out to be clean is worth exactly as much as one
+that is real, and stops the next pass re-chasing it.*
+
+- **REFUTED** — tested and found not to be true.
+- **CONFIRMED** — verified against the code or measured.
+- **SUPERSEDED BY S-nn** — was true when written; a later entry changed the thing it
+  describes. The entry stays as the record of what was believed.
+
+The **anchor** column is the point. It names the file that makes the entry settled, and
+`scripts/check-release.sh` (section 1c, CI job `Release hygiene`) fails if an anchor stops
+resolving — so an entry cannot quietly become the next stale prior. If an anchor moves,
+re-open the entry; do not just fix the path.
+
+## How to use it
+
+1. Read this file **before** fanning out. Generate hypotheses *against* it.
+2. A candidate that contradicts an entry is not reportable until you have disproven that
+   entry's **anchor**. "The code changed since then" is the claim — show it.
+3. Adding an entry is part of finishing an audit. A refutation you do not record here is a
+   refutation the next pass pays for again.
+
+---
+
+## A — Already collapsed (do not re-flag as duplication)
+
+| # | Claim that keeps coming back | Verdict | Anchor — what makes it settled | Since |
+|---|---|---|---|---|
+| S-1 | Architecture dispatch is duplicated across ~8 sites | **REFUTED** | `src/model/model_profile.h` — five booleans + one `AttnVariant`, decided once; the hot path reads those, not the enum. `layer_swa_window()` (`:73`) unifies four SWA variants so mask and KV sizing cannot drift. `ModelArch::` is in 15 files, 9 of them `src/model/`; arch #17 costs 6 files | 2026-07-29 (D1) |
+| S-2 | Quant dispatch is duplicated across 8 formats × 5 concerns | **REFUTED as stated** — CONFIRMED narrowly for KV dtypes only | `src/exec/gemm_kernel_registry.cu` — an 85-LOC table replacing "~33 hand-written kernels", plus 8 `DequantTraits<>` in `src/compute/gemv_dp4a_traits.cuh`, pinned by `tests/test_gemm_kernel_registry.cu` (40 tests of the dispatch *contract*). A new quant format on the GEMM path costs 2 files | 2026-07-29 |
+| S-3 | GGUF and SafeTensors loaders duplicate tensor mapping | **REFUTED** | Name normalisation and layer indexing live once in `src/model/weight_map.cpp` + `src/model/tensor_kind_table.cu`; the loader bodies differ only where the formats differ | 2026-07-29 |
+| S-4 | The KV cache has more than one implementation | **REFUTED** | One `src/memory/kv_cache.h` / `src/memory/kv_cache.cu`, backed by one `src/memory/block_pool.h` | 2026-07-29 |
+| S-5 | Execution paths multiply (eager × graph × batch × spec) | **REFUTED** | One `step()` → `step_decode()` → `step_decode_forward()` chain in `src/runtime/engine.cpp`; the variants are parameters on it, not parallel paths | 2026-07-29 |
+| S-6 | Per-architecture layer primitives are re-pasted | **REFUTED** | RMSNorm, RoPE, SwiGLU and MoE top-k have one implementation each under `src/compute/` | 2026-07-29 |
+| S-7 | Sampling is several overlapping chains and constrained decode bypasses part of it | **REFUTED** | `apply_constraint_mask()` at `src/exec/executor.cu:56` — nine lines called from every sampling path. **Keep the comment with the code**: it records that four copies of this chain is exactly how an unmasked path ships | 2026-07-29 |
+| S-8 | The legacy materialised cuBLAS prefill is a vestige (~18 % of prefill) | **REFUTED, with one exception** | 0.0 % on hd=128/256. **Gemma-4's hd=512 global layers take it by design and by measurement** — `src/compute/attention_cublas.cu`, gated per layer at `src/exec/executor_attention_prefill.cu`. It is a deliberately retained tier, not a vestige | 2026-07-29 (F-16) |
+| S-9 | Nemotron-H / SSM carries a private mini-runtime | **REFUTED for SSM**; CONFIRMED for vision | `src/compute/ssm.cu` and `src/memory/recurrent_snapshot_store.h` sit in the shared tree, not beside the model | 2026-07-29 |
+| S-10 | `tools/`, `tests/` and the bench CLI duplicate benchmark logic | **REFUTED for benching** — CONFIRMED for arg parsing (27 flags, F-15, still open) | `tools/imp-bench/` has no overlap against `tests/`; the perf gate reads `tests/perf_baseline.json` through `scripts/bench_gate.sh` | 2026-07-29 |
+| S-11 | NVFP4 grouped-GEMM has two competing paths | **CONFIRMED — but a designed 4-tier ladder, not a twin** | `src/exec/moe_prefill_decision.h` documents the tiers; each is selected by explicit preconditions and the bottom one serves host-offloaded experts. No death date exists for it | 2026-07-29 |
+
+## B — Deliberate specialisation (consolidating this is the classic false positive)
+
+Named in the 07-29 audit §15.12 as D6 — the delta is per-dtype control flow in the hottest
+loop, and the shared part is already factored out.
+
+- **Paged-decode kernels per KV dtype** — `src/compute/attention_paged.cu`,
+  `attention_paged_fp8.cu`, `attention_paged_fp8_tile.cu`, `attention_paged_int4.cu`,
+  `attention_paged_int8.cu`, `attention_paged_nvfp4.cu`, `attention_paged_nvfp4_tc.cu`.
+  The ~35 % token overlap is the online-softmax rescale, which
+  `src/compute/attention_paged_common.cuh` already holds.
+- **The `mmq_q8_imma` family** — `src/compute/mmq_q8_imma.cu`, `mmq_q8_imma_q4k.cu`,
+  `mmq_q8_imma_q6k.cu`, `mmq_q8_imma_q51.cu`. Same reasoning: the delta is the dequant
+  inner step.
+- **`src/compute/gdn_scan.cu` vs `src/compute/gdn_scan_tc.cu`** — scalar vs tensor-core
+  scan, different arithmetic intensity.
+- **Prefill vs decode kernels throughout** — different arithmetic intensity, by definition.
+- **`src/vision/vision_encoder.cu` (SigLIP) vs `src/vision/qwen3vl_encoder.cu`** —
+  genuinely different tower architectures.
+- **Domain-cohesive files that are large but not conflated** — `src/compute/gdn.cu`,
+  `src/compute/sampling.cu`. Split on conflation, never on size; the metric is recompile
+  blast radius (`tools/filesize_thresholds.toml`).
+- **`GraphExecutor` in `src/exec/`** — intrinsically forward-pass-coupled. The D2
+  runner-extraction track ENDED in a cosmetic friend-backdoor; the header split is already
+  done (1188 → 584 lines). Do not re-attempt runner classes. The `compute/` files are not
+  god-files either.
+
+## C — Hunted and absent (07-29 §6.2 — the sweep already ran)
+
+- No `#if 0` blocks anywhere in `src/` or `tools/`.
+- No `_v2` / `_new` / `_old` symbol pairs. The suffix hunt returned only algorithm-local
+  variables (`m_new`, `h_old`) and legitimate API names (`inc_ref`, `mirostat_v2`).
+- Exactly one file with `legacy` in its name — `src/exec/executor_forward_moe_legacy.cu` —
+  and it is a reachable floor, not a twin.
+- Zero stale-target *code*. All 24 mentions of `wgmma` / `tcgen05` / `TMEM` / `sm_100` in
+  `src/` are comments stating the feature does **not** exist on sm_120a. They read like
+  clutter and they are load-bearing — they stop the next reader reaching for a
+  datacenter-Blackwell design.
+- **A `VramOwned` type does not exist.** Past audits hallucinated it.
+
+## D — Load-bearing; a "cleanup" here is a regression
+
+| # | Thing | Why it must survive |
+|---|---|---|
+| S-20 | `src/memory/span.h` — `StableSpan` vs `DeviceSpan`, passkey-enforced | Encodes in the type system which memory a captured CUDA graph may bake an address into. Turns a bug class that actually happened (`AUDIT.md` B9/B13) into a compile error. Extend it; do not weaken it |
+| S-21 | `src/memory/plan.h` — `plan_memory()` | Plans capacity without ever querying the device; pure function of a plain struct, runs in the CPU-only CI lane. Retired the #1103 class (free VRAM swinging 1.6 GB between identical invocations → different plan) |
+| S-22 | The `throw` in `src/compute/attention_dispatch.cu` (#654) | "No tier accepted" is an error, not a degraded answer. It replaced a silent fallback that produced teacher-forced PPL ~1e10. Never soften it back into a fallback |
+| S-23 | Zero virtual dispatch in `src/exec/` and `src/compute/` | Not one vtable call per token, layer or launch. Polymorphism is templates and traits |
+| S-24 | `src/core/cuda_raii.h` | Move-only wrappers: deleted copy, `noexcept` moves, `[[nodiscard]] create()`, no exceptions in destructors |
+| S-25 | `src/runtime/engine_init_resolver.cpp` | ~25 log lines stating each resolved policy **and its reason**. An operator can read what the engine decided and why |
+| S-26 | `tools/filesize_thresholds.toml` `[allow]` with reason strings | Manages file size instead of silencing it; the gate rejects an empty reason |
+| S-27 | `tools/alloc_allowlist.txt` as a two-way ratchet | Fails on a new allocating file *and* on a listed file that stopped allocating, so the list cannot go stale in either direction |
+| S-28 | Property batteries in the CPU lane | `tests/test_json_constrain_property.cpp`, `tests/test_schema_constrain_property.cpp`, `tests/test_tokenizer_robustness.cpp`, `tests/test_gguf_fault_injection.cpp` — fuzzed in CI, no GPU |
+
+## E — Findings that were themselves wrong (do not re-derive them)
+
+From the 07-29 resolution log. These cost real time and the corrections matter more than
+the fixes did.
+
+- **F-16's "device sync per layer" is false.** The only `cudaDeviceSynchronize` in
+  `src/compute/attention_cublas.cu` is inside `attention_cublas_prewarm()`, called once
+  from `src/runtime/engine.cpp`. The prefill function contains none. The audit read one
+  call site; grepping the file settles it without a profile.
+- **F-17 does not reproduce.** The CUTLASS grouped GEMM genuinely never consults
+  `process_diag_deterministic_gemm()` (`src/runtime/process_diag.h`), but the determinism
+  E2E test is 3/3 green with bit-identical greedy output and perplexity.
+- **F-4's count was wrong** — 3 files was actually 1 (#1206).
+- **#1205's resolved-dispatch line never printed.** The call sat before the final `return`
+  of `Engine::step()`, which the graphs-ON decode path never reaches (fixed in #1210). A
+  gate that cannot be shown to fire has not been validated.
+
+## F — Verify the brief before you generate from it
+
+Every fact below was asserted by the 07-29 audit brief and was wrong. Where the brief and
+the repo disagree, **the repo wins** — but only if someone checks. Each counter-check is
+one command.
+
+| Brief said | Reality | Counter-check |
+|---|---|---|
+| 9 architectures | **16** enumerators | count them in `src/model/model_arch.h` |
+| 6 tested models | ~30 validated checkpoints | `docs/supported-models.md` |
+| C++20 | **C++23** | the standard in `CMakeLists.txt` |
+| `src/graph/` exists | renamed to `src/exec/`; `src/lora/` exists and was unlisted | `ls src/` |
+| no p50/p99 histograms | Prometheus histograms exist | `grep _bucket` in `tools/imp-server/handlers_misc.cpp` |
+| `/v1/messages` streaming is synthetic | real handler plus the shared stream driver | `tools/imp-server/handlers_messages.cpp` |
+
+## G — Open: NOT settled, and not to be treated as closed
+
+Still open from 07-29 with the reason each was not shipped blind — see
+[`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the full argument.
+
+- **F-3 (rest)** — routing replica: a tier reordered ahead of the winner stays invisible.
+- **F-5 (rest)** — GPU CI lane: **declined by the repo owner, 2026-08-03.** The job and its
+  nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
+  locally is the only thing that ever runs a CUDA kernel against correctness or perf.
+- **F-6 (rest)** — 20-39 % of steady-state VRAM unattributed.
+- **F-9** — cuBLASLt algorithm selection unpinned (mechanism confirmed, magnitude refuted).
+- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`.
+- **F-12** — `src/memory/vram_allocator.cu` still has 84 references.
+- **F-24** — `src/runtime/engine.h` god-header.
+
+## Per-area running logs
+
+- **Memory subsystem** — root `AUDIT.md` (CONFIRMED / REFUTED / OPEN per finding, negative
+  results included). Read it before sweeping `src/memory/`; design lives in
+  `docs/MEMORY_ARCHITECTURE.md`.
+- **Architecture / dispatch** — this file, plus
+  [`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the evidence behind each entry.
+- **File size** — [`AUDIT_FILESIZE.md`](AUDIT_FILESIZE.md), per-file rationale.

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -70,6 +70,44 @@ done <<< "$DOCREFS"
 [ "$DOCBROKEN" -eq 0 ] && pass "every docs/*.md path named in code resolves" \
                       || fail "$DOCBROKEN dead doc pointer(s) in code"
 
+# ---------------------------------------------------- 1c. settled-prior anchors
+# docs/audit/SETTLED.md is the ledger an audit reads BEFORE generating
+# hypotheses; each entry names the file that makes it settled. If that anchor
+# stops resolving, the entry is no longer a statement about this engine — it is
+# the next stale prior, which is exactly what cost the 2026-07-29 audit eight of
+# its thirteen hypotheses. Fail loudly so the entry gets re-opened rather than
+# silently repointed. Same shape as 1b, different corpus.
+section "settled-prior anchors"
+if [ ! -e docs/audit/SETTLED.md ]; then
+    fail "docs/audit/SETTLED.md is missing — the audit priors ledger is load-bearing"
+else
+    ANCHORS=$(grep -ohE '\b(src|tests|tools|scripts|docs|include|cmake)/[A-Za-z0-9_./-]+\.[A-Za-z0-9]+\b' \
+              docs/audit/SETTLED.md | sort -u || true)
+    ANCHORBROKEN=0
+    ANCHORN=0
+    while IFS= read -r anchor; do
+        [ -z "$anchor" ] && continue
+        ANCHORN=$((ANCHORN+1))
+        if [ ! -e "$anchor" ]; then
+            echo "  dead anchor: $anchor"
+            ANCHORBROKEN=$((ANCHORBROKEN+1))
+        fi
+    done <<< "$ANCHORS"
+    # Floor, because "0 anchors, all resolving" is a PASS that checked nothing —
+    # the same shape as a --gtest_filter matching no tests and reporting PASSED,
+    # or the `gpu` ctest label that is defined and never runs. The ledger had 49
+    # anchors when this was written; 20 catches a gutted file without tripping on
+    # ordinary edits.
+    ANCHOR_FLOOR=20
+    if [ "$ANCHORN" -lt "$ANCHOR_FLOOR" ]; then
+        fail "only $ANCHORN anchors in docs/audit/SETTLED.md (expected >= $ANCHOR_FLOOR) — ledger gutted or the extraction broke"
+    elif [ "$ANCHORBROKEN" -eq 0 ]; then
+        pass "all $ANCHORN settled-prior anchors resolve"
+    else
+        fail "$ANCHORBROKEN dead anchor(s) in docs/audit/SETTLED.md"
+    fi
+fi
+
 # --------------------------------------------------------- 2. personal paths
 # Flag real personal paths but allow the standard /home/user/ placeholder.
 section "personal path leaks"


### PR DESCRIPTION
## Why

Eight of the 2026-07-29 architecture audit's thirteen hypotheses came back **REFUTED**. The report names the cause itself:

- **§15** — *"Several of these are the reason hypotheses 1, 3, 4, 5, 7, 8, 9 and 11 came back REFUTED"*: they described duplication that earlier campaigns had already collapsed (`ModelProfile`, `gemm_kernel_registry.cu`, one `KVCache`, `plan_memory()`, `apply_constraint_mask()`).
- **§19** — *"Several dispatch priors were stale … 9 vs 16 architectures, C++20 vs C++23, `src/graph/` vs `src/exec/`, missing histograms that exist"*: the brief the hypotheses were generated from carried five verifiably wrong facts about the repo.

Both are generation-stage failures. The verification stage worked — it was fed too much. And one of the refuted hypotheses (*"architecture dispatch duplicated across ~8 sites"*) contradicted a prior written verbatim in `.claude/skills/codebase-audit/SKILL.md`, because that skill's workflow reads priors at step 2 (*"Verify each … demote refuted ones"*) after step 1 (*"Fan out … breadth is fine here"*). Unbounded generation, filter downstream, expensive stage pays.

This does **not** target the other kind of refutation — a perf hypothesis killed by measurement (`[[assume]]`, KPAR, Split-D, launch-class). That one is the yield, not the waste. A falling overall REFUTED rate is explicitly not the success criterion.

## What changed

- **`docs/audit/SETTLED.md`** (new) — the ledger read *before* hypotheses are formed. Collapsed-duplication entries S-1…S-11, the deliberate specialisations §15 calls *"the classic false positive"*, the hunted-and-absent negatives from §6.2, the load-bearing pieces a "cleanup" would regress, the three findings that were themselves wrong (F-16 false, F-17 does not reproduce, F-4 miscounted), the five stale brief facts with one-command counter-checks, and what is still open. Convention follows the memory subsystem's running log (root `AUDIT.md`), which is the one axis that did not produce this failure.
- **`scripts/check-release.sh` §1c** — every anchor path named in the ledger must resolve, with a floor of 20 anchors. Runs in CI as **Release hygiene**; no build, no GPU. Same shape as the existing §1b dead-doc-pointer check. This is what keeps the ledger from becoming the next stale prior: if `gemm_kernel_registry.cu` moves, the entry claiming GEMM dispatch is one table gets re-opened rather than silently repointed.
- **`codebase-audit` skill** — step 0 reads the ledger; a candidate contradicting an entry needs that entry's anchor disproven; brief facts get re-derived before generating from them; refutations are appended when finishing an audit. The four priors now in the ledger were removed from the skill so there is one source.
- **`CLAUDE.md` / `AGENTS.md`** — the auditor role and the task router point at the ledger.

Explicitly **not** in scope: rewriting narrative docs. The §16 doc drift is already resolved (`attention-dispatch.md`, `ARCHMAP.md`, `CLAUDE.md` LOC + env vars all carry 2026-08-02/03 corrections). More prose is more surface that rots silently — the direction here is derived-or-gated instead.

## Verification

`SKIP_VERIFY=1 bash scripts/check-release.sh` → green, 49 anchors resolve.

Mutation-validated, because a green gate proves nothing:

| Mutation | Result |
|---|---|
| anchor repointed at a non-existent file | **FAIL** `dead anchor: src/model/model_profile_RENAMED.h`, exit 1 |
| ledger deleted | **FAIL** `docs/audit/SETTLED.md is missing — the audit priors ledger is load-bearing` |
| ledger emptied of anchors | **passed green** — `PASS all 0 settled-prior anchors resolve` |

The third probe is why the floor exists. `all 0 anchors resolve` is the same shape as a `--gtest_filter` matching no tests and reporting PASSED, or the `gpu` ctest label that is defined and never runs. With the floor it reads `FAIL only 0 anchors (expected >= 20)`.

No `src/` changes; no build, GPU or perf run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B