### PR TITLE
fix(server): validate the JSON schema at admission too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ there instead of retelling it.
   not distinguish from a satisfied constraint. **Breaking:** a client sending a
   pattern imp refuses now gets an error instead of an answer. The two *false*
   rejections that would have made this fire on legitimate input were removed
-  first (`^…$`, `(?:…)`). JSON-Schema validation is not covered yet.
+  first (`^…$`, `(?:…)`). JSON Schema is covered too: an unresolvable or
+  non-local `$ref` is a 400, while the documented tolerances (a free-form
+  `{"type":"object"}`, an unknown `type`) stay accepted.
 
 ### Fixed
 

--- a/tests/test_constraint_validation.cpp
+++ b/tests/test_constraint_validation.cpp
@@ -119,3 +119,44 @@ TEST(ConstraintValidation, NonStringConstraintFieldsAreIgnored) {
     EXPECT_TRUE(accepts(json{{"response_format", {{"type", "regex"}, {"regex", nullptr}}}}));
     EXPECT_TRUE(accepts(json{{"response_format", "not-an-object"}}));
 }
+
+// ---------------------------------------------------------------------------
+// JSON Schema. The failure here is quieter than the regex one: the engine fell
+// back to any-JSON, so the reply was still JSON and still looked right, while
+// the structure the caller asked for was never enforced.
+// ---------------------------------------------------------------------------
+
+namespace {
+json schema_body(const json& schema) {
+    return json{{"response_format", {{"type", "json_schema"}, {"json_schema", {{"schema", schema}}}}}};
+}
+}  // namespace
+
+TEST(ConstraintValidation, EnforceableSchemasAreAccepted) {
+    EXPECT_TRUE(accepts(schema_body(json::parse(R"({"type":"object","properties":{"a":{"type":"string"}}})"))));
+    EXPECT_TRUE(accepts(schema_body(json::parse(R"({"type":"string","enum":["a","b"]})"))));
+    // A local $ref resolves and must keep working.
+    EXPECT_TRUE(accepts(schema_body(json::parse(
+        R"({"$defs":{"S":{"type":"string"}},"type":"object","properties":{"a":{"$ref":"#/$defs/S"}}})"))));
+}
+
+TEST(ConstraintValidation, UnresolvableRefIsRejected) {
+    const std::string msg = rejection_message(schema_body(json::parse(R"({"$ref":"#/definitions/missing"})")));
+    EXPECT_NE(msg.find("$ref"), std::string::npos) << "got: " << msg;
+}
+
+TEST(ConstraintValidation, NonLocalRefIsRejected) {
+    EXPECT_FALSE(accepts(schema_body(json::parse(R"({"$ref":"https://example.com/x.json"})"))));
+}
+
+// Tolerances, not failures — turning these into 400s would break working
+// clients, so they are pinned as accepted on purpose.
+TEST(ConstraintValidation, SchemaTolerancesStayAccepted) {
+    // Free-form object: documented to mean json_object.
+    EXPECT_TRUE(accepts(schema_body(json::parse(R"({"type":"object"})"))));
+    // Unknown type falls back to string rather than failing the parse.
+    EXPECT_TRUE(accepts(schema_body(json::parse(R"({"type":"nonsense"})"))));
+    // json_schema with no schema member at all carries nothing to validate.
+    EXPECT_TRUE(accepts(json{{"response_format", {{"type", "json_schema"}}}}));
+    EXPECT_TRUE(accepts(json{{"response_format", {{"type", "json_schema"}, {"json_schema", {{"name", "x"}}}}}}));
+}

--- a/tools/imp-server/constraint_validation.cpp
+++ b/tools/imp-server/constraint_validation.cpp
@@ -10,6 +10,7 @@
 
 #include "compute/regex_constrain.h"
 #include "compute/gbnf_grammar.h"
+#include "compute/json_schema.h"
 
 #include <string>
 #include <vector>
@@ -35,10 +36,15 @@ bool validate_constraints(const json& body, httplib::Response& res) {
 
     // Every spelling the parameter parser accepts, so validation cannot be
     // sidestepped by using the vLLM/llama.cpp aliases.
-    std::string pattern, grammar;
+    std::string pattern, grammar, schema;
     if (body.contains("response_format") && body["response_format"].is_object()) {
         const auto& rf = body["response_format"];
         const std::string fmt = rf.value("type", "text");
+        if (fmt == "json_schema" && rf.contains("json_schema") && rf["json_schema"].is_object()) {
+            const auto& js = rf["json_schema"];
+            if (js.contains("schema") && js["schema"].is_object())
+                schema = dump_safe(js["schema"]);
+        }
         if (fmt == "regex") {
             if (rf.contains("regex") && rf["regex"].is_string())
                 pattern = rf["regex"].get<std::string>();
@@ -76,6 +82,24 @@ bool validate_constraints(const json& body, httplib::Response& res) {
         if (!imp::parse_gbnf(grammar, rules, root, &err))
             return reject("the GBNF grammar cannot be enforced as a constraint: " + err);
     }
+
+    // A schema the parser cannot build rejects for a narrow set of reasons — an
+    // unresolvable or unsupported `$ref`, or a document that is not JSON. The
+    // engine logged "Failed to parse JSON schema" and carried on, which for a
+    // `json_schema` request means falling back to any-JSON: the reply is still
+    // JSON, so it looks right, while the structure the caller asked for was
+    // never enforced. That is harder to notice than the regex case, not easier.
+    //
+    // Deliberately NOT rejected here: a schema the parser accepts but cannot
+    // extract structure from (`{"type":"object"}` with no properties) is
+    // documented to mean json_object, and an unknown `type` falls back to
+    // string rather than failing. Those are tolerances, not failures, so
+    // turning them into 400s would break working clients.
+    if (!schema.empty() && !imp::parse_json_schema(schema))
+        return reject("the JSON schema cannot be enforced as a constraint: it could not be "
+                      "parsed. An unresolvable or non-local \"$ref\" is the usual cause; "
+                      "only local \"#/$defs/...\" and \"#/definitions/...\" references are "
+                      "supported.");
 
     return true;
 }


### PR DESCRIPTION
Completes #1256. The regex and GBNF halves landed in #1258; this is the schema
half — and its failure mode is the quietest of the three.

## Why this one is easier to miss

`parse_json_schema()` returns null for an unresolvable `$ref`, a non-local
`$ref`, or a document that is not JSON. The engine logged `Failed to parse JSON
schema` and carried on, which for a `json_schema` request means falling back to
**any-JSON**.

So the reply is still JSON. It still *looks* like the constraint worked. Only the
structure the caller asked for was never enforced — no missing braces, no obvious
tell. The regex version at least came back as visible prose.

| request | before | after |
|---|---|---|
| `{"$ref":"#/definitions/missing"}` | 200, any-JSON | **400** |
| `{"$ref":"https://example.com/x.json"}` | 200, any-JSON | **400** |

## Deliberately still accepted

These are **tolerances, not failures**, and rejecting them would break working
clients:

| schema | why it stays 200 |
|---|---|
| `{"type":"object"}` | free-form, documented to mean `json_object` |
| `{"type":"nonsense"}` | unknown type falls back to string; the parse succeeds |
| `json_schema` with no `schema` member | nothing to validate |

Verified end to end: a real schema still constrains
(`{"color":"..."}`), and a free-form one still returns `{}`.

## How the boundary was found

With a throwaway probe over `parse_json_schema` on eight documents, not by
reading the parser — because the tolerant cases are exactly where reading would
have guessed wrong. `{"type":"nonsense"}` looks like it should fail and does not.
Had I inferred the boundary, `{"type":"nonsense"}` would now be a 400 and every
client using a loose schema would be broken.

## Tests

Four added (accepted schemas including a *resolving* local `$ref`, unresolvable
`$ref`, non-local `$ref`, and the tolerances pinned as accepted).
test-core 909 → **913**.

| mutation | tests killed |
|---|---|
| skip the schema check | 2 |
| never extract the schema | 2 |
| reject every schema | 2 |

The third matters most: it is what keeps a future tightening from turning the
documented tolerances into errors unnoticed.

Gate: tg128 **288.13** vs baseline 287.19 (+0.33%, spread 0.03% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8