### PR TITLE
refactor(logging): one logging mechanism — migrate all 90 raw fprintf sites in src/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ there instead of retelling it.
   `max_tokens`. `CommonArgs` is a base class rather than a member, so every
   existing `args.<field>` use site is unchanged.
 
+### Changed
+- **The engine logs through one mechanism again.** All 90 raw
+  `fprintf(stderr, ...)` sites in `src/` now go through `IMP_LOG_*`, so they
+  obey `diagnostics.log_level`, carry a timestamp and `file:line`, and can be
+  silenced. Before this, setting `log_level=error` still produced `[gemm-algo]`,
+  `[DEBUG_FWD]` and `[DEBUG_TPL]` output, because those bypassed the framework
+  entirely. `tools/` keeps its `fprintf` — a CLI writing to stderr is program
+  output, not logging.
+- **`log_message()` is now `__attribute__((format(printf, 4, 5)))`.** Roughly
+  1400 call sites had no compile-time format checking at all; turning it on
+  found five real `%lld`-vs-`int64_t` mismatches in `weight_upload.cu`, fixed
+  here.
+
 ### Added
 - **`diagnostics.log_level`** (`debug` | `info` | `warn` | `error` | `fatal`) —
   the engine's debug logging could not be switched on at all. `log_set_level()`

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -293,7 +293,24 @@ Still open from 07-29 with the reason each was not shipped blind — see
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.
 - **F-9** — cuBLASLt algorithm selection unpinned (mechanism confirmed, magnitude refuted).
-- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`.
+- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`. **Scoped by
+  measurement 2026-08-03, and the audit's estimate is low by 2x.** It proposes extracting
+  "the ~30 dispatch-relevant keys" into a `DispatchPolicy` POD; `src/exec/` actually reads
+  **59 distinct RuntimeConfig leaves** across nine sections — gemm 15, attention 13, moe 12,
+  diagnostics 7, gdn 6, generation 2, ffn 2, speculative 1, kv_cache 1 — at 91 read sites in
+  21 of the 22 files. So the POD is 59 fields and every read site changes.
+  **Access is per-object, not global**: `runtime_config()` in `exec/` is a member accessor
+  on `GraphExecutor` (`src/exec/executor.h:422`) and `QuantPipeline`
+  (`src/exec/quant_pipeline.h:86`), reached as implicit `this->`. `exec/` includes no
+  `engine.h`. Anyone reading the 79 unqualified call sites as a process-global will
+  mis-model the fix — there is still no process-global `RuntimeConfig`.
+  **Both cheap alternatives are closed, tested:** forward-declaring instead of including
+  fails because 21 of 22 files read real members and the owning classes hold the type by
+  reference; and splitting `config.h` by section does not help for the same reason, even
+  though **roughly half the churn (Runtime 67, Vram 19, Server 5, Rope 5 of ~194 hunks)
+  lands in sections `exec/` never reads**. The saving is real but unreachable without
+  changing what the owning classes hold — which is the POD extraction itself.
+  Cost of leaving it: 85 TUs x 130 commits/6mo, the highest in the repo.
 - **F-12** — `src/memory/vram_allocator.cu`: **67** live references (2026-08-03), down from
   the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
   lines excluded or you get 103 and read a regression that is not there.

--- a/src/compute/attention_cublas.cu
+++ b/src/compute/attention_cublas.cu
@@ -44,7 +44,7 @@ static cublasHandle_t get_attn_cublas_handle() {
     if (!s_attn_cublas_handle) {
         cublasStatus_t st = cublasCreate(&s_attn_cublas_handle);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr, "imp::attention_cublas: cublasCreate failed (status %d)\n", (int)st);
+            IMP_LOG_ERROR("imp::attention_cublas: cublasCreate failed (status %d)", (int)st);
             abort();
         }
         cublasSetMathMode(s_attn_cublas_handle, CUBLAS_TF32_TENSOR_OP_MATH);

--- a/src/compute/ffn_sparsity_probe.cu
+++ b/src/compute/ffn_sparsity_probe.cu
@@ -139,22 +139,19 @@ void flush_ffn_sparsity_probe_log() {
         for (int t = 0; t < kNumThresholds; ++t) {
             const unsigned long long under = row[t];
             const double frac = static_cast<double>(under) / static_cast<double>(total);
-            std::fprintf(stderr,
-                         "[ffn-sparsity] layer=%3d thr=%.4f skip_frac=%.4f under=%llu total=%llu\n",
-                         L, h_thresholds[t], frac, under, total);
+            IMP_LOG_DEBUG("[ffn-sparsity] layer=%3d thr=%.4f skip_frac=%.4f under=%llu total=%llu", L,
+                          h_thresholds[t], frac, under, total);
             model_under[t] += under;
         }
         model_total += total;
     }
 
     if (model_total > 0ull) {
-        std::fprintf(stderr, "[ffn-sparsity] MODEL n_layers=%d total_rows_seen=%llu\n",
-                     n_layers, model_total);
+        IMP_LOG_DEBUG("[ffn-sparsity] MODEL n_layers=%d total_rows_seen=%llu", n_layers, model_total);
         for (int t = 0; t < kNumThresholds; ++t) {
             const double frac = static_cast<double>(model_under[t]) / static_cast<double>(model_total);
-            std::fprintf(stderr,
-                         "[ffn-sparsity] MODEL thr=%.4f skip_frac=%.4f under=%llu total=%llu\n",
-                         h_thresholds[t], frac, model_under[t], model_total);
+            IMP_LOG_DEBUG("[ffn-sparsity] MODEL thr=%.4f skip_frac=%.4f under=%llu total=%llu",
+                          h_thresholds[t], frac, model_under[t], model_total);
         }
     }
 

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -24,12 +24,12 @@
 #include <vector>
 #include <utility>
 
