### PR TITLE
fix(runtime): say it out loud when the KV pool falls back to the floor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,6 +653,10 @@ if(IMP_BUILD_TESTS)
         tests/test_memory_backend.cpp
         tests/test_memory_allocators.cpp
         tests/test_memory_plan.cpp
+        # The KV-pool sizing arithmetic (#1251). Pure integers, so it belongs in
+        # the lane CI runs — it used to be inline in engine_kv_cache_init.cpp,
+        # unreachable without a GPU and a 22 GB checkpoint.
+        tests/test_kv_residual_sizing.cpp
         tests/test_graph_slots.cpp
         # T5's engine-persistent half. The property that matters — freed exactly
         # once, never after a move — is ownership, not CUDA, so it belongs in the

--- a/src/memory/vram_query.h
+++ b/src/memory/vram_query.h
@@ -91,4 +91,46 @@ inline size_t vram_reserve_floor(size_t total_bytes, int pct = 10) {
     return share > floor_bytes ? share : floor_bytes;
 }
 
+// Outcome of sizing the KV pool from the measured post-cache residual.
+struct KvResidualSizing {
+    int blocks = 0;         // block count to use
+    bool clamped = false;   // residual was smaller than the planned pool
+    bool floored = false;   // residual could not cover even `floor_blocks`
+};
+
+// The KV pool is sized from what is left AFTER the weight caches are built,
+// minus the allocator headroom above — which is a hard constraint, not a
+// policy knob. The consequence is easy to miss and has now cost two bugs:
+// anyone who sets VRAM aside *for* this pool must set aside the headroom ON
+// TOP of the pool, or the residual they leave is entirely headroom, `room`
+// evaluates to 0, and this returns `floor_blocks` — a rescue, not a size.
+// #1103 was that mismatch between Engine::init and the VRAM budget (1118 MiB
+// on a 32 GiB card); #1251 was the same mismatch in the NVFP4 MoE cache's
+// reserve, which left 1264 MiB against a 1630 MiB headroom and pinned a
+// 35B model to a 512-token pool that cancelled every generation.
+//
+// `floored` distinguishes "the pool is smaller than planned" (normal: the
+// plan is a projection, the residual is the truth) from "there was nothing
+// left to size from" (always an operator-visible fault), so the caller can
+// be quiet about the first and loud about the second.
+inline KvResidualSizing kv_blocks_from_residual(size_t free_bytes, size_t headroom_bytes,
+                                                size_t per_block_bytes, int planned_blocks,
+                                                int floor_blocks) {
+    KvResidualSizing out;
+    out.blocks = planned_blocks;
+    if (per_block_bytes == 0 || planned_blocks <= 0)
+        return out;
+    const size_t room = (free_bytes > headroom_bytes) ? (free_bytes - headroom_bytes) : 0;
+    const size_t fits_sz = room / per_block_bytes;
+    const int fits = fits_sz > static_cast<size_t>(planned_blocks)
+                         ? planned_blocks
+                         : static_cast<int>(fits_sz);
+    if (fits >= planned_blocks)
+        return out;
+    out.clamped = true;
+    out.floored = fits < floor_blocks;
+    out.blocks = out.floored ? floor_blocks : fits;
+    return out;
+}
+
 }  // namespace imp

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -362,14 +362,31 @@ bool Engine::init_kv_cache() {
         size_t free_now = 0, total_now = 0;
         vram_budget_mem_get_info(&free_now, &total_now);
         const size_t headroom = vram_allocator_headroom(total_now);
-        const size_t kv_room = (free_now > headroom) ? (free_now - headroom) : 0;
-        const int fits = static_cast<int>(kv_room / per_block_total_bytes);
-        if (fits < max_blocks) {
+        const int max_blocks_planned = max_blocks;
+        const auto sizing =
+            kv_blocks_from_residual(free_now, headroom, per_block_total_bytes, max_blocks, 16);
+        if (sizing.clamped) {
             IMP_LOG_INFO("KV cache: %d -> %d blocks from the measured post-cache residual "
                          "(%.0f MiB free, %.0f MiB allocator headroom kept)",
-                         max_blocks, std::max(fits, 16), free_now / (1024.0 * 1024.0),
+                         max_blocks, sizing.blocks, free_now / (1024.0 * 1024.0),
                          headroom / (1024.0 * 1024.0));
-            max_blocks = std::max(fits, 16);
+            max_blocks = sizing.blocks;
+        }
+        // The floor is a rescue, not a size: nothing was left to size the pool
+        // from, so every request longer than the floor will be cancelled at
+        // admission while the load still reports success. The hard failure
+        // below only fires with an explicit --vram-budget, so without this the
+        // default path learns about it from cancelled generations (#1251).
+        if (sizing.floored) {
+            IMP_LOG_WARN(
+                "KV cache: only %.0f MiB was left after the weight caches, and the allocator "
+                "keeps %.0f MiB of it as headroom — nothing remained to size the pool from, so "
+                "it fell back to the %d-block floor (%.0f tokens) instead of the planned %d "
+                "blocks. Requests longer than %.0f tokens will be cancelled at admission. "
+                "Lower the weight-cache demand (moe.reserve_mib, --kv-fp8) or raise --vram-budget.",
+                free_now / (1024.0 * 1024.0), headroom / (1024.0 * 1024.0), sizing.blocks,
+                static_cast<double>(sizing.blocks) * kv_bs, max_blocks_planned,
+                static_cast<double>(sizing.blocks) * kv_bs);
         }
     }
 

--- a/tests/test_kv_residual_sizing.cpp
+++ b/tests/test_kv_residual_sizing.cpp
@@ -1,0 +1,99 @@
+// kv_blocks_from_residual — the arithmetic that sizes the KV pool from what is
+// left after the weight caches are built.
+//
+// This is a CPU-lane test on purpose. The decision it covers is pure integer
+// arithmetic, but until #1251 it lived inline in engine_kv_cache_init.cpp,
+// where nothing could reach it without a GPU and a 22 GB checkpoint — so the
+// one case that matters was never asserted anywhere.
+//
+// The case that matters: the caller subtracts the allocator headroom from the
+// measured residual. If whoever reserved room *for* this pool did not also
+// reserve the headroom, the residual is entirely headroom, `room` is 0, and the
+// pool silently falls to the floor. That is a rescue, not a size, and
+// `floored` is what tells the two apart.
+
+#include <gtest/gtest.h>
+
+#include "memory/vram_query.h"
+
+namespace imp {
+namespace {
+
+constexpr size_t kMiB = 1024ULL * 1024ULL;
+
+// Qwen3.6-35B-A3B-UD-Q4_K_M on a 32 GiB 5090: 10 attention layers, block_size
+// 32, 2 KV heads, head_dim 256, FP16 -> 640 KiB per block.
+constexpr size_t k35bPerBlock = 640ULL * 1024ULL;
+
+TEST(KvResidualSizing, PlanFitsSoNothingIsClamped) {
+    const auto s = kv_blocks_from_residual(8192 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(s.blocks, 4096);
+    EXPECT_FALSE(s.clamped);
+    EXPECT_FALSE(s.floored);
+}
+
+TEST(KvResidualSizing, ResidualSmallerThanPlanClampsButDoesNotFloor) {
+    // 2416 MiB free - 1630 MiB headroom = 786 MiB -> 1257 blocks. These are the
+    // post-fix numbers measured on the #1251 repro.
+    const auto s = kv_blocks_from_residual(2416 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(s.blocks, 1257);
+    EXPECT_TRUE(s.clamped);
+    EXPECT_FALSE(s.floored) << "a pool smaller than the plan is normal — the plan is a "
+                               "projection, the residual is the truth";
+}
+
+// The #1251 regression itself, with the numbers straight out of the bug report.
+TEST(KvResidualSizing, HeadroomExceedingResidualFloorsAndSaysSo) {
+    const auto s = kv_blocks_from_residual(1264 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(s.blocks, 16) << "the floor, not a computed size";
+    EXPECT_TRUE(s.clamped);
+    EXPECT_TRUE(s.floored) << "#1251: nothing was left to size the pool from, and the load "
+                              "reported success anyway";
+}
+
+TEST(KvResidualSizing, ResidualExactlyHeadroomLeavesNothing) {
+    const auto s = kv_blocks_from_residual(1630 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(s.blocks, 16);
+    EXPECT_TRUE(s.floored);
+}
+
+// One block short of the floor still floors; exactly the floor does not.
+TEST(KvResidualSizing, FloorBoundaryIsExact) {
+    const size_t headroom = 1000 * kMiB;
+    const auto below = kv_blocks_from_residual(headroom + 15 * k35bPerBlock, headroom,
+                                               k35bPerBlock, 4096, 16);
+    EXPECT_EQ(below.blocks, 16);
+    EXPECT_TRUE(below.floored);
+
+    const auto at = kv_blocks_from_residual(headroom + 16 * k35bPerBlock, headroom, k35bPerBlock,
+                                            4096, 16);
+    EXPECT_EQ(at.blocks, 16);
+    EXPECT_TRUE(at.clamped);
+    EXPECT_FALSE(at.floored) << "16 blocks that were actually computed is not the rescue path";
+}
+
+TEST(KvResidualSizing, MoreRoomThanPlannedNeverGrowsThePool) {
+    const auto s = kv_blocks_from_residual(30000 * kMiB, 1630 * kMiB, k35bPerBlock, 64, 16);
+    EXPECT_EQ(s.blocks, 64) << "the residual can only shrink the plan, never grow it";
+    EXPECT_FALSE(s.clamped);
+}
+
+TEST(KvResidualSizing, DegenerateInputsAreInert) {
+    const auto zero_block = kv_blocks_from_residual(8192 * kMiB, 1630 * kMiB, 0, 4096, 16);
+    EXPECT_EQ(zero_block.blocks, 4096) << "per_block==0 must not divide";
+    EXPECT_FALSE(zero_block.clamped);
+
+    const auto no_plan = kv_blocks_from_residual(8192 * kMiB, 1630 * kMiB, k35bPerBlock, 0, 16);
+    EXPECT_EQ(no_plan.blocks, 0);
+    EXPECT_FALSE(no_plan.floored);
+}
+
+TEST(KvResidualSizing, FreeBelowHeadroomDoesNotUnderflow) {
+    // free < headroom must saturate at 0 room, not wrap around size_t.
+    const auto s = kv_blocks_from_residual(100 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(s.blocks, 16);
+    EXPECT_TRUE(s.floored);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
Follow-up to #1251 (fixed in #1252). That PR fixed the *cause*; this one fixes
the reason nobody found it for so long.

## Why this is worth a second PR

#1251 loaded successfully and then cancelled every generation at ~476 tokens.
The KV pool had been **rescued** by the 16-block floor, not sized — and nothing
said so. The hard failure meant for exactly this case sits behind
`vram_budget_bytes() > 0`, which the default server path never sets:

```cpp
if (vram_budget_bytes() > 0 && per_block_total_bytes > 0) {   // never true by default
    ...
    IMP_LOG_ERROR("--vram-budget %zu MiB is too small for this model: ...");
```

So the first evidence an operator gets is `finish_reason: "cancelled"` with an
empty `content`, hours away from the arithmetic that caused it.

## What changed

**1. The decision moves next to the constant it depends on.**
`kv_blocks_from_residual()` now lives beside `vram_allocator_headroom()` in
`vram_query.h`, whose header comment already documents this exact failure mode:

> Engine::init and the VRAM budget must agree on it — they used to disagree by
> 1118 MiB on 32 GB, and the KV pool happily consumed the difference (#1103).

#1251 was a **third** consumer of that headroom that had never been reconciled —
the same class, a different caller, four months later. Putting the arithmetic
beside the constant makes the coupling visible rather than implied.

**2. `floored` separates two things the old code conflated.**
"Smaller than planned" is normal — the plan is a projection, the measured
residual is the truth. "Nothing was left to size it from" is always a fault. Only
the second now warns:

```
KV cache: only 1264 MiB was left after the weight caches, and the allocator keeps
1630 MiB of it as headroom — nothing remained to size the pool from, so it fell
back to the 16-block floor (512 tokens) instead of the planned 4096 blocks.
Requests longer than 512 tokens will be cancelled at admission. Lower the
weight-cache demand (moe.reserve_mib, --kv-fp8) or raise --vram-budget.
```

**3. The arithmetic gets its first tests** — 8 of them, in the CPU lane
(test-core 887 → 895). It was previously inline in `engine_kv_cache_init.cpp`,
unreachable without a GPU and a 22 GB checkpoint, which is why the #1251 case
was never asserted anywhere. The tests carry the real numbers from the bug report
(1264 MiB free against 1630 MiB headroom → floored).

## Verification

**Behaviour unchanged.** Same block counts on every model measured — Qwen3-30B-A3B-Q4_K_M
1280 blocks, Qwen3.6-35B-A3B-UD-Q4_K_M ~1252 — and no WARN on healthy loads.

**Mutation-validated** (green tests prove nothing on their own):

| Mutation | Tests killed |
|---|---|
| `fits < floor_blocks` → `<=` | 1 (the boundary test written for it) |
| headroom never subtracted | 5 |
| `floored` hardcoded false | 4 |
| floor ignored on clamp | 4 |

**Gate:** tg128 **287.98** vs baseline 287.19 (+0.28%, spread 0.10% over 3
processes), pp512 12608.52 (+1.63%), own_peak 20718 MiB (+0.01%), degeneration
smoke PASS, 835 unit tests green.

## Still open, deliberately

The three KV-reserve computations (`vram_budget.cpp` plans 4096 blocks,
`pre_dequant_phase3_moe.cu` reserves for 16K tokens capped at 1 GiB,
`engine_kv_cache_init.cpp` subtracts the headroom) remain three separate numbers.
#1252 removed the collision and this PR makes a future one audible, but unifying
them is a refactor, not a bugfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8