### PR TITLE
fix(vision): a system message no longer costs the image its tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A system message no longer costs an image its tokens** (#1246). The Gemma
+  vision prompt keyed its image block on *"message index 0 is the user
+  message"*, so any request opening with a system prompt — the normal shape for
+  a pipeline — rendered text-only: the picture was decoded and encoded, the
+  prompt held no soft tokens for the embeddings to replace, and the model
+  answered fluently that it could not see an image. On gemma-3-4b + mmproj the
+  same request goes from **37 prompt tokens and "Bitte stelle mir das Bild zur
+  Verfügung"** to **296 tokens and a correct description**. The block now rides
+  the first *user* turn, matching the Qwen3-VL path. `vision_sight_check.py`
+  sends a system message by default for the same reason.
 - **An mmproj GGUF this loader cannot read is now refused, not half-loaded.**
   Qwen3-VL's mmproj assigned **247 of 316** tensors and reported success; the 69
   it dropped were exactly its fused `attn_qkv` (48), DeepStack mergers (18),

--- a/src/model/chat_template_families.cpp
+++ b/src/model/chat_template_families.cpp
@@ -402,6 +402,27 @@ std::vector<int32_t> ChatTemplate::apply_with_image(const Tokenizer& tok,
         return apply(tok, messages, suppress_thinking, force_thinking);
     }
 
+    // The image rides the FIRST USER turn — not message index 0. Keying it on
+    // index 0 meant any request opening with a system prompt (the normal shape
+    // for a pipeline) rendered text-only: the picture was still decoded and
+    // encoded, but the prompt held no soft tokens for the embeddings to replace,
+    // so the model answered fluently that it could not see an image (#1246).
+    //
+    // "First user turn" matches what the Qwen3-VL path does with its placeholder
+    // blocks: the request parser keeps pictures in order but not which message
+    // they came from, so this is the position that is known rather than guessed.
+    size_t image_turn = messages.size();  // == none
+    for (size_t mi = 0; mi < messages.size(); mi++) {
+        if (messages[mi].role == "user") {
+            image_turn = mi;
+            break;
+        }
+    }
+    // Nowhere to put it: fall back to the text-only render rather than drop the
+    // block on an unrelated turn.
+    if (image_turn == messages.size())
+        return apply(tok, messages, suppress_thinking, force_thinking);
+
     // Gemma vision format:
     // <bos><start_of_turn>user\n<boi><img_soft>*N<eoi>\n{text}<end_of_turn>\n<start_of_turn>model\n
     std::vector<int32_t> tokens;
@@ -416,8 +437,8 @@ std::vector<int32_t> ChatTemplate::apply_with_image(const Tokenizer& tok,
 
         std::string role = (msg.role == "assistant") ? "model" : msg.role;
 
-        if (mi == 0 && msg.role == "user") {
-            // First user message: inject image tokens before text
+        if (mi == image_turn) {
+            // The user turn that carries the picture.
             auto role_ids = tok.encode(role + "\n");
             tokens.insert(tokens.end(), role_ids.begin(), role_ids.end());
 

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -741,6 +741,66 @@ TEST(ChatTemplateVisionTest, GemmaImageTokens) {
     EXPECT_GT(eoi_pos, boi_pos);
 }
 
+// A system message must not cost the image its tokens (#1246).
+//
+// The block used to be keyed on "message index 0 is a user message", so any
+// request that opened with a system prompt — the normal shape for a pipeline —
+// silently produced a text-only prompt. The picture was still decoded and
+// encoded, and the model answered fluently that it could not see an image, which
+// is the hardest kind of failure to attribute.
+TEST(ChatTemplateVisionTest, SystemMessageDoesNotDropTheImage) {
+    Tokenizer tok = make_chat_tokenizer();
+    ChatTemplate tpl;
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
+
+    std::vector<ChatMessage> msgs = {{"system", "Answer briefly."}, {"user", "What is this?"}};
+    auto ids = tpl.apply_with_image(tok, msgs, /*n_image_tokens=*/4);
+
+    ASSERT_FALSE(ids.empty());
+    EXPECT_TRUE(contains(ids, BOI));
+    EXPECT_TRUE(contains(ids, EOI));
+    EXPECT_EQ(std::count(ids.begin(), ids.end(), IMG_SOFT), 4);
+    EXPECT_GT(find_pos(ids, EOI), find_pos(ids, BOI));
+
+    // And the prompt has to be strictly longer than the text-only render —
+    // the count is what the request accounting reports, and a prompt that did
+    // not grow is the observable that this bug presented as.
+    EXPECT_GT(ids.size(), tpl.apply(tok, msgs).size());
+}
+
+// The image rides the FIRST user turn, matching the Qwen3-VL path: the request
+// parser keeps pictures in order but not which message they came from, so this
+// is the position that is known rather than guessed.
+TEST(ChatTemplateVisionTest, ImageGoesOnFirstUserTurnInMultiTurn) {
+    Tokenizer tok = make_chat_tokenizer();
+    ChatTemplate tpl;
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
+
+    std::vector<ChatMessage> msgs = {{"system", "Answer briefly."},
+                                     {"user", "What is this?"},
+                                     {"assistant", "A cat."},
+                                     {"user", "And now?"}};
+    auto ids = tpl.apply_with_image(tok, msgs, /*n_image_tokens=*/4);
+
+    EXPECT_EQ(std::count(ids.begin(), ids.end(), IMG_SOFT), 4);
+    EXPECT_EQ(std::count(ids.begin(), ids.end(), BOI), 1);
+    EXPECT_EQ(std::count(ids.begin(), ids.end(), EOI), 1);
+}
+
+// A conversation with no user message at all must not lose the block silently —
+// it has nowhere to go, and a text-only prompt beside an encoded image is the
+// exact failure this test file now guards.
+TEST(ChatTemplateVisionTest, NoUserTurnFallsBackToTextOnly) {
+    Tokenizer tok = make_chat_tokenizer();
+    ChatTemplate tpl;
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::GEMMA, tok));
+
+    std::vector<ChatMessage> msgs = {{"system", "Answer briefly."}};
+    auto ids = tpl.apply_with_image(tok, msgs, /*n_image_tokens=*/4);
+
+    EXPECT_EQ(ids, tpl.apply(tok, msgs));
+}
+
 TEST(ChatTemplateVisionTest, NonGemmaFallsBackToTextOnly) {
     Tokenizer tok = make_chat_tokenizer();
     ChatTemplate tpl;

--- a/tools/analysis/vision_sight_check.py
+++ b/tools/analysis/vision_sight_check.py
@@ -22,6 +22,11 @@ Two checks, in order of how hard they are to fake:
 Images are generated here (stdlib zlib only, no Pillow), so ground truth is
 exact and nothing binary lands in the repo.
 
+Requests carry a system message by default. That is not cosmetic: the second
+half of #1246 was a prompt builder that keyed the image block on "message index
+0 is the user message", so every request opening with a system prompt rendered
+text-only. A check without a system message walks straight past that.
+
 Usage:
   tools/analysis/vision_sight_check.py --url http://127.0.0.1:8080 --model NAME
   tools/analysis/vision_sight_check.py --model NAME --images 8 --save-dir /tmp/x
@@ -81,20 +86,33 @@ def make_image(n_circles: int, size: int = 448) -> bytes:
     return png(size, size, rows)
 
 
+# Sent by default, and not decoration. The #1246 regression lived exactly here:
+# the image block was keyed on "message index 0 is the user message", so any
+# request opening with a system prompt — the normal shape for a pipeline —
+# rendered text-only. A check that omits the system message passes straight over
+# it. `--no-system` drops it, which is useful for isolating whether a failure is
+# the system message's doing.
+DEFAULT_SYSTEM = "You describe images briefly and factually."
+
+
 def ask(url: str, model: str, prompt: str, image: bytes, max_tokens: int,
-        timeout: float) -> str:
+        timeout: float, system: str | None = DEFAULT_SYSTEM) -> str:
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({
+        "role": "user",
+        "content": [
+            {"type": "text", "text": prompt},
+            {"type": "image_url", "image_url": {
+                "url": "data:image/png;base64," + base64.b64encode(image).decode()}},
+        ],
+    })
     body = {
         "model": model,
         "max_tokens": max_tokens,
         "temperature": 0,
-        "messages": [{
-            "role": "user",
-            "content": [
-                {"type": "text", "text": prompt},
-                {"type": "image_url", "image_url": {
-                    "url": "data:image/png;base64," + base64.b64encode(image).decode()}},
-            ],
-        }],
+        "messages": messages,
     }
     req = urllib.request.Request(
         url.rstrip("/") + "/v1/chat/completions",
@@ -134,6 +152,9 @@ def main() -> int:
                     help="counting-battery size (rounded down to a multiple of "
                          f"{len(COUNTS)} so the counts stay balanced)")
     ap.add_argument("--timeout", type=float, default=180.0)
+    ap.add_argument("--no-system", action="store_true",
+                    help="omit the system message (the default sends one, because "
+                         "that is the request shape #1246 broke on)")
     ap.add_argument("--save-dir", help="also write the generated PNGs here")
     args = ap.parse_args()
 
@@ -150,9 +171,12 @@ def main() -> int:
 
     # ---- Check 1: distinctness ----
     print("== 1. distinctness (different pictures -> different answers) ==")
+    print(f"   system message: {'omitted' if args.no_system else 'sent'}")
     describe = "Describe exactly what is in this image."
     probes = [images[truth.index(c)] for c in (COUNTS[0], COUNTS[-1])]
-    answers = [ask(args.url, args.model, describe, img, 48, args.timeout) for img in probes]
+    system = None if args.no_system else DEFAULT_SYSTEM
+    answers = [ask(args.url, args.model, describe, img, 48, args.timeout, system)
+               for img in probes]
     for count, answer in zip((COUNTS[0], COUNTS[-1]), answers):
         print(f"   {count} circle(s): {answer[:100]!r}")
     identical = answers[0] == answers[1]
@@ -164,7 +188,7 @@ def main() -> int:
                 "Answer with a single digit and nothing else.")
     correct, guesses = 0, []
     for i, (t, img) in enumerate(zip(truth, images)):
-        reply = ask(args.url, args.model, question, img, 8, args.timeout)
+        reply = ask(args.url, args.model, question, img, 8, args.timeout, system)
         got = first_int(reply)
         guesses.append(got)
         ok = got == t
@@ -184,6 +208,9 @@ def main() -> int:
         print("  Check the load log for 'Vision: assigned X / Y tensors' (X<Y is fatal),")
         print("  and that the prompt token count rises by the image-token count when an")
         print("  image is attached — if it does not, the placeholders were never inserted.")
+        if not args.no_system:
+            print("  Then re-run with --no-system: if it passes without the system message,")
+            print("  the prompt builder is dropping the image block off the first user turn.")
     return 0 if sees else 1
 
 


### PR DESCRIPTION
Closes the second half of #1246.

## Root cause

`ChatTemplate::apply_with_image` keyed the image block on **message index 0**:

```cpp
if (mi == 0 && msg.role == "user") {   // <- inject <boi> <soft>*N <eoi>
```

So a request that opens with a system prompt — the normal shape for a pipeline —
put the user turn at index 1 and fell into the `else` branch. **No image tokens
at all.** The picture was still decoded and encoded, `state.vision_embeddings`
was still bound, but the prompt held no soft tokens for
`launch_replace_vision_embeddings` to replace. The model then answered fluently
that it could not see an image, which is the hardest kind of failure to
attribute: nothing is red, nothing is empty, and the reply is well-formed.

The reporter's data is what found it. Their request differed from my repro in
exactly one thing that mattered, and I had ruled the wrong things out first —
streaming, image size, image format, prompt language, request order.

## The A/B

gemma-3-4b + `mmproj-F16`, same server, same request (system message + JPEG,
their exact shape):

```
before    37 prompt tokens   "Bitte stelle mir das Bild zur Verfügung.
                              Ich kann es nicht sehen, ohne dass du es mir zeigst."
after    296 prompt tokens   "Ein einzelner, sitzender Kater. Er sitzt auf einem
                              hellgrauen Mauerwerk. Der Kater hat ein braunes Fell …"
```

The reported symptom was `47 prompt + 24 completion` and *"Das Bild ist nicht
sichtbar. Bitte füge ein Bild hinzu."* — same order of magnitude, same sentence.

Without a system message the path was always fine (281 tokens), which is why my
first investigation found the tower healthy and closed on "does not reproduce".

## The fix

The block rides the **first `user` turn**, whatever its index. That matches what
the Qwen3-VL path already does with its placeholder blocks — the request parser
keeps pictures in order but not which message they came from, so the first user
turn is the position that is known rather than guessed. A conversation with no
user turn falls back to the text-only render instead of dropping the block on an
unrelated message.

## Tests

Three new cases in `test_chat_template.cpp`, mutation-validated:

| mutation | fails |
|---|---|
| restore `mi == 0 && role == "user"` | `SystemMessageDoesNotDropTheImage`, `ImageGoesOnFirstUserTurnInMultiTurn` |
| drop the no-user-turn fallback | `NoUserTurnFallsBackToTextOnly` |

The first test also asserts the prompt is **strictly longer** than the text-only
render — the token count is the observable this bug presented as, and before the
fix it read `60 vs 60`.

`ctest -L unit` 4/4; `test-text` 57/57.

## `vision_sight_check.py` would have missed this

It sent no system message, so it walked straight past the bug — 20 minutes after
I shipped it as the tool for exactly this class of failure. It now sends one by
default, with `--no-system` to isolate. Against the unfixed build it reports:

```
   system message: sent
   1 circle(s): 'Please provide me with the image! I need to see the image to describe it…'
   4 circle(s): 'Please provide me with the image! I need to see the image to describe it…'
   -> IDENTICAL — the tower is not reaching the LM
   accuracy         1/4
   constant-answer  1/4
VERDICT: BLIND (or the embeddings never reach the sequence).
  Then re-run with --no-system: if it passes without the system message,
  the prompt builder is dropping the image block off the first user turn.
```

and against the fixed build, 6/8 vs a 2/8 constant baseline → SEES. (The 4-circle
images are miscounted as 5 by a 4B model — genuinely weak, genuinely sighted,
which is the distinction the tool exists to draw.)

## Perf

None — prompt construction only, no engine or kernel change.