### PR TITLE
fix(server): reject a constraint that cannot be enforced instead of answering anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Changed
+
+- **A constraint imp cannot compile is now a `400`, not an unconstrained
+  answer** (#1256). `response_format: regex`/`grammar` and the `guided_regex` /
+  `guided_grammar` / `grammar` aliases are validated at admission with the same
+  parsers the engine uses; the reply names the pattern and, for GBNF, forwards
+  the parser's own diagnostic. Previously the rejection was logged server-side
+  and the request answered with free-form text at HTTP 200, which a caller could
+  not distinguish from a satisfied constraint. **Breaking:** a client sending a
+  pattern imp refuses now gets an error instead of an answer. The two *false*
+  rejections that would have made this fire on legitimate input were removed
+  first (`^…$`, `(?:…)`). JSON-Schema validation is not covered yet.
+
 ### Fixed
 
 - **`(?:…)` is honoured instead of mis-compiled.** The support check let

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,6 +532,7 @@ if(IMP_BUILD_SERVER)
         tools/imp-server/anthropic.cpp
         tools/imp-server/responses.cpp
         tools/imp-server/handlers.cpp
+        tools/imp-server/constraint_validation.cpp
         tools/imp-server/handlers_chat.cpp
         tools/imp-server/handlers_chat_core.cpp
         tools/imp-server/handlers_chat_params.cpp
@@ -712,6 +713,11 @@ if(IMP_BUILD_TESTS)
             tests/test_reasoning_reconcile.cpp
             tests/test_stream_reasoning_split.cpp
             tests/test_server_auth.cpp
+            # Admission-time rejection of unenforceable constraints (#1256). The
+            # alias coverage is the part that rots: a new spelling in the
+            # parameter parser without a line here is a validation bypass.
+            tools/imp-server/constraint_validation.cpp
+            tests/test_constraint_validation.cpp
             tests/test_server_args.cpp
             tests/test_base64.cpp)
         target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server

