### PR TITLE
refactor(vision,memory): move the Gemma mmproj path into the T2 arena (F-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- **The Gemma mmproj vision path is a T2 arena tenant; `src/vision/` no longer
+  uses `VRAMAllocator` at all** (F-12). The SigLIP tower, the encoder workspace
+  and the pipeline buffers came from 9 raw `cudaMalloc` sites outside the tier
+  model; they now come from the engine arena, which is sized for them before the
+  mmproj is loaded. `tools/alloc_allowlist.txt` loses three files — **482 -> 473**
+  direct allocation sites. Sizing runs the real loader in counting mode rather
+  than through a second parser, so the reservation cannot drift from the upload;
+  the golden runs assert that exactly, and both guards are mutation-validated.
+  What stays on `cudaMalloc` is the per-image pixel fallback, which is
+  request-scoped rather than engine-lifetime.
 - **`runtime/engine.h` now reaches 23 translation units instead of 33** (F-24,
   `src/api/imp_internal.h`). It was the repo's #2 build-cost header (fan-in x
   commits); `imp_internal.h` pulled it in front of 17 includers while storing

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -399,8 +399,8 @@ Still open from 07-29 with the reason each was not shipped blind — see
   reference exists across `src/ tools/ tests/`.
   What remains is volume, not uncertainty: lift nine structs into `core/`, fill
   the policy at `:972`, rename 91 accessors, drop the include from 22 files.
-- **F-12** — `src/memory/vram_allocator.cu`: **56** live references (2026-08-04), down from
-  67 a day earlier and from the audit's 84. Still open, but shrinking; count with the allocator's own files and comment
+- **F-12** — `src/memory/vram_allocator.cu`: **48** live references (2026-08-05), down from
+  56, 67 and the audit's 84. `src/vision/` is at **zero**. Still open, but shrinking; count with the allocator's own files and comment
   lines excluded or you get 103 and read a regression that is not there — and count the type
   name alone, since adding `vram_alloc`/`vram_alloc_force` gives 104.
   **First consumer migrated 2026-08-04: the Qwen3-VL vision tower** (`qwen3vl_vision_upload.cpp`),
@@ -426,33 +426,33 @@ Still open from 07-29 with the reason each was not shipped blind — see
   keep on the first run by failing: `taken_bytes()` counted only the pipeline's own 32.0 MiB and
   not the encoder's 192.1 MiB. **Mutation-validated**: dropping the FFN term from
   `Qwen3VLEncoder::demand_bytes` under-reserves by 32 MiB and the test fails.
-  **Still NOT migrated — and scoped 2026-08-04, because the one-line version of this note was
-  misleading.** It said only that Gemma's mmproj is "not loaded at arena-open time", which reads
-  like the `max_patches` case: find the number earlier and you are done. It is not that.
+  **Gemma's mmproj path migrated 2026-08-05 — F-12's vision line item is closed.**
+  `src/vision/` now has **zero** `VRAMAllocator` references (19 at the start of this campaign),
+  and the I1 allowlist loses three files outright: **482 -> 473 direct allocation sites**, with
+  `vision_encoder.cu`, `vision_loader.cpp` and `vision_model.cpp` deleted from
+  `tools/alloc_allowlist.txt`. What remains in `vision_pipeline.cpp` is a per-image fallback for
+  when the pre-taken pixel buffer is too small — request-scoped, so it belongs to a scratch tier
+  and not to T2; leaving it is deliberate.
+  **The scoping note this replaces was right about the problem and wrong about the fix.** It
+  proposed splitting `load_vision_gguf` into parse and upload so the arena could be sized before
+  the file loads. That would have meant keeping the mmap alive across two phases and widening
+  every tensor slot with its wire type and transpose flag. **The cheaper answer is to run the
+  same function twice, once counting**: `VisionUpload{dry}` replaces every allocation with an
+  addition, so `vision_gguf_probe()` and the real load are literally the same code path and
+  cannot drift. Cost is one extra header/descriptor parse — the dry pass never touches tensor
+  payloads and mmap is lazy.
+  **Both anti-drift guards are mutation-validated, and they are checked inside the golden runs
+  rather than in tests of their own** (`tests/test_vision_golden.cu`): `load_vision_gguf` reports
+  its raw byte total so probe-vs-actual is an exact comparison, and the encoder asserts
+  `demand_bytes() == taken_bytes()`. Dropping the FFN term from `VisionEncoder::demand_bytes`
+  fails the second; making the dry pass skip the transposed tensor fails the first.
+  **Measured on Gemma-3-4b:** mmproj-F16 is 812 MiB on disk, and the tower plus encoder and
+  pipeline workspace now come out of the arena instead of 9 raw `cudaMalloc` sites.
+  **One trap worth keeping:** the first version of the arena guard compared the arena's `used()`
+  against the raw byte sums and failed — the arena pads every take to 256 bytes. Compare raw
+  sums to raw sums, or budget the alignment explicitly; `used()` is not the number the demand
+  functions produce.
 