-#define CUBLASLT_CHECK(call)                                                        \
-    do {                                                                            \
-        cublasStatus_t _st = (call);                                                \
-        if (_st != CUBLAS_STATUS_SUCCESS) {                                         \
-            fprintf(stderr, "imp::gemm: %s failed (status %d)\n", #call, (int)_st); \
-        }                                                                           \
+#define CUBLASLT_CHECK(call)                                                    \
+    do {                                                                        \
+        cublasStatus_t _st = (call);                                            \
+        if (_st != CUBLAS_STATUS_SUCCESS) {                                     \
+            IMP_LOG_ERROR("imp::gemm: %s failed (status %d)", #call, (int)_st); \
+        }                                                                       \
     } while (0)
 
 namespace imp {
@@ -58,7 +58,7 @@ static cublasHandle_t get_cublas_handle() {
     if (!s_cublas_handle) {
         cublasStatus_t st = cublasCreate(&s_cublas_handle);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr, "imp::gemm: cublasCreate failed (status %d)\n", (int)st);
+            IMP_LOG_ERROR("imp::gemm: cublasCreate failed (status %d)", (int)st);
             abort();
         }
         cublasSetMathMode(s_cublas_handle, CUBLAS_TF32_TENSOR_OP_MATH);
@@ -70,7 +70,7 @@ static cublasLtHandle_t get_cublaslt_handle() {
     if (!s_cublaslt_handle) {
         cublasStatus_t st = cublasLtCreate(&s_cublaslt_handle);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr, "imp::gemm: cublasLtCreate failed (status %d)\n", (int)st);
+            IMP_LOG_ERROR("imp::gemm: cublasLtCreate failed (status %d)", (int)st);
             abort();
         }
     }
@@ -170,7 +170,7 @@ static cudaDataType_t dtype_to_cuda(QType dt) {
         case QType::INT32:
             return CUDA_R_32I;
         default:
-            fprintf(stderr, "imp::gemm: unsupported dtype %d\n", std::to_underlying(dt));
+            IMP_LOG_ERROR("imp::gemm: unsupported dtype %d", std::to_underlying(dt));
             return CUDA_R_16F;  // fallback (caller guard should prevent reaching here)
     }
 }
@@ -382,15 +382,15 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
     // [diag] diagnostics.log_gemm_algo: dump shape + per-candidate algoId/tileId.
     // Helps identify which shapes are stuck on legacy WMMA candidates.
     if (gemm_algo_log_enabled() && M > 0) {
-        fprintf(stderr, "[gemm-algo] shape M=%d N=%d K=%d  candidates=%d\n", M, N, K, nresults);
+        IMP_LOG_DEBUG("[gemm-algo] shape M=%d N=%d K=%d  candidates=%d", M, N, K, nresults);
         for (int i = 0; i < nresults; i++) {
             int algo_id = -1, tile_id = -1;
             cublasLtMatmulAlgoCapGetAttribute(&results[i].algo, CUBLASLT_ALGO_CAP_NUMERICAL_IMPL_FLAGS,
                                               &algo_id, sizeof(algo_id), nullptr);
             cublasLtMatmulAlgoConfigGetAttribute(&results[i].algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &tile_id,
                                                  sizeof(tile_id), nullptr);
-            fprintf(stderr, "[gemm-algo]   cand[%d]: numImplFlags=0x%x tile=%d ws=%zu\n", i, algo_id, tile_id,
-                    results[i].workspaceSize);
+            IMP_LOG_DEBUG("[gemm-algo]   cand[%d]: numImplFlags=0x%x tile=%d ws=%zu", i, algo_id, tile_id,
+                          results[i].workspaceSize);
         }
     }
     // [runtime] deterministic_gemm = true skips timing-based selection so
@@ -444,7 +444,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
             (results[pick].workspaceSize <= s_workspace_size) ? results[pick].workspaceSize : 0;
         entry.has_algo = true;
         if (gemm_algo_log_enabled() && M > 0) {
-            fprintf(stderr, "[gemm-algo]   PICKED cand[%d] (deterministic, warmup-validated)\n", pick);
+            IMP_LOG_DEBUG("[gemm-algo]   PICKED cand[%d] (deterministic, warmup-validated)", pick);
         }
         return;
     }
@@ -524,8 +524,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         int picked_tile = -1;
         cublasLtMatmulAlgoConfigGetAttribute(&entry.algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &picked_tile,
                                              sizeof(picked_tile), nullptr);
-        fprintf(stderr, "[gemm-algo]   PICKED cand[%d] tile=%d  best_ms=%.3f\n", best_idx, picked_tile,
-                best_ms);
+        IMP_LOG_DEBUG("[gemm-algo]   PICKED cand[%d] tile=%d  best_ms=%.3f", best_idx, picked_tile, best_ms);
     }
 }
 

--- a/src/compute/gemm_batched.cu
+++ b/src/compute/gemm_batched.cu
@@ -1,6 +1,7 @@
 #include "compute/gemm.h"
 #include "compute/gemm_internal.cuh"
 
+#include "core/logging.h"
 #include <cublas_v2.h>
 #include <cublasLt.h>
 #include <cuda_runtime.h>
@@ -72,7 +73,7 @@ void gemm_kv_batched(const Tensor& input, const Tensor& weight_kv, Tensor& k_out
                                                    CUBLAS_COMPUTE_32F, kGemmAlgo);
 
     if (st != CUBLAS_STATUS_SUCCESS) {
-        fprintf(stderr, "imp::gemm_kv_batched: cublasGemmStridedBatchedEx failed (status %d)\n", (int)st);
+        IMP_LOG_ERROR("imp::gemm_kv_batched: cublasGemmStridedBatchedEx failed (status %d)", (int)st);
     }
 }
 
@@ -99,7 +100,7 @@ void gemm_pair_batched(const Tensor& input, const Tensor& weight_fused, Tensor& 
                                                    CUBLAS_COMPUTE_32F, kGemmAlgo);
 
     if (st != CUBLAS_STATUS_SUCCESS) {
-        fprintf(stderr, "imp::gemm_pair_batched: cublasGemmStridedBatchedEx failed (status %d)\n", (int)st);
+        IMP_LOG_ERROR("imp::gemm_pair_batched: cublasGemmStridedBatchedEx failed (status %d)", (int)st);
     }
 }
 

--- a/src/compute/gemm_gemv_dtype.cu
+++ b/src/compute/gemm_gemv_dtype.cu
@@ -80,7 +80,7 @@ bool gemm_try_sgemm(const Tensor& A, const Tensor& B, Tensor& C, float alpha, fl
                                     &beta, static_cast<float*>(C.data), (int)N  // ldc = N
     );
     if (st != CUBLAS_STATUS_SUCCESS) {
-        fprintf(stderr, "imp::gemm: cublasSgemm failed (status %d)\n", (int)st);
+        IMP_LOG_ERROR("imp::gemm: cublasSgemm failed (status %d)", (int)st);
     }
     return true;
 }

--- a/src/compute/gemm_grouped.cu
+++ b/src/compute/gemm_grouped.cu
@@ -27,7 +27,7 @@ static cublasHandle_t get_cublas_handle() {
     if (!s_grouped_cublas_handle) {
         cublasStatus_t st = cublasCreate(&s_grouped_cublas_handle);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr, "imp::gemm_grouped: cublasCreate failed (status %d)\n", (int)st);
+            IMP_LOG_ERROR("imp::gemm_grouped: cublasCreate failed (status %d)", (int)st);
             abort();
         }
         cublasSetMathMode(s_grouped_cublas_handle, CUBLAS_DEFAULT_MATH);
@@ -68,7 +68,7 @@ static cudaDataType_t dtype_to_cuda(QType dt) {
         case QType::INT32:
             return CUDA_R_32I;
         default:
-            fprintf(stderr, "imp::gemm_grouped: unsupported dtype %d\n", std::to_underlying(dt));
+            IMP_LOG_ERROR("imp::gemm_grouped: unsupported dtype %d", std::to_underlying(dt));
             abort();
     }
 }
@@ -128,10 +128,10 @@ static void run_expert_matmul(cublasHandle_t handle, const Tensor& Ai, const Ten
                                          Bi.data, cuda_dt_B, (int)K, Ai.data, cuda_dt_A, (int)K, &beta,
                                          Ci.data, cuda_dt_C, (int)N, compute_type, kGemmAlgo);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr,
