### PR TITLE
refactor(api): forward-declare Engine in imp_internal.h (F-24, fan-in 33 → 23 TUs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- **`runtime/engine.h` now reaches 23 translation units instead of 33** (F-24,
+  `src/api/imp_internal.h`). It was the repo's #2 build-cost header (fan-in x
+  commits); `imp_internal.h` pulled it in front of 17 includers while storing
+  nothing but a `std::unique_ptr<imp::Engine>`. Forward-declaring `imp::Engine`
+  and moving `ImpContext_T`'s ctor/dtor out of line cuts the rebuild set 30 %.
+  Consumers that genuinely use `Engine` — two, established by deleting every
+  candidate include and reading the compiler's failures — include it directly.
+  The audit's own proposal for F-24 is refuted with numbers in
+  [`docs/audit/SETTLED.md`](docs/audit/SETTLED.md).
 - **The Qwen3-VL vision tower is now an engine-arena (T2) tenant** (F-12,
   `src/vision/qwen3vl_vision_upload.cpp`). It was the one engine-lifetime consumer
   still allocating through `VRAMAllocator`, so 792.2 MiB on Qwen3-VL-4B sat outside

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -462,7 +462,32 @@ Still open from 07-29 with the reason each was not shipped blind — see
   `engine.cpp:915`** — that is where a missing tenant actually under-reserves, and that is where
   the vision tower was added. Do not "fix" the plan fields in isolation and read it as closing a
   VRAM gap.
-- **F-24** — `src/runtime/engine.h` god-header.
+- **F-24** — `src/runtime/engine.h` god-header. **Its proposed fix is REFUTED by measurement,
+  and a different lever was shipped instead (2026-08-04).**
+  The audit proposes extracting the spec-decode member block into a `SpecDecodeState` struct,
+  "the largest self-contained cluster". Largest by member count — **not where the churn is**.
+  Of the 130 commits touching `engine.h` in six months, **3 (2 %) change spec/MTP lines only**;
+  92 (71 %) do not touch spec at all. So the extraction removes ~2 % of the churn at best, and
+  only if `Engine` held the struct by pointer — held by value, `engine.h` includes the new
+  header and the same TUs rebuild for **zero** gain. Do not build it.
+  **Churn is spread across every concern, which is the actual diagnosis:** request/sched 58
+  commits, kv/cache 52, memory/vram 44, graph 40, spec/mtp 38, sampling 35, vision 11.
+  `engine.h` changes because `Engine` is the coordination point for all of it, not because one
+  extractable cluster is hot. **A full pimpl of the private state has a measured ceiling of
+  42 %** (54 of 130 commits touch only the private section) — that is the honest number for
+  anyone considering it, against an indirection on the decode path.
+  **What was shipped attacks the other factor.** Cost is fan-in × churn, and fan-in was the
+  cheap half: `src/api/imp_internal.h` had 17 includers and pulled `runtime/engine.h` in for all
+  of them, while storing nothing but a `std::unique_ptr<imp::Engine>`. Forward-declaring
+  `imp::Engine` there and moving `ImpContext_T`'s ctor/dtor out of line (the single point where
+  `unique_ptr` needs the complete type) took `engine.h` from **33 to 23 rebuilt TUs, -30 %** —
+  cost 4257 → 2967, better than the refuted extraction's 2 % and a fraction of the risk.
+  **Method note, because a loose grep cost me a wrong answer here:** `rg 'engine\.|Engine::'`
+  reported nine consumers needing the include, three of which were matches on
+  `batching_engine.`. Deleting every candidate include and letting the compiler name the
+  failures gave the true set — **two**. Measure fan-in with reverse BFS over the include graph;
+  a forward walk with memoisation silently poisons its cache on include cycles and reported
+  2 of 463 TUs.
 
 ## Per-area running logs
 

--- a/src/api/imp_api.cpp
+++ b/src/api/imp_api.cpp
@@ -19,6 +19,12 @@
 
 #include <cuda_runtime.h>
 
+// Out-of-line so imp_internal.h can forward-declare imp::Engine: this is the
+// single point where unique_ptr<Engine> needs the complete type.
+ImpContext_T::ImpContext_T() = default;
+ImpContext_T::~ImpContext_T() = default;
+
+
 
 // --- Error string ---
 

