### PR TITLE
refactor(vision,memory): move the Qwen3-VL tower into the T2 arena (F-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- **The Qwen3-VL vision tower is now an engine-arena (T2) tenant** (F-12,
+  `src/vision/qwen3vl_vision_upload.cpp`). It was the one engine-lifetime consumer
+  still allocating through `VRAMAllocator`, so 792.2 MiB on Qwen3-VL-4B sat outside
+  the tier model and outside the arena reservation. The arena is now sized for it at
+  open time from `qwen3vl_vision_tower_device_bytes()`, which walks the same tensor
+  list the upload walks — predicted and uploaded agree exactly. Removes the per-block
+  free, and with it the use-after-free the caller-owned scheme had to document.
+  Vision pipeline scratch and Gemma's mmproj tower are unchanged and stay on
+  `VRAMAllocator`; why, and what the next increment needs, is in
+  [`docs/audit/SETTLED.md`](docs/audit/SETTLED.md) F-12.
 - **GEMM algo selection now repeats across process restarts** (F-9,
   `src/compute/gemm.cu`). Each candidate was timed exactly once, and at M=16 that
   window is ~30-120 us — mostly launch overhead — so the pick was noise: 4 of 8

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -401,7 +401,55 @@ Still open from 07-29 with the reason each was not shipped blind — see
   the policy at `:972`, rename 91 accessors, drop the include from 22 files.
 - **F-12** — `src/memory/vram_allocator.cu`: **67** live references (2026-08-03), down from
   the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
-  lines excluded or you get 103 and read a regression that is not there.
+  lines excluded or you get 103 and read a regression that is not there — and count the type
+  name alone, since adding `vram_alloc`/`vram_alloc_force` gives 104.
+  **First consumer migrated 2026-08-04: the Qwen3-VL vision tower** (`qwen3vl_vision_upload.cpp`),
+  which the audit named as the place the tier model was never applied. 792.2 MiB on
+  Qwen3-VL-4B now comes from the T2 engine arena instead of `VRAMAllocator`.
+  **The blocker that had to be solved first — and the reason to solve it the same way for the
+  next consumer:** the arena opens at `engine.cpp:915`, *before* `init_weights()` and long
+  before the vision warmup uploads anything, so a tenant whose bytes are only known at upload
+  time cannot be charged. `qwen3vl_vision_tower_device_bytes()` answers it from shapes alone by
+  walking `qwen3vl_visit_vision_tensors` — the same list the upload walks, so the reservation
+  cannot drift from what is taken. Verified exact: predicted 792.2 MiB, uploaded 792.2 MiB.
+  **What is deliberately NOT migrated, with the reason:** the pipeline's own scratch
+  (`vision_patches`, `vision_out`, deepstack) is sized from `max_patches`, which is not known at
+  arena-open time, so the same trick does not work — it stays on `VRAMAllocator`. Gemma's mmproj
+  tower is a separate GGUF that is not loaded at arena-open time either, so `vision_pipeline.cpp`
+  and `vision_encoder.cu` stay too. Migrating those needs `max_patches` (and the mmproj size)
+  hoisted to before the arena opens; that is the next increment, not an oversight.
+  **Ownership note:** the previous scheme documented the tower's blocks as caller-owned
+  precisely because "a tower holding pointers into an allocator it does not own is a
+  use-after-free the moment a teardown order puts the allocator first". The arena removes the
+  per-block free entirely, so that hazard is gone rather than relocated.
+  **Test trap, hit and fixed:** `Qwen3VLPipelineTest` builds its own `VRAMAllocator` and no
+  arena, so all four cases failed the moment the tower became an arena tenant. Fixtures now open
+  a `ScopedEngineArena` sized from `qwen3vl_vision_tower_device_bytes()` rather than a literal,
+  so a changed fixture checkpoint cannot silently outgrow it. **Mutation-validated**: halving the
+  fixture arena fails all four. Note these tests were *skipped*, not passing, until
+  `IMP_TEST_MODEL_QWEN3VL` was set — the run that looked greenest tested nothing.
+  **Second trap, found by setting that variable: `Qwen3VLPipelineTest` only runs from the source
+  tree.** It loads `tests/fixtures/vision_test_64.png` by relative path and the `imp:test` image
+  ships no `tests/` directory, so setting `IMP_TEST_MODEL_QWEN3VL` for an image run turns three
+  silent skips into three `encode_file` failures that look like a code defect and are not. Run
+  them with the repo mounted (`-v $PWD:/src -w /src ./build-dev/test-e2e`), or leave the variable
+  unset for image runs — the documented full-suite recipe does the latter, which is why its
+  reference state is 1 failure.
+
+- **The memory plan is a SHADOW today — `PlanInput::features` is mostly unfilled, and that is
+  not a bug.** `plan.cpp:111` sums `vision_tower_bytes` and `spec_decode_bytes` into
+  `engine_persistent`, but production writes neither: `plan_shadow.cpp:29-31` fills only
+  `ssm_state_bytes`, `n_swa_layers` and `swa_live_tokens`, and the only writers of
+  `vision_tower_bytes` in the tree are `tests/test_memory_plan.cpp:172,279`. A field that only
+  tests set looks exactly like the vacuous-pass pattern this ledger keeps recording, so it is
+  worth stating plainly why it is not: `plan_shadow.cpp`'s own comment says the plan gets its
+  real shape at **A7 step 6**, "where the plan runs BEFORE the upload and charges everything
+  from a clean slate", and `AUDIT.md` B80 records what step 6 is waiting on (always-on pool
+  bookkeeping). Until then the plan advises and does not allocate, so an unset feature field
+  costs nothing at runtime. **The number that IS authoritative is the arena capacity at
+  `engine.cpp:915`** — that is where a missing tenant actually under-reserves, and that is where
+  the vision tower was added. Do not "fix" the plan fields in isolation and read it as closing a
+  VRAM gap.
 - **F-24** — `src/runtime/engine.h` god-header.
 
 ## Per-area running logs

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1,6 +1,7 @@
 #include "runtime/engine.h"
 #include "core/buffer.h"
 #include "vision/image_processor.h"
