### PR TITLE
refactor(runtime): put four Engine methods back with their family (engine.cpp 800 → 635)

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -191,177 +191,11 @@ Engine::~Engine() {
     // vision_ cleaned up by VisionPipeline RAII
 }
 
-// ── MTP spec-decode API (Phase 3 scaffolding) ─────────────────────────
-bool Engine::enable_mtp_spec_decode(int k) {
-    if (k <= 0) {
-        IMP_LOG_ERROR("enable_mtp_spec_decode: k must be > 0 (got %d)", k);
-        return false;
-    }
-    if (!model_) {
-        IMP_LOG_ERROR("enable_mtp_spec_decode: no model loaded");
-        return false;
-    }
-    if (!model_->mtp_.has_value() || !model_->mtp_->loaded) {
-        IMP_LOG_ERROR("enable_mtp_spec_decode: model has no MTP head loaded");
-        return false;
-    }
-    if (mtp_ws_storage_ != nullptr) {
-        IMP_LOG_WARN("enable_mtp_spec_decode: already enabled, k=%d -> %d", mtp_spec_k_, k);
-        mtp_spec_k_ = k;
-        return true;
-    }
-    const int hidden_dim = model_->config_.d_model;
-    const int vocab_size = model_->config_.vocab_size;
-    // MLP dims come from the HEAD tensors, not the main-model config: the
-    // dense 27B checkpoint pairs a MoE-free MTP head with a plain SwiGLU MLP
-    // (mapped onto the shared_expert fields), and the 35B head's expert d_ff
-    // differs from the main model's.
-    const auto& head = *model_->mtp_;
-    const bool head_moe = head.router.data != nullptr && head.experts_gate_up_packed.data != nullptr;
-    const int n_experts = head_moe ? static_cast<int>(head.router.shape[0]) : 0;
-    const int top_k = head_moe ? model_->config_.n_experts_active : 0;
-    const int expert_d_ff = head_moe ? static_cast<int>(head.experts_gate_up_packed.shape[1]) / 2 : 0;
-    const int shared_d_ff = head.shared_expert_gate_proj.data != nullptr
-                                ? static_cast<int>(head.shared_expert_gate_proj.shape[0])
-                                : 0;
-
-    // MTP attention dims: derived from the MTP head's q_proj / v_proj shapes
-    // because the MTP attention head config differs from the main model
-    // (Qwen3.6 MTP doubles Q output per-head for attn_output_gate).
-    // q_proj shape [2 * num_heads * head_dim, hidden_dim]; v_proj shape
-    // [num_kv_heads * head_dim, hidden_dim]. We use main model's head_dim
-    // as the per-head attention dim and back-compute the MTP head counts.
-    int mtp_num_heads = 0, mtp_num_kv_heads = 0, mtp_head_dim = 0;
-    if (model_->mtp_.has_value() && model_->mtp_->loaded && model_->mtp_->q_proj.data != nullptr &&
-        model_->mtp_->v_proj.data != nullptr) {
-        const int q_out = static_cast<int>(model_->mtp_->q_proj.shape[0]);
-        const int v_out = static_cast<int>(model_->mtp_->v_proj.shape[0]);
-        mtp_head_dim = model_->config_.head_dim;
-        if (mtp_head_dim > 0) {
-            // q_proj outputs 2 × num_heads × head_dim (attn_output_gate=True).
-            mtp_num_heads = q_out / (2 * mtp_head_dim);
-            mtp_num_kv_heads = v_out / mtp_head_dim;
-        }
-    }
-
-    // MTP KV-cache capacity: cap at the smaller of model's max_seq_len and 16K
-    // (Phase 2.2.Attn+KV budget — ~16 MiB each for K and V at Qwen3.6 dims).
-    constexpr int kMtpKvCap = 16384;
-    int mtp_kv_max = std::min(model_->config_.max_seq_len, kMtpKvCap);
-    if (mtp_kv_max <= 0)
-        mtp_kv_max = kMtpKvCap;
-
-    auto* ws = new imp::MtpDraftWorkspace();
-    if (!imp::mtp_workspace_allocate(*ws, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff,
-                                     mtp_num_heads, mtp_num_kv_heads, mtp_head_dim, mtp_kv_max)) {
-        delete ws;
-        IMP_LOG_ERROR("enable_mtp_spec_decode: workspace alloc failed");
-        return false;
-    }
-    // Configure RoPE for the MTP attention (Phase 2.2.Attn+RoPE).
-    // Qwen3.5/3.6 uses partial rope (factor 0.25 → rope_dim=64 of head_dim=256),
-    // theta from config (10M for long-context), NeoX-style.
-    ws->rope_theta = model_->config_.rope_theta;
-    ws->rope_neox = model_->config_.rope_neox;
-    ws->rms_norm_eps = model_->config_.rms_norm_eps;
-    ws->rope_dim = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : mtp_head_dim;
-    // mrope section split. Read from config when the checkpoint carries one
-    // (Qwen3-VL: [24, 20, 20]); the Qwen3.6 constant below stays as the
-    // fallback for checkpoints that ship the split only in their spec.
-    // For text-only generation all 3 positions are equal, so this is
-    // mathematically equivalent to standard partial-rope; the section
-    // split matters only for true multimodal tokens.
-    const ModelConfig& mc = model_->config_;
-    if (mc.has_mrope() &&
-        mc.mrope_section[0] + mc.mrope_section[1] + mc.mrope_section[2] == ws->rope_dim / 2) {
-        ws->mrope_sec0 = mc.mrope_section[0];
-        ws->mrope_sec1 = mc.mrope_section[1];
-        ws->mrope_sec2 = mc.mrope_section[2];
-    } else if (ws->rope_dim == 64) {
-        ws->mrope_sec0 = 11;
-        ws->mrope_sec1 = 11;
-        ws->mrope_sec2 = 10;
-    } else {
-        // Fall back to even-split: all of rope_dim/2 in section 0.
-        ws->mrope_sec0 = ws->rope_dim / 2;
-        ws->mrope_sec1 = 0;
-        ws->mrope_sec2 = 0;
-    }
-    // RoPE scaling — mirror the main forward so the drafter rotates Q/K the
-    // same way as the verifier at extended positions (issue #897). Without
-    // this a rope-scaled model's draft head diverges and acceptance silently
-    // degrades with position.
-    ws->rope_freq_scale = model_->config_.rope_freq_scale;
-    ws->yarn_ext_factor = model_->config_.yarn_ext_factor;
-    ws->yarn_attn_factor = model_->config_.yarn_attn_factor;
-    if (model_->config_.yarn_ext_factor > 0.0f) {
-        int hd = model_->config_.head_dim > 0 ? model_->config_.head_dim
-                                              : (model_->config_.d_model / model_->config_.n_heads);
-        int n_dims = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : hd;
-        int n_ctx_orig = model_->config_.rope_n_ctx_orig > 0 ? model_->config_.rope_n_ctx_orig
-                                                             : model_->config_.max_seq_len;
-        float corr[2] = {0.0f, 0.0f};
-        imp::rope_yarn_corr_dims(n_dims, n_ctx_orig, model_->config_.rope_theta,
-                                 model_->config_.yarn_beta_fast, model_->config_.yarn_beta_slow, corr);
-        ws->yarn_corr_dim_0 = corr[0];
-        ws->yarn_corr_dim_1 = corr[1];
-        IMP_LOG_INFO("MTP YaRN: ext=%.2f attn=%.3f freq_scale=%.4f corr_dims=[%.1f, %.1f]",
-                     ws->yarn_ext_factor, ws->yarn_attn_factor, ws->rope_freq_scale, ws->yarn_corr_dim_0,
-                     ws->yarn_corr_dim_1);
-    }
-    // LongRoPE (Phi-family) isn't plumbed into the single-token MTP kernel — no
-    // MTP model ships it today (Qwen uses YaRN/linear). Warn rather than silently
-    // diverge if that ever changes.
-    if (!model_->config_.rope_short_factor.empty() || !model_->config_.rope_long_factor.empty()) {
-        IMP_LOG_WARN(
-            "MTP spec-decode: model uses LongRoPE scaling, which the draft head does not apply "
-            "— draft rope will diverge from the verifier; expect degraded acceptance");
-    }
-
-    // Diagnostic: generation.mtp_no_rope disables RoPE entirely.
-    if (runtime_config_.generation.mtp_no_rope) {
-        ws->rope_dim = 0;
-    }
-    // Runtime weight_offset matches what the main model's rmsnorm calls pass:
-    // norm_weight_offset from ModelConfig. For Qwen3.5/3.6 this is 0.0 because
-    // the +1 (gamma = 1 + W) was already baked in during weight upload (see
-    // upload_mtp_weights in weight_upload.cu). For Gemma-3 it's 1.0. Don't
-    // double-apply.
-    ws->arch_norm_offset = model_->config_.norm_weight_offset;
-
-    mtp_ws_storage_ = ws;
-    mtp_spec_k_ = k;
-    IMP_LOG_INFO(
-        "MTP spec-decode enabled (k=%d, hidden=%d, vocab=%d, experts=%d/top%d, d_ff_e=%d, "
-        "d_ff_shared=%d, num_heads=%d/%d, head_dim=%d, kv_cap=%d, rope=%g/%d/%s, "
-        "mrope=[%d,%d,%d])",
-        k, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff, mtp_num_heads,
-        mtp_num_kv_heads, mtp_head_dim, mtp_kv_max, ws->rope_theta, ws->rope_dim,
-        ws->rope_neox ? "neox" : "interleaved", ws->mrope_sec0, ws->mrope_sec1, ws->mrope_sec2);
-    return true;
-}
 
 // (mtp_prefill_prompt was replaced by the per-chunk mtp_prefill_feed_chunk
 // in engine_spec_mtp.cpp — chunked-prefill capable, DeepSeek-aligned pairing,
 // feed-only forwards without the lm_head GEMV.)
 