--- a/tests/test_constraint_validation.cpp
+++ b/tests/test_constraint_validation.cpp
@@ -1,0 +1,121 @@
+// =============================================================================
+// Admission-time validation of constrained-decoding requests (#1256).
+//
+// WHY: a constraint imp cannot compile used to be dropped and the request
+// answered anyway — HTTP 200, free-form text, nothing in the reply telling the
+// caller its guarantee was not applied. These assert the 400 contract on the
+// CPU, in CI, where the real handler never runs.
+//
+// The alias coverage is the part most likely to rot: `regex`/`pattern`,
+// `grammar`/`gbnf`, `guided_regex`, `guided_grammar` and llama.cpp's bare
+// `grammar` all reach the same engine, so validation that misses one is a
+// bypass, not a gap. A new spelling added to the parameter parser without a
+// matching line here is exactly the regression these catch.
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include "handlers_internal.h"
+
+#include <nlohmann/json.hpp>
+#include <httplib.h>
+
+using json = nlohmann::json;
+
+namespace {
+
+// Returns true when the body is accepted (no 400 written).
+bool accepts(const json& body) {
+    httplib::Response res;
+    return validate_constraints(body, res);
+}
+
+// Returns the error message a rejected body produces (empty when accepted).
+std::string rejection_message(const json& body) {
+    httplib::Response res;
+    if (validate_constraints(body, res))
+        return {};
+    EXPECT_EQ(res.status, 400);
+    auto parsed = json::parse(res.body, nullptr, false);
+    if (parsed.is_discarded() || !parsed.contains("error"))
+        return "<unparseable>";
+    EXPECT_EQ(parsed["error"].value("type", ""), "invalid_request_error");
+    return parsed["error"].value("message", "");
+}
+
+json regex_body(const std::string& pattern) {
+    return json{{"response_format", {{"type", "regex"}, {"regex", pattern}}}};
+}
+
+json grammar_body(const std::string& gbnf) {
+    return json{{"response_format", {{"type", "grammar"}, {"grammar", gbnf}}}};
+}
+
+}  // namespace
+
+TEST(ConstraintValidation, UnconstrainedRequestIsUntouched) {
+    EXPECT_TRUE(accepts(json::object()));
+    EXPECT_TRUE(accepts(json{{"max_tokens", 16}}));
+    EXPECT_TRUE(accepts(json{{"response_format", {{"type", "text"}}}}));
+    // json_object carries no pattern to compile.
+    EXPECT_TRUE(accepts(json{{"response_format", {{"type", "json_object"}}}}));
+}
+
+TEST(ConstraintValidation, EnforceablePatternsAreAccepted) {
+    EXPECT_TRUE(accepts(regex_body("[0-9]{3}")));
+    // Edge anchors are redundant, not unsupported (#1255) — they must NOT 400.
+    EXPECT_TRUE(accepts(regex_body("^[0-9]{3}$")));
+    EXPECT_TRUE(accepts(regex_body("^(yes|no)$")));
+    // Non-capturing groups compile since #1257.
+    EXPECT_TRUE(accepts(regex_body("(?:ab)+")));
+    EXPECT_TRUE(accepts(grammar_body("root ::= \"yes\" | \"no\"")));
+}
+
+TEST(ConstraintValidation, MalformedRegexIsRejectedWithItsPattern) {
+    const std::string msg = rejection_message(regex_body("^[0-9{3}$"));
+    EXPECT_NE(msg.find("^[0-9{3}$"), std::string::npos)
+        << "the message must quote the pattern the caller sent";
+    EXPECT_NE(msg.find("cannot be enforced"), std::string::npos);
+}
+
+TEST(ConstraintValidation, UnsupportedConstructsAreRejected) {
+    for (const char* bad : {"(?=lookahead)x", "a\\b", "(a)\\1", "a^b"}) {
+        EXPECT_FALSE(accepts(regex_body(bad))) << "should have been rejected: " << bad;
+    }
+}
+
+// A pattern that matches nothing would decode to an empty string with no
+// explanation, which is the failure this whole change exists to remove.
+TEST(ConstraintValidation, EmptyLanguageIsRejected) {
+    EXPECT_FALSE(accepts(regex_body("[z-a]")));
+}
+
+TEST(ConstraintValidation, MalformedGrammarIsRejectedWithTheParserError) {
+    const std::string msg = rejection_message(grammar_body("root ::= <<<"));
+    EXPECT_NE(msg.find("GBNF"), std::string::npos);
+    // The parser's own diagnostic is forwarded rather than replaced by a generic one.
+    EXPECT_NE(msg.find("unexpected character"), std::string::npos) << "got: " << msg;
+}
+
+// Every spelling the parameter parser accepts must be validated, or the check
+// is bypassable by using an alias.
+TEST(ConstraintValidation, AllRegexSpellingsAreValidated) {
+    EXPECT_FALSE(accepts(json{{"response_format", {{"type", "regex"}, {"regex", "(?=x)y"}}}}));
+    EXPECT_FALSE(accepts(json{{"response_format", {{"type", "regex"}, {"pattern", "(?=x)y"}}}}));
+    EXPECT_FALSE(accepts(json{{"guided_regex", "(?=x)y"}})) << "vLLM spelling";
+}
+
+TEST(ConstraintValidation, AllGrammarSpellingsAreValidated) {
+    EXPECT_FALSE(accepts(json{{"response_format", {{"type", "grammar"}, {"grammar", "root ::= <<<"}}}}));
+    EXPECT_FALSE(accepts(json{{"response_format", {{"type", "grammar"}, {"gbnf", "root ::= <<<"}}}}));
+    EXPECT_FALSE(accepts(json{{"grammar", "root ::= <<<"}})) << "llama.cpp spelling";
+    EXPECT_FALSE(accepts(json{{"guided_grammar", "root ::= <<<"}})) << "vLLM spelling";
+}
+
+// Wrong JSON types must not be read as a constraint — and must not crash.
+TEST(ConstraintValidation, NonStringConstraintFieldsAreIgnored) {
+    EXPECT_TRUE(accepts(json{{"guided_regex", 42}}));
+    EXPECT_TRUE(accepts(json{{"grammar", json::array({1, 2})}}));
+    EXPECT_TRUE(accepts(json{{"response_format", {{"type", "regex"}, {"regex", nullptr}}}}));
+    EXPECT_TRUE(accepts(json{{"response_format", "not-an-object"}}));
+}

