### PR TITLE
fix(constrain): parse (?:...) as a group instead of compiling it to something else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`(?:…)` is honoured instead of mis-compiled.** The support check let
+  non-capturing groups through as "fine", but the pattern engine had no `?:`
+  form — `?` was read as a quantifier with no atom and `:` as a literal, so
+  `(?:a|b)c` compiled to `(:a|b)c`: it matched `bc`, rejected `ac`, and reported
+  a successful compile. Affects `response_format: regex` and JSON-Schema
+  `pattern`, which share the engine.
+
 - **`response_format: regex` now honours `^…$`.** Edge anchors are redundant
   under whole-output matching, but they were refused outright — so the most
   natural way to write a pattern was the one that got *no* constraint at all,

--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -747,6 +747,15 @@ bool RegexNfa::parse_atom(Frag& out) {
 
     if (c == '(') {
         pos_++;  // consume '('
+        // `(?:…)` is a non-capturing group. Nothing here captures and
+        // backreferences are refused upstream, so the marker carries no
+        // matching semantics — skip it and parse the body as an ordinary group.
+        // Without this, `?` was read as a quantifier with no atom and `:` as a
+        // literal, so `(?:a|b)c` compiled to `(:a|b)c`: it matched "bc", not
+        // "ac", while reporting a successful compile. A wrong pattern enforced
+        // silently is the one failure mode this parser must not have.
+        if (pos_ + 1 < src_->size() && (*src_)[pos_] == '?' && (*src_)[pos_ + 1] == ':')
+            pos_ += 2;
         if (!parse_alt(out))
             return false;
         if (pos_ >= src_->size() || (*src_)[pos_] != ')') {

--- a/tests/test_regex_constrain.cpp
+++ b/tests/test_regex_constrain.cpp
@@ -154,6 +154,34 @@ TEST(RegexConstrain, InteriorAnchorsStillRefused) {
     }
 }
 
+// `(?:…)` passed the support check ("a plain non-capturing group and is fine")
+// but the engine had no `?:` form: `?` was read as a quantifier with no atom and
+// `:` as a literal, so `(?:a|b)c` compiled to `(:a|b)c` — it accepted "bc",
+// rejected "ac", and reported a successful compile throughout. Accepted AND
+// enforced as something else is the one outcome this layer exists to prevent.
+TEST(RegexConstrain, NonCapturingGroupIsHonoured) {
+    auto plain = make("(?:abc)");
+    EXPECT_TRUE(plain->would_accept("abc"));
+
+    auto alt = make("(?:a|b)c");
+    EXPECT_TRUE(alt->would_accept("ac")) << "the first branch was lost to the ':' literal";
+    EXPECT_TRUE(alt->would_accept("bc"));
+    EXPECT_FALSE(alt->would_accept(":ac")) << "':' must not be matchable";
+
+    EXPECT_TRUE(make("x(?:yz)")->would_accept("xyz"));
+
+    // Quantified — the reason non-capturing groups get written at all.
+    // would_accept asks "is this still inside the language", so a partial
+    // repetition passes it; completeness is is_done()'s question.
+    auto rep = make("(?:ab)+");
+    ASSERT_TRUE(rep->update_text("abab"));
+    EXPECT_TRUE(rep->is_done());
+
+    auto partial = make("(?:ab)+");
+    ASSERT_TRUE(partial->update_text("aba"));
+    EXPECT_FALSE(partial->is_done()) << "half a repetition is not a complete match";
+}
+
 // Documented tolerance rather than a silent surprise: the shared engine reads a
 // reversed bound as the lower one instead of rejecting it, so `a{2,1}` enforces
 // exactly two. Pinned so a future engine change that starts rejecting it is a


### PR DESCRIPTION
Follow-up to #1255, and the second half of the same finding: a constraint layer
whose job is "enforce this or refuse it" had a third outcome — *enforce something
else*.

## The bug

`unsupported_construct` explicitly allows non-capturing groups:

```cpp
if (p[i] == '(' && i + 1 < p.size() && p[i + 1] == '?') {
    // (?: ... ) is a plain non-capturing group and is fine.
    if (i + 2 < p.size() && p[i + 2] == ':')
        continue;
```

The engine behind it has no `?:` form. `parse_atom` consumes `(` and calls
`parse_alt` directly (`json_schema.cpp`), so `?` became a quantifier with no atom
and `:` an ordinary literal. Probed directly:

| pattern | compiles | behaviour |
|---|---|---|
| `(?:abc)` | ✅ | does **not** match `abc` |
| `(?:a\|b)c` | ✅ | matches `bc`, **rejects** `ac` — i.e. it became `(:a\|b)c` |
| `x(?:yz)` | ✅ | does **not** match `xyz` |

Every one reports success. The refusal path directly above this says *"a wrong
grammar is worse than no grammar"* — this construct was neither refused nor
honoured, which is the case that comment is about.

Both users of the engine are affected: `response_format: regex` and JSON-Schema
`pattern`.

## The fix

Skip the `?:` marker in `parse_atom`. It carries no matching semantics here —
nothing captures, and backreferences are refused upstream — so the body parses as
an ordinary group.

Five assertions added: plain group, both alternation branches, suffix position,
and a quantified repetition both complete and incomplete. test-core 895 → 900.

## Mutation validation, including the one that survived

| mutation | tests killed |
|---|---|
| remove the skip | 1 |
| skip one character instead of two | 1 |
| match `?` without requiring `:` | **0** |

The survivor is worth recording rather than papering over with a test written to
kill it. The only other `(?` form, `(?=`, is refused by `unsupported_construct`
*before* it reaches the parser, so no input through `RegexConstrainer` can
distinguish the two. The `:` check is defensive against a caller that reaches the
engine without that gate — which is precisely what JSON-Schema `pattern` does.

## Testing note

**No perf gate on this one.** It is host-side parser logic with no kernel or
hot-path involvement, and the GPU is back to serving the user's imp-server, so a
gate run would have displaced a live service to measure something it cannot move.
Full CPU lane is green: 900 tests, 840 passed, 60 GPU-skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8