-void Engine::mtp_accuracy_reset() noexcept {
-    mtp_accuracy_ = {};
-    mtp_pending_prediction_ = -1;
-    mtp_pending_chain_.clear();
-    mtp_chain_accept_.clear();
-    mtp_chain_accept_w_.clear();
-    mtp_bound_req_ = -1;
-    mtp_history_.clear();
-    mtp_pending_draft_.clear();
-    mtp_draft_ctx_ = -1;
-    mtp_econ_verifies_ = 0;
-    mtp_econ_emitted_ = 0;
-    if (mtp_ws_storage_) {
-        auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
-        imp::mtp_kv_reset(*ws);
-    }
-}
 
 bool Engine::encoder_embed(const int32_t* tokens, int n, std::vector<float>& out) {
     if (encoder_ws_storage_ == nullptr || !model_) {
@@ -373,37 +207,6 @@ bool Engine::encoder_embed(const int32_t* tokens, int n, std::vector<float>& out
     return imp::encoder_embed(*model_, *ews, tokens, n, out.data(), stream_);
 }
 
-bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev, int hidden_dim, int vocab_size,
-                           int* out_token_id, int* out_topk_ids, int top_w, const int32_t* d_prev_token,
-                           int32_t* d_out_token) {
-    if (mtp_ws_storage_ == nullptr) {
-        IMP_LOG_ERROR("mtp_draft_one: spec-decode not enabled");
-        return false;
-    }
-    if (!model_ || !model_->mtp_.has_value() || !model_->mtp_->loaded) {
-        IMP_LOG_ERROR("mtp_draft_one: MTP head not loaded");
-        return false;
-    }
-    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
-    // Chain lm_head via the NVFP4 decode cache when available: the full-vocab
-    // FP16 GEMV is the dominant per-draft cost (#847 lever 3). Draft-only
-    // precision — verify stays lossless. Falls back to the FP16 GEMV when no
-    // cache entry exists (nvfp4_lm_head/_gdn off, or FP8 LM head).
-    imp::NvFP4QuantResult lm_nvfp4;
-    const imp::NvFP4QuantResult* lm_nvfp4_p = nullptr;
-    if (runtime_config_.speculative.mtp_nvfp4_head && executor_ && executor_->lm_head_nvfp4_view(lm_nvfp4)) {
-        lm_nvfp4_p = &lm_nvfp4;
-        static bool logged = false;  // once-per-process path attribution
-        if (!logged) {
-            logged = true;
-            IMP_LOG_INFO("MTP chain lm_head: NVFP4 decode-cache view engaged (N=%lld K=%lld)",
-                         static_cast<long long>(lm_nvfp4.N), static_cast<long long>(lm_nvfp4.K));
-        }
-    }
-    return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_, model_->tok_emb_, model_->out_proj_,
-                               *ws, hidden_dim, vocab_size, out_token_id, decode_stream(), out_topk_ids,
-                               top_w, lm_nvfp4_p, d_prev_token, d_out_token);
-}
 
 // =====================================================================
 // Helper methods
