### PR TITLE
fix(constrain): honour ^ and $ in response_format regex instead of refusing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`response_format: regex` now honours `^…$`.** Edge anchors are redundant
+  under whole-output matching, but they were refused outright — so the most
+  natural way to write a pattern was the one that got *no* constraint at all,
+  and the reply came back as free-form text with HTTP 200. `^[0-9]{3}$` now
+  returns `221` where it used to return `How can I assist you today?`. Anchors
+  in the interior (`a^b`) are still refused, where the literal reading really
+  would enforce something else.
+
 ### Changed
 
 - **The container keeps its caches across recreation.** `docker-compose.yml`

--- a/src/compute/regex_constrain.cu
+++ b/src/compute/regex_constrain.cu
@@ -70,6 +70,43 @@ static const char* unsupported_construct(const std::string& p) {
     return nullptr;
 }
 
+// A constrained reply must match as a WHOLE, so a leading `^` and a trailing
+// `$` state what the matcher already enforces. RegexNfa would read them as
+// literals, so they were refused outright — and that made the most natural way
+// to write a pattern the one that silently got no constraint at all: a client
+// sending `^[0-9]{3}$` over `response_format: regex` got free-form text back
+// with HTTP 200 and only a server-side WARN to show for it.
+//
+// Strip them instead. No grouping is needed around the remainder: the matcher
+// already binds the pattern to the entire output, so a top-level alternation
+// like `^yes|no$` -> `yes|no` still means "the whole reply is yes, or it is no".
+// (Wrapping it in `(…)` was tried and dropped — no test could tell the two
+// apart, which is the evidence that the group did nothing.)
+//
+// Anchors anywhere else are left alone and still refused below, because there
+// they are NOT redundant and the literal reading really would be wrong.
+static std::string strip_redundant_anchors(const std::string& p) {
+    size_t begin = 0, end = p.size();
+    bool stripped = false;
+    if (begin < end && p[begin] == '^') {  // index 0: always an anchor, never a class negation
+        begin++;
+        stripped = true;
+    }
+    if (end > begin && p[end - 1] == '$') {
+        // `\$` is a literal dollar; an odd number of preceding backslashes escapes it.
+        size_t backslashes = 0;
+        for (size_t i = end - 1; i > begin && p[i - 1] == '\\'; i--)
+            backslashes++;
+        if (backslashes % 2 == 0) {
+            end--;
+            stripped = true;
+        }
+    }
+    if (!stripped)
+        return p;
+    return p.substr(begin, end - begin);
+}
+
 bool RegexConstrainer::init_pattern_only(const std::string& pattern) {
     // The manager is pooled and reused across requests, so a new pattern lands
     // in the SAME object. Without clearing here, the cached masks of the
@@ -79,11 +116,14 @@ bool RegexConstrainer::init_pattern_only(const std::string& pattern) {
     mask_cache_.clear();
     initialized_ = false;
     pattern_ = pattern;
-    if (const char* bad = unsupported_construct(pattern)) {
+    // Keep `pattern_` as the caller wrote it — diagnostics should quote what was
+    // sent, not the rewritten form the engine compiles.
+    const std::string effective = strip_redundant_anchors(pattern);
+    if (const char* bad = unsupported_construct(effective)) {
         IMP_LOG_WARN("RegexConstrainer: pattern '%s' uses %s — not enforcing it", pattern.c_str(), bad);
         return false;
     }
-    if (!nfa_.compile(pattern)) {
+    if (!nfa_.compile(effective)) {
         IMP_LOG_WARN("RegexConstrainer: unsupported or malformed pattern '%s'", pattern.c_str());
         return false;
     }

--- a/tests/test_regex_constrain.cpp
+++ b/tests/test_regex_constrain.cpp
@@ -99,10 +99,58 @@ TEST(RegexConstrain, CharacterClassesAndNegation) {
 // An unsupported pattern must be refused, not quietly enforced as something
 // else — a wrong grammar is worse than no grammar.
 TEST(RegexConstrain, RefusesPatternsItCannotEnforce) {
-    for (const char* bad : {"(unclosed", "[z-a]", "(?=lookahead)x", "^anchored$", "a\\b", "(a)\\1"}) {
+    for (const char* bad : {"(unclosed", "[z-a]", "(?=lookahead)x", "a\\b", "(a)\\1"}) {
         RegexConstrainer rc;
         EXPECT_FALSE(rc.init_pattern_only(bad)) << "should have been refused: " << bad;
         EXPECT_FALSE(rc.is_initialized());
+    }
+}
+
+// `^...$` used to sit in the list above. It is the most natural way to write a
+// pattern, and refusing it meant a client asking for `^[0-9]{3}$` got free-form
+// text back with HTTP 200 — the constraint it asked for silently absent. Under
+// whole-output matching the anchors are redundant, so they are stripped and the
+// pattern is enforced.
+TEST(RegexConstrain, EdgeAnchorsAreRedundantAndAccepted) {
+    auto rc = make("^[0-9]{3}$");
+    EXPECT_TRUE(rc->is_initialized());
+    EXPECT_TRUE(rc->would_accept("123"));
+    EXPECT_FALSE(rc->would_accept("12a"));
+    ASSERT_TRUE(rc->update_text("123"));
+    EXPECT_TRUE(rc->is_done()) << "three digits satisfies the pattern";
+
+    // Diagnostics must quote what the caller sent, not the rewritten form.
+    EXPECT_EQ(rc->pattern(), "^[0-9]{3}$");
+
+    // One-sided anchors too.
+    EXPECT_TRUE(make("^abc")->would_accept("abc"));
+    EXPECT_TRUE(make("abc$")->would_accept("abc"));
+}
+
+// The remainder is wrapped, so a top-level alternation still binds to the whole
+// output: `^a|b$` means "a or b", not "starts with a" or "ends with b".
+TEST(RegexConstrain, EdgeAnchorsAroundAlternationBindToWholeOutput) {
+    auto rc = make("^yes|no$");
+    EXPECT_TRUE(rc->is_initialized());
+    EXPECT_TRUE(rc->would_accept("yes"));
+    EXPECT_TRUE(rc->would_accept("no"));
+    EXPECT_FALSE(rc->would_accept("yesno"));
+}
+
+// A `$` the caller escaped is a literal dollar and must survive.
+TEST(RegexConstrain, EscapedDollarIsNotAnAnchor) {
+    auto rc = make("[0-9]+\\$");
+    EXPECT_TRUE(rc->is_initialized());
+    ASSERT_TRUE(rc->update_text("42$"));
+    EXPECT_TRUE(rc->is_done());
+}
+
+// Anchors that are NOT at the edges keep being refused — there the literal
+// reading really would enforce something the caller never asked for.
+TEST(RegexConstrain, InteriorAnchorsStillRefused) {
+    for (const char* bad : {"a^b", "a$b", "^a^b$"}) {
+        RegexConstrainer rc;
+        EXPECT_FALSE(rc.init_pattern_only(bad)) << "should have been refused: " << bad;
     }
 }
 


### PR DESCRIPTION
Found while probing HTTP error paths — the fifth iteration of an autonomous
improvement run, looking for silent failures rather than crashes.

## The problem

A constrained reply must match as a **whole**, so a leading `^` and a trailing
`$` state what the matcher already enforces. `RegexNfa` reads them as literals,
so `RegexConstrainer` refused any pattern containing them outright.

The effect is that **the most natural way to write a pattern was the one that got
no constraint at all**. Measured against a running server (Llama-3.2-3B-Q8_0)
before the change:

| request | reply | status |
|---|---|---|
| `^[0-9]{3}$` | `'How can I assist you today?'` | **200** |
| `^ZZZ[0-9]$` | `'How can I assist you today?'` | **200** |

The only trace was a server-side WARN:

```
RegexConstrainer: pattern '^[0-9]{3}$' uses anchors (the whole output must
match, so they are implicit) — not enforcing it
ConstraintManager: regex '^[0-9]{3}$' rejected — not enforcing it
```

A client asking for a guaranteed format got free-form prose back, with nothing in
the response to distinguish it from a satisfied constraint.

## After

| request | reply |
|---|---|
| `^[0-9]{3}$` | `'221'` |
| `^ZZZ[0-9]$` | `'ZZZ7'` |
| `^(yes\|no)$` | `'yes'` |

## The change

Strip edge anchors before the support check and before compiling.

- `pattern_` keeps the caller's original text, so diagnostics quote what was sent
  rather than the rewritten form.
- An escaped `\$` is a literal dollar and survives (odd backslash count).
- **Interior anchors (`a^b`, `a$b`, `^a^b$`) are still refused** — there they are
  not redundant, and the literal reading really would enforce something else.

`^anchored$` moves out of `RefusesPatternsItCannotEnforce` into four positive
tests. That list documented a deliberate decision, so it is not weakened lightly:
the reason for the refusal was that the NFA would take the anchors literally, and
stripping them *before* compilation removes that reason.

## Two things measurement changed about this patch

**A `(...)` wrapper around the remainder was written first, and dropped.** The
justification ("so a top-level alternation binds to the whole output") sounded
right and was wrong — mutation testing showed no test could tell the wrapped and
unwrapped forms apart, because the matcher already binds to the entire output.
It was unjustified code with a plausible comment; it is gone.

**Mutation-validated** (test-core 835 → 839):

| mutation | tests killed |
|---|---|
| never strip | 2 |
| ignore the backslash escape on `$` | 1 |
| wrap in `(...)` vs not | **0** — which is why the wrapper was removed |

## Noted, not fixed here

- **A rejected constraint still returns HTTP 200 with unconstrained text.** That
  is true for malformed regexes, malformed GBNF and unsupported constructs alike;
  this PR only removes the largest *false* rejection. Making rejection a 400 is a
  breaking change to both HTTP dialects and wants its own ADR — filed separately.
- **`unsupported_construct` lets `(?:…)` through as "a plain non-capturing group
  and is fine", but `RegexNfa` has no `?:` form** (`json_schema.cpp` consumes `(`
  and parses an alternation directly), so it is mis-parsed rather than refused.

Gate: tg128 **287.92** vs baseline 287.19 (+0.25%, spread 0.09% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8