--- a/tools/imp-server/constraint_validation.cpp
+++ b/tools/imp-server/constraint_validation.cpp
@@ -1,0 +1,81 @@
+// Admission-time validation of constrained-decoding requests.
+//
+// Split out of handlers.cpp for the same reason bearer_token_matches() lives in
+// utils.cpp: the CPU test lane compiles this file, and handlers.cpp (with its
+// engine, CUDA and httplib-server dependencies) it does not. A validation rule
+// that only runs inside the real handler is a rule CI never checks.
+
+#include "handlers_internal.h"
+#include "utils.h"
+
+#include "compute/regex_constrain.h"
+#include "compute/gbnf_grammar.h"
+
+#include <string>
+#include <vector>
+
+// A constraint imp cannot compile used to be dropped and the request answered
+// anyway: HTTP 200, free-form text, nothing in the reply to distinguish it from
+// a satisfied constraint (#1256). Constrained decoding is a guarantee, so a
+// pattern that cannot back it is a bad request, not a silent downgrade.
+//
+// Validated here, at admission, rather than where the constrainer is built:
+// ensure_constraints_() runs from prefill and decode, where the only way to
+// report this would be to abort a request that was already accepted.
+//
+// The same parsers the engine uses are called, so the two cannot drift into
+// disagreeing about what is enforceable.
+bool validate_constraints(const json& body, httplib::Response& res) {
+    auto reject = [&res](const std::string& message) {
+        res.status = 400;
+        json err = {{"error", {{"message", message}, {"type", "invalid_request_error"}}}};
+        res.set_content(dump_safe(err), "application/json");
+        return false;
+    };
+
+    // Every spelling the parameter parser accepts, so validation cannot be
+    // sidestepped by using the vLLM/llama.cpp aliases.
+    std::string pattern, grammar;
+    if (body.contains("response_format") && body["response_format"].is_object()) {
+        const auto& rf = body["response_format"];
+        const std::string fmt = rf.value("type", "text");
+        if (fmt == "regex") {
+            if (rf.contains("regex") && rf["regex"].is_string())
+                pattern = rf["regex"].get<std::string>();
+            else if (rf.contains("pattern") && rf["pattern"].is_string())
+                pattern = rf["pattern"].get<std::string>();
+        } else if (fmt == "grammar") {
+            if (rf.contains("grammar") && rf["grammar"].is_string())
+                grammar = rf["grammar"].get<std::string>();
+            else if (rf.contains("gbnf") && rf["gbnf"].is_string())
+                grammar = rf["gbnf"].get<std::string>();
+        }
+    }
+    if (pattern.empty() && body.contains("guided_regex") && body["guided_regex"].is_string())
+        pattern = body["guided_regex"].get<std::string>();
+    if (grammar.empty() && body.contains("grammar") && body["grammar"].is_string())
+        grammar = body["grammar"].get<std::string>();
+    if (grammar.empty() && body.contains("guided_grammar") && body["guided_grammar"].is_string())
+        grammar = body["guided_grammar"].get<std::string>();
+
+    if (!pattern.empty()) {
+        // Pattern-only init: no tokenizer needed, so this runs before a model
+        // is touched and costs nothing on the happy path.
+        imp::RegexConstrainer probe;
+        if (!probe.init_pattern_only(pattern))
+            return reject("\"" + pattern +
+                          "\" cannot be enforced as a constraint: unsupported or malformed regex. "
+                          "Lookaround, word boundaries, backreferences and interior anchors are not "
+                          "supported; a pattern matching nothing is refused too.");
+    }
+
+    if (!grammar.empty()) {
+        std::vector<imp::GbnfRule> rules;
+        int32_t root = -1;
+        std::string err;
+        if (!imp::parse_gbnf(grammar, rules, root, &err))
+            return reject("the GBNF grammar cannot be enforced as a constraint: " + err);
+    }
+
+    return true;
+}

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -705,5 +705,9 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
         }
     }
 
+    if (!validate_constraints(body, res))
+        return false;
+
     return true;
 }
+

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -214,6 +214,10 @@ extern thread_local bool g_in_anthropic_shim;
 bool ensure_model_loaded(ServerState& state, const std::string& requested_model, httplib::Response& res);
 bool validate_sampling_params(const json& body, httplib::Response& res);
 