@@ -705,20 +508,6 @@ bool Engine::preprocess_image(const uint8_t* data, size_t len, ImageData& out) {
     return vision_.preprocess(data, len, out);
 }
 
-bool Engine::encode_image_for(Request& req) {
-    if (!req.image || !vision_.is_available())
-        return false;
-    auto buf = std::make_shared<Buffer>(Buffer::device(vision_.embeddings_bytes()));
-    if (!*buf)
-        return false;
-    if (!vision_.encode_to(*req.image, buf->as<half>(), stream_))
-        return false;
-    req.vision_emb = std::move(buf);
-    req.vision_token_id = vision_.soft_token_id();
-    req.n_vision_tokens = vision_.num_image_tokens();
-    req.image.reset();  // host pixels no longer needed after encode
-    return true;
-}
 
 // =====================================================================
 // Initialization — decomposed into sub-phases

--- a/src/runtime/engine_qwen3vl.cpp
+++ b/src/runtime/engine_qwen3vl.cpp
@@ -394,4 +394,19 @@ bool Engine::attach_qwen_image_(Request& req) {
     return true;
 }
 
+bool Engine::encode_image_for(Request& req) {
+    if (!req.image || !vision_.is_available())
+        return false;
+    auto buf = std::make_shared<Buffer>(Buffer::device(vision_.embeddings_bytes()));
+    if (!*buf)
+        return false;
+    if (!vision_.encode_to(*req.image, buf->as<half>(), stream_))
+        return false;
+    req.vision_emb = std::move(buf);
+    req.vision_token_id = vision_.soft_token_id();
+    req.n_vision_tokens = vision_.num_image_tokens();
+    req.image.reset();  // host pixels no longer needed after encode
+    return true;
+}
+
 }  // namespace imp

