### PR TITLE
refactor(layering): close two backward edges by moving types down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ there instead of retelling it.
   existing `args.<field>` use site is unchanged.
 
 ### Changed
+- **Two layering cycles closed by moving a type down, not by adding an include.**
+  `src/compute/weight_dispatch.h` included `exec/weight_handle.h` for
+  `WeightHandle` — one backward edge against forty forward ones; the struct
+  depends on nothing but `core/` and now lives in `src/core/weight_handle.h`.
+  `src/quant/mxfp4_gemm.h` included a compute header for `CutlassMxFP4Weight`,
+  a dependency-free POD describing a quantised weight layout, now in
+  `src/quant/cutlass_mxfp4_weight.h`. Also: `compute/embedding.cu` and
+  `compute/gemm_dp4a.cu` pulled the 800-LOC `model/model_config.h` just to
+  reach `QType`, which is in `core/qtype.h` — `compute → model` goes 9 → 7.
+  No behaviour change.
 - **The engine logs through one mechanism again.** All 90 raw
   `fprintf(stderr, ...)` sites in `src/` now go through `IMP_LOG_*`, so they
   obey `diagnostics.log_level`, carry a timestamp and `file:line`, and can be

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -165,6 +165,38 @@ loop, and the shared part is already factored out.
   running log (`AUDIT.md`) recorded the fix, in a section headed "NOT settled". Reading the
   per-area log at step 0 is what stopped a day of re-measuring something already done.
 
+**Layering: two backward edges the 07-29 audit's §11.1 table does not list, both closed
+(2026-08-03).** That table is otherwise complete and its verdicts stand — `model → vision`,
+`exec → runtime`, `compute → runtime`, `core → compute` are all there with reasons. Two were
+missing:
+
+- **`compute → exec`** — `src/compute/weight_dispatch.h` included `exec/weight_handle.h`
+  because its three signatures take `const WeightHandle&`. One backward edge against forty
+  the other way. `WeightHandle` depended on nothing but `core/`, so it moved to
+  `src/core/weight_handle.h`; `WeightRegistry` stays in `exec/`, being the executor's
+  container rather than something the kernels need. Edge count now **0**.
+- **`quant → compute`** — `src/quant/mxfp4_gemm.h` included
+  `compute/gemm_cutlass_mxfp4_sm120.h` for `CutlassMxFP4Weight`, a POD with no project
+  dependencies that describes a *quantised weight layout*. Moved to
+  `src/quant/cutlass_mxfp4_weight.h`, which is where it belongs by meaning as well as by
+  layer. **One `quant → compute` edge remains and is NOT an include artefact:**
+  `src/quant/nvfp4_gemm.cu` calls `gemm()` because the NVFP4 fallback dequantises to FP16
+  and hands off to the dense GEMM. Inverting that moves a dispatch decision on a GEMM path,
+  which is not a thing to do unmeasured on a repo with no GPU CI lane.
+
+Also closed: the two `compute → model` includes §11.1 called avoidable —
+`embedding.cu` and `gemm_dp4a.cu` pulled the 800-LOC `model/model_config.h` with the comment
+`// QType` while using neither `ModelConfig` nor `FFNActivation`. `QType` is in
+`core/qtype.h`. **9 → 7**; the remaining seven are the real ones (tokenizer for the four
+constrainers, `model.h` for `encoder_forward`, `mtp_head`, `FFNActivation`).
+
+**Checked on the same sweep and NOT findings:** god-functions by callee count — the list is
+led by `forward_logits` (216), which is the forward pass this ledger already records as
+intrinsically coupled; and repeated function names — the top entries are `operator=` (27
+files), `init` (19), `reset` (16), i.e. noise, not copy-paste. `kv_cache_dtype` "in 4
+representations" (audit Track F) could not be confirmed either way: the name barely appears
+in the tree today, and reconstructing the 07-29 vocabulary was out of scope.
+
 **Build cost, quantified (2026-08-03).** CLAUDE.md says the metric is recompile blast
 radius, not line count — this is what that actually costs. Transitive header fan-in across
 the 450 translation units, multiplied by commits in the last six months:

--- a/src/compute/embedding.cu
+++ b/src/compute/embedding.cu
@@ -1,5 +1,5 @@
 #include "compute/embedding.h"
-#include "model/model_config.h"  // QType
+#include "core/qtype.h"
 #include "core/tensor.h"
 #include "core/logging.h"
 #include <cuda_runtime.h>

--- a/src/compute/gemm_cutlass_mxfp4_sm120.h
+++ b/src/compute/gemm_cutlass_mxfp4_sm120.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <cstddef>
 
+#include "quant/cutlass_mxfp4_weight.h"  // CutlassMxFP4Weight (moved down, see there)
+
 namespace imp {
 
 // MXFP4 weight data for CUTLASS sm_120 block-scaled GEMM.
@@ -19,18 +21,6 @@ namespace imp {
 // For our use case: we convert existing NVFP4 weights (UE4M3 per 16)
 // to MXFP4 format (UE8M0 per 32) to use the MXFP4 tensor core path.
 // This may trade some precision for potentially better hardware scheduling.
-
-struct CutlassMxFP4Weight {
-    const void* data = nullptr;     // [N, K/2] packed E2M1 nibbles
-    void* scale_factors = nullptr;  // SfAtom layout UE8M0 (for CUTLASS prefill)
-    void* linear_scales = nullptr;  // [N, K/32] row-major UE8M0 (for GEMV decode)
-    float tensor_scale = 1.0f;      // deferred global scale
-    int64_t N = 0;
-    int64_t K = 0;
-    size_t sf_bytes = 0;
-    bool owns_data = false;  // true if data was allocated (Hadamard path)
-    int hadamard_bs = 0;     // Hadamard block size for online rotation (0=disabled)
-};
 
 // Compute SfAtom buffer size for MXFP4 (UE8M0, SFVecSize=32).
 size_t cutlass_mxfp4_sf_size(int rows, int K);

--- a/src/compute/gemm_dp4a.cu
+++ b/src/compute/gemm_dp4a.cu
@@ -1,7 +1,7 @@
 #include "compute/gemm.h"
 #include "compute/gemv_dp4a_traits.cuh"
 #include "runtime/pdl.h"
-#include "model/model_config.h"  // QType
+#include "core/qtype.h"
 #include "core/logging.h"
 
 #include <cuda_fp16.h>

--- a/src/compute/weight_dispatch.h
+++ b/src/compute/weight_dispatch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "exec/weight_handle.h"
+#include "core/weight_handle.h"
 #include "core/tensor.h"
 
 #include <cublasLt.h>

--- a/src/core/weight_handle.h
+++ b/src/core/weight_handle.h
@@ -1,0 +1,114 @@
+#pragma once
+
+// WeightHandle is the per-weight storage/tier descriptor. It lives in core/
+// because src/compute/weight_dispatch.h takes it by reference: keeping it in
+// exec/ made compute/ include a higher layer, the one backward edge in an
+// otherwise forward compute -> exec relationship (40 files the other way).
+// WeightRegistry stays in exec/ — it is the executor's container, not a type
+// the kernels need.
+
+#include "core/logging.h"
+#include "core/qtype.h"
+#include "core/tensor_kind.h"
+#include "core/storage_tier.h"
+
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+namespace imp {
+
+struct WeightHandle {
+    TensorID id = kInvalidTensorID;
+    TensorKind kind = TensorKind::UNKNOWN;
+    StorageTier primary_tier = StorageTier::Undefined;
+    StorageTier prefill_tier = StorageTier::Undefined;  // M>1 GEMM dispatch
+    StorageTier decode_tier = StorageTier::Undefined;   // M=1 GEMV dispatch
+    int64_t shape[2] = {0, 0};
+    // Size in bytes of VRAM owned by this handle. Zero means storage is
+    // BORROWED (e.g. via the Phase-2 shim that points handles at wcache_
+    // entries). A non-zero value means this handle's PlanExecutor (Phase 4+)
+    // allocated the storage and is responsible for freeing it in the
+    // registry destructor. Never mix borrowed and owned storage on the same
+    // handle — the freer would double-free or leak.
+    int64_t owned_bytes = 0;
+
+    // Pointer to the ORIGINAL quantized weight bytes (in Model::gpu_allocations_),
+    // and its source qtype. Always borrowed (never freed by the handle).
+    // Used by weight_dispatch for the M=1 dp4a/mmvq fallback when primary_tier
+    // is FP16/FP8/NVFP4 but the source is a GGUF block-quant format and the
+    // small-M path on the original is faster than cuBLAS on the cached overlay.
+    // Phase 5 PR #1 Commit 5.1.3.a — used by the upcoming weight_dispatch shim.
+    const void* source_data = nullptr;
+    QType source_qtype = QType::NONE;
+    void* source_scales = nullptr;
+    float source_tensor_scale = 1.0f;
+
+    union {
+        struct {
+            float* data;
+        } fp32;
+        struct {
+            half* data;
+        } fp16;
+        struct {
+            __nv_fp8_e4m3* data;
+            float* d_scale;
+        } fp8;
+        struct {
+            uint8_t* data;
+            uint8_t* block_scales;
+            float* tensor_scale;
+            float* tensor_scale_2;
+        } nvfp4;
+        struct {
+            void* weight;
+            void* sf;
+            float* global_scale;
+        } cutlass_nvfp4;
+        struct {
+            void* weight;
+            void* scales;
+            void* linear_scales;
+            int hadamard_bs;
+        } mxfp4;
+    } payload{};
+
+    bool is_populated() const { return primary_tier != StorageTier::Undefined; }
+
+    // Phase 5 PR #1 Commit 5.1.4.a: can the original GGUF source bytes
+    // (source_data, owned by Model::gpu_allocations_) be safely freed once
+    // this handle is populated?
+    //
+    // Safe to drop when primary_tier provides BOTH a decode-fast kernel AND
+    // a prefill kernel that consume the overlay payload (not the original).
+    // Tiers that qualify: NVFP4 (gemv_nvfp4_kpar decode + dequant→cuBLAS prefill),
+    // CUTLASS_NVFP4 (NVFP4 GEMV decode + CUTLASS NVFP4 GEMM prefill), FP8
+    // (gemv_fp8 decode + cuBLAS FP8 GEMM prefill), MXFP4 (gemv_mxfp4 +
+    // CUTLASS MXFP4 GEMM).
+    //
+    // Tiers that do NOT qualify: FP16 (decode prefers dp4a on the original
+    // quant — see 5.1.3.c), FP32 (LM-head policy keeps original), Undefined.
+    //
+    // Predicate is conservative: returns true only when both source_data is
+    // present AND the tier covers both M=1 and M>1 paths. Actual freeing
+    // additionally requires dispatch-site audits — done in 5.1.4.b.
+    bool can_drop_source() const {
+        if (source_data == nullptr)
+            return false;
+        switch (primary_tier) {
+            case StorageTier::NVFP4:
+            case StorageTier::CUTLASS_NVFP4:
+            case StorageTier::FP8:
+            case StorageTier::MXFP4:
+                return true;
+            case StorageTier::FP16:
+            case StorageTier::FP32:
+            case StorageTier::Undefined:
+                return false;
+        }
+        return false;
+    }
+};
+
+}  // namespace imp

--- a/src/exec/weight_handle.h
+++ b/src/exec/weight_handle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/logging.h"
+#include "core/weight_handle.h"  // WeightHandle — moved down so compute/ need not include exec/
 #include "core/qtype.h"
 #include "core/tensor_kind.h"
 #include "core/storage_tier.h"
@@ -11,99 +12,6 @@
 #include <vector>
 
 namespace imp {
-
-struct WeightHandle {
-    TensorID id = kInvalidTensorID;
-    TensorKind kind = TensorKind::UNKNOWN;
-    StorageTier primary_tier = StorageTier::Undefined;
-    StorageTier prefill_tier = StorageTier::Undefined;  // M>1 GEMM dispatch
-    StorageTier decode_tier = StorageTier::Undefined;   // M=1 GEMV dispatch
-    int64_t shape[2] = {0, 0};
-    // Size in bytes of VRAM owned by this handle. Zero means storage is
-    // BORROWED (e.g. via the Phase-2 shim that points handles at wcache_
-    // entries). A non-zero value means this handle's PlanExecutor (Phase 4+)
-    // allocated the storage and is responsible for freeing it in the
-    // registry destructor. Never mix borrowed and owned storage on the same
-    // handle — the freer would double-free or leak.
-    int64_t owned_bytes = 0;
-
-    // Pointer to the ORIGINAL quantized weight bytes (in Model::gpu_allocations_),
-    // and its source qtype. Always borrowed (never freed by the handle).
-    // Used by weight_dispatch for the M=1 dp4a/mmvq fallback when primary_tier
-    // is FP16/FP8/NVFP4 but the source is a GGUF block-quant format and the
-    // small-M path on the original is faster than cuBLAS on the cached overlay.
-    // Phase 5 PR #1 Commit 5.1.3.a — used by the upcoming weight_dispatch shim.
-    const void* source_data = nullptr;
-    QType source_qtype = QType::NONE;
-    void* source_scales = nullptr;
-    float source_tensor_scale = 1.0f;
-
-    union {
-        struct {
-            float* data;
-        } fp32;
-        struct {
-            half* data;
-        } fp16;
-        struct {
-            __nv_fp8_e4m3* data;
-            float* d_scale;
-        } fp8;
-        struct {
-            uint8_t* data;
-            uint8_t* block_scales;
-            float* tensor_scale;
-            float* tensor_scale_2;
-        } nvfp4;
-        struct {
-            void* weight;
-            void* sf;
-            float* global_scale;
-        } cutlass_nvfp4;
-        struct {
-            void* weight;
-            void* scales;
-            void* linear_scales;
-            int hadamard_bs;
-        } mxfp4;
-    } payload{};
-
-    bool is_populated() const { return primary_tier != StorageTier::Undefined; }
-
-    // Phase 5 PR #1 Commit 5.1.4.a: can the original GGUF source bytes
-    // (source_data, owned by Model::gpu_allocations_) be safely freed once
-    // this handle is populated?
-    //
-    // Safe to drop when primary_tier provides BOTH a decode-fast kernel AND
-    // a prefill kernel that consume the overlay payload (not the original).
-    // Tiers that qualify: NVFP4 (gemv_nvfp4_kpar decode + dequant→cuBLAS prefill),
-    // CUTLASS_NVFP4 (NVFP4 GEMV decode + CUTLASS NVFP4 GEMM prefill), FP8
-    // (gemv_fp8 decode + cuBLAS FP8 GEMM prefill), MXFP4 (gemv_mxfp4 +
-    // CUTLASS MXFP4 GEMM).
-    //
-    // Tiers that do NOT qualify: FP16 (decode prefers dp4a on the original
-    // quant — see 5.1.3.c), FP32 (LM-head policy keeps original), Undefined.
-    //
-    // Predicate is conservative: returns true only when both source_data is
-    // present AND the tier covers both M=1 and M>1 paths. Actual freeing
-    // additionally requires dispatch-site audits — done in 5.1.4.b.
-    bool can_drop_source() const {
-        if (source_data == nullptr)
-            return false;
-        switch (primary_tier) {
-            case StorageTier::NVFP4:
-            case StorageTier::CUTLASS_NVFP4:
-            case StorageTier::FP8:
-            case StorageTier::MXFP4:
-                return true;
-            case StorageTier::FP16:
-            case StorageTier::FP32:
-            case StorageTier::Undefined:
-                return false;
-        }
-        return false;
-    }
-};
 
 class VRAMAllocator;
 

--- a/src/quant/cutlass_mxfp4_weight.h
+++ b/src/quant/cutlass_mxfp4_weight.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// CutlassMxFP4Weight describes a quantised weight's layout: packed E2M1
+// nibbles plus the two scale representations the prefill and decode paths
+// read. That is a quant concern, so it lives here rather than in
+// compute/gemm_cutlass_mxfp4_sm120.h — where it forced src/quant to include
+// src/compute, one of the two backward edges in an otherwise forward
+// compute -> quant relationship.
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstddef>
+
+namespace imp {
+
+struct CutlassMxFP4Weight {
+    const void* data = nullptr;     // [N, K/2] packed E2M1 nibbles
+    void* scale_factors = nullptr;  // SfAtom layout UE8M0 (for CUTLASS prefill)
+    void* linear_scales = nullptr;  // [N, K/32] row-major UE8M0 (for GEMV decode)
+    float tensor_scale = 1.0f;      // deferred global scale
+    int64_t N = 0;
+    int64_t K = 0;
+    size_t sf_bytes = 0;
+    bool owns_data = false;  // true if data was allocated (Hadamard path)
+    int hadamard_bs = 0;     // Hadamard block size for online rotation (0=disabled)
+};
+
+}  // namespace imp

--- a/src/quant/mxfp4_gemm.h
+++ b/src/quant/mxfp4_gemm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "compute/gemm_cutlass_mxfp4_sm120.h"
+#include "quant/cutlass_mxfp4_weight.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 


### PR DESCRIPTION
You asked for a list of what else is unclean. Here it is, with the three verified items fixed and the checked-but-clean axes recorded so nobody re-runs them.

## The list

**1. `compute → exec` — a cycle the audit's §11.1 table does not list.** `src/compute/weight_dispatch.h` included `exec/weight_handle.h` because `gemm_dispatch` / `gemv_dispatch` / `gemm_grouped_dispatch` take `const WeightHandle&`. **One backward edge against forty forward ones** — the same shape as the `core ↔ compute` cycle R-11 fixed in #1207.

*Fix:* `WeightHandle` depends on nothing but `core/`, so it moved to `src/core/weight_handle.h`. `WeightRegistry` stays in `exec/` — it is the executor's container, not a type the kernels need. **Edge count now 0.**

**2. `quant → compute` — two edges, also missing from that table.** `src/quant/mxfp4_gemm.h` included `compute/gemm_cutlass_mxfp4_sm120.h` for `CutlassMxFP4Weight`: a POD with no project dependencies that describes a *quantised weight layout*.

*Fix:* moved to `src/quant/cutlass_mxfp4_weight.h`, which is where it belongs by meaning as well as by layer.

**3. Two includes of an 800-LOC header to reach a type one layer down.** §11.1 called these avoidable and they still were: `compute/embedding.cu` and `compute/gemm_dp4a.cu` pulled `model/model_config.h` with the comment `// QType` while using neither `ModelConfig` nor `FFNActivation`. `QType` is in `core/qtype.h`. **`compute → model` goes 9 → 7**; the remaining seven are real (tokenizer for the four constrainers, `model.h` for `encoder_forward`, `mtp_head`, `FFNActivation`).

## Not fixed, deliberately

One `quant → compute` edge remains and **it is not an include artefact**: `src/quant/nvfp4_gemm.cu` calls `gemm()` because the NVFP4 fallback dequantises to FP16 and hands off to the dense GEMM. Inverting that moves a dispatch decision on a GEMM path — not something to do unmeasured on a repo whose `gpu` ctest label never runs. Recorded in `SETTLED.md` with that reason.

## Checked and clean — recorded so the sweep is not repeated

- **God functions by callee count.** Led by `forward_logits` at 216 — the forward pass, which the ledger already records as intrinsically coupled ("do not re-attempt runner classes"). Re-flag avoided.
- **Repeated function names.** Top entries are `operator=` (27 files), `init` (19), `reset` (16). Noise, not copy-paste.
- **`model → vision`, `exec → runtime`, `compute → runtime`, `core → compute`.** All already in §11.1 with verdicts; `model → vision` is explicitly justified there.
- **`kv_cache_dtype` "in 4 representations"** (audit Track F): **could not be confirmed either way** — the name barely appears in the tree today. Not claimed as fixed, not claimed as open.

One correction to my own working numbers along the way: I quoted a `compute → model` baseline of 3 from memory when the audit says 9. The 9 → 7 above is the measured figure.

`make dev` green, `ctest -L unit` 4/4, `clang-format` clean on changed lines, anchor gate 65/65. No behaviour change — these are include and type-placement moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B