-                    "imp::gemm_grouped: cublasGemmEx failed for expert "
-                    "(M=%lld, K=%lld, N=%lld, status %d)\n",
-                    (long long)Mi, (long long)K, (long long)N, (int)st);
+            IMP_LOG_ERROR(
+                "imp::gemm_grouped: cublasGemmEx failed for expert "
+                "(M=%lld, K=%lld, N=%lld, status %d)",
+                (long long)Mi, (long long)K, (long long)N, (int)st);
         }
     } else {
         float alpha = 1.0f;
@@ -140,10 +140,10 @@ static void run_expert_matmul(cublasHandle_t handle, const Tensor& Ai, const Ten
                                          Bi.data, cuda_dt_B, (int)K, Ai.data, cuda_dt_A, (int)K, &beta,
                                          Ci.data, cuda_dt_C, (int)N, compute_type, kGemmAlgo);
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr,
-                    "imp::gemm_grouped: cublasGemmEx failed for expert "
-                    "(M=%lld, K=%lld, N=%lld, status %d)\n",
-                    (long long)Mi, (long long)K, (long long)N, (int)st);
+            IMP_LOG_ERROR(
+                "imp::gemm_grouped: cublasGemmEx failed for expert "
+                "(M=%lld, K=%lld, N=%lld, status %d)",
+                (long long)Mi, (long long)K, (long long)N, (int)st);
         }
     }
 }
@@ -171,10 +171,10 @@ void gemm_grouped(const std::vector<Tensor>& A, const std::vector<Tensor>& B, st
     if (num_experts == 0)
         return;
     if (B.size() != num_experts || C.size() != num_experts) {
-        fprintf(stderr,
-                "imp::gemm_grouped: A/B/C vector sizes must match "
-                "(got %zu, %zu, %zu)\n",
-                A.size(), B.size(), C.size());
+        IMP_LOG_DEBUG(
+            "imp::gemm_grouped: A/B/C vector sizes must match "
+            "(got %zu, %zu, %zu)",
+            A.size(), B.size(), C.size());
         return;
     }
 
@@ -394,10 +394,10 @@ void gemm_moe_batched(const void* a_base, void* c_base, const int32_t* offsets, 
             cuda_dt_c, ldc_arr.data(), group_count, group_size_arr.data(), compute_type);
 
         if (st != CUBLAS_STATUS_SUCCESS) {
-            fprintf(stderr,
-                    "imp::gemm_moe_batched: cublasGemmGroupedBatchedEx failed "
-                    "(groups=%d, active=%d, K=%d, N=%d, status %d)\n",
-                    group_count, n_active, K, N, (int)st);
+            IMP_LOG_ERROR(
+                "imp::gemm_moe_batched: cublasGemmGroupedBatchedEx failed "
+                "(groups=%d, active=%d, K=%d, N=%d, status %d)",
+                group_count, n_active, K, N, (int)st);
             // Fallback: per-group cublasGemmBatchedEx
             for (const auto& g : groups) {
                 float g_alpha = g.alpha;

--- a/src/compute/gemm_grouped_nvfp4_smallM.cu
+++ b/src/compute/gemm_grouped_nvfp4_smallM.cu
@@ -802,16 +802,14 @@ bool gemm_grouped_nvfp4_smallM(
                               const_cast<void*>(host_ptr_A[e]),
                               /*gmem_rows=*/M_e, /*gmem_cols=*/K / 2,
                               /*box_rows=*/TILE_M_rt, /*box_cols=*/TILE_K_rt / 2)) {
-            std::fprintf(stderr, "[smallM] cuTensorMapEncodeTiled(A) failed (e=%d M=%d K=%d)\n",
-                         e, M_e, K);
+            IMP_LOG_ERROR("[smallM] cuTensorMapEncodeTiled(A) failed (e=%d M=%d K=%d)", e, M_e, K);
             return false;
         }
         if (!build_tma_2d_u8(&h_descs[2 * e + 1],
                               const_cast<void*>(host_ptr_B[e]),
                               /*gmem_rows=*/N, /*gmem_cols=*/K / 2,
                               /*box_rows=*/TILE_N, /*box_cols=*/TILE_K_rt / 2)) {
-            std::fprintf(stderr, "[smallM] cuTensorMapEncodeTiled(B) failed (e=%d N=%d K=%d)\n",
-                         e, N, K);
+            IMP_LOG_ERROR("[smallM] cuTensorMapEncodeTiled(B) failed (e=%d N=%d K=%d)", e, N, K);
             return false;
         }
     }

--- a/src/core/logging.h
+++ b/src/core/logging.h
@@ -27,7 +27,11 @@ bool log_level_from_string(const char* s, LogLevel& out);
 extern std::atomic<LogLevel> g_log_level;
 inline LogLevel log_get_level() { return g_log_level.load(std::memory_order_relaxed); }
 
-void log_message(LogLevel level, const char* file, int line, const char* fmt, ...);
+// printf-style format checking. Without it a %s/%d mismatch in one of the ~1400
+// call sites compiles clean and prints garbage at runtime — which is how the raw
+// fprintf sites migrated in this change could have gone wrong silently.
+void log_message(LogLevel level, const char* file, int line, const char* fmt, ...)
+    __attribute__((format(printf, 4, 5)));
 
 }  // namespace imp
 

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -172,11 +172,10 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     // is mathematically identical for both Gemma-3 and Gemma-4 (normalize-then-add).
     const bool using_fp32_accum = (fp32_accum_buf_ != nullptr && has_post_attn_norm);
     if (debug_forward_enabled() && layer <= 1) {
-        fprintf(stderr,
-                "[DEBUG_FWD] L%d attn: has_post_attn_norm=%d using_fp32_accum=%d "
-                "post_attn_norm=%p ffn_norm=%p\n",
-                layer, (int)has_post_attn_norm, (int)using_fp32_accum, ly.post_attn_norm.data,
-                ly.ffn_norm.data);
+        IMP_LOG_DEBUG(
+            "[DEBUG_FWD] L%d attn: has_post_attn_norm=%d using_fp32_accum=%d "
+            "post_attn_norm=%p ffn_norm=%p",
+            layer, (int)has_post_attn_norm, (int)using_fp32_accum, ly.post_attn_norm.data, ly.ffn_norm.data);
     }
     const StorageTier wo_tier = (ly.wo_id != kInvalidTensorID) ? registry_.handle(ly.wo_id).primary_tier
                                                                : StorageTier::Undefined;
@@ -640,8 +639,8 @@ after_attention:
             debug_tensor_rows("po_wo-0", view_tokens(po, n), stream);
             debug_tensor_rows("ao_pre_wo-0", view_tokens(ao, n), stream);
             // dump wo weight shape info
-            fprintf(stderr, "[DEBUG_FWD] wo_shape: ndim=%d shape=[%ld,%ld] qtype=%d\n", ly.wo.ndim,
-                    (long)ly.wo.shape[0], (long)ly.wo.shape[1], std::to_underlying(ly.wo.qtype));
+            IMP_LOG_DEBUG("[DEBUG_FWD] wo_shape: ndim=%d shape=[%ld,%ld] qtype=%d", ly.wo.ndim,
+                          (long)ly.wo.shape[0], (long)ly.wo.shape[1], std::to_underlying(ly.wo.qtype));
         }
         if (has_post_attn_norm && using_fp32_accum) {
             // Sandwich norm with FP32 accumulator (Gemma-3):
@@ -649,8 +648,8 @@ after_attention:
             Tensor fp32_h = view_tokens(fp32_hidden_, n);
             float eps = model_->config().rms_norm_eps;
             if (layer == 0 && debug_attn_steps) {
-                fprintf(stderr, "[DEBUG_FWD] L0 fp32_accum_kernel: po=%p h=%p fp32_h=%p d=%d n=%d\n", po.data,
-                        h.data, fp32_h.data, model_->config().d_model, n);
+                IMP_LOG_DEBUG("[DEBUG_FWD] L0 fp32_accum_kernel: po=%p h=%p fp32_h=%p d=%d n=%d", po.data,
+                              h.data, fp32_h.data, model_->config().d_model, n);
             }
             // Add attn output to FP32 accumulator, apply post_attn_norm, write FP16
             // 256 threads: d_model_v = d_model/8 (e.g. 480 for Gemma-3 3840),
@@ -670,8 +669,8 @@ after_attention:
                         fs += v;
                         fss += v * v;
                     }
