### PR TITLE
refactor(vision,memory): move the Qwen3-VL scratch into the T2 arena too (F-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ there instead of retelling it.
   open time from `qwen3vl_vision_tower_device_bytes()`, which walks the same tensor
   list the upload walks — predicted and uploaded agree exactly. Removes the per-block
   free, and with it the use-after-free the caller-owned scheme had to document.
-  Vision pipeline scratch and Gemma's mmproj tower are unchanged and stay on
-  `VRAMAllocator`; why, and what the next increment needs, is in
+  The pipeline and encoder scratch followed in the same series — a further
+  224.1 MiB — once the patch budget turned out to be pure config and moved into
+  one `Qwen3VLPipeline::patch_budget()` shared by the sizing and the init. A test
+  asserts the reservation equals what is actually taken, which caught a 192 MiB
+  undercount on its first run. Gemma's mmproj tower stays on `VRAMAllocator`: it
+  is a separate GGUF that genuinely is not loaded when the arena opens. Details:
   [`docs/audit/SETTLED.md`](docs/audit/SETTLED.md) F-12.
 - **GEMM algo selection now repeats across process restarts** (F-9,
   `src/compute/gemm.cu`). Each candidate was timed exactly once, and at M=16 that

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -399,8 +399,8 @@ Still open from 07-29 with the reason each was not shipped blind — see
   reference exists across `src/ tools/ tests/`.
   What remains is volume, not uncertainty: lift nine structs into `core/`, fill
   the policy at `:972`, rename 91 accessors, drop the include from 22 files.
-- **F-12** — `src/memory/vram_allocator.cu`: **67** live references (2026-08-03), down from
-  the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
+- **F-12** — `src/memory/vram_allocator.cu`: **56** live references (2026-08-04), down from
+  67 a day earlier and from the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
   lines excluded or you get 103 and read a regression that is not there — and count the type
   name alone, since adding `vram_alloc`/`vram_alloc_force` gives 104.
   **First consumer migrated 2026-08-04: the Qwen3-VL vision tower** (`qwen3vl_vision_upload.cpp`),
@@ -412,12 +412,24 @@ Still open from 07-29 with the reason each was not shipped blind — see
   time cannot be charged. `qwen3vl_vision_tower_device_bytes()` answers it from shapes alone by
   walking `qwen3vl_visit_vision_tensors` — the same list the upload walks, so the reservation
   cannot drift from what is taken. Verified exact: predicted 792.2 MiB, uploaded 792.2 MiB.
-  **What is deliberately NOT migrated, with the reason:** the pipeline's own scratch
-  (`vision_patches`, `vision_out`, deepstack) is sized from `max_patches`, which is not known at
-  arena-open time, so the same trick does not work — it stays on `VRAMAllocator`. Gemma's mmproj
-  tower is a separate GGUF that is not loaded at arena-open time either, so `vision_pipeline.cpp`
-  and `vision_encoder.cu` stay too. Migrating those needs `max_patches` (and the mmproj size)
-  hoisted to before the arena opens; that is the next increment, not an oversight.
+  **Second increment, 2026-08-04: the pipeline and encoder scratch followed** (a further
+  224.1 MiB on Qwen3-VL-4B at the default 4096-patch budget). The "`max_patches` is not known at
+  arena-open time" objection this entry recorded an hour earlier was **wrong**: the budget is
+  `runtime.vision_max_patches` (or 4096) rounded down to the merge unit, all config, none of it
+  weights. It now lives in one place, `Qwen3VLPipeline::patch_budget()`, called by both
+  `Engine::init` for sizing and the vision warmup for the actual init, so the two cannot drift.
+  `src/vision/` references: **19 → 8**, repo-wide **67 → 56**.
+  **The anti-drift device is the finding worth keeping.** Tower sizing could reuse the upload's
+  own visitor; the scratch cannot, because the buffers are assigned to named members. So
+  `demand_bytes()` duplicates the list and `taken_bytes()` accumulates what init actually took,
+  and `Qwen3VLPipelineTest.ReservedBytesMatchTakenBytes` asserts they are equal. It earned its
+  keep on the first run by failing: `taken_bytes()` counted only the pipeline's own 32.0 MiB and
+  not the encoder's 192.1 MiB. **Mutation-validated**: dropping the FFN term from
+  `Qwen3VLEncoder::demand_bytes` under-reserves by 32 MiB and the test fails.
+  **Still NOT migrated:** Gemma's mmproj tower is a separate GGUF that genuinely is not loaded at
+  arena-open time (`vision_pipeline.cpp`, `vision_encoder.cu`, 8 references). Migrating it needs
+  the mmproj either loaded or stat-ed before the arena opens — unlike `max_patches`, that is a
+  real ordering change, not an arithmetic one.
   **Ownership note:** the previous scheme documented the tower's blocks as caller-owned
   precisely because "a tower holding pointers into an allocator it does not own is a
   use-after-free the moment a teardown order puts the allocator first". The arena removes the

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -2,6 +2,7 @@
 #include "core/buffer.h"
 #include "vision/image_processor.h"
 #include "vision/qwen3vl_vision_load.h"
+#include "vision/qwen3vl_pipeline.h"
 #include "runtime/request.h"
 #include "lora/lora_adapter.h"
 #include "runtime/engine_internal.h"
@@ -907,12 +908,17 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // the model's shapes here or the arena is sized without it. Gemma's mmproj
         // tower is a separate file that is not loaded yet and stays outside the
         // arena for now (docs/audit/SETTLED.md F-12).
-        const size_t vision_bytes =
-            model_->vision_tower ? qwen3vl_vision_tower_device_bytes(*model_->vision_tower) : 0;
+        size_t vision_bytes = 0;
+        if (model_->vision_tower) {
+            const int patches = Qwen3VLPipeline::patch_budget(*model_->vision_tower,
+                                                              runtime_config_.runtime.vision_max_patches);
+            vision_bytes = qwen3vl_vision_tower_device_bytes(*model_->vision_tower) +
+                           Qwen3VLPipeline::demand_bytes(*model_->vision_tower, patches);
+        }
         // +1/8 for 256-byte alignment padding across the arena's takes.
         const size_t t2_total = d.total() + vision_bytes;
         const size_t cap = std::max(kEngineArenaDefaultBytes, t2_total + t2_total / 8);
-        IMP_LOG_INFO("engine arena demand: %s + vision tower %.1f MiB -> %.1f MiB reserved",
+        IMP_LOG_INFO("engine arena demand: %s + vision %.1f MiB -> %.1f MiB reserved",
                      d.describe().c_str(), vision_bytes / (1024.0 * 1024.0), cap / (1024.0 * 1024.0));
         (void)engine_arena_open(cuda_malloc_backend(), cap);
         // Name the two charges that are already known, HERE rather than after

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -165,12 +165,9 @@ bool Engine::init_features() {
     // not fatal: the text half of the model works, and refusing to load at all
     // would be a worse answer than "images are unavailable".
     if (model_->vision_tower) {
-        const int unit = model_->vision_tower->config.merge_size * model_->vision_tower->config.merge_size;
-        int budget = runtime_config_.runtime.vision_max_patches;
-        if (budget <= 0)
-            budget = 4096;  // a 1024x1024 image at patch 16
-        budget -= budget % unit;
-        if (!qwen_vision_.init(*model_->vision_tower, vram_alloc_, budget)) {
+        const int budget =
+            Qwen3VLPipeline::patch_budget(*model_->vision_tower, runtime_config_.runtime.vision_max_patches);
+        if (!qwen_vision_.init(*model_->vision_tower, budget)) {
             IMP_LOG_WARN("Qwen3-VL vision tower failed to initialise — continuing text-only");
         } else if (model_->tokenizer()) {
             qwen_image_pad_id_ = model_->tokenizer()->find_token("<|image_pad|>");

--- a/src/vision/qwen3vl_encoder.cu
+++ b/src/vision/qwen3vl_encoder.cu
@@ -2,7 +2,7 @@
 #include "core/cuda_static_reset.h"
 
 #include "core/logging.h"
-#include "memory/vram_allocator.h"
+#include "memory/engine_arena.h"
 #include "vision/qwen3vl_encoder_kernels.h"
 
 #include <cublas_v2.h>
@@ -59,12 +59,30 @@ IMP_REGISTER_CUDA_STATIC_RESET(qwen3vl_encoder_reset_static_cuda_state);
 
 Qwen3VLEncoder::~Qwen3VLEncoder() { free_buffers(); }
 
+size_t Qwen3VLEncoder::demand_bytes(const VisionConfig& c, int max_tokens) {
+    const int64_t n = max_tokens;
+    const int64_t H = c.hidden_size;
+    const size_t h = sizeof(half);
+    size_t total = 0;
+    total += static_cast<size_t>(n * H) * h;                       // hidden
+    total += static_cast<size_t>(n * H) * h;                       // normed
+    total += static_cast<size_t>(n * H) * h;                       // proj
+    total += static_cast<size_t>(n * 3 * H) * h;                   // qkv
+    total += static_cast<size_t>(n * H) * h * 4;                   // q, k, v, attn
+    total += static_cast<size_t>(c.num_heads * std::min<int64_t>(kAttnChunk, n) * n) * h;  // scores
+    total += static_cast<size_t>(n * c.intermediate_size) * h;     // ffn
+    total += static_cast<size_t>(n * H) * h * 2;                   // merge_norm, merge_fc
+    total += static_cast<size_t>(n) * sizeof(int32_t) * 2;         // row, col
+    total += static_cast<size_t>(n * kQwenVisionPosTaps) * sizeof(int32_t);  // taps
+    total += static_cast<size_t>(n * kQwenVisionPosTaps) * sizeof(float);    // weights
+    return total;
+}
+
 void Qwen3VLEncoder::free_buffers() {
-    if (alloc_) {
-        for (void* p : allocs_)
-            alloc_->free(p);
-    }
-    allocs_.clear();
+    // The buffers are arena slices; the arena releases wholesale on close, so
+    // there is nothing to hand back here. Dropping the pointers is what keeps a
+    // re-init from reading slices that a closed arena no longer backs.
+    taken_bytes_ = 0;
     d_hidden_ = d_normed_ = d_proj_ = d_qkv_ = nullptr;
     d_q_ = d_k_ = d_v_ = d_attn_ = d_scores_ = d_ffn_ = nullptr;
     d_merge_norm_ = d_merge_fc_ = nullptr;
@@ -80,10 +98,10 @@ int Qwen3VLEncoder::merged_tokens(int tokens) const {
     return tokens / unit;
 }
 
-bool Qwen3VLEncoder::init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens) {
+bool Qwen3VLEncoder::init(const VisionModel& model, int max_tokens) {
     free_buffers();
-    if (!alloc || max_tokens <= 0) {
-        IMP_LOG_ERROR("Qwen3-VL encoder: needs an allocator and a positive token budget");
+    if (max_tokens <= 0) {
+        IMP_LOG_ERROR("Qwen3-VL encoder: needs a positive token budget");
         return false;
     }
     const VisionConfig& c = model.config;
@@ -98,8 +116,8 @@ bool Qwen3VLEncoder::init(const VisionModel& model, VRAMAllocator* alloc, int ma
         return false;
     }
     model_ = &model;
-    alloc_ = alloc;
     max_tokens_ = max_tokens;
+    taken_bytes_ = 0;
 
     const int64_t n = max_tokens;
     const int64_t H = c.hidden_size;
@@ -107,14 +125,17 @@ bool Qwen3VLEncoder::init(const VisionModel& model, VRAMAllocator* alloc, int ma
     auto take = [&](int64_t elems, size_t elem_bytes, const char* tag) -> void* {
         if (!ok)
             return nullptr;
-        void* p = alloc->allocate(static_cast<size_t>(elems) * elem_bytes, tag);
-        if (!p) {
-            IMP_LOG_ERROR("Qwen3-VL encoder: out of VRAM for %s", tag);
+        const size_t bytes = static_cast<size_t>(elems) * elem_bytes;
+        auto slab = engine_arena().take_bytes(bytes);
+        if (slab.empty()) {
+            IMP_LOG_ERROR("Qwen3-VL encoder: engine arena exhausted for %s (%zu bytes) — the arena "
+                          "was reserved without this encoder",
+                          tag, bytes);
             ok = false;
             return nullptr;
         }
-        allocs_.push_back(p);
-        return p;
+        taken_bytes_ += bytes;
+        return slab.data();
     };
     auto take_half = [&](int64_t elems, const char* tag) {
         return static_cast<half*>(take(elems, sizeof(half), tag));

--- a/src/vision/qwen3vl_encoder.h
+++ b/src/vision/qwen3vl_encoder.h
@@ -18,7 +18,6 @@
 
 namespace imp {
 
-class VRAMAllocator;
 
 class Qwen3VLEncoder {
 public:
@@ -29,8 +28,16 @@ public:
 
     // `model` must already be uploaded (qwen3vl_upload_vision_tower). Its
     // lifetime must outlast this encoder — only the pointer is kept.
-    [[nodiscard]] bool init(const VisionModel& model, VRAMAllocator* alloc, int max_tokens);
+    [[nodiscard]] bool init(const VisionModel& model, int max_tokens);
     void free_buffers();
+
+    // Device bytes init() will take from the T2 arena, answerable before the
+    // arena opens (it reads config, not weights). init() records what it actually
+    // took in taken_bytes(); the two are asserted equal in the encoder tests, so a
+    // buffer added to init() without updating this shows up as a test failure
+    // rather than as an arena exhaustion on some other model.
+    static size_t demand_bytes(const VisionConfig& c, int max_tokens);
+    size_t taken_bytes() const { return taken_bytes_; }
 
     int max_tokens() const { return max_tokens_; }
     // Merged image tokens produced for a `tokens`-patch image.
@@ -50,8 +57,8 @@ private:
     bool attention(int tokens, cudaStream_t stream);
 
     const VisionModel* model_ = nullptr;
-    VRAMAllocator* alloc_ = nullptr;
     int max_tokens_ = 0;
+    size_t taken_bytes_ = 0;
 
     half* d_hidden_ = nullptr;  // [max_tokens, hidden]
     half* d_normed_ = nullptr;  // [max_tokens, hidden]
@@ -71,7 +78,6 @@ private:
     int32_t* d_taps_ = nullptr;
     float* d_weights_ = nullptr;
 
-    std::vector<void*> allocs_;
 };
 
 }  // namespace imp

--- a/src/vision/qwen3vl_pipeline.cpp
+++ b/src/vision/qwen3vl_pipeline.cpp
@@ -1,7 +1,7 @@
 #include "vision/qwen3vl_pipeline.h"
 
 #include "core/logging.h"
-#include "memory/vram_allocator.h"
+#include "memory/engine_arena.h"
 #include "vision/image_processor.h"
 #include "vision/qwen3vl_vision_grid.h"
 #include "vision/qwen3vl_vision_upload.h"
@@ -27,14 +27,37 @@ void Qwen3VLPipeline::free_buffers() {
     if (tower_ && uploaded_tower_)
         qwen3vl_release_vision_tower(*tower_);
     uploaded_tower_ = false;
-    if (alloc_)
-        for (void* p : allocs_)
-            alloc_->free(p);
-    allocs_.clear();
+    taken_bytes_ = 0;
     d_patches_ = nullptr;
     d_out_ = nullptr;
     d_deepstack_.clear();
     max_patches_ = 0;
+}
+
+size_t Qwen3VLPipeline::taken_bytes() const {
+    return taken_bytes_ + (encoder_ ? encoder_->taken_bytes() : 0);
+}
+
+int Qwen3VLPipeline::patch_budget(const VisionModel& tower, int configured) {
+    const int unit = tower.config.merge_size * tower.config.merge_size;
+    int budget = configured > 0 ? configured : 4096;  // a 1024x1024 image at patch 16
+    if (unit > 0)
+        budget -= budget % unit;
+    return budget;
+}
+
+size_t Qwen3VLPipeline::demand_bytes(const VisionModel& tower, int max_patches) {
+    const VisionConfig& c = tower.config;
+    const int unit = c.merge_size * c.merge_size;
+    if (unit <= 0 || max_patches <= 0)
+        return 0;
+    const int64_t features = tower.patch_embd_w.shape[1];
+    const int64_t merged = max_patches / unit;
+    const size_t emb = static_cast<size_t>(merged) * c.out_hidden_size * sizeof(half);
+    size_t total = static_cast<size_t>(max_patches) * features * sizeof(half);  // patches
+    total += emb;                                                              // out
+    total += emb * c.deepstack_indexes.size();                                 // deepstack taps
+    return total + Qwen3VLEncoder::demand_bytes(c, max_patches);
 }
 
 int64_t Qwen3VLPipeline::max_pixels() const {
@@ -44,7 +67,7 @@ int64_t Qwen3VLPipeline::max_pixels() const {
     return static_cast<int64_t>(max_patches_) * p * p;
 }
 
-bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_patches) {
+bool Qwen3VLPipeline::init(VisionModel& tower, int max_patches) {
     free_buffers();
     const VisionConfig& c = tower.config;
     if (!c.is_qwen3vl) {
@@ -58,7 +81,6 @@ bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_pat
         return false;
     }
     tower_ = &tower;
-    alloc_ = &alloc;
     max_patches_ = max_patches;
 
     // Idempotent: a tower already on the device (a second pipeline over the same
@@ -75,7 +97,7 @@ bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_pat
     }
 
     encoder_ = std::make_unique<Qwen3VLEncoder>();
-    if (!encoder_->init(tower, &alloc, max_patches)) {
+    if (!encoder_->init(tower, max_patches)) {
         free_buffers();
         return false;
     }
@@ -86,14 +108,16 @@ bool Qwen3VLPipeline::init(VisionModel& tower, VRAMAllocator& alloc, int max_pat
     auto take = [&](size_t bytes, const char* tag) -> half* {
         if (!ok)
             return nullptr;
-        void* p = alloc.allocate(bytes, tag);
-        if (!p) {
-            IMP_LOG_ERROR("Qwen3-VL pipeline: out of VRAM for %s", tag);
+        auto slab = engine_arena().take_bytes(bytes);
+        if (slab.empty()) {
+            IMP_LOG_ERROR("Qwen3-VL pipeline: engine arena exhausted for %s (%zu bytes) — the arena "
+                          "was reserved without this pipeline",
+                          tag, bytes);
             ok = false;
             return nullptr;
         }
-        allocs_.push_back(p);
-        return static_cast<half*>(p);
+        taken_bytes_ += bytes;
+        return reinterpret_cast<half*>(slab.data());
     };
     d_patches_ = take(static_cast<size_t>(max_patches) * features * sizeof(half), "vision_patches");
     const size_t emb_bytes = static_cast<size_t>(merged) * c.out_hidden_size * sizeof(half);

--- a/src/vision/qwen3vl_pipeline.h
+++ b/src/vision/qwen3vl_pipeline.h
@@ -23,7 +23,6 @@
 
 namespace imp {
 
-class VRAMAllocator;
 
 // One encoded image. The buffers belong to the pipeline and stay valid until
 // the next encode call.
@@ -49,7 +48,22 @@ public:
     // device here if it is still host-resident. `max_patches` bounds the image
     // size this pipeline will accept — it sizes every workspace, so it is also
     // what an oversized image is rejected against.
-    [[nodiscard]] bool init(VisionModel& tower, VRAMAllocator& alloc, int max_patches);
+    [[nodiscard]] bool init(VisionModel& tower, int max_patches);
+
+    // Device bytes init() will take from the T2 arena — tower excluded, that is
+    // qwen3vl_vision_tower_device_bytes(). Answerable before the arena opens: it
+    // reads config and tensor shapes, not weights. taken_bytes() reports what was
+    // actually taken, and the two are asserted equal in the pipeline tests.
+    static size_t demand_bytes(const VisionModel& tower, int max_patches);
+
+    // The patch budget the engine will actually use, from the configured value
+    // (0 = default). Engine::init sizes the arena with this and the vision warmup
+    // initialises with it; going through one function is what keeps the
+    // reservation and the allocation from drifting apart.
+    static int patch_budget(const VisionModel& tower, int configured);
+    // Includes the encoder's slices: demand_bytes() covers both, so the pair the
+    // drift test compares has to cover both as well.
+    size_t taken_bytes() const;
 
     bool is_ready() const { return encoder_ != nullptr; }
     int max_patches() const { return max_patches_; }
@@ -86,7 +100,7 @@ private:
     void free_buffers();
 
     VisionModel* tower_ = nullptr;
-    VRAMAllocator* alloc_ = nullptr;
+    size_t taken_bytes_ = 0;
     std::unique_ptr<Qwen3VLEncoder> encoder_;
     int max_patches_ = 0;
     // Whether THIS pipeline uploaded the tower, and so has to invalidate it.

--- a/tests/test_qwen3vl_encoder.cu
+++ b/tests/test_qwen3vl_encoder.cu
@@ -410,7 +410,7 @@ void run_case(int grid_h, int grid_w) {
               cudaSuccess);
 
     Qwen3VLEncoder enc;
-    ASSERT_TRUE(enc.init(tower.model, &alloc, kTokens));
+    ASSERT_TRUE(enc.init(tower.model, kTokens));
     EXPECT_EQ(enc.merged_tokens(kTokens), kMerged);
     ASSERT_TRUE(enc.encode(d_patches, grid, d_out, {d_deep}, nullptr));
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);

--- a/tests/test_qwen3vl_pipeline.cu
+++ b/tests/test_qwen3vl_pipeline.cu
@@ -54,13 +54,14 @@ protected:
         // way Engine::init does — and size it the way Engine::init does too, from
         // the tower's own tensor list rather than from a guess that silently rots
         // when the fixture checkpoint changes.
-        const size_t tower_bytes = qwen3vl_vision_tower_device_bytes(*model_->vision_tower);
-        arena_ = std::make_unique<ScopedEngineArena>(tower_bytes + tower_bytes / 8);
+        const size_t vision_bytes = qwen3vl_vision_tower_device_bytes(*model_->vision_tower) +
+                                    Qwen3VLPipeline::demand_bytes(*model_->vision_tower, 4096);
+        arena_ = std::make_unique<ScopedEngineArena>(vision_bytes + vision_bytes / 8);
         ASSERT_TRUE(arena_->opened());
         ASSERT_TRUE(alloc_.init(0.10f));
         // 4096 patches = a 1024x1024 image at patch 16, and enough to cross the
         // encoder's attention chunk boundary.
-        ASSERT_TRUE(pipeline_.init(*model_->vision_tower, alloc_, 4096));
+        ASSERT_TRUE(pipeline_.init(*model_->vision_tower, 4096));
     }
 
     std::unique_ptr<Model> model_;
@@ -68,6 +69,14 @@ protected:
     VRAMAllocator alloc_;
     Qwen3VLPipeline pipeline_;
 };
+
+// The reservation and the allocation are two separate expressions of the same
+// buffer list, and nothing but this test stops them drifting: a buffer added to
+// init() without updating demand_bytes() under-reserves the arena, which would
+// surface as an exhaustion on whichever model happens to be tight.
+TEST_F(Qwen3VLPipelineTest, ReservedBytesMatchTakenBytes) {
+    EXPECT_EQ(pipeline_.taken_bytes(), Qwen3VLPipeline::demand_bytes(*model_->vision_tower, 4096));
+}
 
 TEST_F(Qwen3VLPipelineTest, EncodesTheFixtureImage) {
     Qwen3VLImage img;


### PR DESCRIPTION
Second F-12 increment, on top of #1229.

## What moved

The Qwen3-VL **pipeline and encoder scratch** — a further **224.1 MiB** on Qwen3-VL-4B at the default 4096-patch budget — now comes from the T2 engine arena. `src/vision/` references to `VRAMAllocator` go **19 → 8**; repo-wide **67 → 56**.

## Correcting #1229

#1229 recorded a reason this could not be done yet: the scratch is sized from `max_patches`, said to be unknown when the arena opens. **That was wrong.** The budget is `runtime.vision_max_patches` (or 4096) rounded down to the merge unit — all config, no weights. It now lives in one place, `Qwen3VLPipeline::patch_budget()`, called by `Engine::init` for sizing and by the vision warmup for the real init, so the reservation and the allocation cannot drift.

## The anti-drift device is the part worth reviewing

The tower could reuse the upload's own tensor visitor, which is why #1229's sizing was exact by construction. The scratch **cannot** — each buffer is assigned to a named member, so a visitor would have to hand results back positionally.

So instead: `demand_bytes()` duplicates the list, `taken_bytes()` accumulates what `init()` actually took, and `Qwen3VLPipelineTest.ReservedBytesMatchTakenBytes` asserts they are equal.

It earned its keep on the first run by **failing**: `taken_bytes()` counted only the pipeline's own 32.0 MiB and missed the encoder's 192.1 MiB. Without the test that is a 192 MiB under-reservation that would have surfaced as an arena exhaustion on whichever model happened to be tight.

**Mutation-validated**: dropping the FFN term from `Qwen3VLEncoder::demand_bytes` under-reserves by 32 MiB and the test fails.

## Still not migrated

Gemma's mmproj tower (`vision_pipeline.cpp`, `vision_encoder.cu`, the remaining 8 references). That one is a separate GGUF that genuinely is not loaded when the arena opens — migrating it is an ordering change, not an arithmetic one.

## Validation

End to end on Qwen3-VL-4B:

```
engine arena demand: … + vision 1016.4 MiB -> 1475.2 MiB reserved
Vision tower: 315 tensors uploaded, 792.2 MiB
Qwen3-VL encoder ready: up to 4096 patches (1024 merged tokens)
Qwen3-VL pipeline ready: <= 4096 patches (1024 image tokens, 1048576 pixels)
```

- Vision tests from the source tree: 6 passed, 1 skipped (`DifferentImagesEncodeDifferently` wants `IMP_TEST_IMAGE_ALT`).
- `verify-fast`: pp4096 +0.36 %, peak VRAM +0.01 %, graphs 2.40×, decode and prefill within threshold, degeneration coherent.
- Full GPU suite at its reference state: 2024 OK, 1 failure (`MtpForwardTest.DraftStepProducesValidToken`, the known capacity case).

Ledger count in `SETTLED.md` updated 67 → 56 in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B