### PR TITLE
docs(audit): close the 07-29 campaign at 25/25, gate the ledger against drift

### DIFF
--- a/.claude/skills/codebase-audit/SKILL.md
+++ b/.claude/skills/codebase-audit/SKILL.md
@@ -30,6 +30,15 @@ written *in this file*. So:
   lists the five that were wrong last time, each with a one-command counter-check.
 - Recording a refutation is part of finishing the audit. One you leave out of `SETTLED.md`
   is one the next pass pays for again.
+- **Closing a finding means updating both sides — the report's status line *and* the
+  ledger.** This is the failure that actually keeps happening, and it is the mirror of the
+  one above: not a refutation left unrecorded, but a *fix* left unrecorded, so the ledger
+  goes on calling a closed finding open. It hit three times in the 07-29 campaign — F-6 was
+  closed before the ledger ever listed it as open, `S-10` read "F-15, still open" for two
+  days after #1209, and §G was headed "Open: NOT settled" for a day after the last of its
+  six closed. A stale *open* entry is worse than a stale closed one: it sends the next pass
+  at work already done. `scripts/check-release.sh` section 1d now fails CI on it, so the
+  cheapest time to fix this is in the PR that closes the finding.
 
 ## Verification recipes (the load-bearing checks)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Changed
+
+- **The 2026-07-29 architecture audit is closed at 25/25**, and the ledger now
+  says so: `SETTLED.md` §G had kept six resolved findings under "Open: NOT
+  settled", and F-10, F-12 and F-24 carried no status line in the report at all.
+  Each entry keeps its measurements — three of the six closed by refuting their
+  own proposed fix.
+- **`check-release.sh` section 1d cross-checks finding status** between
+  `AUDIT_ARCH_2026_07_29.md` and `SETTLED.md`. Section 1c only proves the files
+  a ledger entry names still exist; this proves the entry is still true. The
+  ledger had gone stale the same way three times (F-6, F-15, F-10), each time
+  pointing a later pass at work already done.
+
 ## [0.21.0] - 2026-08-05
 
 ### Added

--- a/docs/audit/AUDIT_ARCH_2026_07_29.md
+++ b/docs/audit/AUDIT_ARCH_2026_07_29.md
@@ -1282,7 +1282,7 @@ be turned off; the once-at-init dump is what an operator actually reads.
 
 ---
 
-**F-3 — The routing tests test a hand-maintained replica, not the dispatch** — ⚠️ MOSTLY FIXED in #1205 + #1211 (residual named below)
+**F-3 — The routing tests test a hand-maintained replica, not the dispatch** — ✅ RESOLVED: FIXED in #1205 + #1211 (attention) and the MoE half in #1212; the residual is ⛔ WON'T FIX **with a mechanism** in #1239 — a chain whose predicates include "did this tier work" can only ever be replayed against a prefix
 `HIGH` · effort `S` · blast 3 files · confidence **HIGH**
 
 *Evidence:* `src/compute/attention_dispatch_decision.h:57-95` and
@@ -1382,7 +1382,7 @@ allocators; it cannot validate numerics.
 
 ---
 