-                    fprintf(stderr, "[DEBUG_FWD] L0_fp32_accum_pre: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f\n",
-                            fs, std::sqrt(fss), fp32_tmp[0], fp32_tmp[1], fp32_tmp[2]);
+                    IMP_LOG_DEBUG("[DEBUG_FWD] L0_fp32_accum_pre: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f", fs,
+                                  std::sqrt(fss), fp32_tmp[0], fp32_tmp[1], fp32_tmp[2]);
                     // Last row (row n-1)
                     int off = (n - 1) * model_->config().d_model;
                     double rs = 0, rss = 0;
@@ -679,9 +678,9 @@ after_attention:
                         rs += fp32_tmp[off + i];
                         rss += fp32_tmp[off + i] * fp32_tmp[off + i];
                     }
-                    fprintf(stderr,
-                            "[DEBUG_FWD] L0_fp32_accum_pre[%d]: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f\n",
-                            n - 1, rs, std::sqrt(rss), fp32_tmp[off], fp32_tmp[off + 1], fp32_tmp[off + 2]);
+                    IMP_LOG_DEBUG("[DEBUG_FWD] L0_fp32_accum_pre[%d]: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f",
+                                  n - 1, rs, std::sqrt(rss), fp32_tmp[off], fp32_tmp[off + 1],
+                                  fp32_tmp[off + 2]);
                 }
             }
             if (fp32_attn_out) {

--- a/src/exec/executor_debug.h
+++ b/src/exec/executor_debug.h
@@ -39,7 +39,7 @@ inline const char* dump_hidden_dir() { return imp::process_diag_dump_hidden_dir(
 inline void write_npy_fp32(const std::string& path, const float* data, int rows, int cols) {
     FILE* f = std::fopen(path.c_str(), "wb");
     if (!f) {
-        std::fprintf(stderr, "[DUMP_NPY] open failed: %s\n", path.c_str());
+        IMP_LOG_ERROR("[DUMP_NPY] open failed: %s", path.c_str());
         return;
     }
     // Build header. Total = 6(magic) + 2(version) + 2(hlen) + header.size
@@ -136,7 +136,7 @@ inline void debug_tensor_stats(const char* name, const Tensor& t, cudaStream_t s
                                            n * sizeof(float), cudaMemcpyDeviceToHost, stream));
         cudaStreamSynchronize(stream);
     } else {
-        fprintf(stderr, "[DEBUG_FWD] %s: unsupported dtype %d\n", name, std::to_underlying(t.qtype));
+        IMP_LOG_ERROR("[DEBUG_FWD] %s: unsupported dtype %d", name, std::to_underlying(t.qtype));
         return;
     }
 
@@ -161,13 +161,13 @@ inline void debug_tensor_stats(const char* name, const Tensor& t, cudaStream_t s
     }
     float mean = vsum / std::max(n - nan_count - inf_count, 1);
     float l2 = std::sqrt(vl2);
-    fprintf(stderr, "[DEBUG_FWD] %-30s  min=%+.6e  max=%+.6e  mean=%+.6e  sum=%+.4f  L2=%.6e", name, vmin,
-            vmax, mean, vsum, l2);
+    std::string extra;
     if (nan_count > 0)
-        fprintf(stderr, "  NaN=%d", nan_count);
+        extra += "  NaN=" + std::to_string(nan_count);
     if (inf_count > 0)
-        fprintf(stderr, "  Inf=%d", inf_count);
-    fprintf(stderr, "\n");
+        extra += "  Inf=" + std::to_string(inf_count);
+    IMP_LOG_DEBUG("[DEBUG_FWD] %-30s  min=%+.6e  max=%+.6e  mean=%+.6e  sum=%+.4f  L2=%.6e%s", name, vmin,
+                  vmax, mean, vsum, l2, extra.c_str());
 }
 
 // Multi-row variant: dump stats over ALL rows of a tensor for cross-impl
@@ -188,8 +188,8 @@ inline void debug_tensor_rows(const char* name, const Tensor& t, cudaStream_t st
     const int max_rows = (nrows < 6) ? nrows : 6;
     const size_t elem_sz = (t.qtype == QType::F16) ? sizeof(half) : sizeof(float);
     // Print one header line with shape/stride so layout bugs are visible.
-    fprintf(stderr, "[DEBUG_FWD_ROW] %s: shape=[%d,%d] stride0=%lld nrows_dump=%d\n", name, nrows, cols,
-            (long long)row_stride, max_rows);
+    IMP_LOG_DEBUG("[DEBUG_FWD_ROW] %s: shape=[%d,%d] stride0=%lld nrows_dump=%d", name, nrows, cols,
+                  (long long)row_stride, max_rows);
     std::vector<float> row_f(cols);
     for (int r = 0; r < max_rows; r++) {
         const char* src = static_cast<const char*>(t.data) + (int64_t)r * row_stride * elem_sz;
@@ -205,9 +205,9 @@ inline void debug_tensor_rows(const char* name, const Tensor& t, cudaStream_t st
         double ss = 0.0;
         for (int i = 0; i < cols; i++)
             ss += (double)row_f[i] * row_f[i];
-        fprintf(stderr, "[DEBUG_FWD_ROW] %s[%d] L2=%.4f  %+.4f %+.4f %+.4f ...  %+.4f %+.4f %+.4f\n", name, r,
-                std::sqrt(ss), row_f[0], row_f[1], row_f[2], row_f[cols - 3], row_f[cols - 2],
-                row_f[cols - 1]);
+        IMP_LOG_DEBUG("[DEBUG_FWD_ROW] %s[%d] L2=%.4f  %+.4f %+.4f %+.4f ...  %+.4f %+.4f %+.4f", name, r,
+                      std::sqrt(ss), row_f[0], row_f[1], row_f[2], row_f[cols - 3], row_f[cols - 2],
+                      row_f[cols - 1]);
     }
 }
 
@@ -219,7 +219,7 @@ inline void debug_tensor_stats_all(const char* name, const Tensor& t, cudaStream
     int nrows = static_cast<int>(t.shape[0]);
     int64_t n = static_cast<int64_t>(cols) * nrows;
     if (t.qtype != QType::F16 && t.qtype != QType::F32) {
-        fprintf(stderr, "[DEBUG_FWD_ALL] %s: unsupported dtype %d\n", name, std::to_underlying(t.qtype));
+        IMP_LOG_ERROR("[DEBUG_FWD_ALL] %s: unsupported dtype %d", name, std::to_underlying(t.qtype));
         return;
     }
     std::vector<float> host(n);
@@ -236,8 +236,8 @@ inline void debug_tensor_stats_all(const char* name, const Tensor& t, cudaStream
         vsum += host[i];
         vss += host[i] * host[i];
     }
-    fprintf(stderr, "[DEBUG_FWD_ALL] %-30s  rows=%d cols=%d  sum=%+.4f  L2=%.4f\n", name, nrows, cols, vsum,
-            std::sqrt(vss));
+    IMP_LOG_DEBUG("[DEBUG_FWD_ALL] %-30s  rows=%d cols=%d  sum=%+.4f  L2=%.4f", name, nrows, cols, vsum,
+                  std::sqrt(vss));
 }
 
 }  // namespace imp

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -120,8 +120,8 @@ void debug_top_logits(const Tensor& logits, cudaStream_t stream, int topk = 10) 
         mx = std::max(mx, host[i]);
         ss += (double)host[i] * host[i];
     }