--- a/src/api/imp_internal.h
+++ b/src/api/imp_internal.h
@@ -3,10 +3,18 @@
 #include "imp/imp.h"
 #include "memory/weight_snapshot.h"
 #include "model/model.h"
-#include "runtime/engine.h"
 #include "runtime/request.h"
 
 #include <memory>
+
+namespace imp {
+// Forward-declared on purpose. ImpContext_T only stores an Engine, and pulling
+// runtime/engine.h in here put it in front of every TU that includes this header
+// — most of which never touch Engine at all. The out-of-line destructor below is
+// what makes the forward declaration legal: std::unique_ptr needs the complete
+// type where the deleter is instantiated, and that is now imp_api.cpp alone.
+class Engine;
+}  // namespace imp
 
 // Internal handle types backing the opaque C API handles.
 // Shared between imp_api.cpp and tool binaries that need
@@ -21,6 +29,9 @@ struct ImpWeightSnapshot_T {
 };
 
 struct ImpContext_T {
+    ImpContext_T();
+    ~ImpContext_T();
+
     ImpModel model_handle = nullptr;
     std::unique_ptr<imp::Engine> engine;
 

--- a/tests/test_e2e.cpp
+++ b/tests/test_e2e.cpp
@@ -3,6 +3,7 @@
 #include "api/imp_internal.h"
 #include "gguf_stub.h"
 #include "test_models.h"
+#include "runtime/engine.h"
 
 #include <cuda_runtime.h>
 

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -8,6 +8,7 @@
 #include "runtime/presets.h"
 #include "runtime/config.h"
 #include "runtime/process_diag.h"
+#include "runtime/engine.h"
 
 #include <chrono>
 #include <cstdio>


### PR DESCRIPTION
`runtime/engine.h` is the repo's **#2 build-cost header** (fan-in × churn, `SETTLED.md`). This attacks it — but not the way the audit proposed, because that way does not work.

## The audit's fix for F-24 is refuted by measurement

It proposes extracting the spec-decode member block into a `SpecDecodeState` struct, "the largest self-contained cluster". Largest by member count — **not where the churn is**. Of the 130 commits touching `engine.h` in six months:

| | commits | share |
|---|---:|---:|
| spec/MTP lines only | **3** | 2 % |
| mixed | 35 | 27 % |
| no spec content at all | 92 | 71 % |

So the extraction removes ~2 % of the churn at best — and only if `Engine` held the struct by pointer. Held by value, `engine.h` includes the new header and the same TUs rebuild for **zero** gain.

Churn by concern shows why: request/sched 58 commits, kv/cache 52, memory/vram 44, graph 40, spec/MTP 38, sampling 35, vision 11. `engine.h` changes because `Engine` is the coordination point for all of it, not because one extractable cluster is hot. A full pimpl of the private state has a **measured ceiling of 42 %** (54 of 130 commits touch only the private section) — the honest number for anyone weighing it against an indirection on the decode path.

## What this does instead

Cost is fan-in × churn, and fan-in was the cheap half. `src/api/imp_internal.h` had **17 includers** and pulled `runtime/engine.h` in front of all of them, while storing nothing but a `std::unique_ptr<imp::Engine>`.

Forward-declaring `imp::Engine` and moving `ImpContext_T`'s ctor/dtor out of line — the single point where `unique_ptr` needs the complete type — takes `engine.h` from **33 to 23 rebuilt TUs (−30 %)**; cost 4257 → 2967.

Two consumers genuinely need the include (`imp-cli/main.cpp`, `tests/test_e2e.cpp`). That set came from deleting every candidate include and reading the compiler's failures — a `'engine\.|Engine::'` grep claimed nine, three of which were matches on `batching_engine.`.

## No perf gate — and it is not needed, verified rather than assumed

The card belongs to the user and I stopped using it. That costs nothing here, because for a header change the stronger claim is available on CPU: **the generated code is unchanged.**

`nm --print-size --defined-only` over `imp-cli`, `imp-server` and `libimp.a`, `main` vs this branch: **42361 symbols, byte-identical**, with exactly three differences, all of them this change:

```
> 0x18  ImpContext_T::ImpContext_T()      (now out of line)
> 0xbf  ImpContext_T::~ImpContext_T()     (now out of line)
  imp_context_free  0xf2 -> 0x31          (dtor body left it; 0x31 + 0xbf = 0xf0)
```

Nothing on any hot path differs, and `imp_context_free` runs once per context at teardown.

`ctest -L unit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B