### PR TITLE
refactor(runtime,memory): move the decode batch pool into the T2 arena (F-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- **The decode batch pool comes from the T2 arena** (F-12, `src/runtime/batch.cpp`).
+  It was the last consumer whose size is knowable before the weights upload, so it
+  is the last one the arena can own; I1 direct allocation sites go **473 -> 471**.
+  `demand_bytes()` is the only place the size sum lives — `allocate()` calls it too
+  — so `Engine::init` can reserve for it without a second formula. The pool is
+  0.06 MiB on an 8B/4096 config: this buys tier ownership and two fewer driver
+  call sites, not VRAM. The arena demand line now itemises it.
 - **The Gemma mmproj vision path is a T2 arena tenant; `src/vision/` no longer
   uses `VRAMAllocator` at all** (F-12). The SigLIP tower, the encoder workspace
   and the pipeline buffers came from 9 raw `cudaMalloc` sites outside the tier

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -417,9 +417,16 @@ Still open from 07-29 with the reason each was not shipped blind — see
   - **Grow-on-demand buffers cannot be arena tenants either.** `d_penalty_tokens_`
     (`engine_sampling_stop.cpp:219-223`) frees and re-allocates larger when a request needs more;
     a bump allocator has no free.
-  - **What genuinely remains migratable is small:** `GPUBatchPool` (`batch.cpp:180-205`, 2 sites).
+  - **`GPUBatchPool` was the one genuinely migratable consumer, and it is done (2026-08-05).**
     Its dimensions are config-derived — `blocks_per_seq = (max_seq_len + kv_bs - 1) / kv_bs` — so
-    it is answerable at arena-open time, unlike everything above.
+    it is answerable at arena-open time, unlike everything above. I1 **473 -> 471**.
+    **State the value honestly: the pool is 0.06 MiB on an 8B/4096 config**, so this bought no
+    VRAM and the arena's 1/8 alignment slack (~43 MiB there) would have absorbed it regardless.
+    What it bought is two fewer driver call sites and the last config-sized tenant sitting in the
+    tier it belongs to. No anti-drift test was added and none is needed — unlike the vision case,
+    `allocate()` calls `demand_bytes()` itself, so there is only ever one formula.
+    `with_swa_tables` is a KV-init decision not known when the arena opens, so the reservation
+    assumes it; guessing high costs a few hundred KiB and guessing low would exhaust the arena.
   **So the honest reading is that `VRAMAllocator`'s residual job is the acquisition path for
   tiers sized after the upload, and F-12 should be judged on that, not on driving the count to
   zero.** Do not re-open it as "48 to go". Anchors: `src/memory/kv_cache.cu`,

--- a/src/runtime/batch.cpp
+++ b/src/runtime/batch.cpp
@@ -1,4 +1,5 @@
 #include "runtime/batch.h"
+#include "memory/engine_arena.h"
 #include "memory/vram_allocator.h"
 #include "core/logging.h"
 #include <algorithm>
@@ -177,18 +178,27 @@ Batch BatchBuilder::build() {
 
 GPUBatchPool::~GPUBatchPool() { free_pool(); }
 
-void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc,
-                            bool with_swa_tables) {
+// 256-byte alignment per sub-buffer, so the offsets below stay valid.
+static size_t align256(size_t x) { return (x + 255) & ~size_t(255); }
+
+size_t GPUBatchPool::demand_bytes(int max_batch_size, int max_blocks_per_seq, bool with_swa_tables) {
+    const size_t block_tab_sz =
+        align256(static_cast<size_t>(max_batch_size) * max_blocks_per_seq * sizeof(int));
+    return align256(static_cast<size_t>(max_batch_size) * sizeof(int32_t)) +      // token ids
+           align256(static_cast<size_t>(max_batch_size) * sizeof(int)) +          // positions
+           align256(static_cast<size_t>(max_batch_size + 1) * sizeof(int)) +      // seq offsets
+           block_tab_sz + (with_swa_tables ? block_tab_sz : 0) +                  // block tables
+           align256(static_cast<size_t>(max_batch_size) * sizeof(int)) +          // ctx lens
+           align256(sizeof(int32_t));                                             // sample result
+}
+
+void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, bool with_swa_tables) {
     free_pool();
-    alloc_ = alloc;
 
     max_batch_size_ = max_batch_size;
     max_blocks_per_seq_ = max_blocks_per_seq;
     last_upload_block_tables_.clear();
     last_upload_block_tables_swa_.clear();
-
-    // Compute sizes with 256-byte alignment per sub-buffer
-    auto align256 = [](size_t x) -> size_t { return (x + 255) & ~size_t(255); };
 
     size_t token_ids_sz = align256(static_cast<size_t>(max_batch_size) * sizeof(int32_t));
     size_t positions_sz = align256(static_cast<size_t>(max_batch_size) * sizeof(int));
@@ -196,22 +206,19 @@ void GPUBatchPool::allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllo
     size_t block_tab_sz = align256(static_cast<size_t>(max_batch_size) * max_blocks_per_seq * sizeof(int));
     size_t swa_tab_sz = with_swa_tables ? block_tab_sz : 0;
     size_t ctx_lens_sz = align256(static_cast<size_t>(max_batch_size) * sizeof(int));
-    size_t sample_res_sz = align256(sizeof(int32_t));
 
-    pool_size_ = token_ids_sz + positions_sz + seq_offsets_sz + block_tab_sz + swa_tab_sz + ctx_lens_sz +
-                 sample_res_sz;
+    pool_size_ = demand_bytes(max_batch_size, max_blocks_per_seq, with_swa_tables);
 
-    if (alloc_) {
-        pool_ = alloc_->allocate(pool_size_, "batch_pool");
-    } else {
-        cudaError_t err = cudaMalloc(&pool_, pool_size_);
-        if (err != cudaSuccess)
-            pool_ = nullptr;
-    }
-    if (!pool_) {
+    auto slab = engine_arena().take_bytes(pool_size_);
+    if (slab.empty()) {
+        IMP_LOG_ERROR("decode batch pool: engine arena exhausted for %zu bytes — the arena was "
+                      "reserved without this pool",
+                      pool_size_);
+        pool_ = nullptr;
         pool_size_ = 0;
         return;
     }
+    pool_ = slab.data();
 
     char* ptr = static_cast<char*>(pool_);
     d_token_ids_ = reinterpret_cast<int32_t*>(ptr);
@@ -300,14 +307,10 @@ GPUBatch GPUBatchPool::upload_into_pool(const Batch& batch, cudaStream_t stream)
     return gpu;
 }
 
+// An arena slice: released wholesale when the arena closes, so this only drops
+// pointers. allocate() runs once per engine, so nothing is leaked by not freeing.
 void GPUBatchPool::free_pool() {
-    if (pool_) {
-        if (alloc_)
-            alloc_->free(pool_);
-        else
-            IMP_CUDA_CHECK_LOG(cudaFree(pool_));
-        pool_ = nullptr;
-    }
+    pool_ = nullptr;
     pool_size_ = 0;
     d_token_ids_ = nullptr;
     d_positions_ = nullptr;

--- a/src/runtime/batch.h
+++ b/src/runtime/batch.h
@@ -7,7 +7,6 @@
 
 namespace imp {
 
-class VRAMAllocator;
 
 // CPU-side batch data (built by BatchBuilder)
 struct Batch {
@@ -60,8 +59,13 @@ public:
     // Allocate pool for the given max configuration. Call once at init.
     // with_swa_tables adds a second block-table region for the SWA-group
     // tables (kv_cache.swa_sizing) — same stride, stable pointer.
-    void allocate(int max_batch_size, int max_blocks_per_seq, VRAMAllocator* alloc = nullptr,
-                  bool with_swa_tables = false);
+    // The pool is one contiguous engine-lifetime slab out of the T2 arena, sized
+    // entirely from config. demand_bytes() is the ONLY place that sum lives —
+    // allocate() calls it too — so Engine::init can reserve for it before the
+    // pool exists without a second formula that could drift.
+    static size_t demand_bytes(int max_batch_size, int max_blocks_per_seq, bool with_swa_tables);
+
+    void allocate(int max_batch_size, int max_blocks_per_seq, bool with_swa_tables);
 
     // Upload a CPU batch into the pre-allocated pool (async).
     // Returns a GPUBatch with pointers into the pool (caller must NOT free them).
@@ -81,7 +85,6 @@ public:
     int32_t* d_sample_result() const { return d_sample_result_; }
 
 private:
-    VRAMAllocator* alloc_ = nullptr;
     void* pool_ = nullptr;
     size_t pool_size_ = 0;
 

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -703,11 +703,19 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
                                  : 0;
         if (!config_.mmproj_path.empty())
             vision_bytes += vision_mmproj_arena_bytes(config_.mmproj_path, model_->config_.d_model);
+        // The decode batch pool is engine-lifetime and config-sized, but allocated
+        // after KV sizing, so reserve for it here. with_swa_tables is a KV-init
+        // decision not known yet; assume it — the pool is a few hundred KiB, so
+        // guessing high costs nothing and guessing low would exhaust the arena.
+        const int kv_bs = config_.kv_block_size > 0 ? config_.kv_block_size : 16;
+        const size_t batch_pool_bytes = GPUBatchPool::demand_bytes(
+            config_.max_batch_size, (config_.max_seq_len + kv_bs - 1) / kv_bs, /*with_swa_tables=*/true);
         // *9/8 for 256-byte alignment padding across the arena's takes (integer
         // identical to t + t/8, just one expression instead of two).
-        const size_t cap = std::max(kEngineArenaDefaultBytes, (d.total() + vision_bytes) * 9 / 8);
-        IMP_LOG_INFO("engine arena demand: %s + vision %.1f MiB -> %.1f MiB reserved",
-                     d.describe().c_str(), vision_bytes / (1024.0 * 1024.0), cap / (1024.0 * 1024.0));
+        const size_t cap = std::max(kEngineArenaDefaultBytes, (d.total() + vision_bytes + batch_pool_bytes) * 9 / 8);
+        IMP_LOG_INFO("engine arena demand: %s + vision %.1f + batchpool %.2f MiB -> %.1f MiB reserved",
+                     d.describe().c_str(), vision_bytes / (1024.0 * 1024.0),
+                     batch_pool_bytes / (1024.0 * 1024.0), cap / (1024.0 * 1024.0));
         (void)engine_arena_open(cuda_malloc_backend(), cap);
         // Name the two charges that are already known, HERE rather than after
         // warmup. Both are facts by now — the context was measured above, the

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -653,7 +653,7 @@ bool Engine::init_kv_cache() {
         IMP_LOG_INFO("Weight cache: FP8 E4M3 (2x prefill throughput on sm_120)");
 
     // Pre-allocate decode batch pool + penalty buffer
-    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq, &vram_alloc_,
+    decode_batch_pool_.allocate(config_.max_batch_size, blocks_per_seq,
                                 /*with_swa_tables=*/swa_sizing_active_);
     {
         d_penalty_tokens_capacity_ = static_cast<size_t>(config_.max_seq_len);

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -5,7 +5,7 @@
 # be justified in review; the gate fails on any file that allocates and is
 # not listed, and equally on any listed file that no longer allocates.
 #
-# remaining: 71 files, 482 sites
+# remaining: 68 files, 471 sites
 
 src/compute/attention_cublas.cu  # 14
 src/compute/attention_fmha_sm120.cu  # 2
@@ -65,7 +65,7 @@ src/quant/fp8_quant.cu  # 6
 src/quant/gpt_oss_mxfp4_convert.cu  # 9
 src/quant/nvfp4_gemm.cu  # 3
 src/quant/nvfp4_quant.cu  # 16
-src/runtime/batch.cpp  # 12
+src/runtime/batch.cpp  # 10
 src/runtime/cuda_graph.cu  # 26
 src/runtime/engine.cpp  # 6
 src/runtime/engine_graph_decode.cpp  # 31


### PR DESCRIPTION
The last consumer whose size is knowable **before** the weights upload, and therefore the last one the arena can own. #1237 established why the rest cannot be: they are sized from the residual *after* the upload, or they grow on demand.

**I1 direct allocation sites: 473 → 471.**

## Why this one needs no anti-drift test

`demand_bytes()` is the only place the size sum lives — `allocate()` calls it too. There is only ever one formula, so `Engine::init` can reserve for the pool without a second expression that could drift.

That is the difference from the vision migration (#1230, #1235), where the buffers land in named members and the list genuinely had to be written twice — which is why *those* needed `ReservedBytesMatchTakenBytes` and a probe-vs-actual check.

`with_swa_tables` is a KV-init decision not known when the arena opens, so the reservation assumes it. Guessing high costs a few hundred KiB; guessing low would exhaust the arena.

## Honest accounting of what this buys

**The pool is 0.06 MiB on an 8B/4096 config.** This bought **no VRAM** — the arena's 1/8 alignment slack (~43 MiB there) would have absorbed it regardless. What it bought is two fewer driver call sites and the last config-sized tenant sitting in the tier it belongs to.

The arena demand line now itemises it, so the number is visible rather than assumed:

```
engine arena demand: … + vision 0.0 + batchpool 0.06 MiB -> 391.6 MiB reserved
```

## Validation

- `verify-fast` on a quiet host: decode −0.14 %, prefill +1.46 %, pp4096 +0.80 %, peak VRAM +0.01 %, graphs 2.58×, spread **0.19 %**.
- Full GPU suite at its reference state: 2024 OK, 1 failure (`MtpForwardTest.DraftStepProducesValidToken`, the known capacity case).
- Loads verified on a non-SWA model and on Gemma-3 with SWA active — neither exhausts the arena.
- Alloc-site, file-size and release-hygiene gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDYD2f9J4PWDsFP4v9151B