-    fprintf(stderr, "[DEBUG_FWD] logits row=%d/%d  min=%+.4f max=%+.4f L2=%.4f\n", row, nrows, mn, mx,
-            std::sqrt(ss));
+    IMP_LOG_DEBUG("[DEBUG_FWD] logits row=%d/%d  min=%+.4f max=%+.4f L2=%.4f", row, nrows, mn, mx,
+                  std::sqrt(ss));
 
     // Find top-k by partial sort
     std::vector<std::pair<float, int>> scored(vocab);
@@ -129,9 +129,9 @@ void debug_top_logits(const Tensor& logits, cudaStream_t stream, int topk = 10) 
         scored[i] = {host[i], i};
     std::partial_sort(scored.begin(), scored.begin() + std::min(topk, vocab), scored.end(),
                       [](auto& a, auto& b) { return a.first > b.first; });
-    fprintf(stderr, "[DEBUG_FWD] Top-%d logits:\n", topk);
+    IMP_LOG_DEBUG("[DEBUG_FWD] Top-%d logits:", topk);
     for (int i = 0; i < std::min(topk, vocab); i++) {
-        fprintf(stderr, "  [%2d] token_id=%6d  logit=%+.6f\n", i, scored[i].second, scored[i].first);
+        IMP_LOG_DEBUG("  [%2d] token_id=%6d  logit=%+.6f", i, scored[i].second, scored[i].first);
     }
 }
 
@@ -274,18 +274,22 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         std::vector<int32_t> h_ids(n);
         IMP_CUDA_CHECK_LOG(
             cudaMemcpy(h_ids.data(), state.token_ids, n * sizeof(int32_t), cudaMemcpyDeviceToHost));
-        fprintf(stderr, "[DEBUG_FWD] [step=%d] input_tokens (%d):", decode_step, n);
-        for (int i = 0; i < n; i++)
-            fprintf(stderr, " %d", h_ids[i]);
-        fprintf(stderr, "\n");
+        std::string ids_line;
+        for (int i = 0; i < n; i++) {
+            ids_line += ' ';
+            ids_line += std::to_string(h_ids[i]);
+        }
+        IMP_LOG_DEBUG("[DEBUG_FWD] [step=%d] input_tokens (%d):%s", decode_step, n, ids_line.c_str());
         // Dump positions
         std::vector<int> h_pos(n);
         IMP_CUDA_CHECK_LOG(
             cudaMemcpy(h_pos.data(), state.positions, n * sizeof(int), cudaMemcpyDeviceToHost));
-        fprintf(stderr, "[DEBUG_FWD] [step=%d] positions (%d):", decode_step, n);
-        for (int i = 0; i < std::min(n, 30); i++)
-            fprintf(stderr, " %d", h_pos[i]);
-        fprintf(stderr, "\n");
+        std::string pos_line;
+        for (int i = 0; i < std::min(n, 30); i++) {
+            pos_line += ' ';
+            pos_line += std::to_string(h_pos[i]);
+        }
+        IMP_LOG_DEBUG("[DEBUG_FWD] [step=%d] positions (%d):%s", decode_step, n, pos_line.c_str());
     }
     Tensor h = view_tokens(hidden_, n);
     embedding_lookup(model_->token_embedding(), state.token_ids, n, h, model_->tok_emb_.qtype, stream);
@@ -331,8 +335,8 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
         cudaMemcpyAsync(tmp, view_tokens(fp32_hidden_, n).data, 4 * sizeof(float), cudaMemcpyDeviceToHost,
                         stream);
         cudaStreamSynchronize(stream);
-        fprintf(stderr, "[DEBUG_FWD] [step=%d] fp32_accum_init: [%.4f %.4f %.4f %.4f]\n", decode_step, tmp[0],
-                tmp[1], tmp[2], tmp[3]);
+        IMP_LOG_DEBUG("[DEBUG_FWD] [step=%d] fp32_accum_init: [%.4f %.4f %.4f %.4f]", decode_step, tmp[0],
+                      tmp[1], tmp[2], tmp[3]);
     }
     // Binary dump: write the full FP16 hidden state to file
     if (!runtime_config().diagnostics.dump_hidden_dir.empty()) {
@@ -345,7 +349,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
             fwrite(h_buf.data(), sizeof(half), h_buf.size(), f);
             fclose(f);
         }
-        fprintf(stderr, "[DUMP_BIN] Wrote %s (%zu halfs)\n", fname, h_buf.size());
+        IMP_LOG_DEBUG("[DUMP_BIN] Wrote %s (%zu halfs)", fname, h_buf.size());
     }
 
     if (profile_active)
@@ -462,17 +466,17 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                     cudaStreamSynchronize(stream);
                     sval = __half2float(h_scale);
                     if (i == 0 || i == 29)
-                        fprintf(stderr, "[DEBUG_FWD] L%d_out_scale = %.6f\n", i, sval);
+                        IMP_LOG_DEBUG("[DEBUG_FWD] L%d_out_scale = %.6f", i, sval);
                     // Dump FP16 hidden after scale for all layers (decode only)
                     if (n == 1 && debug_forward_enabled()) {
                         half h_tmp[8];
                         cudaMemcpyAsync(h_tmp, view_tokens(h, n).data, 8 * sizeof(half),
                                         cudaMemcpyDeviceToHost, stream);
                         cudaStreamSynchronize(stream);
-                        fprintf(stderr, "[DUMP] step=%d L%02d h=[%.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f]\n",
-                                decode_step, i, __half2float(h_tmp[0]), __half2float(h_tmp[1]),
-                                __half2float(h_tmp[2]), __half2float(h_tmp[3]), __half2float(h_tmp[4]),
-                                __half2float(h_tmp[5]), __half2float(h_tmp[6]), __half2float(h_tmp[7]));
+                        IMP_LOG_DEBUG("[DUMP] step=%d L%02d h=[%.4f %.4f %.4f %.4f %.4f %.4f %.4f %.4f]",
+                                      decode_step, i, __half2float(h_tmp[0]), __half2float(h_tmp[1]),
+                                      __half2float(h_tmp[2]), __half2float(h_tmp[3]), __half2float(h_tmp[4]),
+                                      __half2float(h_tmp[5]), __half2float(h_tmp[6]), __half2float(h_tmp[7]));
                     }
                     // Binary dump: full hidden state for selected layers.
                     // [diagnostics] dump_hidden_dir = "<path>"  → layers 0/5/15/29.
@@ -718,7 +722,7 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 Tensor w_fp16(w_fp16_dev, QType::F16, 2, w_shape, true);
                 gemm(no_last, w_fp16, lg, 1.0f, 0.0f, stream);
                 IMP_CUDA_CHECK_LOG(cudaFreeAsync(w_fp16_dev, stream));