+#include "vision/qwen3vl_vision_load.h"
 #include "runtime/request.h"
 #include "lora/lora_adapter.h"
 #include "runtime/engine_internal.h"
@@ -901,10 +902,18 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         const auto d = exec_t2_demand(*model_, config_.max_seq_len, config_.max_batch_size,
                                       config_.use_fp8_prefill, runtime_config_.attention.mla_absorb,
                                       capture_cap);
+        // The Qwen3-VL tower is engine-lifetime and an arena tenant, but it uploads
+        // during warmup — long after this point — so its demand has to be read off
+        // the model's shapes here or the arena is sized without it. Gemma's mmproj
+        // tower is a separate file that is not loaded yet and stays outside the
+        // arena for now (docs/audit/SETTLED.md F-12).
+        const size_t vision_bytes =
+            model_->vision_tower ? qwen3vl_vision_tower_device_bytes(*model_->vision_tower) : 0;
         // +1/8 for 256-byte alignment padding across the arena's takes.
-        const size_t cap = std::max(kEngineArenaDefaultBytes, d.total() + d.total() / 8);
-        IMP_LOG_INFO("engine arena demand: %s -> %.1f MiB reserved", d.describe().c_str(),
-                     cap / (1024.0 * 1024.0));
+        const size_t t2_total = d.total() + vision_bytes;
+        const size_t cap = std::max(kEngineArenaDefaultBytes, t2_total + t2_total / 8);
+        IMP_LOG_INFO("engine arena demand: %s + vision tower %.1f MiB -> %.1f MiB reserved",
+                     d.describe().c_str(), vision_bytes / (1024.0 * 1024.0), cap / (1024.0 * 1024.0));
         (void)engine_arena_open(cuda_malloc_backend(), cap);
         // Name the two charges that are already known, HERE rather than after
         // warmup. Both are facts by now — the context was measured above, the

