### PR TITLE
refactor(exec): remove three KV/bias kernels that were built but never launched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ there instead of retelling it.
   (`compute/dispatch_record.h`), not predicted from a second copy of the routing
   rules, so it cannot disagree with what ran.
 
+### Removed
+- **Three KV/bias kernels that were built and linked but never launched** —
+  `write_kv_cache_kernel`, `write_kv_cache_fp8_kernel` and
+  `add_fp16_bias_to_fp32_kernel`, plus an inert `pdl::enable` registration on the
+  first. The FP8 one was orphaned when the fused FP8 KV write replaced its four
+  launch sites; the bias one was never launched at all, from the commit that
+  introduced it. No behaviour change — nothing called them. The two tests that
+  covered the non-fused FP16 write moved onto `write_kv_cache_fused_kernel`, so
+  the shared block-table indexing is now asserted on the kernel the engine
+  actually launches. Sweep and method recorded in `docs/audit/SETTLED.md`.
+
 ### Changed
 - **Pre-`cudaDeviceReset` hooks register themselves** (#1207). The eleven module
   hooks that free lazily-created CUDA statics (cuBLAS handles, CUTLASS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ there instead of retelling it.
   rules, so it cannot disagree with what ran.
 
 ### Removed
-- **Three KV/bias kernels that were built and linked but never launched** —
+- **Three KV/bias kernels that were built and linked but never launched** (#1216) —
   `write_kv_cache_kernel`, `write_kv_cache_fp8_kernel` and
   `add_fp16_bias_to_fp32_kernel`, plus an inert `pdl::enable` registration on the
   first. The FP8 one was orphaned when the fused FP8 KV write replaced its four

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -92,6 +92,27 @@ loop, and the shared part is already factored out.
   clutter and they are load-bearing — they stop the next reader reaching for a
   datacenter-Blackwell design.
 - **A `VramOwned` type does not exist.** Past audits hallucinated it.
+- **The `src/exec/executor_kernels.h` decl-only sweep ran on 2026-08-03.** Three kernels had
+  a declaration and a definition and nothing else — no launch, no address-taken use, no
+  test — and were removed: `add_fp16_bias_to_fp32_kernel`, `write_kv_cache_fp8_kernel`,
+  `write_kv_cache_kernel`. **Every other kernel declared in that header has a caller**; do
+  not re-run this sweep on it without a reason. Two of the three are worth remembering
+  because they are different failure modes: the FP8 one was orphaned by `d5dd4bbd`, which
+  replaced its four launch sites with one `write_kv_cache_fp8_fused_kernel`; the bias one
+  was **never launched at all** — it entered the tree under the old `src/graph/` path with
+  no caller, gained a header declaration it never needed, and was carried through the
+  file-size split #784 by three commits that each moved it without noticing.
+- **`write_kv_cache_fused_kernel` is the only FP16 KV-write path, deliberately.** The
+  non-fused twin is gone (above), so its absence is not a gap. Its coverage moved onto the
+  fused kernel in `tests/test_kv_cache_write.cu`: multi-token writes across a block
+  boundary, and the 2-D `bt[seq * max_blocks_per_seq + block_idx]` indexing every paged
+  write kernel shares — the only direct assertion on that indexing in the write path.
+
+**Method note for "is this dead" findings.** A call-graph tool reporting *no callers* is
+only evidence if the tool can see calls at all. Control it against a symbol you have
+already proven live before you trust the negative — for the sweep above, `codegraph callers
+write_kv_cache_fp8_fused_kernel` and `… write_kv_cache_nvfp4_kernel` both correctly returned
+`write_kv_cache`, which is what made the two empty answers meaningful.
 
 ## D — Load-bearing; a "cleanup" here is a regression
 

--- a/src/exec/executor_elementwise.cu
+++ b/src/exec/executor_elementwise.cu
@@ -362,20 +362,6 @@ __global__ __launch_bounds__(256) void elementwise_add_fp32_kernel(float* __rest
     }
 }
 
-// Add FP16 bias to each row of FP32 matrix: out[i,j] += bias[j]
-// Grid: n_tokens, Block: 256, each thread handles multiple expert indices.
-__global__ __launch_bounds__(256) void add_fp16_bias_to_fp32_kernel(float* __restrict__ data,
-                                                                    const half* __restrict__ bias,
-                                                                    int n_tokens, int n_cols) {
-    int token = blockIdx.x;
-    if (token >= n_tokens)
-        return;
-    float* row = data + static_cast<int64_t>(token) * n_cols;
-    for (int j = threadIdx.x; j < n_cols; j += blockDim.x) {
-        row[j] += __half2float(bias[j]);
-    }
-}
-
 // Scale FP32 expert weights in-place: weights[i] *= scale
 __global__ __launch_bounds__(256) void scale_fp32_kernel(float* __restrict__ data, float scale, int64_t n) {
     int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;

--- a/src/exec/executor_kernels.h
+++ b/src/exec/executor_kernels.h
@@ -58,22 +58,10 @@ __global__ __launch_bounds__(256) void fp16_to_fp32_kernel(const half* __restric
 __global__ __launch_bounds__(256) void elementwise_add_fp32_kernel(float* __restrict__ a,
                                                                    const float* __restrict__ b, int64_t n);
 
-__global__ __launch_bounds__(256) void write_kv_cache_kernel(const half* __restrict__ data_in,
-                                                             const int* __restrict__ positions,
-                                                             const int* __restrict__ block_tables,
-                                                             half* __restrict__ cache_base, int block_stride,
-                                                             int row_elems, int block_size, int n_tokens,
-                                                             int max_blocks_per_seq, int n_sequences);
-
 __global__ __launch_bounds__(256) void write_kv_cache_fused_kernel(
     const half* __restrict__ k_in, const half* __restrict__ v_in, const int* __restrict__ positions,
     const int* __restrict__ block_tables, half* __restrict__ k_cache_base, half* __restrict__ v_cache_base,
     int block_stride, int row_elems, int block_size, int n_tokens, int max_blocks_per_seq, int n_sequences);
-
-__global__ __launch_bounds__(256) void write_kv_cache_fp8_kernel(
-    const half* __restrict__ data_in, const int* __restrict__ positions, const int* __restrict__ block_tables,
-    __nv_fp8_e4m3* __restrict__ cache_base, float inv_scale, int block_stride, int row_elems, int block_size,
-    int n_tokens, int max_blocks_per_seq, int n_sequences);
 
 __global__ __launch_bounds__(256) void write_kv_cache_fp8_fused_kernel(
     const half* __restrict__ k_in, const half* __restrict__ v_in, const int* __restrict__ positions,
@@ -169,10 +157,6 @@ __global__ __launch_bounds__(256) void rope_q_only_fp16_kernel(half* __restrict_
                                                                int head_dim, float theta, float inv_scaling,
                                                                int rope_pairs, bool neox,
                                                                const float* __restrict__ longrope_inv_freqs);
-
-__global__ __launch_bounds__(256) void add_fp16_bias_to_fp32_kernel(float* __restrict__ data,
-                                                                    const half* __restrict__ bias,
-                                                                    int n_tokens, int n_cols);
 
 __global__ __launch_bounds__(256) void scale_fp32_kernel(float* __restrict__ data, float scale, int64_t n);
 

--- a/src/exec/executor_kv_write_kernels.cu
+++ b/src/exec/executor_kv_write_kernels.cu
@@ -5,52 +5,17 @@
 
 namespace imp {
 
-// Copy K/V for a set of tokens into paged KV cache blocks.
-// Each token's K (or V) slice is copied to the correct slot in the right block.
+// Shared parameter contract for the paged KV-write kernels below. Each token's
+// K (and V) slice is copied into the correct slot of the right block.
 //
-// data_in:          [n_tokens, n_kv_heads * head_dim] contiguous
+// k_in / v_in:      [n_tokens, n_kv_heads * head_dim] contiguous
 // positions:        [n_tokens] position of each token in the sequence
 // block_tables:     [n_sequences, max_blocks_per_seq] or [max_blocks] block IDs
-// cache_base:       base pointer of the KV pool for this layer (block 0)
+// *_cache_base:     base pointer of the KV pool for this layer (block 0)
 // block_stride:     elements per block = kKVBlockSize * n_kv_heads * head_dim
 // row_elems:        n_kv_heads * head_dim (elements per token)
 // max_blocks_per_seq: stride for 2D block table (0 = legacy flat)
 // n_sequences:      number of sequences in the batch
-__global__ __launch_bounds__(256) void write_kv_cache_kernel(const half* __restrict__ data_in,
-                                                             const int* __restrict__ positions,
-                                                             const int* __restrict__ block_tables,
-                                                             half* __restrict__ cache_base, int block_stride,
-                                                             int row_elems, int block_size, int n_tokens,
-                                                             int max_blocks_per_seq, int n_sequences) {
-    int token_idx = blockIdx.x;
-    if (token_idx >= n_tokens)
-        return;
-
-    int pos = positions[token_idx];
-    int slot_in_block;
-    int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
-                                   slot_in_block);
-    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
-    // sentinel, or a future block-table bug — would index the KV pool OOB.
-    // block_id is uniform across the block (derived from blockIdx.x), so this
-    // skips the whole write without divergence. Never fires today (host-side
-    // admission guarantees every written position has a real block).
-    if (block_id < 0)
-        return;
-
-    half* dst = cache_base + static_cast<int64_t>(block_id) * block_stride +
-                static_cast<int64_t>(slot_in_block) * row_elems;
-    const half* src = data_in + static_cast<int64_t>(token_idx) * row_elems;
-
-    // Vectorized 128-bit copy (8 FP16 per store) — row_elems is always a
-    // multiple of 8 (n_kv_heads * head_dim, where head_dim is power of 2).
-    const int vec_elems = row_elems / 8;
-    const float4* src4 = reinterpret_cast<const float4*>(src);
-    float4* dst4 = reinterpret_cast<float4*>(dst);
-    for (int i = threadIdx.x; i < vec_elems; i += blockDim.x) {
-        dst4[i] = src4[i];
-    }
-}
 
 // Fused K+V write to paged KV cache in a single launch.
 // blockIdx.x = token index, blockIdx.y = 0 (K) or 1 (V).
@@ -97,52 +62,6 @@ __global__ __launch_bounds__(256) void write_kv_cache_fused_kernel(
     float4* dst4 = reinterpret_cast<float4*>(dst);
     for (int i = threadIdx.x; i < vec_elems; i += blockDim.x) {
         dst4[i] = src4[i];
-    }
-}
-
-// FP16 -> FP8 E4M3 quantization + write to paged KV cache
-__global__ __launch_bounds__(256) void write_kv_cache_fp8_kernel(
-    const half* __restrict__ data_in, const int* __restrict__ positions, const int* __restrict__ block_tables,
-    __nv_fp8_e4m3* __restrict__ cache_base,  // FP8 cache
-    float inv_scale,                         // 1.0 / kv_scale
-    int block_stride, int row_elems, int block_size, int n_tokens, int max_blocks_per_seq, int n_sequences) {
-    int token_idx = blockIdx.x;
-    if (token_idx >= n_tokens)
-        return;
-
-    int pos = positions[token_idx];
-    int slot_in_block;
-    int block_id = kv_resolve_slot(block_tables, pos, block_size, token_idx, max_blocks_per_seq, n_sequences,
-                                   slot_in_block);
-    // Defense-in-depth (F-A12): a negative block_id — a freed StreamingLLM -1
-    // sentinel, or a future block-table bug — would index the KV pool OOB.
-    // block_id is uniform across the block (derived from blockIdx.x), so this
-    // skips the whole write without divergence. Never fires today (host-side
-    // admission guarantees every written position has a real block).
-    if (block_id < 0)
-        return;
-
-    __nv_fp8_e4m3* dst = cache_base + static_cast<int64_t>(block_id) * block_stride +
-                         static_cast<int64_t>(slot_in_block) * row_elems;
-    const half* src = data_in + static_cast<int64_t>(token_idx) * row_elems;
-
-    // Packed PTX cvt: 2 paired conversions per 4 elements (half→e4m3x2).
-    // Scale applied in FP16 before conversion — sufficient precision for E4M3.
-    const half inv_scale_h = __float2half(inv_scale);
-    const half2 inv_scale_h2 = make_half2(inv_scale_h, inv_scale_h);
-    const int vec_elems = row_elems / 4;
-    const half2* src2 = reinterpret_cast<const half2*>(src);
-    uint32_t* dst4 = reinterpret_cast<uint32_t*>(dst);
-    for (int i = threadIdx.x; i < vec_elems; i += blockDim.x) {
-        half2 lo = __hmul2(src2[2 * i], inv_scale_h2);
-        half2 hi = __hmul2(src2[2 * i + 1], inv_scale_h2);
-        uint16_t e4m3_lo = cvt_f16x2_to_e4m3x2(*reinterpret_cast<uint32_t*>(&lo));
-        uint16_t e4m3_hi = cvt_f16x2_to_e4m3x2(*reinterpret_cast<uint32_t*>(&hi));
-        dst4[i] = static_cast<uint32_t>(e4m3_lo) | (static_cast<uint32_t>(e4m3_hi) << 16);
-    }
-    // Scalar tail for non-aligned remainder
-    for (int i = vec_elems * 4 + threadIdx.x; i < row_elems; i += blockDim.x) {
-        dst[i] = __nv_fp8_e4m3(__half2float(src[i]) * inv_scale);
     }
 }
 

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -189,7 +189,6 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     if (use_pdl_ && pdl::is_available()) {
         pdl::enable(reinterpret_cast<const void*>(&elementwise_add_fp16_kernel));
         pdl::enable(reinterpret_cast<const void*>(&elementwise_add_fp32_kernel));
-        pdl::enable(reinterpret_cast<const void*>(&write_kv_cache_kernel));
         pdl::enable(reinterpret_cast<const void*>(&write_kv_cache_fused_kernel));
         pdl::enable(reinterpret_cast<const void*>(&write_kv_cache_rope_fused_kernel));
         pdl::enable(reinterpret_cast<const void*>(&fp16_to_fp32_kernel));

--- a/tests/test_kv_cache_write.cu
+++ b/tests/test_kv_cache_write.cu
@@ -58,7 +58,11 @@ struct MockPagedCache {
 };
 
 // =========================================================================
-// write_kv_cache_kernel: single K or V write to paged blocks
+// Paged slot resolution — multiple tokens, flat block table, crossing a
+// block boundary. Exercised through write_kv_cache_fused_kernel: the
+// non-fused write_kv_cache_kernel was removed once it had no production
+// caller, so the shared kv_resolve_slot() logic is asserted on the kernel
+// the engine actually launches.
 // =========================================================================
 
 TEST(KVCacheWriteTest, BasicPagedWrite) {
@@ -67,15 +71,19 @@ TEST(KVCacheWriteTest, BasicPagedWrite) {
     const int n_tokens = 2;
     const int row_elems = n_kv_heads * head_dim;
 
-    // Input data: token 0 = all 1.0, token 1 = all 2.0
-    std::vector<half> h_data(n_tokens * row_elems);
+    // Input data: token t → K = t+1, V = 10*(t+1), so a K/V mix-up is visible.
+    std::vector<half> h_k(n_tokens * row_elems), h_v(n_tokens * row_elems);
     for (int t = 0; t < n_tokens; t++)
-        for (int i = 0; i < row_elems; i++)
-            h_data[t * row_elems + i] = __float2half(static_cast<float>(t + 1));
+        for (int i = 0; i < row_elems; i++) {
+            h_k[t * row_elems + i] = __float2half(static_cast<float>(t + 1));
+            h_v[t * row_elems + i] = __float2half(10.0f * static_cast<float>(t + 1));
+        }
 
-    half* d_data;
-    cudaMalloc(&d_data, h_data.size() * sizeof(half));
-    cudaMemcpy(d_data, h_data.data(), h_data.size() * sizeof(half), cudaMemcpyHostToDevice);
+    half *d_k, *d_v;
+    cudaMalloc(&d_k, h_k.size() * sizeof(half));
+    cudaMalloc(&d_v, h_v.size() * sizeof(half));
+    cudaMemcpy(d_k, h_k.data(), h_k.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, h_v.data(), h_v.size() * sizeof(half), cudaMemcpyHostToDevice);
 
     // Positions: token 0 → pos 3, token 1 → pos 19
     int h_positions[2] = {3, 19};
@@ -91,35 +99,43 @@ TEST(KVCacheWriteTest, BasicPagedWrite) {
     cudaMalloc(&d_bt, 2 * sizeof(int));
     cudaMemcpy(d_bt, h_bt, 2 * sizeof(int), cudaMemcpyHostToDevice);
 
-    // Allocate cache with 8 physical blocks
-    MockPagedCache cache(n_kv_heads, head_dim, 8);
+    // Allocate caches with 8 physical blocks
+    MockPagedCache k_cache(n_kv_heads, head_dim, 8);
+    MockPagedCache v_cache(n_kv_heads, head_dim, 8);
 
-    // Launch kernel
-    write_kv_cache_kernel<<<n_tokens, 256, 0, nullptr>>>(d_data, d_positions, d_bt, cache.d_cache,
-                                                         cache.block_stride, row_elems, kBlockSize, n_tokens,
-                                                         0 /* max_blocks_per_seq=0 → flat */,
-                                                         1 /* n_sequences */);
+    dim3 grid(n_tokens, 2);  // blockIdx.y: 0=K, 1=V
+    write_kv_cache_fused_kernel<<<grid, 256, 0, nullptr>>>(d_k, d_v, d_positions, d_bt, k_cache.d_cache,
+                                                           v_cache.d_cache, k_cache.block_stride, row_elems,
+                                                           kBlockSize, n_tokens,
+                                                           0 /* max_blocks_per_seq=0 → flat */,
+                                                           1 /* n_sequences */);
     cudaDeviceSynchronize();
 
-    // Verify: block 5, slot 3 should have all 1.0
-    auto slot0 = cache.read_slot(5, 3);
+    // Verify: block 5, slot 3 holds token 0 (K=1.0, V=10.0)
+    auto k_slot0 = k_cache.read_slot(5, 3);
+    auto v_slot0 = v_cache.read_slot(5, 3);
     for (int i = 0; i < row_elems; i++) {
-        EXPECT_NEAR(slot0[i], 1.0f, 0.01f) << "Block 5, slot 3, index " << i;
+        EXPECT_NEAR(k_slot0[i], 1.0f, 0.01f) << "K block 5, slot 3, index " << i;
+        EXPECT_NEAR(v_slot0[i], 10.0f, 0.01f) << "V block 5, slot 3, index " << i;
     }
 
-    // Verify: block 2, slot 3 should have all 2.0
-    auto slot1 = cache.read_slot(2, 3);
+    // Verify: block 2, slot 3 holds token 1 (K=2.0, V=20.0) — block_idx 1, i.e.
+    // the position crossed a block boundary.
+    auto k_slot1 = k_cache.read_slot(2, 3);
+    auto v_slot1 = v_cache.read_slot(2, 3);
     for (int i = 0; i < row_elems; i++) {
-        EXPECT_NEAR(slot1[i], 2.0f, 0.01f) << "Block 2, slot 3, index " << i;
+        EXPECT_NEAR(k_slot1[i], 2.0f, 0.01f) << "K block 2, slot 3, index " << i;
+        EXPECT_NEAR(v_slot1[i], 20.0f, 0.01f) << "V block 2, slot 3, index " << i;
     }
 
     // Verify: block 0, slot 0 should still be zero (untouched)
-    auto untouched = cache.read_slot(0, 0);
+    auto untouched = k_cache.read_slot(0, 0);
     for (int i = 0; i < row_elems; i++) {
         EXPECT_FLOAT_EQ(untouched[i], 0.0f) << "Block 0, slot 0 should be untouched";
     }
 
-    cudaFree(d_data);
+    cudaFree(d_k);
+    cudaFree(d_v);
     cudaFree(d_positions);
     cudaFree(d_bt);
 }
@@ -184,7 +200,10 @@ TEST(KVCacheWriteTest, FusedKVWrite) {
 }
 
 // =========================================================================
-// write_kv_cache_kernel with batched block table (n_sequences > 1)
+// Batched block table (n_sequences > 1) — the 2-D indexing
+// bt[seq * max_blocks_per_seq + block_idx] that every paged write kernel
+// shares. This is the only direct assertion on it in the write path, so it
+// rides the fused kernel now that the non-fused one is gone.
 // =========================================================================
 
 TEST(KVCacheWriteTest, BatchedBlockTable) {
@@ -195,16 +214,20 @@ TEST(KVCacheWriteTest, BatchedBlockTable) {
     const int n_tokens = 2;
     const int max_blocks_per_seq = 3;
 
-    // Input: token 0 = 10.0, token 1 = 20.0
-    std::vector<half> h_data(n_tokens * row_elems);
+    // Input: token 0 → K 10.0 / V 100.0, token 1 → K 20.0 / V 200.0
+    std::vector<half> h_k(n_tokens * row_elems), h_v(n_tokens * row_elems);
     for (int i = 0; i < row_elems; i++) {
-        h_data[i] = __float2half(10.0f);
-        h_data[row_elems + i] = __float2half(20.0f);
+        h_k[i] = __float2half(10.0f);
+        h_k[row_elems + i] = __float2half(20.0f);
+        h_v[i] = __float2half(100.0f);
+        h_v[row_elems + i] = __float2half(200.0f);
     }
 
-    half* d_data;
-    cudaMalloc(&d_data, h_data.size() * sizeof(half));
-    cudaMemcpy(d_data, h_data.data(), h_data.size() * sizeof(half), cudaMemcpyHostToDevice);
+    half *d_k, *d_v;
+    cudaMalloc(&d_k, h_k.size() * sizeof(half));
+    cudaMalloc(&d_v, h_v.size() * sizeof(half));
+    cudaMemcpy(d_k, h_k.data(), h_k.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_v, h_v.data(), h_v.size() * sizeof(half), cudaMemcpyHostToDevice);
 
     // Positions: seq0 at pos 8, seq1 at pos 33
     // pos 8 → block_idx 0, slot 8
@@ -222,26 +245,34 @@ TEST(KVCacheWriteTest, BatchedBlockTable) {
     cudaMalloc(&d_bt, 6 * sizeof(int));
     cudaMemcpy(d_bt, h_bt, 6 * sizeof(int), cudaMemcpyHostToDevice);
 
-    MockPagedCache cache(n_kv_heads, head_dim, 10);
+    MockPagedCache k_cache(n_kv_heads, head_dim, 10);
+    MockPagedCache v_cache(n_kv_heads, head_dim, 10);
 
-    write_kv_cache_kernel<<<n_tokens, 256, 0, nullptr>>>(d_data, d_pos, d_bt, cache.d_cache,
-                                                         cache.block_stride, row_elems, kBlockSize, n_tokens,
-                                                         max_blocks_per_seq, 2 /* n_sequences */);
+    dim3 grid(n_tokens, 2);  // blockIdx.y: 0=K, 1=V
+    write_kv_cache_fused_kernel<<<grid, 256, 0, nullptr>>>(d_k, d_v, d_pos, d_bt, k_cache.d_cache,
+                                                           v_cache.d_cache, k_cache.block_stride, row_elems,
+                                                           kBlockSize, n_tokens, max_blocks_per_seq,
+                                                           2 /* n_sequences */);
     cudaDeviceSynchronize();
 
     // seq0: pos 8 → block_idx 0, slot 8. bt[0*3+0]=1 → physical block 1
-    auto s0 = cache.read_slot(1, 8);
+    auto k0 = k_cache.read_slot(1, 8);
+    auto v0 = v_cache.read_slot(1, 8);
     for (int i = 0; i < row_elems; i++) {
-        EXPECT_NEAR(s0[i], 10.0f, 0.01f) << "Seq0 mismatch at " << i;
+        EXPECT_NEAR(k0[i], 10.0f, 0.01f) << "Seq0 K mismatch at " << i;
+        EXPECT_NEAR(v0[i], 100.0f, 0.01f) << "Seq0 V mismatch at " << i;
     }
 
     // seq1: pos 33 → block_idx 2, slot 1. bt[1*3+2]=0 → physical block 0
-    auto s1 = cache.read_slot(0, 1);
+    auto k1 = k_cache.read_slot(0, 1);
+    auto v1 = v_cache.read_slot(0, 1);
     for (int i = 0; i < row_elems; i++) {
-        EXPECT_NEAR(s1[i], 20.0f, 0.01f) << "Seq1 mismatch at " << i;
+        EXPECT_NEAR(k1[i], 20.0f, 0.01f) << "Seq1 K mismatch at " << i;
+        EXPECT_NEAR(v1[i], 200.0f, 0.01f) << "Seq1 V mismatch at " << i;
     }
 
-    cudaFree(d_data);
+    cudaFree(d_k);
+    cudaFree(d_v);
     cudaFree(d_pos);
     cudaFree(d_bt);
 }


### PR DESCRIPTION
## The finding

Reported as a side finding: `add_fp16_bias_to_fp32_kernel` and `write_kv_cache_fp8_kernel` occur in `src/ tools/ tests/ include/` only as a declaration and a definition, and both TUs are compiled (`CMakeLists.txt:331-332`). Verified, and it holds — with two corrections to the shape of it.

Escape hatches checked and all empty: macro-generated launches (`##_kernel`), string / `cudaLaunchKernel` references, templates, `pdl::enable` address-taken use, tests. Second independent signal from `codegraph callers` — **controlled against two proven-live kernels first**, since a call-graph tool that cannot see `<<<` at all would report "no callers" for everything:

```
codegraph callers write_kv_cache_fp8_fused_kernel  → write_kv_cache (executor_kv_write.cu:21)
codegraph callers write_kv_cache_nvfp4_kernel      → write_kv_cache (executor_kv_write.cu:21)
codegraph callers write_kv_cache_fp8_kernel        → No callers found
codegraph callers add_fp16_bias_to_fp32_kernel     → No callers found
```

**Two different failure modes, worth separating:**

- **`write_kv_cache_fp8_kernel`** was orphaned on 2026-03-14 by `d5dd4bbd`, which replaced its **four** `write_kv_cache_fp8_kernel<<<` launch sites with one `write_kv_cache_fp8_fused_kernel<<<`. The fused twin is live. Only the definition stayed behind.
- **`add_fp16_bias_to_fp32_kernel`** was **never launched** — `git log -S"add_fp16_bias_to_fp32_kernel<<<"` returns nothing across the whole history. It entered the tree under the old `src/graph/` path with no caller, gained a header declaration it never needed, and was carried into a new TU by the file-size split #784. Three commits moved it; none noticed it had no caller.

A third turned up in the same sweep and is removed too: **`write_kv_cache_kernel`** (non-fused FP16) is never launched in `src/` either. It survived on two tests and a `pdl::enable` registration — PDL on a kernel production never starts is a no-op.

The sweep covered every kernel declared in `src/exec/executor_kernels.h`; these three are the only ones with no caller.

## Coverage moved, not dropped

The two tests that used the non-fused kernel now exercise `write_kv_cache_fused_kernel`, which the engine actually launches:

- `BasicPagedWrite` — multi-token write with a position crossing a block boundary, flat block table, untouched-slot check.
- `BatchedBlockTable` — the 2-D `bt[seq * max_blocks_per_seq + block_idx]` indexing with `n_sequences=2`. This is the **only** direct assertion on that indexing in the write path: `FusedKVWrite` and `Int8PerHeadScale` both run `max_blocks_per_seq=0, n_sequences=1`, and the indexing is shared by every paged write kernel (fused, int8, int4, nvfp4, mxfp4).

Both now also assert V routing, which neither original did.

## Verification

| Check | Result |
|---|---|
| `make dev` | compiles — the real proof; a missed consumer fails here |
| `ctest -L unit` (CI lane) | 4/4 |
| `test-kv` on the GPU | 4/4 |
| clang-format on changed lines | clean |
| `check-release.sh` settled anchors | 51/51 resolve |

**Mutation-validated**, because 4/4 green proves nothing on its own:

| Mutation | Result |
|---|---|
| `BatchedBlockTable` expects physical block 0 instead of 1 | **FAILED** — the 2-D indexing assertion fires |
| `BasicPagedWrite` expects V=2.0 instead of 20.0 | **FAILED** — the V-routing assertion fires |

Restored afterwards byte-identical, clean re-run green.

No behaviour change: nothing called these kernels. No perf claim — the `ptxas` saving in two TUs is not measurable and is not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B