### PR TITLE
feat(diagnostics): settable log level (76 dead sites) + retire audit finding F-6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ there instead of retelling it.
   existing `args.<field>` use site is unchanged.
 
 ### Added
+- **`diagnostics.log_level`** (`debug` | `info` | `warn` | `error` | `fatal`) —
+  the engine's debug logging could not be switched on at all. `log_set_level()`
+  was the only writer of the level and nothing called it; there was no config
+  key and no flag, so `g_log_level` stayed at `info` and all 76
+  `IMP_LOG_DEBUG` sites were unreachable. Applied in `process_diag_install()`,
+  which runs from both tool mains and `Engine::init`, so a C-API consumer gets
+  it too. An unrecognised value warns and keeps the current level instead of
+  falling back to `info` — a silent fallback is what the bug was.
+  Measured: same model and prompt, 0 debug lines by default, 359 from 10 source
+  files with `--set diagnostics.log_level=debug`.
 - **The MoE prefill dispatch now checks itself against its routing model**, the
   same treatment the attention half got in the F-3 campaign. `select_moe_prefill_path`
   had zero production callers — ten test callers and a comment asking for the two

--- a/docs/MEMORY_ARCHITECTURE.md
+++ b/docs/MEMORY_ARCHITECTURE.md
@@ -159,7 +159,25 @@ Per-pool `note()` attribution at steady state:
 | **tracked total** | **11238.3** | **19311.0** | **10473.2** |
 | **untracked residual** | **7177.2 (39 %)** | **4738.5 (20 %)** | **4516.4 (30 %)** |
 
-Acceptance criterion 6 asks for ≥95 % accounted. Today it is **61–80 %**.
+Acceptance criterion 6 asks for ≥95 % accounted. The table above is the state that
+**motivated** the campaign, kept because the shape of the gap is what the fixes were aimed
+at — it is not the state today.
+
+**Criterion 6 is met.** The pool ledger is always on rather than gated behind
+`--mem-report` (`AUDIT.md` B80/B81), and the library charge is measured over the whole
+init instead of the warmup-forward window, so the residual means what it says on every
+start. Re-measured 2026-08-03 with `--mem-report`, one run each:
+
+| config | accounted | residual |
+|---|---:|---:|
+| Qwen3-4B-Q8_0 (dense GGUF — was 39 % untracked) | **99.9 %** | 16 MiB |
+| Qwen3-30B-A3B-NVFP4 (MoE — was 20 %) | **99.9 %** | 12 MiB |
+| Qwen3-8B-NVFP4 | **99.9 %** | 0 MiB |
+| Qwen3-14B-NVFP4 | **99.9 %** | 0 MiB |
+
+The 07-29 architecture audit's F-6 was written against the old table and stayed open in
+`docs/audit/SETTLED.md` until this measurement retired it. Do not re-open it from the
+numbers above.
 
 ### A1.5 F4 — the ~3.9 GiB first-forward claim
 

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -152,6 +152,19 @@ loop, and the shared part is already factored out.
   runs confirmed to have actually loaded the model (the first attempt compared two *failed*
   runs at 0 vs 0 because the model path was wrong — a control that proves nothing).
 
+- **F-6 (VRAM attribution) is CLOSED — and it was closed before this ledger listed it as
+  open.** The 07-29 audit measured 20-39 % of steady-state VRAM unattributed against a
+  ≥95 % criterion. The memory campaign then fixed it (`AUDIT.md` B80/B81: the pool ledger
+  is always on instead of gated behind `--mem-report`, and the library charge is measured
+  over the whole init rather than the warmup-forward window). Re-measured 2026-08-03 on the
+  three config families the audit named plus one more — dense GGUF (was 39 %), MoE (was
+  20 %), and two NVFP4 dense — **all read 99.9-100.0 % accounted, residual 0-16 MiB**.
+  `docs/MEMORY_ARCHITECTURE.md` still carried the old 61-80 % table, which is where the
+  stale prior came from; corrected there too. **This is the ledger's own failure mode
+  caught in the act**: an entry that was true when written, describing a subsystem whose
+  running log (`AUDIT.md`) recorded the fix, in a section headed "NOT settled". Reading the
+  per-area log at step 0 is what stopped a day of re-measuring something already done.
+
 **`ccg coverage` is a ONE-LEVEL check, not reachability.** It asks "does this kernel have a
 launcher", not "is that launcher reachable from a live root". `gemv_q4k_ggml_compat_kernel`
 counted toward its 420/423 *live* precisely because its launcher existed — and the launcher