-                fprintf(stderr, "[DEBUG_FWD] LM head via dequant->FP16->cuBLAS path\n");
+                IMP_LOG_DEBUG("[DEBUG_FWD] LM head via dequant->FP16->cuBLAS path");
             } else {
                 auto* q8 = static_cast<block_q8_1*>(qscratch_.q8_1_buf);
                 rmsnorm_quantize_q8_1(static_cast<const half*>(h_last.data),

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -150,10 +150,13 @@ void dump_top8_gate_logits(int layer, int n, int ne, const float* d_logits) {
     for (int i = 0; i < ne; ++i) sorted.emplace_back(h_logits[i], i);
     std::partial_sort(sorted.begin(), sorted.begin() + 8, sorted.end(),
                       [](auto& a, auto& b) { return a.first > b.first; });
-    fprintf(stderr, "[LOGITS] L%02d tok=%d top8_by_value: ", layer, last_tok);
-    for (int i = 0; i < 8; ++i)
-        fprintf(stderr, "[e=%d v=%.4f] ", sorted[i].second, sorted[i].first);
-    fprintf(stderr, "\n");
+    std::string top8;
+    for (int i = 0; i < 8; ++i) {
+        char buf[48];
+        snprintf(buf, sizeof(buf), "[e=%d v=%.4f] ", sorted[i].second, sorted[i].first);
+        top8 += buf;
+    }
+    IMP_LOG_DEBUG("[LOGITS] L%02d tok=%d top8_by_value: %s", layer, last_tok, top8.c_str());
 }
 
 }  // anonymous namespace
@@ -758,9 +761,8 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
                        ne * sizeof(float), cudaMemcpyDeviceToHost);
             double rsum = 0, rss = 0;
             for (auto v : rl) { rsum += v; rss += v * v; }
-            fprintf(stderr,
-                    "[DEBUG_FWD] L0_router_logits[%d]: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f\n",
-                    last_tok, rsum, std::sqrt(rss), rl[0], rl[1], rl[2]);
+            IMP_LOG_DEBUG("[DEBUG_FWD] L0_router_logits[%d]: sum=%.4f L2=%.4f [0..2]=%.6f %.6f %.6f",
+                          last_tok, rsum, std::sqrt(rss), rl[0], rl[1], rl[2]);
         }
         if (dump_logits) dump_top8_gate_logits(layer, n, ne, static_cast<const float*>(gate_logits_f32.data));
         run_topk(gate_logits_f32);
@@ -779,12 +781,11 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
             cudaMemcpy(h_wts.data(),
                        static_cast<const float*>(routing.expert_weights.data) + last_tok * top_k,
                        top_k * sizeof(float), cudaMemcpyDeviceToHost);
-            fprintf(stderr,
-                    "[ROUTE] L%02d tok=%d experts=[%3d,%3d,%3d,%3d,%3d,%3d,%3d,%3d] "
-                    "weights=[%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f]\n",
-                    layer, last_tok, h_idx[0], h_idx[1], h_idx[2], h_idx[3], h_idx[4], h_idx[5],
-                    h_idx[6], h_idx[7], h_wts[0], h_wts[1], h_wts[2], h_wts[3], h_wts[4], h_wts[5],
-                    h_wts[6], h_wts[7]);
+            IMP_LOG_DEBUG(
+                "[ROUTE] L%02d tok=%d experts=[%3d,%3d,%3d,%3d,%3d,%3d,%3d,%3d] "
+                "weights=[%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f]",
+                layer, last_tok, h_idx[0], h_idx[1], h_idx[2], h_idx[3], h_idx[4], h_idx[5], h_idx[6],
+                h_idx[7], h_wts[0], h_wts[1], h_wts[2], h_wts[3], h_wts[4], h_wts[5], h_wts[6], h_wts[7]);
         }
     }
 
