### PR TITLE
fix(tests): land the two commits auto-merge dropped from #1225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ there instead of retelling it.
   0 / 25 / 26 / 27 IMA lines at `--gtest_repeat=1/2/3/4` before, 0 / 0 / 0 / 0
   after. The full GPU suite goes from **57 failures to 1** (the remaining one
   is pre-existing and passes in isolation), and from 111 IMA lines to none.
+  The `cublasLtMatmul failed (status 14)` line that preceded every IMA was the
+  same symptom rather than a second defect — it appears in every run with the
+  dangling pointer and in none without, before or after the fix.
 - **`StubModelTest.CreateContextAndInfer` no longer hides a poisoned context.**
   Its contract was "the key check is no crash", and it met that while corrupting
   the CUDA context; the failure path skipped with "expected without GPU", which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ there instead of retelling it.
   The `cublasLtMatmul failed (status 14)` line that preceded every IMA was the
   same symptom rather than a second defect — it appears in every run with the
   dangling pointer and in none without, before or after the fix.
+- **`EngineRelaunchTest.ReloadAfterInferenceReleasesVramAndDoesNotCrash` asserted
+  on a process-wide counter.** Its bound on `cudaMemPoolAttrUsedMemCurrent` was
+  absolute (1024 MiB), so it only held when the test ran first: in the full
+  test-e2e run earlier tests leave blocks in the default pool and it read 1792
+  MiB, while passing in isolation. The test already rejected the *device* figure
+  for exactly this reason (`AUDIT B36`); the pool figure is process-wide too. It
+  now takes a baseline and asserts on the delta this cycle owns. Still catches
+  what it exists for — reverting #834's `cudaFreeAsync` makes it fire at 4076
+  MiB retained.
 - **`StubModelTest.CreateContextAndInfer` no longer hides a poisoned context.**
   Its contract was "the key check is no crash", and it met that while corrupting
   the CUDA context; the failure path skipped with "expected without GPU", which

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -371,11 +371,11 @@ TEST_F(StubModelTest, CreateContextAndInfer) {
         ASSERT_EQ(sticky, cudaSuccess)
             << "context creation failed AND left the CUDA context in an error state ("
             << cudaGetErrorString(sticky) << "). Every later test in this binary will fail on a "
-            << "context it did not break. Reproducer: the FIRST engine cycle on the stub model is "
-            << "clean, the second is not (0/25/26/27 error lines at --gtest_repeat=1/2/3/4). A real "
-            << "model is unaffected — EngineRelaunchTest.SecondEngineOnSameModelHandleNeverIMAs "
-            << "passes on Qwen3-4B — so this is the stub's geometry (1 layer, d_model 64, "
-            << "head_dim 32), and it is NOT fixed yet.";
+            << "context it did not break. This guard exists because that is exactly what happened: "
+            << "~Engine closed the T2 arena without re-arming the module statics that had taken a "
+            << "slice from it, so the second engine matmul'd into freed memory. Fixed by calling "
+            << "reset_static_cuda_state() after engine_arena_close(); this assertion is what makes "
+            << "a regression of that class loud instead of silent.";
         GTEST_SKIP() << "Context creation failed (expected without GPU): " << imp_error_string(err);
     }
     ASSERT_NE(ctx, nullptr);