@@ -250,10 +263,11 @@ Still open from 07-29 with the reason each was not shipped blind — see
 - **F-5 (rest)** — GPU CI lane: **declined by the repo owner, 2026-08-03.** The job and its
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.
-- **F-6 (rest)** — 20-39 % of steady-state VRAM unattributed.
 - **F-9** — cuBLASLt algorithm selection unpinned (mechanism confirmed, magnitude refuted).
 - **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`.
-- **F-12** — `src/memory/vram_allocator.cu` still has 84 references.
+- **F-12** — `src/memory/vram_allocator.cu`: **67** live references (2026-08-03), down from
+  the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
+  lines excluded or you get 103 and read a regression that is not there.
 - **F-24** — `src/runtime/engine.h` god-header.
 
 ## Per-area running logs

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -138,6 +138,20 @@ loop, and the shared part is already factored out.
     file: its own `.cpp`. (Grepping `ThreadPool` across the repo hits Python files where
     the word is coincidental — restrict to C++ globs.)
 
+- **The debug-logging facility could not be switched on, and now can** (found and fixed
+  2026-08-03). All 76 `IMP_LOG_DEBUG` sites are guarded by
+  `log_get_level() <= LogLevel::DEBUG`; `g_log_level` initialises to `INFO` and its only
+  writer, `log_set_level`, had no callers and no config key — so the guard never opened.
+  `log_set_level` was on the decl-only removal list by signature; removing it would have
+  cemented the gap and taken away the hook. Fixed with `diagnostics.log_level`, applied in
+  `process_diag_install()` — the one function that runs from both tool mains *and*
+  `Engine::init`, so a C-API consumer reaches it too. An unrecognised word warns and keeps
+  the current level rather than falling back to `INFO`, which would have restored the same
+  silent-default failure. **Measured, not assumed:** same model, same prompt, default level
+  → 0 `[DEBUG]` lines, `--set diagnostics.log_level=debug` → 359 from 10 source files, both
+  runs confirmed to have actually loaded the model (the first attempt compared two *failed*
+  runs at 0 vs 0 because the model path was wrong — a control that proves nothing).
+
 **`ccg coverage` is a ONE-LEVEL check, not reachability.** It asks "does this kernel have a
 launcher", not "is that launcher reachable from a live root". `gemv_q4k_ggml_compat_kernel`
 counted toward its 420/423 *live* precisely because its launcher existed — and the launcher
@@ -213,14 +227,6 @@ one command.
 Still open from 07-29 with the reason each was not shipped blind — see
 [`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the full argument.
 
-- **All 76 `IMP_LOG_DEBUG` sites are unreachable** (found 2026-08-03, not fixed). Every one
-  is guarded by `log_get_level() <= LogLevel::DEBUG`; `g_log_level` in
-  `src/core/logging.cpp` initialises to `INFO`, and its **only** writer is `log_set_level`,
-  which nothing calls. There is no config key and no CLI flag for the level. So the engine
-  has a debug-logging facility that cannot be switched on. `log_set_level` was left in
-  place deliberately — it was on the decl-only removal list, and deleting it would have
-  cemented the gap and taken away the obvious hook. The fix is a `RuntimeConfig` key that
-  calls it (no ad-hoc env read), not a removal.
 - **F-3 (rest)** — routing replica. **This entry understated the gap until 2026-08-03**: it
   described the residual limit of the *attention* half (a tier reordered ahead of the winner
   stays invisible, because the chain short-circuits and never asks it) as if that were all
@@ -233,6 +239,14 @@ Still open from 07-29 with the reason each was not shipped blind — see
   `src/compute/attention_dispatch.cu`); the short-circuit limit above is what genuinely
   remains, for both. **Lesson for this ledger: an open entry that records one half of a
   symmetric problem reads as if the other half were closed.**