-**F-6 — 20-39 % of steady-state VRAM is unattributed** — ⚠️ REPORTING FIXED in #1211; the attribution itself is open
+**F-6 — 20-39 % of steady-state VRAM is unattributed** — ✅ RESOLVED: reporting FIXED in #1211, and the attribution itself re-measured 2026-08-03 across four config families at **99.9-100.0 % accounted** (residual 0-16 MiB) against the ≥95 % criterion
 `HIGH` · effort `M` · blast `memory/` · confidence **HIGH** (project's own measurement)
 
 *Evidence:* `docs/MEMORY_ARCHITECTURE.md:150-160` — tracked total 19 311 of 23 872 MiB on the
@@ -1438,7 +1438,7 @@ the harness for the other five dtypes.
 
 ---
 
-**F-9 — cuBLASLt algorithm selection is neither cached nor pinned** — ⚠️ mechanism CONFIRMED, magnitude REFUTED (3.50 %, not 2.6×; see open question 5)
+**F-9 — cuBLASLt algorithm selection is neither cached nor pinned** — ✅ FIXED in #1228 by repairing the estimator, not by persisting the result (mechanism CONFIRMED, magnitude REFUTED — 3.50 %, not 2.6×; R-16 REJECTED, see open question 5)
 `MEDIUM` · effort `M` · blast 2 files · confidence **MEDIUM** (mechanism confirmed; the 2.6× figure
 is from the dispatch, not re-measured)
 
@@ -1460,7 +1460,7 @@ is right.
 
 ---
 
-**F-10 — `runtime/config.h` (1124 LOC) is included by 22 files in `src/exec/`**
+**F-10 — `runtime/config.h` (1124 LOC) is included by 22 files in `src/exec/`** — ✅ FIXED in #1227
 `MEDIUM` · effort `L` · blast wide · confidence **HIGH**
 
 *Evidence:* `docs/audit/arch_2026_07_29_evidence/layering_tally.txt` — `exec → runtime` 27 files, 22 of them `config.h`;
@@ -1500,7 +1500,7 @@ attention/GEMM/vision paths is a change with its own risk.
 
 ---
 
-**F-12 — `VRAMAllocator` is a sixth allocator with 84 live references**
+**F-12 — `VRAMAllocator` is a sixth allocator with 84 live references** — ✅ RESOLVED in #1229-#1238, and RE-SCOPED: the migratable consumers moved to the T2 arena, the residual is structural
 `MEDIUM` · effort `L` · blast 20 files · confidence **HIGH**
 
 *Evidence:* `src/memory/vram_allocator.{h,cu}`; 84 references across 20 files including
@@ -1717,7 +1717,7 @@ and touches every construction site.
 
 ---
 
-**F-24 — `Engine` is a 1200-LOC header with ~150 members and 131 commits in six months**
+**F-24 — `Engine` is a 1200-LOC header with ~150 members and 131 commits in six months** — ✅ RESOLVED in #1233: the proposed extraction was REFUTED on churn, fan-in was cut instead (33 → 23 TUs)
 `LOW` · effort `L` · blast wide · confidence **HIGH**
 
 *Evidence:* `src/runtime/engine.h`; churn `engine.cpp` 253 / `engine.h` 131 (six months), the

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -28,6 +28,13 @@ The **anchor** column is the point. It names the file that makes the entry settl
 resolving — so an entry cannot quietly become the next stale prior. If an anchor moves,
 re-open the entry; do not just fix the path.
 
+An anchor only proves the *file* still exists, never that the *claim* is still true. The
+claim is covered by **section 1d**, which cross-checks this file against the status lines in
+[`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md): every finding must carry a status,
+and the set the report calls open must equal the set filed here under an "Open" heading.
+It exists because this ledger went stale in the same direction three times (F-6, F-15,
+F-10) — always a finding that got fixed while the ledger kept calling it open.
+
 ## How to use it
 
 1. Read this file **before** fanning out. Generate hypotheses *against* it.
@@ -51,7 +58,7 @@ re-open the entry; do not just fix the path.
 | S-7 | Sampling is several overlapping chains and constrained decode bypasses part of it | **REFUTED** | `apply_constraint_mask()` at `src/exec/executor.cu:56` — nine lines called from every sampling path. **Keep the comment with the code**: it records that four copies of this chain is exactly how an unmasked path ships | 2026-07-29 |
 | S-8 | The legacy materialised cuBLAS prefill is a vestige (~18 % of prefill) | **REFUTED, with one exception** | 0.0 % on hd=128/256. **Gemma-4's hd=512 global layers take it by design and by measurement** — `src/compute/attention_cublas.cu`, gated per layer at `src/exec/executor_attention_prefill.cu`. It is a deliberately retained tier, not a vestige | 2026-07-29 (F-16) |
 | S-9 | Nemotron-H / SSM carries a private mini-runtime | **REFUTED for SSM**; CONFIRMED for vision | `src/compute/ssm.cu` and `src/memory/recurrent_snapshot_store.h` sit in the shared tree, not beside the model | 2026-07-29 |
-| S-10 | `tools/`, `tests/` and the bench CLI duplicate benchmark logic | **REFUTED for benching** — CONFIRMED for arg parsing (27 flags, F-15, still open) | `tools/imp-bench/` has no overlap against `tests/`; the perf gate reads `tests/perf_baseline.json` through `scripts/bench_gate.sh` | 2026-07-29 |
+| S-10 | `tools/`, `tests/` and the bench CLI duplicate benchmark logic | **REFUTED for benching** — was CONFIRMED for arg parsing (27 flags, F-15), **fixed in #1209**: the shared table lives in `tools/common/args_common.cpp` | `tools/imp-bench/` has no overlap against `tests/`; the perf gate reads `tests/perf_baseline.json` through `scripts/bench_gate.sh`; `tools/common/args_common.h` | 2026-07-29, F-15 closed 2026-08-02 |
 | S-11 | NVFP4 grouped-GEMM has two competing paths | **CONFIRMED — but a designed 4-tier ladder, not a twin** | `src/exec/moe_prefill_decision.h` documents the tiers; each is selected by explicit preconditions and the bottom one serves host-offloaded experts. No death date exists for it | 2026-07-29 |
 
 ## B — Deliberate specialisation (consolidating this is the classic false positive)
@@ -296,10 +303,31 @@ one command.
 | no p50/p99 histograms | Prometheus histograms exist | `grep _bucket` in `tools/imp-server/handlers_misc.cpp` |
 | `/v1/messages` streaming is synthetic | real handler plus the shared stream driver | `tools/imp-server/handlers_messages.cpp` |
 
-## G — Open: NOT settled, and not to be treated as closed
+## G — The six that closed last, and what each verdict rests on
 
-Still open from 07-29 with the reason each was not shipped blind — see
-[`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the full argument.
+**The 07-29 campaign is finished: 25 of 25 findings resolved as of 2026-08-05.** Nothing in
+this section is open. It is kept because each entry carries the *measurements* behind its
+verdict, and three of the six were closed by refuting their own proposed fix — a next pass
+that re-derives them pays for that work twice. See
+[`AUDIT_ARCH_2026_07_29.md`](AUDIT_ARCH_2026_07_29.md) for the full argument per finding.
+
+| Finding | Verdict | Landed |
+|---|---|---|
+| F-3 (rest) | WON'T FIX **with a mechanism** — the chain's predicates include "did this tier work", so the model can only ever be replayed against a prefix | #1239 |
+| F-5 (rest) | WON'T FIX — no GPU runner, repo-owner decision 2026-08-03; the consequence is load-bearing and stated below | #1211 (dormant) |
+| F-9 | FIXED by repairing the estimator, **not** by persisting the result; R-16 REJECTED | #1228 |
+| F-10 | FIXED — the nine dispatch sections lifted into `core/DispatchPolicy`; `src/exec/` includes `runtime/config.h` **zero** times | #1227 |
+| F-12 | RE-SCOPED and closed — migratable consumers moved to the T2 arena; the residual is `VRAMAllocator`'s acquisition job for tiers sized *after* the upload | #1229-#1238 |
+| F-24 | Proposed extraction REFUTED on churn (2 % of commits); fan-in cut instead, 33 → 23 TUs | #1233 |
+
+**This section was headed "Open: NOT settled" for a day after the last of them landed, and
+that is the third time this ledger has gone stale in the same direction** (F-6 was closed
+before the file listed it as open; S-10 carried "F-15, still open" for two days after #1209).
+A stale *open* entry is worse than a stale closed one: it sends the next pass to work that is
+already done. `scripts/check-release.sh` section 1d now cross-checks this file against the
+report's status lines so the fourth occurrence fails CI instead of costing a day.
+
+**Where the open work actually is: [`docs/roadmap.md`](../roadmap.md), not here.**
 
 - **F-3 (rest)** — routing replica. **This entry understated the gap until 2026-08-03**: it
   described the residual limit of the *attention* half (a tier reordered ahead of the winner
@@ -382,7 +410,11 @@ Still open from 07-29 with the reason each was not shipped blind — see
   correctly stays put on the two where nothing is 10 % better.
   **A 3 % margin was tried first and was useless** — it sat below the residual noise. Set a
   threshold like this from the measured spread, not from what sounds tight.
-- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`. **Scoped by
+- **F-10** — `src/runtime/config.h` included by 22 files in `src/exec/`. **CLOSED 2026-08-04
+  (#1227): the nine sections are lifted into `src/core/dispatch_policy.h` and `src/exec/`
+  includes `runtime/config.h` zero times.** The scoping below is kept because it is what
+  redirected the fix away from the audit's proposal — read it before proposing a POD
+  extraction anywhere else in this repo. **Scoped by
   measurement 2026-08-03, and the audit's estimate is low by 2x.** It proposes extracting
   "the ~30 dispatch-relevant keys" into a `DispatchPolicy` POD; `src/exec/` actually reads
   **59 distinct RuntimeConfig leaves** across nine sections — gemm 15, attention 13, moe 12,
@@ -415,8 +447,11 @@ Still open from 07-29 with the reason each was not shipped blind — see
   (c) Those sections are nested inside `RuntimeConfig`, so they must be lifted
   out — and that is nearly free: **exactly one** explicit `RuntimeConfig::<Section>`
   reference exists across `src/ tools/ tests/`.
-  What remains is volume, not uncertainty: lift nine structs into `core/`, fill
-  the policy at `:972`, rename 91 accessors, drop the include from 22 files.
+  What remained was volume, not uncertainty — and that is what shipped in #1227: nine
+  structs lifted into `core/`, the policy filled after the resolvers, 91 accessors
+  renamed, the include dropped from 22 files. **Prediction (b) held**: sections-by-value
+  made every read site a prefix rename, instead of a hand-enumerated 59-field POD that
+  could drift from the config it mirrors.
 - **F-12** — `src/memory/vram_allocator.cu`: **48** live references (2026-08-05), down from
   56, 67 and the audit's 84. `src/vision/` is at **zero**.
   **RE-SCOPED 2026-08-05: the remaining 48 are mostly NOT a migration backlog, and treating them

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -125,6 +125,94 @@ else
     fi
 fi
 
+# ------------------------------------------------ 1d. finding-status coherence
+# 1c checks that the FILES the ledger names still exist. It cannot check that
+# the ledger's CLAIMS are still true, and that is the failure mode that has now
+# hit three times, always in the same direction — a finding gets fixed and the
+# ledger keeps listing it as open:
+#   F-6  closed before SETTLED.md ever listed it as open (the file says so itself)
+#   F-15 fixed in #1209; S-10 read "still open" for two days
+#   F-10 fixed in #1227; section G read "Open: NOT settled" for a day
+# A stale *open* entry is strictly worse than a stale closed one: it sends the
+# next audit pass to work that is already done, which is the exact cost this
+# ledger exists to prevent (eight of thirteen hypotheses in the 07-29 pass).
+#
+# The report is the authority on status: every finding there carries one status
+# line. This cross-checks it against the ledger, both ways.
+#   * every F-nn headline must carry a status mark  — no mark is how F-10, F-12
+#     and F-24 sat statusless for a day, which is what let G go stale unnoticed
+#   * ✅ / ⛔ mean resolved; ⚠️ means still open
+#   * the set the report calls open must equal the set the ledger files under an
+#     "Open" heading — a fixed finding left under "Open", or an open one missing
+#     from the ledger entirely, both fail
+#
+# Note honestly: with 25/25 resolved the set comparison currently compares two
+# empty sets. It is a ratchet for the next campaign, not a check that is doing
+# work today. The per-finding status-mark check IS doing work today — it runs
+# over all 25 — and the floor below is what stops the whole section degrading
+# into a vacuous pass if the extraction ever silently stops matching.
+#
+# Known and deliberate: the ledger side collects EVERY F-nn mentioned under an
+# "Open" heading, prose included, not just the entry headers. Mutation-testing
+# this section surfaced it — renaming G back to "Open: NOT settled" reported
+# eight findings because the section's preamble names F-6 and F-15 while
+# explaining how they went stale. Tightening it to entry headers only would
+# make the check miss a finding discussed but never given its own bullet, which
+# is the likelier drift. A false positive here prints both sets and costs one
+# read; a false negative costs the next audit pass a day.
+#
+# Mutation-validated 2026-08-05, all four fail as intended: strip a status mark
+# (F-21) -> statusless; mark F-8 ⚠️ with no ledger entry -> sets disagree; rename
+# G back to "Open: NOT settled" -> sets disagree; rename the F-nn headlines ->
+# floor trips at 0.
+section "finding-status coherence"
+ARCH_REPORT=docs/audit/AUDIT_ARCH_2026_07_29.md
+if [ ! -e "$ARCH_REPORT" ] || [ ! -e docs/audit/SETTLED.md ]; then
+    fail "$ARCH_REPORT or docs/audit/SETTLED.md is missing — the audit ledger is load-bearing"
+else
+    STATUSLESS=""
+    OPEN_IN_REPORT=""
+    FINDINGN=0
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        id=$(echo "$line" | grep -oE '^\*\*F-[0-9]+' | tr -d '*' || true)
+        [ -z "$id" ] && continue
+        FINDINGN=$((FINDINGN+1))
+        # Resolved marks win over the open mark: F-3 is "✅ RESOLVED … the
+        # residual is ⛔ WON'T FIX", which carries both and is resolved.
+        if echo "$line" | grep -q '✅\|⛔'; then
+            :
+        elif echo "$line" | grep -q '⚠️'; then
+            OPEN_IN_REPORT="$OPEN_IN_REPORT $id"
+        else
+            STATUSLESS="$STATUSLESS $id"
+        fi
+    done <<< "$(grep -E '^\*\*F-[0-9]+ ' "$ARCH_REPORT" || true)"
+
+    # Findings the ledger files under a heading that says "Open".
+    OPEN_IN_LEDGER=$(awk '
+        /^## / { open = (tolower($0) ~ /open/) }
+        open && match($0, /F-[0-9]+/) { print substr($0, RSTART, RLENGTH) }
+    ' docs/audit/SETTLED.md | sort -u | tr '\n' ' ')
+
+    norm() { echo " $* " | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ' || true; }
+    R_OPEN=$(norm "$OPEN_IN_REPORT")
+    L_OPEN=$(norm "$OPEN_IN_LEDGER")
+
+    FINDING_FLOOR=20
+    if [ "$FINDINGN" -lt "$FINDING_FLOOR" ]; then
+        fail "only $FINDINGN findings parsed from $ARCH_REPORT (expected >= $FINDING_FLOOR) — the extraction broke"
+    elif [ -n "$STATUSLESS" ]; then
+        fail "finding(s) with no status mark in $ARCH_REPORT:$STATUSLESS — add ✅ FIXED / ⚠️ open / ⛔ WON'T FIX"
+    elif [ "$R_OPEN" != "$L_OPEN" ]; then
+        echo "  report calls open: ${R_OPEN:-<none>}"
+        echo "  ledger calls open: ${L_OPEN:-<none>}"
+        fail "the report and docs/audit/SETTLED.md disagree on which findings are open"
+    else
+        pass "all $FINDINGN findings carry a status; report and ledger agree on ${R_OPEN:-none} open"
+    fi
+fi
+
 # --------------------------------------------------------- 2. personal paths
 # Flag real personal paths but allow the standard /home/user/ placeholder.
 section "personal path leaks"


### PR DESCRIPTION
## What

The 2026-07-29 architecture audit is finished — **25 of 25 findings resolved**. The ledger did not say so.

- `SETTLED.md` §G was headed **"Open: NOT settled, and not to be treated as closed"** and contained six findings that are all resolved (F-3, F-5, F-9, F-10, F-12, F-24).
- **F-10, F-12 and F-24 carried no status line in the report at all** — the three worked on most recently.
- `S-10` still read "F-15, still open"; F-15 was fixed in #1209 and `tools/common/args_common.cpp` has existed since.

Every entry keeps its measurements. Three of the six closed by **refuting their own proposed fix** (F-24's extraction on churn, F-9's R-16 cache, F-3's model-as-source-of-truth), and that is exactly the reasoning a next pass must not pay for twice.

## Why a gate, not just a correction

This is the third time the ledger has gone stale in the same direction, always a finding that got fixed while the ledger kept calling it open:

| | |
|---|---|
| F-6 | closed *before* `SETTLED.md` ever listed it as open — the file documents this about itself |
| F-15 | fixed in #1209; `S-10` read "still open" for two days |
| F-10 | fixed in #1227; §G read "Open: NOT settled" for a day |

Section 1c checks that the **files** a ledger entry names still exist. It cannot check that the **claim** is still true, and a stale *open* entry is worse than a stale closed one: it sends the next audit pass at work already done — the precise cost this ledger exists to prevent.

New **section 1d** treats the report as the authority on status and cross-checks it against the ledger both ways: every finding must carry a status mark (✅/⛔ resolved, ⚠️ open), and the set the report calls open must equal the set the ledger files under an "Open" heading.

## Verification

**Mutation-validated — all four fail as intended**, control run green afterwards and the tree restored:

| mutation | result |
|---|---|
| strip F-21's status mark | `FAIL … no status mark: F-21` |
| mark F-8 ⚠️ open, no ledger entry | `FAIL … disagree` (`report: F-8`, `ledger: <none>`) |
| rename §G back to "Open: NOT settled" | `FAIL … disagree` (the F-10 case verbatim) |
| rename the `F-nn` headlines | `FAIL only 0 findings parsed … the extraction broke` |

`check-release.sh` hygiene sections all pass, including `all 25 findings carry a status; report and ledger agree on none open`.

**`make verify-fast` reports decode 270.58 tok/s, −5.78 % vs the 287.19 baseline.** Not attributable to this change, and this is structural rather than a judgement call: the diff contains **no compiled file** (4 files: 3 × `.md`, 1 × `.sh`), and `verify-fast` does not build — it measures the existing `imp:test` image. This run therefore measured the same binary as `main`. Two of the user's containers (`mmm-review`, `cryptotrader`) were up throughout, which is the documented −4…−8 % load effect. Tests, peak VRAM (20718 vs 20716 MiB), the graphs-ON gate (2.39x) and the degeneration smoke all pass.

## Where the open work actually is

`docs/roadmap.md`, and §G now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)