--- a/src/runtime/engine_spec_mtp.cpp
+++ b/src/runtime/engine_spec_mtp.cpp
@@ -260,4 +260,202 @@ void Engine::mtp_prefill_feed_chunk(const Request& req, int offset, int chunk_le
         mtp_unbind_("prefill feed failed (kv cap or forward error)");
 }
 
+// ── MTP spec-decode API (Phase 3 scaffolding) ─────────────────────────
+bool Engine::enable_mtp_spec_decode(int k) {
+    if (k <= 0) {
+        IMP_LOG_ERROR("enable_mtp_spec_decode: k must be > 0 (got %d)", k);
+        return false;
+    }
+    if (!model_) {
+        IMP_LOG_ERROR("enable_mtp_spec_decode: no model loaded");
+        return false;
+    }
+    if (!model_->mtp_.has_value() || !model_->mtp_->loaded) {
+        IMP_LOG_ERROR("enable_mtp_spec_decode: model has no MTP head loaded");
+        return false;
+    }
+    if (mtp_ws_storage_ != nullptr) {
+        IMP_LOG_WARN("enable_mtp_spec_decode: already enabled, k=%d -> %d", mtp_spec_k_, k);
+        mtp_spec_k_ = k;
+        return true;
+    }
+    const int hidden_dim = model_->config_.d_model;
+    const int vocab_size = model_->config_.vocab_size;
+    // MLP dims come from the HEAD tensors, not the main-model config: the
+    // dense 27B checkpoint pairs a MoE-free MTP head with a plain SwiGLU MLP
+    // (mapped onto the shared_expert fields), and the 35B head's expert d_ff
+    // differs from the main model's.
+    const auto& head = *model_->mtp_;
+    const bool head_moe = head.router.data != nullptr && head.experts_gate_up_packed.data != nullptr;
+    const int n_experts = head_moe ? static_cast<int>(head.router.shape[0]) : 0;
+    const int top_k = head_moe ? model_->config_.n_experts_active : 0;
+    const int expert_d_ff = head_moe ? static_cast<int>(head.experts_gate_up_packed.shape[1]) / 2 : 0;
+    const int shared_d_ff = head.shared_expert_gate_proj.data != nullptr
+                                ? static_cast<int>(head.shared_expert_gate_proj.shape[0])
+                                : 0;
+
+    // MTP attention dims: derived from the MTP head's q_proj / v_proj shapes
+    // because the MTP attention head config differs from the main model
+    // (Qwen3.6 MTP doubles Q output per-head for attn_output_gate).
+    // q_proj shape [2 * num_heads * head_dim, hidden_dim]; v_proj shape
+    // [num_kv_heads * head_dim, hidden_dim]. We use main model's head_dim
+    // as the per-head attention dim and back-compute the MTP head counts.
+    int mtp_num_heads = 0, mtp_num_kv_heads = 0, mtp_head_dim = 0;
+    if (model_->mtp_.has_value() && model_->mtp_->loaded && model_->mtp_->q_proj.data != nullptr &&
+        model_->mtp_->v_proj.data != nullptr) {
+        const int q_out = static_cast<int>(model_->mtp_->q_proj.shape[0]);
+        const int v_out = static_cast<int>(model_->mtp_->v_proj.shape[0]);
+        mtp_head_dim = model_->config_.head_dim;
+        if (mtp_head_dim > 0) {
+            // q_proj outputs 2 × num_heads × head_dim (attn_output_gate=True).
+            mtp_num_heads = q_out / (2 * mtp_head_dim);
+            mtp_num_kv_heads = v_out / mtp_head_dim;
+        }
+    }
+
+    // MTP KV-cache capacity: cap at the smaller of model's max_seq_len and 16K
+    // (Phase 2.2.Attn+KV budget — ~16 MiB each for K and V at Qwen3.6 dims).
+    constexpr int kMtpKvCap = 16384;
+    int mtp_kv_max = std::min(model_->config_.max_seq_len, kMtpKvCap);
+    if (mtp_kv_max <= 0)
+        mtp_kv_max = kMtpKvCap;
+
+    auto* ws = new imp::MtpDraftWorkspace();
+    if (!imp::mtp_workspace_allocate(*ws, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff,
+                                     mtp_num_heads, mtp_num_kv_heads, mtp_head_dim, mtp_kv_max)) {
+        delete ws;
+        IMP_LOG_ERROR("enable_mtp_spec_decode: workspace alloc failed");
+        return false;
+    }
+    // Configure RoPE for the MTP attention (Phase 2.2.Attn+RoPE).
+    // Qwen3.5/3.6 uses partial rope (factor 0.25 → rope_dim=64 of head_dim=256),
+    // theta from config (10M for long-context), NeoX-style.
+    ws->rope_theta = model_->config_.rope_theta;
+    ws->rope_neox = model_->config_.rope_neox;
+    ws->rms_norm_eps = model_->config_.rms_norm_eps;
+    ws->rope_dim = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : mtp_head_dim;
+    // mrope section split. Read from config when the checkpoint carries one
+    // (Qwen3-VL: [24, 20, 20]); the Qwen3.6 constant below stays as the
+    // fallback for checkpoints that ship the split only in their spec.
+    // For text-only generation all 3 positions are equal, so this is
+    // mathematically equivalent to standard partial-rope; the section
+    // split matters only for true multimodal tokens.
+    const ModelConfig& mc = model_->config_;
+    if (mc.has_mrope() &&
+        mc.mrope_section[0] + mc.mrope_section[1] + mc.mrope_section[2] == ws->rope_dim / 2) {
+        ws->mrope_sec0 = mc.mrope_section[0];
+        ws->mrope_sec1 = mc.mrope_section[1];
+        ws->mrope_sec2 = mc.mrope_section[2];
+    } else if (ws->rope_dim == 64) {
+        ws->mrope_sec0 = 11;
+        ws->mrope_sec1 = 11;
+        ws->mrope_sec2 = 10;
+    } else {
+        // Fall back to even-split: all of rope_dim/2 in section 0.
+        ws->mrope_sec0 = ws->rope_dim / 2;
+        ws->mrope_sec1 = 0;
+        ws->mrope_sec2 = 0;
+    }
+    // RoPE scaling — mirror the main forward so the drafter rotates Q/K the
+    // same way as the verifier at extended positions (issue #897). Without
+    // this a rope-scaled model's draft head diverges and acceptance silently
+    // degrades with position.
+    ws->rope_freq_scale = model_->config_.rope_freq_scale;
+    ws->yarn_ext_factor = model_->config_.yarn_ext_factor;
+    ws->yarn_attn_factor = model_->config_.yarn_attn_factor;
+    if (model_->config_.yarn_ext_factor > 0.0f) {
+        int hd = model_->config_.head_dim > 0 ? model_->config_.head_dim
+                                              : (model_->config_.d_model / model_->config_.n_heads);
+        int n_dims = (model_->config_.rope_dim > 0) ? model_->config_.rope_dim : hd;
+        int n_ctx_orig = model_->config_.rope_n_ctx_orig > 0 ? model_->config_.rope_n_ctx_orig
+                                                             : model_->config_.max_seq_len;
+        float corr[2] = {0.0f, 0.0f};
+        imp::rope_yarn_corr_dims(n_dims, n_ctx_orig, model_->config_.rope_theta,
+                                 model_->config_.yarn_beta_fast, model_->config_.yarn_beta_slow, corr);
+        ws->yarn_corr_dim_0 = corr[0];
+        ws->yarn_corr_dim_1 = corr[1];
+        IMP_LOG_INFO("MTP YaRN: ext=%.2f attn=%.3f freq_scale=%.4f corr_dims=[%.1f, %.1f]",
+                     ws->yarn_ext_factor, ws->yarn_attn_factor, ws->rope_freq_scale, ws->yarn_corr_dim_0,
+                     ws->yarn_corr_dim_1);
+    }
+    // LongRoPE (Phi-family) isn't plumbed into the single-token MTP kernel — no
+    // MTP model ships it today (Qwen uses YaRN/linear). Warn rather than silently
+    // diverge if that ever changes.
+    if (!model_->config_.rope_short_factor.empty() || !model_->config_.rope_long_factor.empty()) {
+        IMP_LOG_WARN(
+            "MTP spec-decode: model uses LongRoPE scaling, which the draft head does not apply "
+            "— draft rope will diverge from the verifier; expect degraded acceptance");
+    }
+
+    // Diagnostic: generation.mtp_no_rope disables RoPE entirely.
+    if (runtime_config_.generation.mtp_no_rope) {
+        ws->rope_dim = 0;
+    }
+    // Runtime weight_offset matches what the main model's rmsnorm calls pass:
+    // norm_weight_offset from ModelConfig. For Qwen3.5/3.6 this is 0.0 because
+    // the +1 (gamma = 1 + W) was already baked in during weight upload (see
+    // upload_mtp_weights in weight_upload.cu). For Gemma-3 it's 1.0. Don't
+    // double-apply.
+    ws->arch_norm_offset = model_->config_.norm_weight_offset;
+
+    mtp_ws_storage_ = ws;
+    mtp_spec_k_ = k;
+    IMP_LOG_INFO(
+        "MTP spec-decode enabled (k=%d, hidden=%d, vocab=%d, experts=%d/top%d, d_ff_e=%d, "
+        "d_ff_shared=%d, num_heads=%d/%d, head_dim=%d, kv_cap=%d, rope=%g/%d/%s, "
+        "mrope=[%d,%d,%d])",
+        k, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff, mtp_num_heads,
+        mtp_num_kv_heads, mtp_head_dim, mtp_kv_max, ws->rope_theta, ws->rope_dim,
+        ws->rope_neox ? "neox" : "interleaved", ws->mrope_sec0, ws->mrope_sec1, ws->mrope_sec2);
+    return true;
+}
+void Engine::mtp_accuracy_reset() noexcept {
+    mtp_accuracy_ = {};
+    mtp_pending_prediction_ = -1;
+    mtp_pending_chain_.clear();
+    mtp_chain_accept_.clear();
+    mtp_chain_accept_w_.clear();
+    mtp_bound_req_ = -1;
+    mtp_history_.clear();
+    mtp_pending_draft_.clear();
+    mtp_draft_ctx_ = -1;
+    mtp_econ_verifies_ = 0;
+    mtp_econ_emitted_ = 0;
+    if (mtp_ws_storage_) {
+        auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+        imp::mtp_kv_reset(*ws);
+    }
+}
+bool Engine::mtp_draft_one(int prev_token_id, const void* d_h_prev, int hidden_dim, int vocab_size,
+                           int* out_token_id, int* out_topk_ids, int top_w, const int32_t* d_prev_token,
+                           int32_t* d_out_token) {
+    if (mtp_ws_storage_ == nullptr) {
+        IMP_LOG_ERROR("mtp_draft_one: spec-decode not enabled");
+        return false;
+    }
+    if (!model_ || !model_->mtp_.has_value() || !model_->mtp_->loaded) {
+        IMP_LOG_ERROR("mtp_draft_one: MTP head not loaded");
+        return false;
+    }
+    auto* ws = static_cast<imp::MtpDraftWorkspace*>(mtp_ws_storage_);
+    // Chain lm_head via the NVFP4 decode cache when available: the full-vocab
+    // FP16 GEMV is the dominant per-draft cost (#847 lever 3). Draft-only
+    // precision — verify stays lossless. Falls back to the FP16 GEMV when no
+    // cache entry exists (nvfp4_lm_head/_gdn off, or FP8 LM head).
+    imp::NvFP4QuantResult lm_nvfp4;
+    const imp::NvFP4QuantResult* lm_nvfp4_p = nullptr;
+    if (runtime_config_.speculative.mtp_nvfp4_head && executor_ && executor_->lm_head_nvfp4_view(lm_nvfp4)) {
+        lm_nvfp4_p = &lm_nvfp4;
+        static bool logged = false;  // once-per-process path attribution
+        if (!logged) {
+            logged = true;
+            IMP_LOG_INFO("MTP chain lm_head: NVFP4 decode-cache view engaged (N=%lld K=%lld)",
+                         static_cast<long long>(lm_nvfp4.N), static_cast<long long>(lm_nvfp4.K));
+        }
+    }
+    return imp::mtp_draft_step(prev_token_id, d_h_prev, *model_->mtp_, model_->tok_emb_, model_->out_proj_,
+                               *ws, hidden_dim, vocab_size, out_token_id, decode_stream(), out_topk_ids,
+                               top_w, lm_nvfp4_p, d_prev_token, d_out_token);
+}
+
 }  // namespace imp