+  **The MoE verifier is runtime-verified**, on Qwen3-30B-A3B-NVFP4-Modelopt, all three
+  tiers, both directions — the real image silent and a build with
+  `select_moe_prefill_path` forced to `LEGACY` firing and naming both answers, for
+  `device_args`, `grouped` (`--set moe.nvfp4_device_args=false`) and `small_m`
+  (`+ --set moe.nvfp4_smallM=true`). The silent run alone would not have shown this: a
+  check that is never reached is silent too, which is exactly how #1205's resolved-dispatch
+  line went unnoticed. The one-shot guard also holds — one error line although the tier
+  fires on every layer.
 - **F-5 (rest)** — GPU CI lane: **declined by the repo owner, 2026-08-03.** The job and its
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -165,6 +165,35 @@ loop, and the shared part is already factored out.
   running log (`AUDIT.md`) recorded the fix, in a section headed "NOT settled". Reading the
   per-area log at step 0 is what stopped a day of re-measuring something already done.
 
+**Build cost, quantified (2026-08-03).** CLAUDE.md says the metric is recompile blast
+radius, not line count — this is what that actually costs. Transitive header fan-in across
+the 450 translation units, multiplied by commits in the last six months:
+
+| header | TUs rebuilt | commits/6mo | cost |
+|---|---:|---:|---:|
+| `src/runtime/config.h` | 85 | 130 | **11050** |
+| `src/runtime/engine.h` | 41 | 129 | 5289 |
+| `src/exec/executor.h` | 77 | 55 | 4235 |
+| `src/model/model_config.h` | 133 | 31 | 4123 |
+
+So the two open findings **F-10 and F-24 are the #1 and #2 build-cost items in the repo** —
+the audit argued them on coupling and churn, and did not have the product. `core/qtype.h`
+and `core/tensor.h` have the widest fan-in (254, 248) and are nowhere near the top: they
+barely change, which is what a core type should do.
+
+**Three cheap-win hypotheses died on measurement — do not re-run them:**
+- *Trim the includes and forward-declare instead.* Dead on all three top headers: 31 of 33
+  `config.h` includers read real members, 22 of 24 for `engine.h`, 42 of 43 for
+  `executor.h`. This confirms the audit's wording that `config.h` in `exec/` is
+  **algorithmic**, not incidental — the only real fix is the deferred `DispatchPolicy`
+  extraction.
+- *The file-size gate must be missing the big churny `.cu`s.* No: `check_filesize.py`
+  reports `violations=0`, and `weight_upload.cu`, `executor_workspace_buffers.cu` and
+  `cuda_graph.cu` are all allowlisted with reasons. A hand-rolled LOC grep reads ~11 %
+  higher than the tool because it strips comments differently — use the tool.
+- *Some `.cu` is a split candidate on cost alone.* The repo's rule is split on conflation,
+  never on size, and the top of the churn×LOC ranking is allowlisted on cohesion grounds.
+
 **`ccg coverage` is a ONE-LEVEL check, not reachability.** It asks "does this kernel have a
 launcher", not "is that launcher reachable from a live root". `gemv_q4k_ggml_compat_kernel`
 counted toward its 420/423 *live* precisely because its launcher existed — and the launcher

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -638,6 +638,11 @@ sparsity_probe       = false
 sparsity_threshold   = 0.0
 
 [diagnostics]
+# Process log level: debug | info | warn | error | fatal.
+# "debug" is what unlocks the IMP_LOG_DEBUG statements throughout the engine;
+# before this key existed the level was pinned at info and they never printed.
+# An unrecognised value warns and keeps the current level.
+log_level            = info
 # Verbose per-layer forward dumps. Heavy I/O — use only for bisecting bugs.
 debug_forward        = false
 # Print intermediate Jinja2 chat-template rendering steps.

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -4,12 +4,42 @@
 #include <ctime>
 #include <atomic>
 #include <utility>