@@ -959,7 +960,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         if (!non_gated_experts) {
             if (cfg.ffn_activation == FFNActivation::GEGLU) {
                 if (layer == 0 && runtime_config().diagnostics.debug_forward)
-                    fprintf(stderr, "[DEBUG_MoE] Using GEGLU activation for MoE experts\n");
+                    IMP_LOG_DEBUG("[DEBUG_MoE] Using GEGLU activation for MoE experts");
                 geglu_quantize_q8_1(gate_buf, up_buf, q8, qscratch_.d8_buf, top_k * eff, stream);
             } else {
                 swiglu_quantize_q8_1(gate_buf, up_buf, q8, qscratch_.d8_buf, top_k * eff, stream);

--- a/src/memory/alloc_interpose.cpp
+++ b/src/memory/alloc_interpose.cpp
@@ -98,7 +98,7 @@ void print_sites() {
         return;
     std::sort(g_sites.begin(), g_sites.end(),
               [](const Site& a, const Site& b) { return a.calls > b.calls; });
-    std::fprintf(stderr, "    by call site (addr2line -e <binary> <offset>):\n");
+    IMP_LOG_DEBUG("    by call site (addr2line -e <binary> <offset>):");
     for (const auto& s : g_sites) {
         Dl_info info{};
         const char* obj = "?";
@@ -107,12 +107,12 @@ void print_sites() {
             obj = info.dli_fname ? info.dli_fname : "?";
             off = (unsigned long long)((const char*)s.ret - (const char*)info.dli_fbase);
         }
-        std::fprintf(stderr, "      %8llu calls  %9.3f MiB   %s +0x%llx\n",
-                     (unsigned long long)s.calls, s.bytes / (1024.0 * 1024.0), obj, off);
+        IMP_LOG_DEBUG("      %8llu calls  %9.3f MiB   %s +0x%llx", (unsigned long long)s.calls,
+                      s.bytes / (1024.0 * 1024.0), obj, off);
     }
     if (g_sites_overflow_calls)
-        std::fprintf(stderr, "      %8llu calls  (further sites, table full)\n",
-                     (unsigned long long)g_sites_overflow_calls);
+        IMP_LOG_DEBUG("      %8llu calls  (further sites, table full)",
+                      (unsigned long long)g_sites_overflow_calls);
 }
 
 void record(Counter& c, size_t bytes, imp::RegionTag tag, const void* site, bool device) {
@@ -132,19 +132,19 @@ struct Reporter {
         const uint64_t ds = g_dev_sync.calls.load(), da = g_dev_async.calls.load(),
                        hp = g_host_pinned.calls.load();
         if ((ds | da | hp) == 0) {
-            std::fprintf(stderr,
-                         "[alloc-interpose] steady state clean: 0 cudaMalloc, "
-                         "0 cudaMallocAsync, 0 pinned-host allocations while serving\n");
+            IMP_LOG_DEBUG(
+                "[alloc-interpose] steady state clean: 0 cudaMalloc, "
+                "0 cudaMallocAsync, 0 pinned-host allocations while serving");
             return;
         }
-        std::fprintf(stderr,
-                     "[alloc-interpose] I2 VIOLATIONS while serving:\n"
-                     "    cudaMalloc       %8llu calls  %10.2f MiB\n"
-                     "    cudaMallocAsync  %8llu calls  %10.2f MiB\n"
-                     "    pinned host      %8llu calls  %10.2f MiB\n",
-                     (unsigned long long)ds, g_dev_sync.bytes.load() / (1024.0 * 1024.0),
-                     (unsigned long long)da, g_dev_async.bytes.load() / (1024.0 * 1024.0),
-                     (unsigned long long)hp, g_host_pinned.bytes.load() / (1024.0 * 1024.0));
+        IMP_LOG_DEBUG(
+            "[alloc-interpose] I2 VIOLATIONS while serving:"
+            "    cudaMalloc       %8llu calls  %10.2f MiB\n"
+            "    cudaMallocAsync  %8llu calls  %10.2f MiB\n"
+            "    pinned host      %8llu calls  %10.2f MiB\n",
+            (unsigned long long)ds, g_dev_sync.bytes.load() / (1024.0 * 1024.0), (unsigned long long)da,
+            g_dev_async.bytes.load() / (1024.0 * 1024.0), (unsigned long long)hp,
+            g_host_pinned.bytes.load() / (1024.0 * 1024.0));
         print_sites();
     }
 };

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -804,7 +804,7 @@ std::vector<int32_t> ChatTemplate::apply_jinja(const Tokenizer& tok, const std::
             else
                 escaped += c;
         }
-        fprintf(stderr, "[DEBUG_TPL_JINJA] rendered: \"%s\"\n", escaped.c_str());
+        IMP_LOG_DEBUG("[DEBUG_TPL_JINJA] rendered: \"%s\"", escaped.c_str());
     }
 
     auto result = tokenize_rendered(tok, rendered);

--- a/src/model/chat_template_families.cpp
+++ b/src/model/chat_template_families.cpp
@@ -2,6 +2,20 @@
 #include "core/logging.h"
 #include "runtime/process_diag.h"
 
+namespace {
+// These debug dumps used to be a prefix fprintf, a loop of partial writes and a
+// trailing newline — three calls the logging framework cannot express, which is
+// exactly why they bypassed it. Build the line, then log it once.
+std::string join_token_ids(const std::vector<int32_t>& t) {
+    std::string s;
+    for (int32_t id : t) {
+        s += ' ';
+        s += std::to_string(id);
+    }
+    return s;
+}
+}  // namespace
+
 #include <algorithm>
 #include <functional>
 
@@ -78,10 +92,7 @@ std::vector<int32_t> ChatTemplate::apply_chatml(const Tokenizer& tok, const std:
     tokens.insert(tokens.end(), asst_ids.begin(), asst_ids.end());
 
     if (imp::process_diag_debug_template()) {
-        fprintf(stderr, "[DEBUG_TPL] chatml %zu tokens:", tokens.size());
-        for (size_t i = 0; i < tokens.size(); i++)
-            fprintf(stderr, " %d", tokens[i]);
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[DEBUG_TPL] chatml %zu tokens:%s", tokens.size(), join_token_ids(tokens).c_str());
     }
 
     return tokens;
@@ -224,10 +235,7 @@ std::vector<int32_t> ChatTemplate::apply_gemma(const Tokenizer& tok,
 
     // Debug: print template token IDs
     if (imp::process_diag_debug_template()) {
-        fprintf(stderr, "[DEBUG_TPL] %zu tokens:", tokens.size());
-        for (size_t i = 0; i < tokens.size(); i++)
-            fprintf(stderr, " %d", tokens[i]);
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[DEBUG_TPL] %zu tokens:%s", tokens.size(), join_token_ids(tokens).c_str());
     }
 
     return tokens;
@@ -300,26 +308,23 @@ std::vector<int32_t> ChatTemplate::apply_phi(const Tokenizer& tok,
 
     // Debug: print template token IDs
     if (imp::process_diag_debug_template()) {
-        fprintf(stderr, "[DEBUG_TPL] phi %zu tokens:", tokens.size());
-        for (size_t i = 0; i < tokens.size(); i++)
-            fprintf(stderr, " %d", tokens[i]);
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[DEBUG_TPL] phi %zu tokens:%s", tokens.size(), join_token_ids(tokens).c_str());
         // Also decode back to text for verification
-        fprintf(stderr, "[DEBUG_TPL] decoded: ");
+        std::string decoded;
         for (size_t i = 0; i < tokens.size(); i++) {
             std::string piece = tok.decode_token(tokens[i]);
             // Escape control chars for readability
             for (char c : piece) {
                 if (c == '\n')
-                    fprintf(stderr, "\\n");
+                    decoded += "\\n";
                 else if (c == '\r')
-                    fprintf(stderr, "\\r");
+                    decoded += "\\r";
                 else
-                    fputc(c, stderr);
+                    decoded += c;
             }
-            fprintf(stderr, "|");
+            decoded += '|';
         }
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[DEBUG_TPL] decoded: %s", decoded.c_str());
     }
 
     return tokens;
@@ -381,10 +386,7 @@ std::vector<int32_t> ChatTemplate::apply_harmony(const Tokenizer& tok,
     open_role("assistant");
 
     if (imp::process_diag_debug_template()) {
-        fprintf(stderr, "[DEBUG_TPL] harmony %zu tokens:", tokens.size());
-        for (size_t i = 0; i < tokens.size(); i++)
-            fprintf(stderr, " %d", tokens[i]);
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[DEBUG_TPL] harmony %zu tokens:%s", tokens.size(), join_token_ids(tokens).c_str());
     }
 
     return tokens;

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1171,7 +1171,8 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i, const Upl
                 IMP_LOG_ERROR("Failed to dequant GPTQ %s for layer %d", name, i);
                 return false;
             }
-            IMP_LOG_DEBUG("GPTQ dequant %s layer %d -> [%lld, %lld] FP16", name, i, w.shape[0], w.shape[1]);
+            IMP_LOG_DEBUG("GPTQ dequant %s layer %d -> [%lld, %lld] FP16", name, i, (long long)w.shape[0],
+                          (long long)w.shape[1]);
         }
     }
 
@@ -1267,7 +1268,8 @@ static bool upload_layer_attention_weights(TransformerLayer& L, int i, const Upl
     // rope_freqs: upload as raw FP32 (NOT converted to FP16).
     // The RoPE kernel reads these as float* — FP16 conversion would corrupt them.
     if (L.rope_freqs.data && !L.rope_freqs.on_device && L.rope_freqs.qtype == QType::F32) {
-        IMP_LOG_INFO("Layer %d: uploading rope_freqs as raw FP32 (%lld elements)", i, L.rope_freqs.numel());
+        IMP_LOG_INFO("Layer %d: uploading rope_freqs as raw FP32 (%lld elements)", i,
+                     (long long)L.rope_freqs.numel());
         size_t bytes = L.rope_freqs.nbytes();
         void* d_data = nullptr;
         IMP_CUDA_CHECK_LOG(cudaMallocAsync(&d_data, bytes, ctx.stream));
@@ -1311,7 +1313,8 @@ static bool upload_layer_ffn_weights(TransformerLayer& L, int i, const UploadCtx
                 IMP_LOG_ERROR("Failed to dequant GPTQ %s for layer %d", name, i);
                 return false;
             }
-            IMP_LOG_DEBUG("GPTQ dequant %s layer %d -> [%lld, %lld] FP16", name, i, w.shape[0], w.shape[1]);
+            IMP_LOG_DEBUG("GPTQ dequant %s layer %d -> [%lld, %lld] FP16", name, i, (long long)w.shape[0],
+                          (long long)w.shape[1]);
         }
     }
 

--- a/src/quant/dequant_fp16.cu
+++ b/src/quant/dequant_fp16.cu
@@ -1,4 +1,5 @@
 #include "quant/dequant_fp16.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -61,7 +62,7 @@ void dequant_int4_fp16(const void* input, void* output, const void* scales, int 
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "dequant_int4_fp16 launch failed: %s\n", cudaGetErrorString(err));
+        IMP_LOG_ERROR("dequant_int4_fp16 launch failed: %s", cudaGetErrorString(err));
     }
 }
 