-  1. **The Gemma tower never touches `VRAMAllocator` at all.** `upload_tensor_fp16` in
-     `src/vision/vision_loader.cpp` calls **raw `cudaMalloc`**. Counting the whole Gemma vision
-     path there are **15** `cudaMalloc`/`cudaFree` sites across `vision_loader.cpp` (4),
-     `vision_pipeline.cpp` (4), `vision_encoder.cu` (6) and `vision_model.cpp` (1). All are
-     already on the I1 allowlist (`tools/alloc_allowlist.txt`) with counts, so
-     `tools/check_alloc_sites.py` is green — accepted baseline, not a new violation. Migrating
-     therefore closes **I1 sites as well as** the 8 remaining `VRAMAllocator` type references,
-     which is more value than the reference count alone suggests.
-  2. **There is no parse/upload split to hang the sizing on.** `load_vision_gguf` interleaves
-     both in one function — the `cudaMalloc` sits inside the tensor loop. A metadata-only
-     pre-pass would have to re-parse header, KVs and tensor descriptors, ~100 duplicated lines
-     whose drift from the real upload is exactly what `ReservedBytesMatchTakenBytes` had to be
-     invented for on the Qwen3-VL side. **Do not write a second parser.** Split
-     `load_vision_gguf` into `parse` (host tensors, no device memory) and `upload` (arena), which
-     is the structure Qwen3-VL already has; `Engine::init` then parses before opening the arena
-     and sizes from the parsed model, and the warmup uploads.
-  3. **`stat()` as an upper bound is not cheap enough to shrug at:** mmproj-F16 is 812 MiB and
-     the Gemma-4 BF16 tower 1139 MiB, so a file-size bound wastes on the order of a GiB of arena.
-  4. **Validation is GPU-only.** `VisionGolden.Gemma3SigLIP` and `Gemma4v` (need `IMP_TEST_MMPROJ`
-     / `IMP_TEST_MMPROJ_GEMMA4`) are the only things that exercise this path. The
-     symbol-size-identity trick that made F-24 provable on CPU does not apply — this change
-     really does alter the generated code. Budget a quiet card for it, and note this repo's
-     history of *silent* vision failures when scoping the risk.
   **Ownership note:** the previous scheme documented the tower's blocks as caller-owned
   precisely because "a tower holding pointers into an allocator it does not own is a
   use-after-free the moment a teardown order puts the allocator first". The arena removes the

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -2,6 +2,7 @@
 #include "core/buffer.h"
 #include "vision/image_processor.h"
 #include "vision/qwen3vl_vision_load.h"
+#include "vision/vision_pipeline.h"
 #include "runtime/request.h"
 #include "lora/lora_adapter.h"
 #include "runtime/engine_internal.h"
@@ -696,10 +697,12 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
         // the model's shapes here or the arena is sized without it. Gemma's mmproj
         // tower is a separate file that is not loaded yet and stays outside the
         // arena for now (docs/audit/SETTLED.md F-12).
-        const size_t vision_bytes =
+        size_t vision_bytes =
             model_->vision_tower ? qwen3vl_vision_arena_bytes(*model_->vision_tower,
                                                               runtime_config_.runtime.vision_max_patches)
                                  : 0;
