### PR TITLE
fix(compute): make cuBLASLt algo selection repeat across restarts (F-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- **GEMM algo selection now repeats across process restarts** (F-9,
+  `src/compute/gemm.cu`). Each candidate was timed exactly once, and at M=16 that
+  window is ~30-120 us — mostly launch overhead — so the pick was noise: 4 of 8
+  shapes on Qwen3-1.7B chose 3-4 different kernels over 5 fresh processes. Timed
+  windows are now sized to a target duration, and a candidate must beat the
+  heuristic's own first choice by 10 % in *every* round, compared against it inside
+  that same round. 7 of 8 shapes now pick identically; the eighth alternates between
+  two candidates that are equal within noise and both 8-45 % faster than the previous
+  fallback. No load-time or throughput cost (alternating A/B). Reachable only from
+  dense BF16/FP16 SafeTensors and the vision encoders. Rationale, the rejected algo
+  cache, and the two designs that were measured and failed:
+  [`docs/audit/SETTLED.md`](docs/audit/SETTLED.md) F-9.
 - **`imp-cli --max-tokens` now defaults to 8192, not 256** (#1209). 256 predates
   reasoning models: on a trace-reasoner the think block alone overruns it, so the
   answer comes back empty with `finish_reason=length`. `imp-server` was already

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -324,7 +324,46 @@ Still open from 07-29 with the reason each was not shipped blind — see
 - **F-5 (rest)** — GPU CI lane: **declined by the repo owner, 2026-08-03.** The job and its
   nightly trigger stay dormant in `.github/workflows/ci.yml`. Consequence: `make verify-fast`
   locally is the only thing that ever runs a CUDA kernel against correctness or perf.
-- **F-9** — cuBLASLt algorithm selection unpinned (mechanism confirmed, magnitude refuted).
+- **F-9** — cuBLASLt algorithm selection unpinned. **Closed 2026-08-04 by fixing the
+  estimator, not by persisting the result** (`src/compute/gemm.cu`). The magnitude the audit
+  inherited was never measured; measuring it is what redirected the fix.
+  **Measured on Qwen3-1.7B, 5 fresh processes, 8 shapes** (`diagnostics.log_gemm_algo`, and
+  note the path is only reachable at all from dense BF16/FP16 SafeTensors and the vision
+  encoders — a Q8_0 GGUF, including the perf-gate model, never enters it):
+  the instability is **entirely in near-ties**. Every shape whose best candidate is genuinely
+  ahead already picked the same one every time — M=512 N=6144 K=2048 spans 0.196-0.449 ms and
+  chose cand[0] in 5/5, its cost reproducing to **0.3 %**, and it chose right even in a run
+  where cold clocks inflated everything ~5x. Every unstable shape had its top candidates inside
+  ~5-10 %, i.e. inside the measurement's own error, so what a flip costs is bounded by how close
+  the tie is. Result 4/8 shapes stable before, **7/8 after**, the eighth alternating between two
+  candidates that are equal within noise *and* both 8-45 % ahead of the heuristic — so it now
+  takes a gain it previously threw away. No load-time cost (alternating A/B: 60.6 s vs 61.8 s
+  median) and no throughput cost (311.0 vs 308.8 tok/s).
+  **R-16 (persist the algo per shape+dtype) is REJECTED, not deferred.** Selection timed each
+  candidate exactly once; a cache would have frozen whatever that noisy first run chose and
+  handed it to every later process, converting a per-process mispick into a permanent one — on
+  top of needing invalidation against driver and cuBLAS version, for an opaque blob cuBLAS does
+  not promise is portable across library versions. Anchor: the timing loop in
+  `benchmark_and_select_algo`, `src/compute/gemm.cu`.
+  **Two designs were built and measured and did NOT work — do not re-try them blind:**
+  (1) *k interleaved rounds, per-candidate minimum across rounds.* Assumes per-sample jitter.
+  The noise is not jitter but **sustained slow windows**: a contaminated run inflates every
+  candidate together (one run put all 8 candidates within 20 % where a quiet run spreads them
+  over 40 %), so a minimum taken inside that window is just as wrong, and the longer selection
+  window even made the previously-stable M=512 shapes flip.
+  (2) *Requiring the same candidate to win every round.* Two challengers that are tied with each
+  other but both clearly ahead of the heuristic split the round wins, unanimity fails, and the
+  fallback keeps a base that is 8-45 % slower.
+  What works is a **paired comparison inside each round** — every candidate against `base` timed
+  in that same round, and it must win by `kAlgoMargin` in *every* round. Contamination scales
+  both sides, so the ratio still carries signal where absolute times carry none. Plus sizing the
+  timed window (`kTargetWindowMs`) instead of fixing the rep count: five reps at M=16 timed
+  ~30-120 us, which is mostly launch overhead, and that is why small M was a coin flip while
+  M=512 was not. **Mutation-validated**: with `base` forced to the *last* valid candidate, the
+  switch fires on all four shapes with a real spread (M=512 N=6144 back to cand[0], 2.2x) and
+  correctly stays put on the two where nothing is 10 % better.
+  **A 3 % margin was tried first and was useless** — it sat below the residual noise. Set a
+  threshold like this from the measured spread, not from what sounds tight.
 - **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`. **Scoped by
   measurement 2026-08-03, and the audit's estimate is low by 2x.** It proposes extracting
   "the ~30 dispatch-relevant keys" into a `DispatchPolicy` POD; `src/exec/` actually reads

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -18,6 +18,7 @@
 #include <cuda_bf16.h>
 #include <cstdio>
 #include <cstdlib>
+#include <algorithm>
 #include <unordered_map>
 #include <mutex>
 #include <stdexcept>
@@ -348,6 +349,50 @@ static inline void set_gemm_scale_pointers(cublasLtMatmulDesc_t opDesc, const fl
 static constexpr int kMaxAlgoCandidates = 8;
 static constexpr int kBenchmarkIters = 5;
 
+// Selection stability (F-9). A single timed sample per candidate made the choice
+// a coin flip at small M: measured over 5 fresh processes on Qwen3-1.7B, all four
+// M=512 shapes picked the same tile every time, while all four M=16 shapes picked
+// 3-4 *different* tiles, and the winning time for one shape ranged 0.055-0.321 ms
+// (5.8x). At M=16 a candidate runs ~0.05 ms, so kBenchmarkIters spans ~0.25 ms —
+// short enough that one scheduling hiccup decides the winner.
+//
+// Two fixes, both on the estimator rather than on persistence. An on-disk algo
+// cache (the other candidate fix) would freeze whatever the first noisy run chose
+// and hand it to every later process, turning a per-process mispick into a
+// permanent one — on top of needing invalidation against driver/cuBLAS version.
+//
+// Logging every candidate's cost (not just the winner's) showed where the
+// instability actually lives: shapes whose best candidate is genuinely ahead pick
+// the same one every time — M=512 N=6144 K=2048 spans 0.196-0.449 ms and chose
+// cand[0] in 4/4 runs, its cost reproducing to 0.3 % (0.1961/0.1964/0.1961/0.1966),
+// and it chose right even in a run where cold clocks inflated everything 5x. Every
+// unstable shape instead has its top candidates bunched within ~5-10 %, i.e. inside
+// the measurement's own error. So the flips are ties resolved by noise, and the
+// throughput at stake in a flip is bounded by how close the tie is.
+//
+// Two fixes, both on the estimator rather than on persistence. An on-disk algo
+// cache (the other candidate fix) would freeze whatever the first noisy run chose
+// and hand it to every later process, turning a per-process mispick into a
+// permanent one — on top of needing invalidation against driver/cuBLAS version.
+//
+//  1. Size the timed window instead of fixing the rep count. A fixed
+//     kBenchmarkIters makes the window scale with the shape, and at M=16 a
+//     candidate runs ~6-24 us, so five reps time ~30-120 us — mostly launch
+//     overhead. A probe round now sizes each candidate's reps for a
+//     ~kTargetWindowMs window, which puts every shape at comparable measurement
+//     quality. Costs are then compared per rep.
+//  2. kAlgoMargin hysteresis toward heuristic order. A candidate replaces the
+//     incumbent only if it beats it by more than the margin; otherwise the lower
+//     heuristic index wins. Heuristic order is deterministic for a given shape and
+//     device, so candidates inside the margin resolve the same way in every process
+//     instead of by measurement noise. The margin is set from the measured residual
+//     spread, not guessed — an earlier 3 % attempt sat below the noise and left the
+//     picks as unstable as before.
+static constexpr int kBenchmarkRounds = 3;
+static constexpr float kTargetWindowMs = 0.5f;
+static constexpr int kMaxBenchIters = 512;
+static constexpr float kAlgoMargin = 0.10f;
+
 // Diagnostic: when diagnostics.log_gemm_algo is set, log shape + per-candidate algoId/tileId + chosen algo for every
 // benchmark_and_select_algo call. Used to enumerate which exact GEMM shapes
 // select cuBLAS legacy WMMA kernels (Finding 1/5).
@@ -461,8 +506,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
-    float best_ms = 1e30f;
-    int best_idx = 0;
+    std::vector<float> cand_ms(nresults, 1e30f);
 
     // Warmup all candidates first so steady-state caches are warm before any
     // candidate is timed. One warmup call per candidate (the previous policy)
@@ -491,11 +535,9 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         }
     }
 
-    for (int i = 0; i < nresults; i++) {
-        if (!algo_ok[i])
-            continue;
+    auto time_candidate = [&](int i, int iters) {
         cudaEventRecord(start, stream);
-        for (int r = 0; r < kBenchmarkIters; r++)
+        for (int r = 0; r < iters; r++)
             cublasLtMatmul(lt, entry.opDesc, p_alpha, B_data, entry.Bdesc, A_data, entry.Adesc, p_zero, temp_c,
                            entry.Cdesc, temp_c, entry.Cdesc, &results[i].algo, s_workspace,
                            results[i].workspaceSize, stream);
@@ -503,16 +545,91 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         cudaEventSynchronize(stop);
         float ms = 0;
         cudaEventElapsedTime(&ms, start, stop);
-        if (ms < best_ms) {
-            best_ms = ms;
-            best_idx = i;
+        return ms / static_cast<float>(iters);
+    };
+
+    // Probe round — its timings are thrown away, they only size the real rounds.
+    std::vector<int> reps(nresults, kBenchmarkIters);
+    for (int i = 0; i < nresults; i++) {
+        if (!algo_ok[i])
+            continue;
+        const float per_rep = time_candidate(i, kBenchmarkIters);
+        const int want = (per_rep > 1e-5f) ? static_cast<int>(kTargetWindowMs / per_rep) : kMaxBenchIters;
+        reps[i] = std::clamp(want, kBenchmarkIters, kMaxBenchIters);
+    }
+
+    // The heuristic's own first choice, among candidates that survived warmup.
+    // Everything below is measured against it.
+    int base = -1;
+    for (int i = 0; i < nresults && base < 0; i++) {
+        if (algo_ok[i])
+            base = i;
+    }
+
+    // Interleaved rounds. Each round compares every candidate against `base`
+    // timed in that SAME round, and a candidate keeps its claim only by beating
+    // base by kAlgoMargin in every round. Pairing the comparison inside a round is
+    // what makes it survive a bad one: cold clocks or a busy host inflate base and
+    // challenger together, so their ratio still carries signal where their absolute
+    // times carry none. Comparing per-candidate minima across rounds does not have
+    // this property, and measurably did not work.
+    std::vector<bool> beats_base(nresults, base >= 0);
+    for (int round = 0; round < kBenchmarkRounds && base >= 0; round++) {
+        // Base is timed first and explicitly — every other candidate in this round
+        // is judged against this number, so it must exist before they are timed.
+        const float base_ms = time_candidate(base, reps[base]);
+        if (base_ms < cand_ms[base])
+            cand_ms[base] = base_ms;
+        beats_base[base] = false;
+        for (int i = 0; i < nresults; i++) {
+            if (i == base)
+                continue;
+            if (!algo_ok[i]) {
+                beats_base[i] = false;
+                continue;
+            }
+            const float per_rep = time_candidate(i, reps[i]);
+            if (per_rep < cand_ms[i])
+                cand_ms[i] = per_rep;
+            if (per_rep >= base_ms * (1.0f - kAlgoMargin))
+                beats_base[i] = false;
         }
     }
 
     cudaEventDestroy(start);
     cudaEventDestroy(stop);
 
-    if (!algo_ok[best_idx]) {
+    // [diag] per-candidate cost, so the margin below can be chosen from measured
+    // spread instead of guessed. Without this only the winner's time is logged,
+    // which cannot answer "how much does the choice actually matter for this shape".
+    if (gemm_algo_log_enabled() && M > 0) {
+        for (int i = 0; i < nresults; i++)
+            IMP_LOG_DEBUG("[gemm-algo]   cost[%d] per_ms=%.5f reps=%d%s", i, cand_ms[i], reps[i],
+                          algo_ok[i] ? "" : " REJECTED");
+    }
+
+    // Lowest-indexed candidate that beat base in every round wins; otherwise base.
+    // Taking the lowest index rather than the smallest time matters: where two
+    // challengers are tied with each other but both clearly ahead of base — which is
+    // exactly what M=512 N=1024 K=2048 does here, cand[3] and cand[5] both ~8-45 %
+    // ahead — picking by time flips between them run to run, and demanding a single
+    // undisputed winner throws away a real gain to keep the slower base. Index order
+    // is stable across processes, so this takes the gain and stays reproducible.
+    //
+    // The reason the timing loop exists is preserved: a legacy WMMA candidate whose
+    // steady-state cost is 3-9x worse never beats base by the margin in any round,
+    // and a base that bad loses to every challenger in every round.
+    int best_idx = base;
+    for (int i = 0; i < nresults; i++) {
+        if (beats_base[i]) {
+            best_idx = i;
+            break;
+        }
+    }
+
+    const float best_ms = (best_idx >= 0) ? cand_ms[best_idx] : 0.0f;
+
+    if (best_idx < 0 || !algo_ok[best_idx]) {
         entry.has_algo = false;
         entry.workspace_size = 0;
         return;


### PR DESCRIPTION
Closes audit finding **F-9** — "cuBLASLt algorithm selection is neither cached nor pinned".

## What was actually wrong

The audit inherited a 2.6x magnitude from its dispatch and never re-measured it. Measuring it first is what changed the fix.

Selection timed each candidate **exactly once**. At M=16 a candidate runs ~6-24 us, so `kBenchmarkIters = 5` timed a ~30-120 us window — mostly launch overhead. Over 5 fresh processes on Qwen3-1.7B (`diagnostics.log_gemm_algo`):

| shape | tiles chosen over 5 processes | |
|---|---|---|
| M=512, all four | 320 / 15 / 30 / 24, each identical | stable |
| M=16 N=2048 K=2048 | 393, 487, 393, 393, 394 | flips |
| M=16 N=1024 K=2048 | 487, 394, 487, 393, 394 | flips |
| M=16 N=6144 K=2048 | 515, 486, 487, 486, 394 | flips |
| M=16 N=2048 K=6144 | 393, 394, 394, 487, 393 | flips |

The winning time for one shape ranged 0.055-0.321 ms across runs (5.8x). Note the path is only reachable from dense BF16/FP16 SafeTensors and the vision encoders — a Q8_0 GGUF, including the perf-gate model, never enters it.

Logging every candidate's cost (added here, behind the existing flag) located the instability precisely: **it is entirely in near-ties.** Shapes with a genuine spread were already stable *and correct* — M=512 N=6144 K=2048 spans 0.196-0.449 ms, chose cand[0] in 5/5, its cost reproducing to 0.3 %, and it chose right even in a run where cold clocks inflated everything ~5x. Every unstable shape had its top candidates within ~5-10 %, i.e. inside the measurement's own error — so what a flip costs is bounded by how close the tie is.

## The fix

1. **Size the timed window** (`kTargetWindowMs`) instead of fixing the rep count, so every shape is measured at comparable quality. Costs are compared per rep.
2. **Paired in-round comparison.** A challenger must beat `base` — the heuristic's own first valid choice — by `kAlgoMargin` in *every* round, timed against it inside that same round. Contamination scales both sides, so the ratio still carries signal where absolute times carry none.

Ties therefore resolve to heuristic order, which is deterministic for a given shape and device.

## Results

- **7 of 8 shapes now pick identically across processes** (was 4 of 8). The eighth alternates between two candidates that are equal within noise *and* both 8-45 % ahead of the heuristic — so it now takes a gain the old code threw away.
- Alternating A/B: no load-time cost (**60.6 s vs 61.8 s** median wall) and no throughput cost (**311.0 vs 308.8** tok/s).
- `verify-fast`: decode −0.21 %, prefill +1.08 %, pp4096 +0.69 %, peak VRAM +0.01 %, graphs 2.16x, degeneration coherent — spread 0.40 %.
- Full GPU suite: 2024 OK, 1 failure = the known `MtpForwardTest.DraftStepProducesValidToken` capacity case, unchanged from the #1225 reference state.

**Mutation-validated.** With `base` forced to the *last* valid candidate, the switch fires on all four shapes with a real spread (M=512 N=6144 back to cand[0], 2.2x) and correctly stays put on the two where nothing is 10 % better — so the reason the timing loop exists, catching a legacy WMMA candidate 3-9x off steady state, is preserved and demonstrated rather than asserted.

## What was rejected, and why it is worth recording

**R-16 (persist the resolved algo per shape+dtype) is rejected, not deferred.** Because selection timed each candidate once, a cache would have frozen whatever that noisy first run chose and handed it to every later process — turning a per-process mispick into a permanent one — on top of needing invalidation against driver and cuBLAS version for an opaque blob cuBLAS does not promise is portable across library versions.

Two designs were built and measured and **failed**; both are recorded in `docs/audit/SETTLED.md` so the next pass does not re-pay for them:

1. *k interleaved rounds, per-candidate minimum across rounds.* Assumes per-sample jitter. The noise is instead a **sustained slow window** — a contaminated run compresses all 8 candidates into 20 % where a quiet run spreads them over 40 % — so the minimum is just as wrong, and the longer window made the previously-stable M=512 shapes flip.
2. *Requiring one candidate to win every round.* Two challengers tied with each other but both clearly ahead of `base` split the round wins, unanimity fails, and the fallback keeps a `base` that is 8-45 % slower.

A 3 % margin was also tried first and was useless — it sat below the residual noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B