### PR TITLE
docs(audit): scope F-10 by measurement — the estimate is low by 2x

### DIFF
--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -293,7 +293,24 @@ Still open from 07-29 with the reason each was not shipped blind — see
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.
 - **F-9** — cuBLASLt algorithm selection unpinned (mechanism confirmed, magnitude refuted).
-- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`.
+- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`. **Scoped by
+  measurement 2026-08-03, and the audit's estimate is low by 2x.** It proposes extracting
+  "the ~30 dispatch-relevant keys" into a `DispatchPolicy` POD; `src/exec/` actually reads
+  **59 distinct RuntimeConfig leaves** across nine sections — gemm 15, attention 13, moe 12,
+  diagnostics 7, gdn 6, generation 2, ffn 2, speculative 1, kv_cache 1 — at 91 read sites in
+  21 of the 22 files. So the POD is 59 fields and every read site changes.
+  **Access is per-object, not global**: `runtime_config()` in `exec/` is a member accessor
+  on `GraphExecutor` (`src/exec/executor.h:422`) and `QuantPipeline`
+  (`src/exec/quant_pipeline.h:86`), reached as implicit `this->`. `exec/` includes no
+  `engine.h`. Anyone reading the 79 unqualified call sites as a process-global will
+  mis-model the fix — there is still no process-global `RuntimeConfig`.
+  **Both cheap alternatives are closed, tested:** forward-declaring instead of including
+  fails because 21 of 22 files read real members and the owning classes hold the type by
+  reference; and splitting `config.h` by section does not help for the same reason, even
+  though **roughly half the churn (Runtime 67, Vram 19, Server 5, Rope 5 of ~194 hunks)
+  lands in sections `exec/` never reads**. The saving is real but unreachable without
+  changing what the owning classes hold — which is the POD extraction itself.
+  Cost of leaving it: 85 TUs x 130 commits/6mo, the highest in the repo.
 - **F-12** — `src/memory/vram_allocator.cu`: **67** live references (2026-08-03), down from
   the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
   lines excluded or you get 103 and read a regression that is not there.


### PR DESCRIPTION
F-10 proposes extracting *"the ~30 dispatch-relevant keys"* from `runtime/config.h` into a `DispatchPolicy` POD. Before spending the `L`, I measured what is actually there.

## The scope is double the estimate

`src/exec/` reads **59 distinct `RuntimeConfig` leaves**, at **91 read sites** in **21 of the 22** including files:

| section | leaves |
|---|---:|
| gemm | 15 |
| attention | 13 |
| moe | 12 |
| diagnostics | 7 |
| gdn | 6 |
| generation / ffn | 2 / 2 |
| speculative / kv_cache | 1 / 1 |

So the POD is 59 fields, and every read site changes.

## Access is per-object, not global

`runtime_config()` in `exec/` is a **member accessor** on `GraphExecutor` (`src/exec/executor.h:422`) and `QuantPipeline` (`src/exec/quant_pipeline.h:86`), reached as implicit `this->`. `exec/` includes no `engine.h`.

Recorded because the misreading is one grep away: 79 of the 91 sites are *unqualified* `runtime_config()`, which looks exactly like a free function. It is not, and **there is still no process-global `RuntimeConfig`** — reading it as one would mis-model the fix.

## Both cheap alternatives are closed

- **Forward-declare instead of include.** Dead: 21 of 22 files read real members, and the owning classes hold the type by reference.
- **Split `config.h` by section.** Dead for the same reason — even though the churn distribution says it *should* work: roughly **half** the hunks in six months land in sections `exec/` never reads (Runtime 67, Vram 19, Server 5, Rope 5 of ~194). The saving is real and unreachable without changing what the owning classes hold, which is the POD extraction itself.

## Why this is the deliverable rather than the refactor

Cost of leaving F-10 alone: **85 TUs × 130 commits in six months**, the highest build cost in the repo (#1221 quantified the ranking). That argues for doing it.

Against doing it *now*: 59 fields, 91 sites, 22 files, changing what dispatch reads at runtime — the one class this repo has no CI net for, since the `gpu` ctest label never runs. Doing it halfway leaves two config paths, which is precisely the F-1 shape the extraction exists to retire.

So this PR turns an estimate into numbers and stops there. The decision to spend the `L` now rests on measurement rather than on the audit's guess.

No code change. Anchor gate 60/60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B