+        if (!config_.mmproj_path.empty())
+            vision_bytes += vision_mmproj_arena_bytes(config_.mmproj_path, model_->config_.d_model);
         // *9/8 for 256-byte alignment padding across the arena's takes (integer
         // identical to t + t/8, just one expression instead of two).
         const size_t cap = std::max(kEngineArenaDefaultBytes, (d.total() + vision_bytes) * 9 / 8);

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -157,7 +157,7 @@ bool Engine::init_features() {
 
     // Vision
     if (!config_.mmproj_path.empty()) {
-        if (!vision_.init(config_.mmproj_path, mcfg.d_model, model_.get(), vram_alloc_, stream_))
+        if (!vision_.init(config_.mmproj_path, mcfg.d_model, model_.get(), stream_))
             return false;
     }
     // Qwen3-VL's tower came in with the checkpoint, so there is no mmproj path

--- a/src/runtime/plan_shadow.cpp
+++ b/src/runtime/plan_shadow.cpp
@@ -98,7 +98,8 @@ std::string shadow_plan_report(const ShadowPlanProbe& probe, const PlanResult& s
     if (!probe.workspace_estimate_available)
         emit("  note: executor workspaces not modelled in this probe");
     if (probe.vision_tower_unmodelled)
-        emit("  note: vision tower not modelled (size unknown until the mmproj loads)");
+        emit("  note: vision tower not in the shadow plan (the arena does reserve it, from a "
+             "pre-load probe)");
     emit("  note: forward scratch not modelled until A7 step 4 measures its high-water");
     return out;
 }

--- a/src/vision/vision_encoder.cu
+++ b/src/vision/vision_encoder.cu
@@ -1,4 +1,5 @@
 #include "vision/vision_encoder.h"
+#include "memory/engine_arena.h"
 #include "compute/warp_reduce.cuh"
 #include "core/cuda_static_reset.h"
 #include "memory/vram_allocator.h"
@@ -398,42 +399,39 @@ __global__ void replace_vision_embeddings_v2_kernel(half* __restrict__ hidden,
 
 VisionEncoder::~VisionEncoder() { free_buffers(); }
 
+// The workspace is T2 arena slices; the arena releases wholesale on close, so
+// this only drops pointers. Freeing them individually would hand arena memory
+// back to the driver.
 void VisionEncoder::free_buffers() {
-    auto safe_free = [this](half*& p) {
-        if (p) {
-            if (alloc_)
-                alloc_->free(p);
-            else
-                cudaFree(p);
-            p = nullptr;
-        }
-    };
-    safe_free(d_patches_);
-    safe_free(d_hidden_);
-    safe_free(d_residual_);
-    safe_free(d_q_);
-    safe_free(d_k_);
-    safe_free(d_v_);
-    safe_free(d_attn_out_);
-    safe_free(d_attn_scores_);
-    safe_free(d_ffn_);
-    safe_free(d_pooled_);
-    safe_free(d_gate_);
-    if (d_pos_x_) {
-        cudaFree(d_pos_x_);
-        d_pos_x_ = nullptr;
-    }
-    if (d_pos_y_) {
-        cudaFree(d_pos_y_);
-        d_pos_y_ = nullptr;
-    }
+    d_patches_ = d_hidden_ = d_residual_ = nullptr;
+    d_q_ = d_k_ = d_v_ = d_attn_out_ = nullptr;
+    d_attn_scores_ = d_ffn_ = d_pooled_ = d_gate_ = nullptr;
+    d_pos_x_ = d_pos_y_ = nullptr;
+    taken_bytes_ = 0;
 }
 
-bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t stream,
-                         VRAMAllocator* alloc_in) {
+size_t VisionEncoder::demand_bytes(const VisionConfig& cfg) {
+    const int64_t np = cfg.num_patches;
+    const int64_t hd = cfg.hidden_size;
+    const int64_t ff = cfg.intermediate_size;
+    const int64_t nh = cfg.num_heads;
+    const int64_t pd = static_cast<int64_t>(cfg.patch_size) * cfg.patch_size * 3;
+    size_t total = static_cast<size_t>(np * pd) * sizeof(half);          // patches
+    total += static_cast<size_t>(np * hd) * sizeof(half) * 6;            // hidden,residual,q,k,v,attn_out
+    total += static_cast<size_t>(nh * np * np) * sizeof(half);           // attn scores
+    total += static_cast<size_t>(np * ff) * sizeof(half);                // ffn
+    total += static_cast<size_t>(cfg.num_image_tokens * hd) * sizeof(half);  // pooled
+    if (cfg.is_gemma4v) {
+        total += static_cast<size_t>(np * ff) * sizeof(half);            // geglu gate
+        total += static_cast<size_t>(np) * sizeof(int) * 2;              // axial pos x/y
+    }
+    return total;
+}
+
+bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t stream) {
     model_ = &model;
     lm_d_model_ = lm_d_model;
-    alloc_ = alloc_in;
+    taken_bytes_ = 0;
 
     const auto& cfg = model.config;
     int np = cfg.num_patches;                      // 4096
@@ -442,13 +440,20 @@ bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t 
     int nh = cfg.num_heads;                        // 16
     int pd = cfg.patch_size * cfg.patch_size * 3;  // 588
 
-    auto alloc = [this](half*& ptr, size_t n) -> bool {
-        size_t bytes = n * sizeof(half);
-        if (alloc_) {
-            ptr = static_cast<half*>(alloc_->allocate(bytes, "vision_encoder"));
-            return ptr != nullptr;
+    auto take = [this](size_t bytes) -> void* {
+        auto slab = engine_arena().take_bytes(bytes);
+        if (slab.empty()) {
+            IMP_LOG_ERROR("Vision encoder: engine arena exhausted for %zu bytes — the arena was "
+                          "reserved without this encoder",
+                          bytes);
+            return nullptr;
         }
-        return cudaMalloc(&ptr, bytes) == cudaSuccess;
+        taken_bytes_ += bytes;
+        return slab.data();
+    };
+    auto alloc = [&take](half*& ptr, size_t n) -> bool {
+        ptr = reinterpret_cast<half*>(take(n * sizeof(half)));
+        return ptr != nullptr;
     };
 
     if (!alloc(d_patches_, np * pd) || !alloc(d_hidden_, np * hd) || !alloc(d_residual_, np * hd) ||
@@ -464,9 +469,9 @@ bool VisionEncoder::init(const VisionModel& model, int lm_d_model, cudaStream_t 
     // indices (column = patch % grid, row = patch / grid).
     if (cfg.is_gemma4v) {
         int grid = cfg.image_size / cfg.patch_size;
-        if (!alloc(d_gate_, np * ff) ||
-            cudaMalloc(&d_pos_x_, np * sizeof(int)) != cudaSuccess ||
-            cudaMalloc(&d_pos_y_, np * sizeof(int)) != cudaSuccess) {
+        d_pos_x_ = static_cast<int*>(take(np * sizeof(int)));
+        d_pos_y_ = static_cast<int*>(take(np * sizeof(int)));
+        if (!alloc(d_gate_, np * ff) || !d_pos_x_ || !d_pos_y_) {
             IMP_LOG_ERROR("Vision encoder: gemma4v workspace allocation failed");
             free_buffers();
             return false;

--- a/src/vision/vision_encoder.h
+++ b/src/vision/vision_encoder.h
@@ -7,16 +7,20 @@
 
 namespace imp {
 
-class VRAMAllocator;
-
 class VisionEncoder {
 public:
     VisionEncoder() = default;
     ~VisionEncoder();
 
     // Initialize workspace buffers. lm_d_model = LLM hidden dim.
-    [[nodiscard]] bool init(const VisionModel& model, int lm_d_model, cudaStream_t stream,
-                            VRAMAllocator* alloc = nullptr);
+    [[nodiscard]] bool init(const VisionModel& model, int lm_d_model, cudaStream_t stream);
+
+    // Device bytes init() takes from the T2 arena, answerable from config alone so
+    // Engine::init can size the arena before the mmproj is loaded. taken_bytes()
+    // reports what was actually taken; a test asserts they agree, because these are
+    // two expressions of one buffer list and nothing else stops them drifting.
+    static size_t demand_bytes(const VisionConfig& cfg);
+    size_t taken_bytes() const { return taken_bytes_; }
 
     // Encode a preprocessed image.
     // d_pixels: [3, image_size, image_size] FP16 on device
@@ -24,7 +28,7 @@ public:
     bool encode(const half* d_pixels, half* d_output, cudaStream_t stream);
 
 private:
-    VRAMAllocator* alloc_ = nullptr;
+    size_t taken_bytes_ = 0;
     const VisionModel* model_ = nullptr;
     int lm_d_model_ = 0;
 

--- a/src/vision/vision_loader.cpp
+++ b/src/vision/vision_loader.cpp
@@ -1,5 +1,6 @@
 #include "vision/vision_loader.h"
 #include "model/gguf_loader.h"
+#include "memory/engine_arena.h"
 #include "core/logging.h"
 
 #include <fcntl.h>
@@ -206,17 +207,41 @@ uint64_t val_uint(const VGGUFValue& v) {
     }
 }
 
+// One sink for both passes over a mmproj. `dry` runs the whole load with every
+// allocation replaced by an addition, which is how the arena reservation is
+// computed: the counting pass and the real pass are the SAME code, so the number
+// cannot drift from what the upload takes. The alternative — a second parser that
+// walks header, KVs and tensor descriptors on its own — is ~100 duplicated lines
+// whose drift is precisely what the Qwen3-VL side needed a test to catch.
+struct VisionUpload {
+    bool dry = false;
+    size_t bytes = 0;
+};
+
 // Upload raw tensor data to GPU as FP16.
 // Handles F32 -> FP16 conversion and F16 passthrough.
 bool upload_tensor_fp16(const void* src, GgufWireType type, int64_t n_elements, void** d_out,
-                        std::vector<void*>& gpu_allocs) {
+                        VisionUpload& up) {
     size_t fp16_bytes = static_cast<size_t>(n_elements) * sizeof(half);
-    half* d_ptr = nullptr;
-    if (cudaMalloc(&d_ptr, fp16_bytes) != cudaSuccess) {
-        IMP_LOG_ERROR("Vision: cudaMalloc failed for %zu bytes", fp16_bytes);
+    // Validate before counting so a dry run cannot report a size for a load that
+    // will fail on the type.
+    if (type != GgufWireType::F16 && type != GgufWireType::F32 && type != GgufWireType::BF16) {
+        IMP_LOG_ERROR("Vision: unsupported GGML type %u for tensor upload", std::to_underlying(type));
         return false;
     }
-    gpu_allocs.push_back(d_ptr);
+    up.bytes += fp16_bytes;
+    if (up.dry) {
+        *d_out = nullptr;
+        return true;
+    }
+    auto slab = engine_arena().take_bytes(fp16_bytes);
+    if (slab.empty()) {
+        IMP_LOG_ERROR("Vision: engine arena exhausted for %zu bytes — the arena was reserved "
+                      "without this mmproj",
+                      fp16_bytes);
+        return false;
+    }
+    half* d_ptr = reinterpret_cast<half*>(slab.data());
 
     if (type == GgufWireType::F16) {
         IMP_CUDA_CHECK_LOG(cudaMemcpy(d_ptr, src, fp16_bytes, cudaMemcpyHostToDevice));
@@ -255,8 +280,17 @@ bool upload_tensor_fp16(const void* src, GgufWireType type, int64_t n_elements, 
 // where the LLaVA-style projectors store ne0=in). Transposing at load lets the
 // same vision_gemm projection path consume it unchanged.
 bool upload_tensor_fp16_transposed(const void* src, GgufWireType type, int64_t rows, int64_t cols,
-                                   void** d_out, std::vector<void*>& gpu_allocs) {
+                                   void** d_out, VisionUpload& up) {
     int64_t n = rows * cols;
+    if (type != GgufWireType::F16 && type != GgufWireType::F32 && type != GgufWireType::BF16) {
+        IMP_LOG_ERROR("Vision: unsupported GGML type %u for transposed upload", std::to_underlying(type));
+        return false;
+    }
+    up.bytes += static_cast<size_t>(n) * sizeof(half);
+    if (up.dry) {
+        *d_out = nullptr;
+        return true;
+    }
     std::vector<half> h_src(static_cast<size_t>(n));
     if (type == GgufWireType::F16) {
         std::memcpy(h_src.data(), src, static_cast<size_t>(n) * sizeof(half));
@@ -283,13 +317,13 @@ bool upload_tensor_fp16_transposed(const void* src, GgufWireType type, int64_t r
         for (int64_t c = 0; c < cols; c++)
             h_dst[c * rows + r] = h_src[r * cols + c];
 
-    half* d_ptr = nullptr;
-    if (cudaMalloc(&d_ptr, static_cast<size_t>(n) * sizeof(half)) != cudaSuccess) {
-        IMP_LOG_ERROR("Vision: cudaMalloc failed for transposed %zu bytes",
+    auto slab = engine_arena().take_bytes(static_cast<size_t>(n) * sizeof(half));
+    if (slab.empty()) {
+        IMP_LOG_ERROR("Vision: engine arena exhausted for transposed %zu bytes",
                       static_cast<size_t>(n) * sizeof(half));
         return false;
     }
-    gpu_allocs.push_back(d_ptr);
+    half* d_ptr = reinterpret_cast<half*>(slab.data());
     IMP_CUDA_CHECK_LOG(
         cudaMemcpy(d_ptr, h_dst.data(), static_cast<size_t>(n) * sizeof(half), cudaMemcpyHostToDevice));
     *d_out = d_ptr;
@@ -298,7 +332,7 @@ bool upload_tensor_fp16_transposed(const void* src, GgufWireType type, int64_t r
 
 }  // anonymous namespace
 
-std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
+static std::unique_ptr<VisionModel> load_vision_gguf_impl(const std::string& path, VisionUpload& up) {
     // 1. Open and mmap
     int fd = open(path.c_str(), O_RDONLY);
     if (fd < 0) {
@@ -517,7 +551,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
                 out_dim = ne0;
                 in_dim = ne1;
                 if (!upload_tensor_fp16_transposed(tensor_data, info.type, in_dim, out_dim, &dp,
-                                                   model->gpu_allocs)) {
+                                                   up)) {
                     IMP_LOG_ERROR("Vision: failed to upload mm.input_projection.weight (transposed)");
                     munmap(mmap_base, file_size);
                     return nullptr;
@@ -526,7 +560,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
                 // ne0=in=hidden (LLaVA convention): raw layout already matches.
                 out_dim = ne1;
                 in_dim = ne0;
-                if (!upload_tensor_fp16(tensor_data, info.type, ne0 * ne1, &dp, model->gpu_allocs)) {
+                if (!upload_tensor_fp16(tensor_data, info.type, ne0 * ne1, &dp, up)) {
                     IMP_LOG_ERROR("Vision: failed to upload mm.input_projection.weight");
                     munmap(mmap_base, file_size);
                     return nullptr;
@@ -540,7 +574,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
 
         // Upload to GPU as FP16
         void* d_ptr = nullptr;
-        if (!upload_tensor_fp16(tensor_data, info.type, n_elements, &d_ptr, model->gpu_allocs)) {
+        if (!upload_tensor_fp16(tensor_data, info.type, n_elements, &d_ptr, up)) {
             IMP_LOG_ERROR("Vision: failed to upload tensor %s", info.name.c_str());
             munmap(mmap_base, file_size);
             return nullptr;
@@ -668,7 +702,7 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
     }
 
     // Determine LLM d_model from mm_proj output dimension
-    if (model->mm_proj_w.data) {
+    if (model->mm_proj_w.shape[0] > 0) {
         model->lm_d_model = static_cast<int>(model->mm_proj_w.shape[0]);
         IMP_LOG_INFO("Vision: LLM d_model = %d (from mm_proj)", model->lm_d_model);
     }
@@ -679,6 +713,27 @@ std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path) {
     munmap(mmap_base, file_size);
 
     return model;
+}
+
+std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path, size_t* out_device_bytes) {
+    VisionUpload up;
+    auto model = load_vision_gguf_impl(path, up);
+    if (out_device_bytes)
+        *out_device_bytes = up.bytes;
+    return model;
+}
+
+size_t vision_gguf_probe(const std::string& path, VisionConfig* out_cfg, int* out_lm_d_model) {
+    VisionUpload up;
+    up.dry = true;
+    auto model = load_vision_gguf_impl(path, up);
+    if (!model)
+        return 0;
+    if (out_cfg)
+        *out_cfg = model->config;
+    if (out_lm_d_model)
+        *out_lm_d_model = model->lm_d_model;
+    return up.bytes;
 }
 
 }  // namespace imp

--- a/src/vision/vision_loader.h
+++ b/src/vision/vision_loader.h
@@ -8,6 +8,17 @@ namespace imp {
 
 // Load a SigLIP vision model from an mmproj GGUF file.
 // Weights are uploaded to GPU as FP16.
-std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path);
+// `out_device_bytes` reports the raw device bytes taken, the same accumulator
+// vision_gguf_probe() returns — so a caller can assert the two agree exactly
+// instead of trusting that the dry pass and the real pass stayed in step.
+std::unique_ptr<VisionModel> load_vision_gguf(const std::string& path, size_t* out_device_bytes = nullptr);
+
+// Device bytes the tower will take from the T2 arena, plus the parsed config,
+// answered without allocating anything. This runs the SAME load path in counting
+// mode rather than re-parsing the file, so the reservation cannot drift from what
+// the upload takes. Engine::init needs it because the arena opens long before the
+// vision warmup loads the mmproj. Returns 0 if the file cannot be parsed.
+size_t vision_gguf_probe(const std::string& path, VisionConfig* out_cfg = nullptr,
+                         int* out_lm_d_model = nullptr);
 
 }  // namespace imp

--- a/src/vision/vision_model.cpp
+++ b/src/vision/vision_model.cpp
@@ -3,14 +3,9 @@
 
 namespace imp {
 
-VisionModel::~VisionModel() { free_gpu(); }
-
-void VisionModel::free_gpu() {
-    for (void* ptr : gpu_allocs) {
-        if (ptr)
-            cudaFree(ptr);
-    }
-    gpu_allocs.clear();
-}
+// The tower's blocks are T2 arena slices since F-12; the arena releases them
+// wholesale on close, so there is nothing to hand back per tensor. Keeping the
+// old cudaFree loop would now free arena memory out from under the arena.
+VisionModel::~VisionModel() = default;
 
 }  // namespace imp

--- a/src/vision/vision_model.h
+++ b/src/vision/vision_model.h
@@ -5,7 +5,6 @@
 
 namespace imp {
 
-class VRAMAllocator;
 
 struct VisionConfig {
     int image_size = 896;
@@ -98,17 +97,14 @@ struct VisionModel {
     // Transformer layers
     std::vector<VisionLayerWeights> layers;
 
-    // GPU allocations for cleanup (the legacy GGUF mmproj path, which allocates
-    // them itself). The Qwen3-VL path does NOT use this: its device copies are
-    // owned by the pipeline that made them, because a VisionModel outliving the
-    // allocator it borrowed from is a use-after-free waiting for a teardown
-    // order to expose it.
-    std::vector<void*> gpu_allocs;
-
     int lm_d_model = 0;  // LLM hidden dimension (from mm_proj output)
 
+    // Both towers are T2 arena tenants now (F-12), so a VisionModel owns no device
+    // memory and needs no teardown of its own. The old per-tensor cudaFree list is
+    // gone with the last raw cudaMalloc in this path; the note it carried — that a
+    // VisionModel outliving the allocator it borrowed from is a use-after-free — is
+    // answered by the arena outliving every model it served.
     ~VisionModel();
-    void free_gpu();
 };
 
 }  // namespace imp

--- a/src/vision/vision_pipeline.cpp
+++ b/src/vision/vision_pipeline.cpp
@@ -1,4 +1,5 @@
 #include "vision/vision_pipeline.h"
+#include "memory/engine_arena.h"
 #include "vision/vision_loader.h"
 #include "vision/image_processor.h"
 #include "model/model.h"
@@ -8,20 +9,40 @@
 
 namespace imp {
 
+// Arena slices: the arena releases wholesale on close, so this only drops
+// pointers (F-12).
 VisionPipeline::~VisionPipeline() {
-    if (d_embeddings_ && alloc_) {
-        alloc_->free(d_embeddings_);
-        d_embeddings_ = nullptr;
-    }
-    if (d_pixels_ && alloc_) {
-        alloc_->free(d_pixels_);
-        d_pixels_ = nullptr;
-    }
+    d_embeddings_ = nullptr;
+    d_pixels_ = nullptr;
+}
+
+// Everything the T2 arena owes the mmproj (Gemma-3 / Gemma-4v) path: the SigLIP
+// tower plus the pipeline and encoder workspace. Engine::init asks this one
+// question before the arena opens; the probe runs the real loader in counting
+// mode, so the answer cannot drift from what the warmup then takes.
+size_t vision_mmproj_arena_bytes(const std::string& mmproj_path, int lm_d_model) {
+    VisionConfig cfg;
+    int probed_lm_d = 0;
+    const size_t tower = vision_gguf_probe(mmproj_path, &cfg, &probed_lm_d);
+    if (tower == 0)
+        return 0;
+    const int lm_d = probed_lm_d > 0 ? probed_lm_d : lm_d_model;
+    return tower + VisionPipeline::demand_bytes(cfg, lm_d);
+}
+
+size_t VisionPipeline::taken_bytes() const {
+    return taken_bytes_ + (encoder_ ? encoder_->taken_bytes() : 0);
+}
+
+size_t VisionPipeline::demand_bytes(const VisionConfig& cfg, int lm_d_model) {
+    size_t total = static_cast<size_t>(cfg.num_image_tokens) * lm_d_model * sizeof(half);  // embeddings
+    total += static_cast<size_t>(3) * cfg.image_size * cfg.image_size * sizeof(half);  // pixels
+    return total + VisionEncoder::demand_bytes(cfg);
 }
 
 bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model* text_model,
-                          VRAMAllocator& alloc, cudaStream_t stream) {
-    alloc_ = &alloc;
+                          cudaStream_t stream) {
+    taken_bytes_ = 0;
 
     model_ = load_vision_gguf(mmproj_path);
     if (!model_) {
@@ -32,7 +53,7 @@ bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model*
     int lm_d = model_->lm_d_model > 0 ? model_->lm_d_model : lm_d_model;
     lm_d_ = lm_d;
     encoder_ = std::make_unique<VisionEncoder>();
-    if (!encoder_->init(*model_, lm_d, stream, &alloc)) {
+    if (!encoder_->init(*model_, lm_d, stream)) {
         IMP_LOG_ERROR("Failed to init vision encoder");
         encoder_.reset();
         model_.reset();
@@ -42,7 +63,12 @@ bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model*
     // Allocate device buffer for vision embeddings
     int n_img_tokens = model_->config.num_image_tokens;
     size_t emb_bytes = static_cast<size_t>(n_img_tokens) * lm_d * sizeof(half);
-    d_embeddings_ = static_cast<half*>(alloc.allocate(emb_bytes, "vision_embeddings"));
+    {
+        auto slab = engine_arena().take_bytes(emb_bytes);
+        d_embeddings_ = slab.empty() ? nullptr : reinterpret_cast<half*>(slab.data());
+        if (d_embeddings_)
+            taken_bytes_ += emb_bytes;
+    }
     if (!d_embeddings_) {
         IMP_LOG_ERROR("Failed to allocate vision embedding buffer (%zu bytes)", emb_bytes);
         encoder_.reset();
@@ -53,7 +79,12 @@ bool VisionPipeline::init(const std::string& mmproj_path, int lm_d_model, Model*
     // Pre-allocate pixel buffer to avoid per-image cudaMalloc/Free
     int img_sz = model_->config.image_size;
     d_pixels_size_ = static_cast<size_t>(3) * img_sz * img_sz * sizeof(half);
-    d_pixels_ = static_cast<half*>(alloc.allocate(d_pixels_size_, "vision_pixels"));
+    {
+        auto slab = engine_arena().take_bytes(d_pixels_size_);
+        d_pixels_ = slab.empty() ? nullptr : reinterpret_cast<half*>(slab.data());
+        if (d_pixels_)
+            taken_bytes_ += d_pixels_size_;
+    }
     if (!d_pixels_) {
         IMP_LOG_WARN("Failed to pre-allocate vision pixel buffer (%.1f MiB), will alloc per-image",
                      d_pixels_size_ / (1024.0 * 1024.0));

--- a/src/vision/vision_pipeline.h
+++ b/src/vision/vision_pipeline.h
@@ -24,7 +24,13 @@ public:
 
     // Initialize vision encoder from mmproj GGUF. Returns false on failure.
     [[nodiscard]] bool init(const std::string& mmproj_path, int lm_d_model, Model* model,
-                            VRAMAllocator& alloc, cudaStream_t stream);
+                            cudaStream_t stream);
+
+    // Device bytes init() takes from the T2 arena, encoder included. Answerable
+    // from the probed config before the mmproj is loaded, which is what lets
+    // Engine::init size the arena for it.
+    static size_t demand_bytes(const VisionConfig& cfg, int lm_d_model);
+    size_t taken_bytes() const;
 
     // Encode an image from file path. Blocks on stream sync.
     [[nodiscard]] bool set_image(const std::string& path, cudaStream_t stream);
@@ -62,7 +68,7 @@ public:
 private:
     std::unique_ptr<VisionModel> model_;
     std::unique_ptr<VisionEncoder> encoder_;
-    VRAMAllocator* alloc_ = nullptr;
+    size_t taken_bytes_ = 0;
 
     half* d_embeddings_ = nullptr;
     half* d_pixels_ = nullptr;
@@ -77,5 +83,8 @@ private:
     // Internal: upload pixels and encode
     bool encode_image(const half* h_pixels, int n_pixels, cudaStream_t stream);
 };
+
+// Arena demand for the mmproj vision path, answerable before the file is loaded.
+size_t vision_mmproj_arena_bytes(const std::string& mmproj_path, int lm_d_model);
 
 }  // namespace imp

--- a/tests/test_memory_plan.cpp
+++ b/tests/test_memory_plan.cpp
@@ -362,7 +362,10 @@ TEST(ShadowPlan, ReportSaysWhatItDoesNotModel) {
         << "the report still describes itself as a shadow";
     EXPECT_NE(r.find("workspaces not modelled"), std::string::npos)
         << "a probe that hides its gaps is worse than no probe";
-    EXPECT_NE(r.find("vision tower not modelled"), std::string::npos);
+    // The note says the shadow plan does not model the tower — it no longer claims
+    // the size is unknowable, because since F-12 the arena reserves it from a
+    // pre-load probe. Match on what stayed true, not on the old reason.
+    EXPECT_NE(r.find("vision tower not in the shadow plan"), std::string::npos);
     EXPECT_NE(r.find("forward scratch not modelled"), std::string::npos);
 }
 

--- a/tests/test_vision_golden.cu
+++ b/tests/test_vision_golden.cu
@@ -46,6 +46,8 @@
 #include "vision/vision_model.h"
 
 #include "refs/vision_encoder_golden.h"
+#include "scoped_engine_arena.h"
+#include "memory/engine_arena.h"
 
 namespace imp {
 namespace {
@@ -85,7 +87,26 @@ bool file_exists(const std::string& p) {
 // skips are decided before we get here, on file presence).
 bool run_vision_pipeline(const std::string& mmproj_path, const std::string& image_path,
                          std::vector<float>& out, int& num_tokens, int& d_model, std::string& err) {
-    std::unique_ptr<VisionModel> model = load_vision_gguf(mmproj_path);
+    // The tower and the encoder workspace are T2 arena tenants (F-12), so this
+    // harness has to open an arena the way Engine::init does — and size it the
+    // same way, from the probe rather than a literal, so a different mmproj
+    // cannot silently outgrow it.
+    VisionConfig probe_cfg;
+    int probe_lm_d = 0;
+    const size_t tower_bytes = vision_gguf_probe(mmproj_path, &probe_cfg, &probe_lm_d);
+    if (tower_bytes == 0) {
+        err = "vision_gguf_probe failed for " + mmproj_path;
+        return false;
+    }
+    const size_t need = tower_bytes + VisionEncoder::demand_bytes(probe_cfg);
+    ScopedEngineArena arena(need + need / 8);
+    if (!arena.opened()) {
+        err = "engine arena unavailable";
+        return false;
+    }
+
+    size_t tower_actual = 0;
+    std::unique_ptr<VisionModel> model = load_vision_gguf(mmproj_path, &tower_actual);
     if (!model) {
         err = "load_vision_gguf failed";
         return false;
@@ -110,8 +131,24 @@ bool run_vision_pipeline(const std::string& mmproj_path, const std::string& imag
     }
 
     VisionEncoder encoder;
-    if (!encoder.init(*model, d_model, stream, &alloc)) {
+    if (!encoder.init(*model, d_model, stream)) {
         err = "VisionEncoder init failed";
+        cudaStreamDestroy(stream);
+        return false;
+    }
+
+    // Anti-drift, checked on every golden run rather than in a test of its own:
+    // demand_bytes() and the reservation are two expressions of one buffer list,
+    // and a buffer added to init() without updating demand_bytes() under-reserves
+    // the arena — which surfaces on whichever model happens to be tight, not here.
+    // The arena's own `used` covers the tower too, so this pins the probe as well.
+    if (encoder.taken_bytes() != VisionEncoder::demand_bytes(model->config)) {
+        err = "encoder demand_bytes != taken_bytes";
+        cudaStreamDestroy(stream);
+        return false;
+    }
+    if (tower_actual != tower_bytes) {
+        err = "vision_gguf_probe disagrees with what the real load took";
         cudaStreamDestroy(stream);
         return false;
     }

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -74,7 +74,4 @@ src/runtime/engine_kv_cache_init.cpp  # 3
 src/runtime/engine_scheduler.cpp  # 24
 src/runtime/engine_spec_ngram.cpp  # 13
 src/runtime/engine_workspace_warmup.cpp  # 2
-src/vision/vision_encoder.cu  # 6
-src/vision/vision_loader.cpp  # 2
-src/vision/vision_model.cpp  # 1
 src/vision/vision_pipeline.cpp  # 2


### PR DESCRIPTION
Closes **F-12's vision line item**. `src/vision/` now has **zero** `VRAMAllocator` references — 19 when this campaign started — and the SigLIP tower, encoder workspace and pipeline buffers come from the engine arena instead of **9 raw `cudaMalloc` sites** outside the tier model. `tools/alloc_allowlist.txt` loses three files: **I1 goes 482 → 473**.

## Correcting my own scoping note

`SETTLED.md` (from #1234) said to split `load_vision_gguf` into `parse` and `upload` so the arena could be sized before the file loads. That would mean keeping the mmap alive across two phases and widening every tensor slot with its wire type and transpose flag.

**Running the same function twice, once counting, is cheaper and strictly safer.** `VisionUpload{dry}` replaces every allocation with an addition, so `vision_gguf_probe()` and the real load are *literally the same code path* and cannot drift. The dry pass never touches tensor payloads and mmap is lazy, so the cost is one header/descriptor parse.

## Two anti-drift guards, checked inside the golden runs

Not as tests of their own — as assertions every golden run makes, so they cannot rot unnoticed. Both mutation-validated:

| guard | mutation that breaks it |
|---|---|
| `load_vision_gguf` reports its raw byte total → probe-vs-actual is **exact** | make the dry pass skip the transposed tensor → *"vision_gguf_probe disagrees with what the real load took"* |
| `VisionEncoder::demand_bytes() == taken_bytes()` | drop the FFN term from `demand_bytes` → *"encoder demand_bytes != taken_bytes"* |

A first attempt compared the arena's `used()` against raw byte sums and failed — the arena pads every take to 256 bytes. Raw sums must be compared to raw sums; that trap is recorded in the ledger.

## What deliberately stays

The per-image pixel fallback in `vision_pipeline.cpp`, used when the pre-taken buffer is too small. It is request-scoped rather than engine-lifetime, so it belongs to a scratch tier and not to T2.

## One message that had gone stale

`plan_shadow`'s *"vision tower not modelled (size unknown until the mmproj loads)"* was true when written and is not any more — the arena reserves it from the probe. The note and `ShadowPlan.ReportSaysWhatItDoesNotModel` now assert what stayed true instead of restating the old reason. **The suite caught this, not review.**

## Validation

Measured on Gemma-3-4b (mmproj-F16, 812 MiB on disk):

```
engine arena demand: … + vision 1411.4 MiB -> 1922.1 MiB reserved
Vision encoder: workspace 595 MiB (patches=4096, hidden=1152, ffn=4304)
Vision encoder ready: 256 image tokens -> 2560-dim embeddings
```

…and the model actually sees the image: *"A beautiful tabby cat is the main subject. It has a classic tabby pattern with dark brown stripes…"*

- `verify-fast` on a quiet host: decode **+0.32 %**, prefill +1.56 %, pp4096 +1.11 %, peak VRAM +0.01 %, graphs 2.47×, spread **0.12 %**.
- Full GPU suite at its reference state: 2024 OK, 1 failure (`MtpForwardTest.DraftStepProducesValidToken`, the known capacity case).
- `VisionGolden` 2/2 from the source tree; alloc-site and file-size gates green.

**A note on measurement, since it nearly cost a false conclusion:** an earlier gate run read decode −6.6 % and reproduced. A symbol-size comparison showed only `Engine::init` and `Engine::Engine()` changed (init-time, +19 and +22 bytes) with no hot-path symbol touched, and running the identical gate on `main` read **−8.4 %** — worse than the branch. It was host load, not the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B