### PR TITLE
fix(exec): couple the MoE prefill dispatch to its routing model (F-3, other half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ there instead of retelling it.
   existing `args.<field>` use site is unchanged.
 
 ### Added
+- **The MoE prefill dispatch now checks itself against its routing model**, the
+  same treatment the attention half got in the F-3 campaign. `select_moe_prefill_path`
+  had zero production callers — ten test callers and a comment asking for the two
+  predicates to be kept in sync by hand — so a reorder in
+  `executor_forward_moe_cutlass.cu` left the routing test green while describing a
+  dispatch that no longer existed. Each tier now replays the model against what the
+  chain observed and logs a one-shot error on divergence. Six new CPU tests; the
+  reorder-catching ones are the tier-precedence pair, verified by mutation (the
+  replay tests stay green under a reorder, exactly as on the attention side).
 - **`docs/audit/SETTLED.md`** (#1215) — the ledger an audit reads *before* forming
   hypotheses, gated by a new `settled-prior anchors` section in
   `scripts/check-release.sh` (CI job `Release hygiene`, 49 anchors). Eight of the

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -165,7 +165,18 @@ one command.
 Still open from 07-29 with the reason each was not shipped blind — see
 [`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the full argument.
 
-- **F-3 (rest)** — routing replica: a tier reordered ahead of the winner stays invisible.
+- **F-3 (rest)** — routing replica. **This entry understated the gap until 2026-08-03**: it
+  described the residual limit of the *attention* half (a tier reordered ahead of the winner
+  stays invisible, because the chain short-circuits and never asks it) as if that were all
+  that was left. The **MoE** half had no runtime check at all — `select_moe_prefill_path`
+  had zero production callers, ten test callers, and a comment in
+  `src/exec/executor_forward_moe.cu` asking for the two predicates to be kept in sync by
+  hand. Found with the call graph, confirmed by grep. Both halves now replay the model
+  against what the chain observed (`verify_against_moe_routing_model` in
+  `src/exec/executor_forward_moe_cutlass.cu`, mirroring
+  `src/compute/attention_dispatch.cu`); the short-circuit limit above is what genuinely
+  remains, for both. **Lesson for this ledger: an open entry that records one half of a
+  symmetric problem reads as if the other half were closed.**
 - **F-5 (rest)** — GPU CI lane: **declined by the repo owner, 2026-08-03.** The job and its
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -7,6 +7,7 @@
 #include "exec/executor.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_forward_moe_internal.h"
+#include "exec/moe_prefill_decision.h"  // select_moe_prefill_path — the mirror this file verifies against
 #include "runtime/config.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_grouped_3x.h"
@@ -29,6 +30,44 @@
 
 namespace imp {
 
+// The path-selection ORDER + arch/config gates below are mirrored as a pure host
+// function `select_moe_prefill_path` in moe_prefill_decision.h.
+//
+// That mirror used to be TEST-ONLY: test_routing_decision.cpp was its sole
+// caller, so a reorder here left the test green and its stated purpose unmet —
+// audit finding F-3. The attention half of F-3 got its runtime check
+// (verify_against_routing_model, attention_dispatch.cu); this half did not, and
+// the comment at executor_forward_moe.cu asked for the two predicates to be kept
+// in sync by hand. Nothing enforced that.
+//
+// This function now CONSULTS the mirror. Each tier records what it actually did
+// — not what its preconditions promised, since device-args and smallM can both
+// fail *inside* and fall through — and once a tier wins, the model is replayed
+// against those observations and must name the same winner.
+//
+// KNOWN LIMIT, same as the attention side and stated rather than implied: a tier
+// reordered ahead of the winner that WOULD have accepted stays invisible,
+// because the chain short-circuits and never asks it.
+//
+// One-shot so a divergence cannot flood a serving log; the first occurrence is
+// the one that matters and it names both answers.
+static void verify_against_moe_routing_model(ModelArch arch, const RuntimeConfig& rcfg,
+                                             const MoePrefillWorkspace& obs, MoePrefillPath chosen) {
+    const MoePrefillPath modeled = select_moe_prefill_path(arch, rcfg, obs);
+    if (modeled == chosen)
+        return;
+    static bool warned = false;
+    if (warned)
+        return;
+    warned = true;
+    IMP_LOG_ERROR(
+        "MoE routing model disagrees with the dispatch: dispatch ran %s, "
+        "select_moe_prefill_path() says %s. executor_forward_moe_cutlass.cu and "
+        "moe_prefill_decision.h have drifted apart (F-3) — the routing unit test "
+        "is now describing a dispatch that does not exist.",
+        moe_prefill_path_name(chosen), moe_prefill_path_name(modeled));
+}
+
 // ---------------------------------------------------------------------------
 bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t stream,
                                                           MoeFfnContext& ctx) {
@@ -42,20 +81,6 @@ bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t
     bool& non_gated_experts = ctx.non_gated_experts;
     MoeRoutingResult& routing = ctx.routing;
 
-    // Predicate: CUTLASS 3.x NVFP4 grouped path.
-    // Measured on Qwen3-Coder-30B-A3B-FP4:
-    //   Prefill n=120: ~2750 tok/s (vs legacy ~77)   — 35x win
-    //   Decode n=1:    ~48 tok/s (vs legacy ~38)     — 25% win
-    // After shared-quantize gate+up (2026-04-20), 3.x beats legacy at all n.
-    // The moe.no_cutlass3x config flag (was IMP_NO_CUTLASS3X_MOE env) forces
-    // legacy for debugging.
-    static const bool force_off = runtime_config().moe.no_cutlass3x;
-    if (force_off)
-        return false;
-    if (!cutlass_grouped_3x_nvfp4_available())
-        return false;
-    if (!moe_.cutlass3x_packed || !moe_.cutlass3x_sf)
-        return false;
     auto covers_ids = [&](const std::vector<TensorID>& ids) {
         if (static_cast<int>(ids.size()) < ctx.ne)
             return false;
@@ -67,12 +92,28 @@ bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t
         }
         return true;
     };
-    if (!covers_ids(ly.expert_up_ids))
+    // Predicate: CUTLASS 3.x NVFP4 grouped path.
+    // Measured on Qwen3-Coder-30B-A3B-FP4:
+    //   Prefill n=120: ~2750 tok/s (vs legacy ~77)   — 35x win
+    //   Decode n=1:    ~48 tok/s (vs legacy ~38)     — 25% win
+    // After shared-quantize gate+up (2026-04-20), 3.x beats legacy at all n.
+    // The moe.no_cutlass3x config flag (was IMP_NO_CUTLASS3X_MOE env) forces
+    // legacy for debugging.
+    //
+    // Observations for the routing-model replay, filled in as the chain is
+    // walked. A tier the chain never reaches keeps its `false` — see the KNOWN
+    // LIMIT above. Same short-circuit order as the six early returns this
+    // conjunction replaces, so the cheap checks still gate the expensive ones.
+    MoePrefillWorkspace obs{};
+    static const bool force_off = runtime_config().moe.no_cutlass3x;
+    obs.grouped_available = !force_off && cutlass_grouped_3x_nvfp4_available() && moe_.cutlass3x_packed &&
+                            moe_.cutlass3x_sf && covers_ids(ly.expert_up_ids) &&
+                            covers_ids(ly.expert_down_ids) &&
+                            (ctx.non_gated_experts || covers_ids(ly.expert_gate_ids));
+    if (!obs.grouped_available) {
+        verify_against_moe_routing_model(cfg.arch, runtime_config(), obs, MoePrefillPath::LEGACY);
         return false;
-    if (!covers_ids(ly.expert_down_ids))
-        return false;
-    if (!ctx.non_gated_experts && !covers_ids(ly.expert_gate_ids))
-        return false;
+    }
 
 // =========================================================================
 // CUTLASS 3.x NVFP4 BlockScaled Grouped GEMM path (NVFP4 × NVFP4 → FP16).
@@ -295,7 +336,12 @@ bool device_args_done = false;
         }
         if (ok) {
             device_args_done = true;
+            // What the tier DID, not what its preconditions promised: the block
+            // above can still fail on dispatch and fall through to the legacy
+            // host-args path below.
+            obs.device_args_ready = true;
             dispatch_record::set_moe_prefill_tier(MoePrefillPath::DEVICE_ARGS);
+            verify_against_moe_routing_model(cfg.arch, runtime_config(), obs, MoePrefillPath::DEVICE_ARGS);
         } else {
             IMP_LOG_ERROR(
                 "device-args full path failed; falling back to legacy");
@@ -627,7 +673,13 @@ bool smallM_done = false;
                         cudaFreeAsync(d_act_tscales_dn, stream));
                     if (ok_down) {
                         smallM_done = true;
+                        // Again the outcome, not the gate: a smallM gate/up or
+                        // down dispatch failure falls through to GROUPED below.
+                        obs.smallM_available = true;
+                        obs.smallM_under_threshold = true;
                         dispatch_record::set_moe_prefill_tier(MoePrefillPath::SMALL_M);
+                        verify_against_moe_routing_model(cfg.arch, runtime_config(), obs,
+                                                         MoePrefillPath::SMALL_M);
                     } else {
                         IMP_LOG_ERROR(
                             "smallM down dispatch failed; falling back to "
@@ -650,6 +702,8 @@ bool smallM_done = false;
 
 if (!smallM_done) {
     dispatch_record::set_moe_prefill_tier(MoePrefillPath::GROUPED);
+    obs.grouped_ready = true;
+    verify_against_moe_routing_model(cfg.arch, runtime_config(), obs, MoePrefillPath::GROUPED);
     if (layer == 0)
         IMP_LOG_INFO("MoE prefill: CUTLASS 3.x NVFP4 grouped (n=%d, expanded=%d)", n, expanded);
 }

--- a/tests/test_routing_decision.cpp
+++ b/tests/test_routing_decision.cpp
@@ -388,3 +388,111 @@ TEST(AttnTierPrecedence, FmhaSm120BeatsBlackwellWhenBothAccept) {
     ASSERT_TRUE(sup.fmha_sm120_accepts && sup.blackwell_accepts);
     EXPECT_EQ(select_attn_prefill_path(cfg, sup), AttnPrefillPath::FMHA_SM120);
 }
+
+// --------------------------------------------------------------------------
+// MoE model/dispatch COUPLING — the same treatment the attention half got
+// --------------------------------------------------------------------------
+//
+// executor_forward_moe_cutlass.cu now replays select_moe_prefill_path() against
+// what the chain observed and logs loudly on divergence
+// (verify_against_moe_routing_model). These pin the replay so the check cannot
+// fire on a *correct* dispatch.
+//
+// The observations mirror what the .cu records, which is what each tier DID —
+// not what its preconditions promised. Device-args and smallM can both pass
+// their gate and then fail inside, falling through to a later tier, so the
+// dispatch sets the flag only after the tier has actually completed.
+
+namespace {
+
+MoePrefillWorkspace moe_observed_when(MoePrefillPath winner) {
+    MoePrefillWorkspace ws;  // all false — the dispatch's starting state
+    switch (winner) {
+        case MoePrefillPath::DEVICE_ARGS:
+            ws.grouped_available = true;
+            ws.device_args_ready = true;
+            break;
+        case MoePrefillPath::SMALL_M:
+            ws.grouped_available = true;
+            ws.smallM_available = true;
+            ws.smallM_under_threshold = true;
+            break;
+        case MoePrefillPath::GROUPED:
+            ws.grouped_available = true;
+            ws.grouped_ready = true;
+            break;
+        case MoePrefillPath::LEGACY:
+            break;  // the six entry gates refused → grouped_available stays false
+    }
+    return ws;
+}
+
+}  // namespace
+
+TEST(MoeRoutingModelCoupling, EveryTierReplaysToItself) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_smallM = true;  // so the smallM tier is reachable at all
+
+    const MoePrefillPath tiers[] = {MoePrefillPath::DEVICE_ARGS, MoePrefillPath::SMALL_M,
+                                    MoePrefillPath::GROUPED, MoePrefillPath::LEGACY};
+    for (MoePrefillPath t : tiers) {
+        EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, moe_observed_when(t)), t)
+            << "the dispatch would run " << moe_prefill_path_name(t) << " but the model replays to "
+            << moe_prefill_path_name(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, moe_observed_when(t)))
+            << " — verify_against_moe_routing_model() would fire on a correct dispatch";
+    }
+}
+
+// gpt-oss enters the same chain but is arch-gated off the two fast tiers, so its
+// only non-legacy answer is GROUPED. The dispatch records exactly that.
+TEST(MoeRoutingModelCoupling, GptOssReplaysToGrouped) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_smallM = true;
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::GPT_OSS, cfg, moe_observed_when(MoePrefillPath::GROUPED)),
+              MoePrefillPath::GROUPED);
+}
+
+// --------------------------------------------------------------------------
+// MoE tier PRECEDENCE — same reasoning as AttnTierPrecedence above
+// --------------------------------------------------------------------------
+//
+// The replay tests cannot catch a reorder: each observation pattern has exactly
+// one eligible tier, so swapping two tiers in select_moe_prefill_path() leaves
+// every answer unchanged. These make two tiers eligible at once and assert the
+// earlier one wins.
+
+TEST(MoeTierPrecedence, DeviceArgsBeatsSmallM) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_smallM = true;
+    auto ws = all_ready();
+    ASSERT_TRUE(cfg.moe.nvfp4_device_args && ws.device_args_ready);
+    ASSERT_TRUE(ws.smallM_available && ws.smallM_under_threshold);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::DEVICE_ARGS);
+}
+
+TEST(MoeTierPrecedence, SmallMBeatsGrouped) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;  // device-args out of the way
+    cfg.moe.nvfp4_smallM = true;
+    auto ws = all_ready();
+    ASSERT_TRUE(ws.smallM_available && ws.smallM_under_threshold && ws.grouped_ready);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::SMALL_M);
+}
+
+TEST(MoeTierPrecedence, GroupedBeatsLegacyWhenReady) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_device_args = false;
+    auto ws = all_ready();
+    ws.smallM_available = false;  // smallM out of the way
+    ASSERT_TRUE(ws.grouped_available && ws.grouped_ready);
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::GROUPED);
+}
+
+// The entry gate short-circuits every CUTLASS tier, however ready they look.
+TEST(MoeTierPrecedence, EntryGateBeatsEveryReadyTier) {
+    auto cfg = default_cfg();
+    cfg.moe.nvfp4_smallM = true;
+    auto ws = all_ready();
+    ws.grouped_available = false;  // the six early returns in the .cu
+    EXPECT_EQ(select_moe_prefill_path(ModelArch::QWEN3_MOE, cfg, ws), MoePrefillPath::LEGACY);
+}


### PR DESCRIPTION
## What the call graph showed

Both prefill dispatches have a pure "routing model" that a CPU test pins. Only one of them was wired to the code it models:

```
callers of select_attn_prefill_path (20)
  → verify_against_routing_model   src/compute/attention_dispatch.cu:58   ← production
  → TEST …                          tests/test_routing_decision.cpp

callers of select_moe_prefill_path (10)
  → all ten in tests/test_routing_decision.cpp
```

Confirmed by grep, not just the graph: the only other mention of `select_moe_prefill_path` in `src/` is a **comment** at `executor_forward_moe.cu:355` — *"Keep the two predicates in sync"*. By hand, with nothing enforcing it. So a reorder in `executor_forward_moe_cutlass.cu` left the routing test green while it described a dispatch that no longer existed. The F-3 campaign fixed the attention half and left this one.

## The change

`executor_forward_moe_cutlass.cu` now replays the model against what the chain observed, at each of the three tier-record sites plus the legacy exit, and logs a one-shot error on divergence — the same shape as `verify_against_routing_model`.

The observations record what a tier **did**, not what its preconditions promised: device-args and smallM can both pass their gate and then fail *inside*, falling through to a later tier. Recording the gate instead of the outcome would make the verifier fire on a correct dispatch. The six entry `return false`s collapse into one short-circuit conjunction in the same order, which is also what makes `grouped_available` observable.

Same KNOWN LIMIT as the attention side, stated in the code: a tier reordered *ahead* of the winner stays invisible, because the chain short-circuits and never asks it.

## Tests, and which one actually earns its keep

Six new CPU tests in the CI lane (`test-core` → `ctest -L unit`), so this is one of the few things here that gets real CI coverage.

Mutation-validated — **moving smallM ahead of device-args in the model**:

| Suite | Under the reorder |
|---|---|
| `MoeRoutingModelCoupling` (replay) | **PASSED 2** — green, catches nothing |
| `MoeTierPrecedence` | **FAILED** `DeviceArgsBeatsSmallM` |

That reproduces for the MoE half what `test_routing_decision.cpp` already records for the attention half: each replay pattern has exactly one eligible tier, so a reorder changes no answer. The precedence tests are the ones that catch it.

A second mutation — **dropping the gpt-oss arch gate from the device-args tier** — is caught by the *pre-existing* `MoePrefillTable.GptOssSkipsDeviceArgsTakesGrouped`, **not** by the new replay tests (their observation has `device_args_ready = false`, so the gate is unreachable either way). The division is deliberate: table tests cover gates, the new ones cover replay and precedence.

16 MoE routing tests total, all green; full CPU lane 4/4; `clang-format` clean on changed lines (checked with `git clang-format --diff origin/main`, not a whole-file reformat).

## Ledger correction

`SETTLED.md`'s F-3 entry described only the attention half's residual limit, which read as though the rest were closed. Corrected, with the lesson recorded: *an open entry that records one half of a symmetric problem reads as if the other half were closed.*

## What is NOT verified

**The verifier has not been observed firing, or staying silent, on a real NVFP4 MoE prefill.** No test drives `try_run_moe_cutlass3x_nvfp4_prefill_` without a real model, the `gpu` ctest label does not run in CI, and the card had three unrelated containers on it — not a state to load a 20 GB model into. The DEVICE_ARGS site's reachability rests on #1210's evidence (`resolved dispatch: … moe_prefill=cutlass3x → device_args`); SMALL_M and GROUPED are by construction only. Worth one run on a free card before trusting the silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B