### PR DESCRIPTION
`src/runtime/engine.cpp` sat at **exactly 800** code LOC against the file-size gate's hard threshold of 800 for a TU. Any code line added anywhere in it turned CI red — which is what happened in #1230.

## Not a size split

Four methods were simply in the wrong translation unit:

| Method | Was in | Family already lives in |
|---|---|---|
| `enable_mtp_spec_decode` | `engine.cpp` | `engine_spec_mtp.cpp` |
| `mtp_draft_one` | `engine.cpp` | `engine_spec_mtp.cpp` |
| `mtp_accuracy_reset` | `engine.cpp` | `engine_spec_mtp.cpp` |
| `encode_image_for` | `engine.cpp` | `engine_qwen3vl.cpp` |

`engine_spec_mtp.cpp` already holds `mtp_unbind_`, `mtp_take_draft_`, `mtp_feed_pairs_`, `mtp_post_verify_update_` and `mtp_prefill_feed_chunk` — the MTP family was split across two TUs for no reason. Same for `encode_image_for` against `engine_qwen3vl.cpp`, which holds `set_image` and the whole mrope block.

**Result: 800 → 635 code LOC** (raw 1201 → 990). 165 under the hard threshold instead of 0. Targets stay under the warn threshold (461 and 412 raw lines).

Pure relocation — no signature, body, or ordering change.

## Why I stopped at 635

engine.cpp is still 35 over the **advisory** warn threshold of 600. The obvious next candidate is the constraint pool: `ensure_constraints_`, `constraints_checkout_` and `constraints_return_` are the only three things that touch `constraint_pool_`, so it is genuinely cohesive.

I checked whether it would buy compile-time isolation, and it would not — `ConstraintManager` arrives through `engine.h`, not a local include, so a new TU would remove no dependency and exist only to cross an advisory line. `CLAUDE.md`'s "split on conflation, not size" applies to me as much as to an audit finding, so I left it.

## Validation

- File size gate: green.
- `verify-fast`: decode −0.49 %, prefill +0.70 %, pp4096 +0.88 %, peak VRAM +0.01 %, graphs 2.50×, degeneration coherent.
- Full GPU suite at its reference state: 2024 OK, 1 failure (`MtpForwardTest.DraftStepProducesValidToken`, the known capacity case) — the MTP path that moved is exercised there.
- Rebuild from touched sources produced no unused-symbol warnings, so nothing was left orphaned behind the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B