@@ -399,12 +399,14 @@ TEST_F(StubModelTest, CreateContextAndInfer) {
     // CUDA context in an error state: every teardown free failed with an illegal
     // memory access, the engine's #815 guard swallowed it, and the ~57 tests that
     // run after this one in test-e2e died on a context they did not break.
-    // Reproducer, measured 2026-08-04: one engine cycle on the stub is clean, the
-    // SECOND raises the IMA (0 / 25 / 26 / 27 error lines at --gtest_repeat=1/2/3/4).
-    // A real model is unaffected — EngineRelaunchTest.SecondEngineOnSameModelHandle
-    // NeverIMAs passes on Qwen3-4B — so this is specific to the stub's geometry
-    // (1 layer, d_model 64, head_dim 32). The underlying defect is NOT fixed here.
-    // What is fixed is the silence: a test that poisons the process now says so.
+    // Root cause (fixed): ~Engine closed the T2 arena without re-arming the module
+    // statics holding a slice of it, so the SECOND engine in a process matmul'd
+    // into freed memory. Measured before/after, --gtest_repeat=1/2/3/4:
+    // 0/25/26/27 illegal-memory-access lines -> 0/0/0/0, and the full GPU suite
+    // 57 failures -> 1. The "cublasLtMatmul failed (status 14)" line that preceded
+    // the IMA was the same symptom, not a separate defect: it appears in every run
+    // that has the dangling pointer and in none that does not.
+    // This assertion stays because the class is silent by construction.
     {
         cudaError_t sticky = cudaDeviceSynchronize();
         if (sticky == cudaSuccess)

--- a/tests/test_engine_relaunch.cpp
+++ b/tests/test_engine_relaunch.cpp
@@ -99,6 +99,22 @@ TEST(EngineRelaunchTest, ReloadAfterInferenceReleasesVramAndDoesNotCrash) {
     size_t free_before = device_free_mib();
     ASSERT_GT(free_before, 0u);
 
+    // Pool "used" is a PROCESS-wide counter, so an absolute bound on it is only
+    // true when this test runs first. It did not: in the full test-e2e run
+    // earlier tests leave blocks in the default pool and the figure read 1792
+    // MiB against a 1024 MiB bound, while the same test passed in isolation.
+    // That is the same category error the comment below rejects for the DEVICE
+    // figure, one level down — so take a baseline and assert on the delta,
+    // which is the part this cycle actually owns.
+    unsigned long long pool_used_before = 0;
+    {
+        cudaMemPool_t p0 = nullptr;
+        int d0 = 0;
+        cudaGetDevice(&d0);
+        if (cudaDeviceGetDefaultMemPool(&p0, d0) == cudaSuccess)
+            (void)cudaMemPoolGetAttribute(p0, cudaMemPoolAttrUsedMemCurrent, &pool_used_before);
+    }
+
     run_one_cycle(get_model_path());
     if (::testing::Test::HasFatalFailure())
         return;
@@ -135,13 +151,14 @@ TEST(EngineRelaunchTest, ReloadAfterInferenceReleasesVramAndDoesNotCrash) {
         // that regression.
         unsigned long long used = 0;
         ASSERT_EQ(cudaMemPoolGetAttribute(pool, cudaMemPoolAttrUsedMemCurrent, &used), cudaSuccess);
-        EXPECT_LT(used >> 20, 1024u)
-            << "the default mempool still holds " << (used >> 20)
-            << " MiB as USED after model teardown — the weights were freed with an API that "
-            << "does not return stream-ordered blocks to the pool (#507/#834), so the trim can "
-            << "reclaim nothing. Device-reported free went " << free_before << " -> "
-            << free_between << " MiB, which is expected on this platform (AUDIT B36) and is "
-            << "NOT what this assertion is about.";
+        const unsigned long long retained = used > pool_used_before ? used - pool_used_before : 0;
+        EXPECT_LT(retained >> 20, 1024u)
+            << "this cycle left " << (retained >> 20) << " MiB in the default mempool as USED ("
+            << (pool_used_before >> 20) << " -> " << (used >> 20)
+            << " MiB) — the weights were freed with an API that does not return stream-ordered "
+            << "blocks to the pool (#507/#834), so the trim can reclaim nothing. Device-reported "
+            << "free went " << free_before << " -> " << free_between << " MiB, which is expected "
+            << "on this platform (AUDIT B36) and is NOT what this assertion is about.";
     }
 
     // Re-init after inference: before the prewarm stream-rebind fix this


### PR DESCRIPTION
**#1225 merged with one of its three commits.** Auto-merge fired between my pushes, and I reported all three as landed. They were not. This PR carries the two that were lost, unchanged.

## What is actually on main right now

`a392904d` contains three files — `CHANGELOG.md`, `src/runtime/engine.cpp`, `tests/test_e2e.cpp` — i.e. only the first commit. Verifiable directly:

```
git show a392904d:tests/test_e2e.cpp | rg -c "NOT fixed yet"   -> 1
```

That string is the claim the measurement refuted. It is live on `main`.

## 1. `docs: correct a claim in the previous commit — status 14 was the same defect`

The engine-fix commit said *"NOT fixed: … the status-14 selection failure predates it and is still open"*. Measured:

| | status 14 | IMA |
|---|---|---|
| before fix, 1 engine cycle | 0 | 0 |
| before fix, 2+ cycles | **2** | **25+** |
| after fix, every cycle | **0** | **0** |

`CUBLAS_STATUS_INTERNAL_ERROR` never occurred without the dangling workspace and does not occur once it is gone — cuBLASLt handed a freed pointer, the same defect one step earlier. Corrects two test comments and the CHANGELOG.

## 2. `fix(tests): relaunch VRAM assertion used an absolute bound on a process counter`

`EngineRelaunchTest.ReloadAfterInferenceReleasesVramAndDoesNotCrash` bounded `cudaMemPoolAttrUsedMemCurrent` at an absolute 1024 MiB. That counter is process-wide, so the bound only held when the test ran first: in the full run it reads 1792 MiB while passing in isolation.

The test had already caught this category one level up — its own comment rejects the *device* figure because WSL2/WDDM keeps a process's peak commitment (`AUDIT B36`). The pool figure is process-wide too; the correction was half made. It now takes a baseline and asserts on the delta this cycle owns.

**Mutation-validated, because it makes an assertion more permissive:** reverting #834 (`cudaFreeAsync` → `cudaFree`) makes it fire with *"this cycle left **4076 MiB** in the default mempool as USED (0 → 4076 MiB)"*. Restored, green.

## How this surfaced

Not by noticing the merge — by running the GPU suite against unrelated work and seeing `EngineRelaunchTest` fail with `(used >> 20) < (1024u), actual: 1792 vs 1024`, which is the **old** assertion text. A fix that is merged cannot fail with its pre-fix message; that mismatch is what exposed it.

Worth stating plainly: `git branch --contains` is useless here (squash-merge), so "did my commit land" has to be answered by reading the merge commit's content, not its ancestry. I asserted it from the PR page instead.

`ctest -L unit` 4/4. Both commits are cherry-picks of the originals, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B