--- a/src/quant/dequant_int8.cu
+++ b/src/quant/dequant_int8.cu
@@ -1,4 +1,5 @@
 #include "quant/dequant_int8.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cstdint>
@@ -80,7 +81,7 @@ void dequant_int8_fp16(const void* input, void* output, const void* scales, int 
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "dequant_int8_fp16 launch failed: %s\n", cudaGetErrorString(err));
+        IMP_LOG_ERROR("dequant_int8_fp16 launch failed: %s", cudaGetErrorString(err));
     }
 }
 

--- a/src/quant/fp8_utils.cu
+++ b/src/quant/fp8_utils.cu
@@ -1,4 +1,5 @@
 #include "quant/fp8_utils.h"
+#include "core/logging.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
@@ -201,7 +202,7 @@ void cast_fp16_to_fp8(const void* input, void* output, int n, cudaStream_t strea
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "cast_fp16_to_fp8 launch failed: %s\n", cudaGetErrorString(err));
+        IMP_LOG_ERROR("cast_fp16_to_fp8 launch failed: %s", cudaGetErrorString(err));
     }
 }
 
@@ -217,7 +218,7 @@ void cast_fp8_to_fp16(const void* input, void* output, int n, cudaStream_t strea
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "cast_fp8_to_fp16 launch failed: %s\n", cudaGetErrorString(err));
+        IMP_LOG_ERROR("cast_fp8_to_fp16 launch failed: %s", cudaGetErrorString(err));
     }
 }
 

--- a/src/quant/mxfp4_gemm.cu
+++ b/src/quant/mxfp4_gemm.cu
@@ -454,8 +454,8 @@ __global__ void __launch_bounds__(kKparThreads, 12) gemv_mxfp4_geglu_residual_ke
 void gemv_mxfp4_kpar(const CutlassMxFP4Weight& W, const half* x, half* y, int N, int K, cudaStream_t stream) {
     static int kpar_dbg = 0;
     if (++kpar_dbg <= 200 && (K != 5120 || kpar_dbg <= 3))
-        fprintf(stderr, "[GEMV_DBG] N=%d K=%d W.N=%lld W.K=%lld data=%p scales=%p x=%p y=%p\n", N, K,
-                (long long)W.N, (long long)W.K, W.data, W.linear_scales, x, y);
+        IMP_LOG_DEBUG("[GEMV_DBG] N=%d K=%d W.N=%lld W.K=%lld data=%p scales=%p x=%p y=%p", N, K,
+                      (long long)W.N, (long long)W.K, W.data, W.linear_scales, x, y);
     int n_groups = K / kMxGroupSize;
     int mr_blocks = (N + kMRWarps - 1) / kMRWarps;
     if (use_multirow(n_groups, mr_blocks)) {

--- a/src/quant/quant_gemm.cu
+++ b/src/quant/quant_gemm.cu
@@ -202,7 +202,7 @@ void quant_gemm_int4(const Tensor& A, const Tensor& B_quant, const Tensor& scale
 
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "quant_gemm_int4 launch failed: %s\n", cudaGetErrorString(err));
+        IMP_LOG_ERROR("quant_gemm_int4 launch failed: %s", cudaGetErrorString(err));
     }
 }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -490,12 +490,15 @@ bool Engine::end_perplexity_capture(double* out_ppl) {
     if (!runtime_config_.diagnostics.ppl_dump.empty()) {
         const char* dump = runtime_config_.diagnostics.ppl_dump.c_str();
         const bool full = (strcmp(dump, "full") == 0);
-        fprintf(stderr, "[PPL-DUMP] per-pos nll:");
+        std::string nll_line;
         for (int i = 0; i < n - 1; ++i) {
-            if (full || i < 16 || i % 16 == 0 || i > n - 6)
-                fprintf(stderr, " [%d]=%.3f", i, h_nll_pos[i]);
+            if (full || i < 16 || i % 16 == 0 || i > n - 6) {
+                char buf[32];
+                snprintf(buf, sizeof(buf), " [%d]=%.3f", i, h_nll_pos[i]);
+                nll_line += buf;
+            }
         }
-        fprintf(stderr, "\n");
+        IMP_LOG_DEBUG("[PPL-DUMP] per-pos nll:%s", nll_line.c_str());
     }
     double h_nll = 0.0;
     for (int i = first; i <= last; ++i)


### PR DESCRIPTION
The engine had **two** ways to emit: `IMP_LOG_*` (level-gated, timestamped, `file:line`) at ~1300 sites, and raw `fprintf(stderr, ...)` at 191. The second obeyed nothing.

#1221 gave the framework a working level for the first time, which is what made the split matter: set `diagnostics.log_level=error` and you still got `[gemm-algo]`, `[DEBUG_FWD]` and `[DEBUG_TPL]` on stderr — untimestamped, unattributed, unsuppressable.

All **90 sites in `src/`** now go through the framework. `tools/` keeps its `fprintf`: a CLI writing to stderr is program output, not logging, and that is where the layering line already sits.

## Two things I am not going to hide

**My own conversion script introduced a bug.** `fprintf(stderr, "\n")` is a line *terminator*, not a message — the mechanical pass turned ten of them into `IMP_LOG_DEBUG("")`, i.e. empty log lines. It compiled clean and every test stayed green, because nothing asserts on debug output. It surfaced only because a later exact-text match failed for an unrelated reason. Those blocks are now assembled properly: build the line, log it once.

**`log_message()` had no printf format checking**, across ~1400 call sites. Adding `__attribute__((format(printf, 4, 5)))` is what actually verifies a migration of this shape:

- **zero** mismatches in the 90 conversions
- **five pre-existing** ones in `weight_upload.cu` (`%lld` against `int64_t`, which is `long` on LP64), invisible until now — fixed here

## Verified at runtime, not just compiled

With `log_level=debug`: **360 DEBUG lines, zero empty ones**, and the hand-assembled blocks read correctly:

```
executor_forward.cu:282: [DEBUG_FWD] [step=0] input_tokens (16): 1 1 1 1 1 1 ...
executor_forward.cu:292: [DEBUG_FWD] [step=0] positions (16): 0 1 2 3 4 5 ...
executor_debug.h:169:    [DEBUG_FWD] after_embedding  min=-9.619141e-02  max=+8.355713e-02 ...
```

That covers both distinct hand-assembly patterns — loop-join and optional-suffix.

**NOT runtime-verified**, stated because a green build is not the same claim: the chatml/llama3/phi/harmony token dumps and the decode dump in `chat_template_families.cpp` (the test model takes the Jinja path), the `[PPL-DUMP]` block and the `[LOGITS]` top-8 block. They reuse the two patterns verified above, but they were not executed.

`ctest -L unit` 4/4, `clang-format` clean on changed lines, `make dev` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B