--- a/src/vision/qwen3vl_pipeline.cpp
+++ b/src/vision/qwen3vl_pipeline.cpp
@@ -19,8 +19,11 @@ Qwen3VLPipeline::~Qwen3VLPipeline() { free_buffers(); }
 
 void Qwen3VLPipeline::free_buffers() {
     encoder_.reset();
-    // Order matters: the tower's slots point into `allocs_`, so they are
-    // invalidated before the memory goes away rather than after.
+    // The tower's blocks live in the T2 arena and are not in `allocs_`; releasing
+    // its slots here keeps a tower that outlives the arena from being read. What
+    // `allocs_` still holds is this pipeline's own scratch, which is sized from
+    // max_patches and so cannot be pre-charged to the arena at open time
+    // (docs/audit/SETTLED.md F-12).
     if (tower_ && uploaded_tower_)
         qwen3vl_release_vision_tower(*tower_);
     uploaded_tower_ = false;
@@ -63,7 +66,7 @@ bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_pat
     if (!tower.patch_embd_w.on_device) {
         size_t bytes = 0;
         std::string err;
-        if (!qwen3vl_upload_vision_tower(tower, &alloc, allocs_, bytes, err)) {
+        if (!qwen3vl_upload_vision_tower(tower, bytes, err)) {
             IMP_LOG_ERROR("Qwen3-VL pipeline: %s", err.c_str());
             free_buffers();
             return false;

--- a/src/vision/qwen3vl_vision_load.cpp
+++ b/src/vision/qwen3vl_vision_load.cpp
@@ -258,6 +258,15 @@ bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& 
     return stats.missing == 0;
 }
 
+size_t qwen3vl_vision_tower_device_bytes(VisionModel& model) {
+    size_t total = 0;
+    // sizeof(half): the upload runs every slot through to_fp16() regardless of the
+    // source qtype, so the device figure is numel * 2 and not the host size.
+    qwen3vl_visit_vision_tensors(
+        model, [&](Tensor& t, const std::string&) { total += static_cast<size_t>(t.numel()) * sizeof(uint16_t); });
+    return total;
+}
+
 void qwen3vl_visit_vision_tensors(VisionModel& model,
                                   const std::function<void(Tensor&, const std::string&)>& fn) {
     fn(model.patch_embd_w, "patch_embed.proj.weight");

--- a/src/vision/qwen3vl_vision_load.h
+++ b/src/vision/qwen3vl_vision_load.h
@@ -39,4 +39,11 @@ bool load_qwen3vl_vision_tensors(const std::unordered_map<std::string, Tensor>& 
 void qwen3vl_visit_vision_tensors(VisionModel& model,
                                   const std::function<void(Tensor&, const std::string&)>& fn);
 
+// Device bytes the tower will occupy once uploaded. Walks the same list as
+// qwen3vl_visit_vision_tensors for the reason given above — a slot added to the
+// upload cannot be missed here — and reads shapes only, never data, so it is
+// answerable BEFORE the upload. That is what lets the engine arena be sized for
+// the tower at open time, which happens long before the vision warmup runs.
+size_t qwen3vl_vision_tower_device_bytes(VisionModel& model);
+
 }  // namespace imp

--- a/src/vision/qwen3vl_vision_upload.cpp
+++ b/src/vision/qwen3vl_vision_upload.cpp
@@ -1,7 +1,7 @@
 #include "vision/qwen3vl_vision_upload.h"
 
 #include "core/logging.h"
-#include "memory/vram_allocator.h"
+#include "memory/engine_arena.h"
 #include "vision/qwen3vl_vision_load.h"
 
 #include <cuda_fp16.h>
@@ -48,16 +48,12 @@ bool to_fp16(const Tensor& t, std::vector<half>& out, std::string& err) {
 
 }  // namespace
 
-bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::vector<void*>& out_allocs,
-                                 size_t& bytes_out, std::string& err) {
-    if (!alloc) {
-        err = "no VRAM allocator for the vision tower";
-        return false;
-    }
-
-    // Collected first, applied last: on any failure the already-allocated blocks
-    // are released and every Tensor still points at the host mapping, which is
-    // the only state the caller can safely drop the tower from.
+bool qwen3vl_upload_vision_tower(VisionModel& model, size_t& bytes_out, std::string& err) {
+    // Collected first, applied last: on any failure every Tensor still points at
+    // the host mapping, which is the only state the caller can safely drop the
+    // tower from. The arena takes are not rewound on that path — it is a bump
+    // allocator — but a failed tower upload ends vision for this engine anyway,
+    // and the bytes go back when the arena closes.
     struct Pending {
         Tensor* slot;
         void* device;
@@ -82,14 +78,15 @@ bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::
             return;
         }
         const size_t bytes = staging.size() * sizeof(half);
-        void* d = alloc->allocate(bytes, "vision_tower");
-        if (!d) {
-            err = "out of VRAM uploading vision tower tensor '" + what + "'";
+        auto slab = engine_arena().take_bytes(bytes);
+        if (slab.empty()) {
+            err = "engine arena exhausted uploading vision tower tensor '" + what +
+                  "' — the arena was reserved without this tower";
             ok = false;
             return;
         }
+        void* d = slab.data();
         if (cudaMemcpy(d, staging.data(), bytes, cudaMemcpyHostToDevice) != cudaSuccess) {
-            alloc->free(d);
             err = "upload failed for vision tower tensor '" + what + "'";
             ok = false;
             return;
@@ -98,18 +95,14 @@ bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::
         total += bytes;
     });
 
-    if (!ok) {
-        for (const auto& p : pending)
-            alloc->free(p.device);
+    if (!ok)
         return false;
-    }
 
     for (const auto& p : pending) {
         p.slot->data = p.device;
         p.slot->qtype = QType::F16;
         p.slot->on_device = true;
         p.slot->compute_strides();
-        out_allocs.push_back(p.device);
     }
     bytes_out = total;
     IMP_LOG_INFO("Vision tower: %zu tensors uploaded, %.1f MiB", pending.size(),

--- a/src/vision/qwen3vl_vision_upload.h
+++ b/src/vision/qwen3vl_vision_upload.h
@@ -15,18 +15,22 @@
 
 namespace imp {
 
-class VRAMAllocator;
-
-// `alloc` may be null, in which case the tower is left alone and this returns
-// false — the encoder has no fallback for host-resident weights.
+// The tower is engine-lifetime, so its blocks come from the T2 engine arena
+// (docs/MEMORY_ARCHITECTURE.md). The arena is sized for exactly this in
+// Engine::init, from qwen3vl_vision_tower_device_bytes() — the tower uploads long
+// after the arena opens, so the two numbers have to be derived from the same
+// tensor list to stay in step.
 //
-// The device blocks are appended to `out_allocs` and belong to the CALLER, not
-// to the VisionModel. That is deliberate: a tower holding pointers into an
-// allocator it does not own is a use-after-free the moment a teardown order
-// puts the allocator first. The caller frees them and calls
-// `qwen3vl_release_vision_tower` to invalidate the tower in the same breath.
-bool qwen3vl_upload_vision_tower(VisionModel& model, VRAMAllocator* alloc, std::vector<void*>& out_allocs,
-                                 size_t& bytes_out, std::string& err);
+// There is no longer a per-block free, and with it goes the hazard the previous
+// caller-owned scheme documented: a tower holding pointers into an allocator it
+// did not own was a use-after-free the moment teardown ordered the allocator
+// first. The arena releases wholesale on close, after which nothing dereferences
+// the slots — callers still invoke `qwen3vl_release_vision_tower` so a tower that
+// outlives the arena cannot be read.
+//
+// Returns false with `err` set when the arena cannot serve the tower, which means
+// the plan under-reserved: the encoder has no fallback for host-resident weights.
+bool qwen3vl_upload_vision_tower(VisionModel& model, size_t& bytes_out, std::string& err);
 
 // Point every tensor slot back at nothing. Call this when the device blocks the
 // upload handed out are released, so a tower that outlives them cannot be

--- a/tests/test_qwen3vl_encoder.cu
+++ b/tests/test_qwen3vl_encoder.cu
@@ -23,6 +23,7 @@
 #include "vision/qwen3vl_encoder.h"
 #include "vision/qwen3vl_vision_grid.h"
 #include "vision/qwen3vl_vision_upload.h"
+#include "scoped_engine_arena.h"
 
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -374,12 +375,17 @@ void run_case(int grid_h, int grid_w) {
     W.deep.resize(1);
     fill_merger(tower.model.deepstack_mergers[0], W.deep[0], true);
 
+    // The tower is a T2 arena tenant now, so this test has to open an arena the
+    // way Engine::init does. Without one, take_bytes() returns empty and the
+    // upload fails — which is the intended signal, not a fallback.
+    ScopedEngineArena arena(64ull << 20);
+    ASSERT_TRUE(arena.opened());
+    // The test's own scratch stays on VRAMAllocator — only the tower moved.
     VRAMAllocator alloc;
     ASSERT_TRUE(alloc.init(0.10f));
     size_t bytes = 0;
     std::string err;
-    std::vector<void*> tower_allocs;
-    ASSERT_TRUE(qwen3vl_upload_vision_tower(tower.model, &alloc, tower_allocs, bytes, err)) << err;
+    ASSERT_TRUE(qwen3vl_upload_vision_tower(tower.model, bytes, err)) << err;
     EXPECT_GT(bytes, 0u);
 
     QwenVisionGrid grid;
@@ -443,8 +449,6 @@ void run_case(int grid_h, int grid_w) {
     alloc.free(d_out);
     alloc.free(d_deep);
     qwen3vl_release_vision_tower(tower.model);
-    for (void* p : tower_allocs)
-        alloc.free(p);
 }
 
 TEST(Qwen3VLEncoder, MatchesAnIndependentCpuReference) {

--- a/tests/test_qwen3vl_pipeline.cu
+++ b/tests/test_qwen3vl_pipeline.cu
@@ -14,6 +14,8 @@
 #include "model/safetensors_loader.h"
 #include "vision/image_processor.h"
 #include "vision/qwen3vl_pipeline.h"
+#include "vision/qwen3vl_vision_load.h"
+#include "scoped_engine_arena.h"
 #include "vision/vision_model.h"
 
 #include <cuda_fp16.h>
@@ -48,6 +50,13 @@ protected:
         model_ = load_safetensors(model_dir(), /*load_mtp_head=*/false);
         ASSERT_NE(model_, nullptr);
         ASSERT_NE(model_->vision_tower, nullptr) << "checkpoint carries no vision tower";
+        // The tower is a T2 arena tenant, so this fixture has to open an arena the
+        // way Engine::init does — and size it the way Engine::init does too, from
+        // the tower's own tensor list rather than from a guess that silently rots
+        // when the fixture checkpoint changes.
+        const size_t tower_bytes = qwen3vl_vision_tower_device_bytes(*model_->vision_tower);
+        arena_ = std::make_unique<ScopedEngineArena>(tower_bytes + tower_bytes / 8);
+        ASSERT_TRUE(arena_->opened());
         ASSERT_TRUE(alloc_.init(0.10f));
         // 4096 patches = a 1024x1024 image at patch 16, and enough to cross the
         // encoder's attention chunk boundary.
@@ -55,6 +64,7 @@ protected:
     }
 
     std::unique_ptr<Model> model_;
+    std::unique_ptr<ScopedEngineArena> arena_;
     VRAMAllocator alloc_;
     Qwen3VLPipeline pipeline_;
 };


### PR DESCRIPTION
First consumer migrated for audit finding **F-12** — "`VRAMAllocator` is a sixth allocator", whose own incremental fix says to start with `vision/`, "the one place where the tier model was never applied".

## What moved

The Qwen3-VL vision tower — **792.2 MiB on Qwen3-VL-4B** — now comes from the T2 engine arena instead of `VRAMAllocator`.

## The blocker that had to be solved first

The arena opens in `Engine::init` **before** `init_weights()` and long before the vision warmup uploads anything. A tenant whose size is only known at upload time therefore cannot be charged — which is plausibly why this consumer was never migrated.

`qwen3vl_vision_tower_device_bytes()` answers it from shapes alone, by walking `qwen3vl_visit_vision_tensors` — the *same* list the upload walks, whose header already documents itself as the single source of truth so "a slot added to one cannot be forgotten by the other". Verified exact:

```
engine arena demand: … + vision tower 792.2 MiB -> 1223.0 MiB reserved
Vision tower: 315 tensors uploaded, 792.2 MiB
```

Predicted and taken agree to the decimal, and the arena goes 431.9 → 1223.0 MiB reserved.

## Ownership gets simpler, not just different

The previous scheme handed the blocks to the caller and documented why: *"a tower holding pointers into an allocator it does not own is a use-after-free the moment a teardown order puts the allocator first."* There is no per-block free any more — the arena releases wholesale on close and nothing dereferences the slots — so that hazard is **removed rather than relocated**. `qwen3vl_release_vision_tower` still runs so a tower outliving the arena cannot be read.

## What is deliberately NOT migrated

- The pipeline's own scratch (`vision_patches`, `vision_out`, deepstack) is sized from `max_patches`, unknown at arena-open time.
- Gemma's mmproj tower is a separate GGUF that is not loaded at arena-open time either.

Both stay on `VRAMAllocator`. `docs/audit/SETTLED.md` F-12 records exactly what the next increment needs (hoisting `max_patches` and the mmproj size ahead of the arena open) so this reads as a scoped step, not an oversight.

## Validation

- **Mutation-validated**: halving the fixture arena fails all four `Qwen3VLPipelineTest` cases, so the fixture genuinely exercises the arena path.
- Vision tests from the tree: 5 passed, 1 skipped (`DifferentImagesEncodeDifferently` wants `IMP_TEST_IMAGE_ALT`).
- `verify-fast`: decode −0.68 %, prefill +1.10 %, pp4096 +0.63 %, peak VRAM +0.01 %, graphs 2.23×, degeneration coherent.
- Full GPU suite at its reference state: 2024 OK, 1 failure (`MtpForwardTest.DraftStepProducesValidToken`, the known capacity case).

## Two test traps recorded in the ledger

1. `Qwen3VLPipelineTest` was **skipped**, not passing, until `IMP_TEST_MODEL_QWEN3VL` was set — the greenest-looking run tested nothing, and all four failed the moment the tower became an arena tenant.
2. Setting that variable for an *image* run then produces three `encode_file` failures that look like a code defect and are not: the tests load `tests/fixtures/vision_test_64.png` by relative path and `imp:test` ships no `tests/` directory. Run them with the repo mounted.

## One correction to the record

While scoping this I flagged `PlanInput::features::vision_tower_bytes` as a dead plan line — written only by `tests/test_memory_plan.cpp` and never in production. That is true but **does not cause a VRAM bug**: `plan_shadow.cpp` says the plan gets its real shape at A7 step 6, "where the plan runs BEFORE the upload"; today it advises and does not allocate. The number that *is* authoritative is the arena capacity, which is what this PR fixes. Recorded in `SETTLED.md` so the next pass does not mistake the unfilled field for a leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B