### PR TITLE
fix(docker): keep the warm cache and library reserve across container recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Changed
+
+- **The container keeps its caches across recreation.** `docker-compose.yml`
+  gives imp-server a named `imp-cache` volume, and the image now creates
+  `/home/imp/.cache/imp` so a fresh volume inherits `imp`'s ownership — without
+  that, mounting one leaves a root-owned directory the server cannot write, which
+  disables *both* the warm weight cache (#956) and the library-reserve
+  measurement. Cold init on Qwen3-14B-NVFP4 drops from **7949 ms to 2099 ms**
+  (median of 3, spreads 1106/178 ms) once the volume is populated.
+
 ### Fixed
 
 - **A MoE GGUF could load fine and then cancel every generation** (#1251). The

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,10 +133,20 @@ COPY --from=builder /tmp/test-gd[n] /usr/local/bin/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Non-root user with write access to /models
+# Non-root user with write access to /models and to the cache directory.
+#
+# The cache dir must EXIST in the image and be owned by imp, even though nothing
+# is shipped in it: Docker only copies ownership into a fresh named volume from
+# a directory that is already there. Mounting a volume over a path the image
+# does not create yields a root-owned mount that `imp` cannot write, which
+# silently disables both caches that live here — the library-reserve
+# measurement (A1.5) and the warm weight cache (#956). Measured: with the volume
+# and without this line, "library reserve: could not write" and "Warm cache: not
+# writable — skipping", i.e. mounting the volume was WORSE than not mounting it.
 RUN useradd -m -s /bin/bash imp \
-    && mkdir -p /models \
-    && chown imp:imp /models
+    && mkdir -p /models /home/imp/.cache/imp \
+    && chown imp:imp /models \
+    && chown -R imp:imp /home/imp/.cache
 
 USER imp
 WORKDIR /home/imp

--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ x86-64 + sm_120a):
 # Drop a GGUF or SafeTensors model into ./models/
 mkdir -p models
 
-# Run the server from the prebuilt image
-docker run --gpus all -v ./models:/models -p 8080:8080 \
+# Run the server from the prebuilt image. The cache volume is optional but
+# pays for itself on the second start: it holds the transformed weights
+# (Qwen3-14B-NVFP4 init 7.9 s -> 2.1 s) and the measured library reserve.
+docker run --gpus all -v ./models:/models -v imp-cache:/home/imp/.cache/imp \
+  -p 8080:8080 \
   ghcr.io/kekzl/imp:latest --model /models/your-model.gguf
 
 # Hit the OpenAI-compatible endpoint (the model id is the file/dir basename;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
       - "${IMP_PORT:-8080}:${IMP_PORT:-8080}"
     volumes:
       - ${IMP_MODELS_DIR:-./models}:/models
+      # Survives `up --force-recreate` and image updates. Holds the
+      # library-reserve measurement (a model that charges the 3900 MiB constant
+      # instead of its measured value gives up that much KV pool — 2725 MiB on
+      # Qwen3.6-35B-A3B-UD-Q4_K_M) and the warm weight cache (#956, cold boots
+      # skip weight conversion). Both are rebuilt if the volume is dropped.
+      - imp-cache:/home/imp/.cache/imp
     environment:
       - IMP_MODEL=${IMP_MODEL:-}
       - IMP_HOST=0.0.0.0
@@ -119,6 +125,7 @@ services:
       - prometheus
 
 volumes:
+  imp-cache:
   open-webui:
   prometheus-data:
   grafana-data:


### PR DESCRIPTION
## The gap

imp writes two caches under `~/.cache/imp`:

- the **warm weight cache** (#956 — "cold boots skip weight conversion")
- the **measured library reserve** (A1.5 — a model that charges the 3900 MiB
  constant instead of its measured value gives up that much KV pool)

Neither survives `docker compose up --force-recreate` or an image update:
imp-server was the **only** service in `docker-compose.yml` without a volume,
while open-webui, Prometheus and Grafana all have one. So the default deployment
— which is also how the project ships — rebuilt both caches on every start.

## Why the one-line fix is wrong

Adding just the volume makes things **worse**. A named volume mounted over a path
the image does not create is owned by `root`, and the server runs as `imp`
(uid 1001). Measured, with the volume and without the image change:

```
library reserve: could not write /home/imp/.cache/imp/library_reserve
                 — the next start will charge the constant again
Warm cache: /home/imp/.cache/imp/warm/... not writable — skipping
```

Both caches worked *without* the volume (container filesystem, owned by `imp`)
and stopped working *with* it. Docker only copies ownership into a fresh volume
from a directory that already exists in the image, and `/home/imp/.cache` did not
exist. Hence the `mkdir -p` + `chown` in the Dockerfile — it is the part that
makes the volume line safe, not a tidy-up.

## Measured

Qwen3-14B-NVFP4, init time, median of 3 independent container starts:

| | median | runs | spread |
|---|---|---|---|
| cold (no volume) | **7948.93 ms** | 7864.56 / 7948.93 / 8970.97 | 1106 ms |
| warm (populated volume) | **2098.59 ms** | 1973.82 / 2098.59 / 2151.30 | 178 ms |

**−73.6%**, and the effect is ~5× the cold spread. The gain is the 2.90 GiB of
transformed uploads being mapped instead of reconverted.

**It scales with how much conversion the checkpoint needs, and I am not claiming
more than I measured:** on Qwen3.6-35B-A3B-UD-Q4_K_M the warm cache is only
0.05 GiB, and there the difference (~5193 → ~4902 ms) sits *inside* the cold
spread — so on that model it is not a demonstrated win.

Dropping the volume stays safe: both caches rebuild from scratch, and a missing
or corrupt file already reads as "charge the constant and measure again".

## What this does NOT do

I expected the recovered library reserve (3900 → 1821 MiB charged) to enlarge the
KV pool. **It does not** — measured 1252 → 1257 blocks, i.e. noise. The freed
budget is taken by the NVFP4 MoE cache first (`moe_budget = free_mem −
total_reserve`), so it becomes cache coverage rather than context. Recording that
here because the opposite is the intuitive guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8