+#include <cstring>
+#include <cctype>
 
 namespace imp {
 
 std::atomic<LogLevel> g_log_level{LogLevel::INFO};
 
 void log_set_level(LogLevel level) { g_log_level.store(level, std::memory_order_relaxed); }
+
+bool log_level_from_string(const char* s, LogLevel& out) {
+    if (!s || !*s)
+        return false;
+    // Lowercase in place into a small buffer; the longest accepted word is
+    // "fatal", so anything longer cannot match and is rejected below.
+    char buf[8] = {};
+    size_t n = 0;
+    for (; s[n] && n < sizeof(buf) - 1; ++n)
+        buf[n] = static_cast<char>(std::tolower(static_cast<unsigned char>(s[n])));
+    if (s[n])
+        return false;  // longer than any accepted word
+    struct Entry {
+        const char* name;
+        LogLevel level;
+    };
+    static constexpr Entry kTable[] = {
+        {"debug", LogLevel::DEBUG}, {"info", LogLevel::INFO},   {"warn", LogLevel::WARN},
+        {"error", LogLevel::ERROR}, {"fatal", LogLevel::FATAL},
+    };
+    for (const auto& e : kTable) {
+        if (std::strcmp(buf, e.name) == 0) {
+            out = e.level;
+            return true;
+        }
+    }
+    return false;
+}
 
 static const char* level_str(LogLevel level) {
     switch (level) {

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -17,6 +17,11 @@ enum class LogLevel : int {
 
 void log_set_level(LogLevel level);
 
+// "debug" | "info" | "warn" | "error" | "fatal" (case-insensitive) → level.
+// Returns false and leaves `out` untouched on anything else, so the caller can
+// warn instead of silently picking a level nobody asked for.
+bool log_level_from_string(const char* s, LogLevel& out);
+
 // Inline for zero-overhead log level check in hot paths.
 // The atomic is defined in logging.cpp; declared here for inlining.
 extern std::atomic<LogLevel> g_log_level;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -270,6 +270,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("paths.mmproj", cfg.paths.mmproj);
 
     // [diagnostics]
+    S("diagnostics.log_level", cfg.diagnostics.log_level);
     B("diagnostics.debug_forward", cfg.diagnostics.debug_forward);
     B("diagnostics.debug_template", cfg.diagnostics.debug_template);
     S("diagnostics.dump_hidden_dir", cfg.diagnostics.dump_hidden_dir);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -1011,6 +1011,14 @@ struct RuntimeConfig {
     } ffn;
 
     struct Diagnostics {
+        // Process log level: "debug" | "info" | "warn" | "error" | "fatal".
+        // Applied by process_diag_install(), which runs from both tool mains
+        // AND Engine::init, so a C-API consumer reaches it too.
+        // Until 2026-08-03 there was no way to set this at all: log_set_level()
+        // was the only writer of g_log_level and nothing called it, so the level
+        // was pinned at INFO and all 76 IMP_LOG_DEBUG sites were unreachable —
+        // a debug facility that could not be switched on.
+        std::string log_level = "info";
         bool debug_forward = false;
         bool debug_template = false;
         std::string dump_hidden_dir;

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -1,5 +1,6 @@
 #include "runtime/process_diag.h"
 #include "runtime/config.h"
+#include "core/logging.h"
 
 namespace imp {
 
@@ -63,6 +64,21 @@ ProcessDiag& slot() {
 
 void process_diag_install(const RuntimeConfig& cfg) {
     auto& d = slot();
+    // Log level first, so anything this function or its callers log afterwards
+    // already obeys it. An unknown word warns rather than silently picking a
+    // level: the whole point of this key is that the level used to be
+    // unsettable, and a typo that quietly resolves to INFO would restore that.
+    {
+        LogLevel lvl;
+        if (log_level_from_string(cfg.diagnostics.log_level.c_str(), lvl)) {
+            log_set_level(lvl);
+        } else {
+            IMP_LOG_WARN(
+                "diagnostics.log_level: unknown value '%s' — keeping the current level "
+                "(expected debug|info|warn|error|fatal)",
+                cfg.diagnostics.log_level.c_str());
+        }
+    }
     d.debug_forward = cfg.diagnostics.debug_forward;
     d.debug_template = cfg.diagnostics.debug_template;
     d.graph_diag = cfg.diagnostics.graph_diag;

--- a/tests/test_process_diag.cpp
+++ b/tests/test_process_diag.cpp
@@ -18,6 +18,9 @@
 // process_diag indirection and it keeps the check in the CI unit lane.
 
 #include "runtime/config.h"
+#include "core/logging.h"
+
+#include <utility>
 #include "runtime/process_diag.h"
 
 #include <gtest/gtest.h>
@@ -75,7 +78,14 @@ RuntimeConfig make_non_default() {
 // Restores the process-wide slot so test ordering inside the binary cannot
 // leak a non-default snapshot into an unrelated test.
 struct ProcessDiagGuard {
-    ~ProcessDiagGuard() { process_diag_install(RuntimeConfig{}); }
+    // install() now also sets the process log level, so restoring the defaults
+    // has to put that back too — otherwise one test leaks DEBUG into every
+    // later test in this binary.
+    LogLevel saved_level = log_get_level();
+    ~ProcessDiagGuard() {
+        process_diag_install(RuntimeConfig{});
+        log_set_level(saved_level);
+    }
 };
 
 }  // namespace
@@ -177,4 +187,71 @@ TEST(ProcessDiag, DumpHiddenDirShorthandResolves) {
     process_diag_install(c);
     ASSERT_NE(process_diag_dump_hidden_dir(), nullptr);
     EXPECT_EQ(std::string(process_diag_dump_hidden_dir()), "/tmp");
+}
+
+// --------------------------------------------------------------------------
+// Log level (2026-08-03)
+// --------------------------------------------------------------------------
+//
+// `log_set_level` was the only writer of g_log_level and NOTHING called it, so
+// the level was pinned at INFO and all 76 IMP_LOG_DEBUG sites in the engine
+// were unreachable — a debug facility that could not be switched on. The fix is
+// a config key applied here, in the one function that runs from both tool mains
+// AND Engine::init. These tests pin both halves: the parse and the transfer.
+
+TEST(LogLevel, FromStringMapsEveryWordCaseInsensitively) {
+    const std::pair<const char*, LogLevel> cases[] = {
+        {"debug", LogLevel::DEBUG}, {"DEBUG", LogLevel::DEBUG}, {"Info", LogLevel::INFO},
+        {"warn", LogLevel::WARN},   {"error", LogLevel::ERROR}, {"FATAL", LogLevel::FATAL},
+    };
+    for (const auto& [word, expected] : cases) {
+        LogLevel got = LogLevel::FATAL;
+        ASSERT_TRUE(log_level_from_string(word, got)) << word;
+        EXPECT_EQ(got, expected) << word;
+    }
+}
+
+// Rejection has to be explicit, not "falls back to INFO": a typo that silently
+// resolves to the default would restore exactly the state this key fixed.
+TEST(LogLevel, FromStringRejectsAnythingElseAndLeavesOutAlone) {
+    for (const char* bad : {"", "verbose", "dbg", "informational", "debug ", "0"}) {
+        LogLevel got = LogLevel::WARN;  // sentinel: must survive untouched
+        EXPECT_FALSE(log_level_from_string(bad, got)) << "'" << bad << "'";
+        EXPECT_EQ(got, LogLevel::WARN) << "'" << bad << "' modified out";
+    }
+    LogLevel got = LogLevel::WARN;
+    EXPECT_FALSE(log_level_from_string(nullptr, got));
+}
+
+TEST(ProcessDiag, InstallAppliesTheConfiguredLogLevel) {
+    ProcessDiagGuard restore;
+    RuntimeConfig c;
+    c.diagnostics.log_level = "debug";
+    process_diag_install(c);
+    EXPECT_EQ(log_get_level(), LogLevel::DEBUG);
+
+    c.diagnostics.log_level = "error";
+    process_diag_install(c);
+    EXPECT_EQ(log_get_level(), LogLevel::ERROR);
+}
+
+TEST(ProcessDiag, InstallKeepsTheCurrentLevelOnAnUnknownWord) {
+    ProcessDiagGuard restore;
+    RuntimeConfig c;
+    c.diagnostics.log_level = "warn";
+    process_diag_install(c);
+    ASSERT_EQ(log_get_level(), LogLevel::WARN);
+
+    c.diagnostics.log_level = "louder-please";
+    process_diag_install(c);
+    EXPECT_EQ(log_get_level(), LogLevel::WARN) << "an unknown word must not silently reset the level";
+}
+
+// The default must be the level the engine had before the key existed, so
+// adding it changed nothing for anyone who does not set it.
+TEST(ProcessDiag, DefaultConfigLeavesTheLevelAtInfo) {
+    ProcessDiagGuard restore;
+    log_set_level(LogLevel::ERROR);
+    process_diag_install(RuntimeConfig{});
+    EXPECT_EQ(log_get_level(), LogLevel::INFO);
 }


### PR DESCRIPTION
Two things, batched because both touch `docs/audit/SETTLED.md` and splitting them guarantees a conflict.

---

# 1. The debug log level could not be switched on

imp has **76 `IMP_LOG_DEBUG` statements**, each guarded by `log_get_level() <= LogLevel::DEBUG`. `g_log_level` initialises to `INFO`, its only writer is `log_set_level()`, and **nothing called it** — no config key, no flag. The guard never opened.

It surfaced during the dead-code sweep: `log_set_level()` has a declaration, a definition and no callers — exactly the signature #1218/#1220 removed twenty-six times. Deleting it would have cemented the gap and taken away the hook. The one case where *uncalled* meant *the wiring is missing*.

- **`diagnostics.log_level`** = `debug|info|warn|error|fatal`, default `info`.
- Applied in **`process_diag_install()`** — runs from both tool mains **and** `Engine::init` (since #1205), so a C-API consumer reaches it too. Set first, so later logging already obeys it.
- An unrecognised word **warns and keeps the current level**; `log_level_from_string()` leaves its out-param untouched on rejection. A silent fallback to `INFO` is precisely the bug.

**Verification.** Unit tests for the parse (every word, case-insensitive; rejection of `""`, `verbose`, `dbg`, `informational`, `"debug "`, `nullptr`) and the transfer. `ProcessDiagGuard` restores the level too, or one test leaks `DEBUG` into the rest of the binary. Mutation: dropping the `log_set_level()` call turns exactly the two covering tests red.

**Measured end to end**, because the unit tests only prove `g_log_level` moves:

| Run | model loaded | `[DEBUG]` lines |
|---|---|---|
| default level | yes (`Resolved dispatch` present) | **0** |
| `--set diagnostics.log_level=debug` | yes | **359**, from 10 source files |

The first attempt compared two **failed** runs at 0 vs 0 — wrong model path, neither loaded. Stated because that is the shape of a control that proves nothing.

---

# 2. Audit finding F-6 is closed — and had been for a while

F-6: *20-39 % of steady-state VRAM unattributed*, against a ≥95 % criterion. The memory campaign fixed it **after** the audit was written (`AUDIT.md` B80/B81 — the pool ledger is always on instead of gated behind `--mem-report`; the library charge is measured over the whole init instead of the warmup-forward window). It stayed listed as OPEN anyway.

Re-measured with `--mem-report`, one run each, on the three config families the audit named plus one more:

| config | accounted | residual |
|---|---:|---:|
| Qwen3-4B-Q8_0 — dense GGUF, was **39 %** untracked | **99.9 %** | 16 MiB |
| Qwen3-30B-A3B-NVFP4 — MoE, was **20 %** | **99.9 %** | 12 MiB |
| Qwen3-8B-NVFP4 | **99.9 %** | 0 MiB |
| Qwen3-14B-NVFP4 | **99.9 %** | 0 MiB |

`docs/MEMORY_ARCHITECTURE.md` still carried the 61-80 % table the finding was written from — that is where the stale prior came from, corrected there too, with the old table kept as the state that motivated the campaign.

Also corrected: **F-12 reads 67 live `VRAMAllocator` references, not 84** — shrinking, not growing. Count without excluding the allocator's own files and comment lines and you get 103, which reads like a regression that is not there.

**This is the ledger's own failure mode caught in the act**: an entry true when written, describing a subsystem whose running log recorded the fix, sitting under a heading that says *NOT settled*. Reading the per-area log at step 0 — which the `codebase-audit` skill requires — is what stopped a day of re-measuring something already done.

Remaining open: F-3 (rest), F-5 (declined), F-9, F-10, F-12, F-24.

---

`ctest -L unit` 4/4, `clang-format` clean on changed lines, anchor gate 57/57. The perf gate ran green against `main` beforehand (decode +0.21 %, prefill +0.06 %, spread 0.43 %). Also recorded: #1217's MoE routing verifier is now **runtime-verified** on all three tiers, both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B