### PR TITLE
fix(runtime,vision): keep engine.cpp under the file-size gate (F-12 follow-up)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -2,7 +2,6 @@
 #include "core/buffer.h"
 #include "vision/image_processor.h"
 #include "vision/qwen3vl_vision_load.h"
-#include "vision/qwen3vl_pipeline.h"
 #include "runtime/request.h"
 #include "lora/lora_adapter.h"
 #include "runtime/engine_internal.h"
@@ -908,16 +907,13 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // the model's shapes here or the arena is sized without it. Gemma's mmproj
         // tower is a separate file that is not loaded yet and stays outside the
         // arena for now (docs/audit/SETTLED.md F-12).
-        size_t vision_bytes = 0;
-        if (model_->vision_tower) {
-            const int patches = Qwen3VLPipeline::patch_budget(*model_->vision_tower,
-                                                              runtime_config_.runtime.vision_max_patches);
-            vision_bytes = qwen3vl_vision_tower_device_bytes(*model_->vision_tower) +
-                           Qwen3VLPipeline::demand_bytes(*model_->vision_tower, patches);
-        }
-        // +1/8 for 256-byte alignment padding across the arena's takes.
-        const size_t t2_total = d.total() + vision_bytes;
-        const size_t cap = std::max(kEngineArenaDefaultBytes, t2_total + t2_total / 8);
+        const size_t vision_bytes =
+            model_->vision_tower ? qwen3vl_vision_arena_bytes(*model_->vision_tower,
+                                                              runtime_config_.runtime.vision_max_patches)
+                                 : 0;
+        // *9/8 for 256-byte alignment padding across the arena's takes (integer
+        // identical to t + t/8, just one expression instead of two).
+        const size_t cap = std::max(kEngineArenaDefaultBytes, (d.total() + vision_bytes) * 9 / 8);
         IMP_LOG_INFO("engine arena demand: %s + vision %.1f MiB -> %.1f MiB reserved",
                      d.describe().c_str(), vision_bytes / (1024.0 * 1024.0), cap / (1024.0 * 1024.0));
         (void)engine_arena_open(cuda_malloc_backend(), cap);

--- a/src/vision/qwen3vl_pipeline.cpp
+++ b/src/vision/qwen3vl_pipeline.cpp
@@ -1,4 +1,5 @@
 #include "vision/qwen3vl_pipeline.h"
+#include "vision/qwen3vl_vision_load.h"
 
 #include "core/logging.h"
 #include "memory/engine_arena.h"
@@ -36,6 +37,11 @@ void Qwen3VLPipeline::free_buffers() {
 
 size_t Qwen3VLPipeline::taken_bytes() const {
     return taken_bytes_ + (encoder_ ? encoder_->taken_bytes() : 0);
+}
+
+size_t qwen3vl_vision_arena_bytes(VisionModel& tower, int configured_max_patches) {
+    const int patches = Qwen3VLPipeline::patch_budget(tower, configured_max_patches);
+    return qwen3vl_vision_tower_device_bytes(tower) + Qwen3VLPipeline::demand_bytes(tower, patches);
 }
 
 int Qwen3VLPipeline::patch_budget(const VisionModel& tower, int configured) {

--- a/src/vision/qwen3vl_vision_load.h
+++ b/src/vision/qwen3vl_vision_load.h
@@ -46,4 +46,10 @@ void qwen3vl_visit_vision_tensors(VisionModel& model,
 // the tower at open time, which happens long before the vision warmup runs.
 size_t qwen3vl_vision_tower_device_bytes(VisionModel& model);
 
+// Everything the T2 arena owes the Qwen3-VL half: the tower plus the pipeline and
+// encoder scratch at the budget the engine will actually use. Engine::init asks
+// this one question instead of composing three, which keeps the arena's sizing
+// from knowing the vision layer's internal split.
+size_t qwen3vl_vision_arena_bytes(VisionModel& tower, int configured_max_patches);
+
 }  // namespace imp


### PR DESCRIPTION
#1230 pushed `src/runtime/engine.cpp` to **805 code LOC** against a hard threshold of 800, so the blocking `File size` job is red on `main`. It merged because only `Build` is a required check — my miss.

## Why not the allowlist

`tools/filesize_thresholds.toml`'s `[allow]` is for legitimately monolithic files. `engine.cpp` is the god-TU that **F-24** is about; an allowlist entry would have papered over an open finding.

The real smell was in the code anyway: the arena's sizing had no business knowing how the vision half splits its memory between tower and scratch. `qwen3vl_vision_arena_bytes()` now answers "what does the arena owe the Qwen3-VL half" in a single call, next to the vision code, and `Engine::init` asks that instead of composing three functions.

That left it one line over, so the `+1/8` alignment pad folds into the `cap` expression. For integers `floor(t + t/8) == floor(9t/8)`, and the reservation is unchanged — verified, not assumed:

```
… + vision 1016.4 MiB -> 1475.2 MiB reserved
```

identical to #1230.

## Checks

- `File size` gate: green (800, threshold `> 800`).
- `ctest -L unit`: green.
- Qwen3-VL-4B loads, pipeline ready, no arena exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B