+// Rejects a constraint imp cannot compile with 400 instead of answering
+// unconstrained (#1256). Called from validate_sampling_params.
+bool validate_constraints(const json& body, httplib::Response& res);
+
 // Defined in handlers_chat_core.cpp.
 void log_request_jsonl(ServerState& state, bool skip, const std::chrono::system_clock::time_point& t_start,
                        const std::string& req_id, const std::string& endpoint, const std::string& client_ip,


### PR DESCRIPTION
Closes #1256. Final piece of a three-PR sequence — and the order was the whole
plan, see "Why this is last" below.

## The problem

Constrained decoding is a **guarantee**. A pattern imp could not compile was
dropped and the request answered regardless: HTTP 200, free-form text, nothing in
the reply to distinguish it from a satisfied constraint. The rejection was
detected and logged the entire time; only the caller never learned of it.

| request | before |
|---|---|
| `{"type":"regex","regex":"^[0-9{3}$"}` | **200** `'53'` |
| `{"type":"grammar","grammar":"root ::= <<<"}` | **200** `'Yes'` |

The valid/invalid pair is what makes it concrete: `root ::= "yes" \| "no"`
returned `'yes'`, the malformed grammar returned `'Yes'` — a capital the grammar
forbids. The constraint was genuinely absent, not satisfied by luck.

For an agent loop, that turns a typo in a schema into malformed downstream state
instead of a failed request.

## After

```
BAD  regex    -> 400  "^[0-9{3}$" cannot be enforced as a constraint: unsupported
                      or malformed regex. Lookaround, word boundaries, ...
BAD  grammar  -> 400  the GBNF grammar cannot be enforced as a constraint:
                      unexpected character '<' (at offset 9)
BAD  via alias-> 400  (guided_regex is validated too)

GOOD ^[0-9]{3}$          -> 200  '555'
GOOD root ::= "yes"|"no" -> 200  'yes'
GOOD no constraint       -> 200  'Hello! How can I'
```

## Design

- **Validated at admission** (`validate_sampling_params`), not where the
  constrainer is built: `ensure_constraints_()` runs from prefill and decode,
  where the only way to report this would be to abort a request that was already
  accepted.
- **The same parsers the engine uses** (`RegexConstrainer::init_pattern_only`,
  `parse_gbnf`) — so validation and enforcement cannot drift into disagreeing
  about what is enforceable. No tokenizer needed, so it costs nothing on the
  happy path.
- **Every spelling is covered**: `regex`/`pattern`, `grammar`/`gbnf`,
  `guided_regex`, `guided_grammar`, llama.cpp's bare `grammar`. Validation that
  misses one is a bypass, not a gap.
- **Own translation unit**, for the reason `bearer_token_matches()` lives in
  `utils.cpp`: the CPU lane compiles it and `handlers.cpp` it does not, so these
  rules now actually run in CI.

## Why this is last, and why that matters

**This is a breaking change to both HTTP dialects.** A client sending a pattern
imp refuses now gets an error instead of an answer.

It is deliberately the *third* PR. The two **false** rejections that would have
made a 400 fire on perfectly legitimate input were removed first:

1. #1255 — `^…$` was refused although edge anchors are redundant
2. #1257 — `(?:…)` was accepted and mis-compiled

Had this landed first, every client sending `^\d+$` would have started getting
400s — a self-inflicted outage. The ordering was the point, not an accident.

## Tests

9 tests, test-core 900 → **909**. Mutation-validated:

| mutation | tests killed |
|---|---|
| drop the `guided_regex` alias | 1 |
| drop the bare `grammar` alias | 1 |
| drop the `"pattern"` spelling | 1 |
| skip the regex check | 4 |
| skip the GBNF check | 2 |

The alias mutations are the ones worth having: a new spelling added to the
parameter parser without a matching line here is exactly the regression that
would reopen this hole quietly.

Gate: tg128 **288.32** vs baseline 287.19 (+0.39%, spread 0.07% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

## Not covered

JSON-Schema validation. `{"type":"json_schema"}` with a schema that carries no
enforceable structure still falls through to the any-JSON path rather than
erroring — a different code path with its own free-form-object semantics, noted
in #1256 rather than guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8