### PR TITLE
fix(memory): count the allocator headroom in the MoE cache's KV reserve (#1251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A MoE GGUF could load fine and then cancel every generation** (#1251). The
+  NVFP4 MoE cache reserved room for the KV pool without counting the allocator
+  headroom that KV sizing subtracts moments later, so the residual it left was
+  *entirely* headroom and the pool fell to the 16-block / 512-token floor.
+  Qwen3.6-35B-A3B-UD-Q4_K_M went from **16 blocks (512 tokens)** and
+  `finish_reason: "cancelled"` at ~476 tokens to **1257 blocks (40224 tokens)**
+  and a full 1200-token reply. Allocation is byte-identical on Qwen3-30B-A3B-Q4_K_M
+  and Gemma-4-26B-A4B-UD-Q4_K_M, where the MoE budget is not the binding
+  constraint.
+
 ## [0.22.0] - 2026-08-05
 
 ### Added

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -289,7 +289,18 @@ void QuantPipeline::nvfp4_decode_cache_moe_experts_(const ModelConfig& cfg,
         IMP_LOG_DEBUG("MoE reserve: %.0f MiB (n_attn=%d, kv_heads=%d, hd=%d → %.0f MiB KV at 16K + 256 MiB workspace)",
                       kMoeReserve / (1024.0 * 1024.0), n_attn_layers, kv_heads, hd,
                       kv_reserve / (1024.0 * 1024.0));
-        constexpr size_t kRuntimeHeadroom = 512ULL * 1024 * 1024;
+        // The runtime headroom must cover what the KV sizing subtracts, not just
+        // what the runtime touches. init_kv_cache computes its pool from
+        // (free - vram_allocator_headroom(total)); reserving less than that
+        // headroom here leaves a residual that is ENTIRELY headroom, so kv_room
+        // evaluates to 0 and the pool drops to the 16-block / 512-token floor
+        // however many blocks the plan granted. Qwen3.6-35B-A3B UD-Q4_K_M hit
+        // exactly that: 1088 MiB reserved here, 1630 MiB headroom subtracted
+        // there, KV 4096 -> 16 blocks and every generation cancelled at
+        // admission (#1251). Keep the 512 MiB as the floor for cards where 5%
+        // is smaller than that.
+        const size_t kRuntimeHeadroom =
+            std::max(static_cast<size_t>(512ULL * 1024 * 1024), vram_allocator_headroom(total_mem));
         size_t total_reserve = kMoeReserve + kRuntimeHeadroom;
         moe_budget = (free_mem > total_reserve) ? (free_mem - total_reserve) : 0;
         // Prequant models: the plan grants the MoE


### PR DESCRIPTION
Closes #1251.

## What was wrong

`Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` loaded successfully and then cancelled every
generation at ~476 tokens with an empty `content`. Its KV pool sat at the
16-block / 512-token floor, and no documented knob recovered it.

Three places compute a KV reserve, and they did not agree:

| Where | Reserves for KV | Value on this model |
|---|---|---|
| `vram_budget.cpp` (planner) | `guarantee_blocks` | 4096 blocks = 2560 MiB |
| `pre_dequant_phase3_moe.cu` | `kKvFloorTokens=16384`, capped at 1 GiB, +512 MiB | **1088 MiB** |
| `engine_kv_cache_init.cpp` | subtracts `vram_allocator_headroom(total)` | **1630 MiB** |

The MoE cache left 1264 MiB standing. KV sizing subtracted 1630 MiB of allocator
headroom from it, so `kv_room` evaluated to **0** and `std::max(fits, 16)` pinned
the pool at 16 blocks — regardless of the 4096 the planner had granted.

`vram_allocator_headroom()` is used in `engine_kv_cache_init.cpp` and
`vram_budget.cpp`, but not in the one place that sets aside room *for* the KV pool.

## The fix

Floor Phase 3's runtime headroom at `vram_allocator_headroom(total_mem)`, keeping
the previous 512 MiB as the lower bound for cards where 5% is smaller. 12 lines,
11 of them the comment explaining the coupling.

## Measured

| Model (GGUF + MoE) | main | with fix |
|---|---|---|
| **Qwen3.6-35B-A3B-UD-Q4_K_M** | **16 blocks (512 tok)** | **1257 blocks (40224 tok)** |
| Qwen3-30B-A3B-Q4_K_M | 1280 blocks, MoE 2592.01 MiB | identical |
| Gemma-4-26B-A4B-it-UD-Q4_K_M | 659 blocks | identical |
| ornith-1.0-35b-Q4_K_M | 1916 blocks, MoE 2880.02 MiB | 2162 blocks, MoE unchanged |

The three unaffected models are byte-identical in allocation where the MoE budget
is not the binding constraint — deterministic arithmetic, so equality is a
stronger argument here than a noisy perf A/B. `ornith` was the model the code
comments name as the case that once lost its cache to an oversized KV pool; its
MoE cache is untouched.

The issue's own reproducer now returns `finish_reason: "length"` with 1200
completion tokens and non-empty content, instead of `"cancelled"` with 476 and
an empty string.

**Gate** (Qwen3-8B-Q8_0, median of 3 independent processes, quiet host,
sm 2902 MHz / mem 13801 MHz / 504 W):

- decode `tg128` **287.52** tok/s vs baseline 287.19 — **+0.11%**, spread 0.18%
- prefill `pp512` 12618.77 (+1.71%), `pp4096` 15543.73 (+1.43%)
- `own_peak` VRAM 20718 MiB vs 20716 — +0.01%
- graphs ON/OFF 2.53x, degeneration smoke PASS, 827 unit tests green

## Not fixed here, on purpose

The load stayed **silent** because the guard meant to catch exactly this
(`engine_kv_cache_init.cpp:385`) sits behind `vram_budget_bytes() > 0`, which is
never true without an explicit `--vram-budget`. Fixing that would have made the
model loudly unusable rather than quietly unusable — worth doing, but it is a
separate change, and the next bug of this class would otherwise still be silent.
Same for unifying the three reserve computations: this closes the collision, not
the divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8