### PR TITLE
docs(audit): scope what F-12's Gemma remainder actually costs

### DIFF
--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -426,10 +426,33 @@ Still open from 07-29 with the reason each was not shipped blind — see
   keep on the first run by failing: `taken_bytes()` counted only the pipeline's own 32.0 MiB and
   not the encoder's 192.1 MiB. **Mutation-validated**: dropping the FFN term from
   `Qwen3VLEncoder::demand_bytes` under-reserves by 32 MiB and the test fails.
-  **Still NOT migrated:** Gemma's mmproj tower is a separate GGUF that genuinely is not loaded at
-  arena-open time (`vision_pipeline.cpp`, `vision_encoder.cu`, 8 references). Migrating it needs
-  the mmproj either loaded or stat-ed before the arena opens — unlike `max_patches`, that is a
-  real ordering change, not an arithmetic one.
+  **Still NOT migrated — and scoped 2026-08-04, because the one-line version of this note was
+  misleading.** It said only that Gemma's mmproj is "not loaded at arena-open time", which reads
+  like the `max_patches` case: find the number earlier and you are done. It is not that.
+
+  1. **The Gemma tower never touches `VRAMAllocator` at all.** `upload_tensor_fp16` in
+     `src/vision/vision_loader.cpp` calls **raw `cudaMalloc`**. Counting the whole Gemma vision
+     path there are **15** `cudaMalloc`/`cudaFree` sites across `vision_loader.cpp` (4),
+     `vision_pipeline.cpp` (4), `vision_encoder.cu` (6) and `vision_model.cpp` (1). All are
+     already on the I1 allowlist (`tools/alloc_allowlist.txt`) with counts, so
+     `tools/check_alloc_sites.py` is green — accepted baseline, not a new violation. Migrating
+     therefore closes **I1 sites as well as** the 8 remaining `VRAMAllocator` type references,
+     which is more value than the reference count alone suggests.
+  2. **There is no parse/upload split to hang the sizing on.** `load_vision_gguf` interleaves
+     both in one function — the `cudaMalloc` sits inside the tensor loop. A metadata-only
+     pre-pass would have to re-parse header, KVs and tensor descriptors, ~100 duplicated lines
+     whose drift from the real upload is exactly what `ReservedBytesMatchTakenBytes` had to be
+     invented for on the Qwen3-VL side. **Do not write a second parser.** Split
+     `load_vision_gguf` into `parse` (host tensors, no device memory) and `upload` (arena), which
+     is the structure Qwen3-VL already has; `Engine::init` then parses before opening the arena
+     and sizes from the parsed model, and the warmup uploads.
+  3. **`stat()` as an upper bound is not cheap enough to shrug at:** mmproj-F16 is 812 MiB and
+     the Gemma-4 BF16 tower 1139 MiB, so a file-size bound wastes on the order of a GiB of arena.
+  4. **Validation is GPU-only.** `VisionGolden.Gemma3SigLIP` and `Gemma4v` (need `IMP_TEST_MMPROJ`
+     / `IMP_TEST_MMPROJ_GEMMA4`) are the only things that exercise this path. The
+     symbol-size-identity trick that made F-24 provable on CPU does not apply — this change
+     really does alter the generated code. Budget a quiet card for it, and note this repo's
+     history of *silent* vision failures when scoping the risk.
   **Ownership note:** the previous scheme documented the tower's blocks as caller-owned
   precisely because "a tower holding pointers into an allocator it does not own is a
   use-after-free the moment a teardown order puts the allocator first". The arena removes the


### PR DESCRIPTION
Docs only. The note #1230 left behind for F-12's remaining half was misleading, and this replaces it with what measuring it found.

## What the old note said, and why it was wrong

> Gemma's mmproj tower is a separate GGUF that genuinely is not loaded at arena-open time. Migrating it needs the mmproj either loaded or stat-ed before the arena opens.

That reads like the `max_patches` case from #1230 — find the number earlier and you are done. It is not that.

## What it actually costs

1. **The Gemma tower never touches `VRAMAllocator`.** `upload_tensor_fp16` in `src/vision/vision_loader.cpp` calls **raw `cudaMalloc`**. The whole Gemma vision path has **15** `cudaMalloc`/`cudaFree` sites across `vision_loader.cpp` (4), `vision_pipeline.cpp` (4), `vision_encoder.cu` (6) and `vision_model.cpp` (1) — all already on the I1 allowlist with counts, so `check_alloc_sites.py` is green. Migrating therefore closes **I1 sites as well as** the 8 remaining `VRAMAllocator` references, which is more value than the reference count alone shows.

2. **There is no parse/upload split to hang the sizing on.** `load_vision_gguf` interleaves both — the `cudaMalloc` is inside the tensor loop. A metadata-only pre-pass would re-parse header, KVs and tensor descriptors: ~100 duplicated lines, i.e. exactly the drift that `ReservedBytesMatchTakenBytes` had to be invented for on the Qwen3-VL side. The entry now says explicitly **do not write a second parser** — split `load_vision_gguf` into `parse` (host tensors, no device memory) and `upload` (arena), the structure Qwen3-VL already has.

3. **`stat()` as an upper bound is not cheap enough to shrug at:** mmproj-F16 is 812 MiB, the Gemma-4 BF16 tower 1139 MiB — roughly a GiB of arena wasted.

4. **Validation is GPU-only.** `VisionGolden.Gemma3SigLIP` and `Gemma4v` are the only tests that reach this path. The symbol-size-identity check that made #1233 provable without touching the GPU does not apply, because this change really does alter the generated code.

Anchor gate green — 71 settled-prior anchors resolve, including the files newly named here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B