### PR TITLE
test(server): pin that constraint validation covers every dialect, not just one

### DIFF
--- a/tests/test_constraint_validation.cpp
+++ b/tests/test_constraint_validation.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "handlers_internal.h"
+#include "responses.h"
 
 #include <nlohmann/json.hpp>
 #include <httplib.h>
@@ -159,4 +160,35 @@ TEST(ConstraintValidation, SchemaTolerancesStayAccepted) {
     // json_schema with no schema member at all carries nothing to validate.
     EXPECT_TRUE(accepts(json{{"response_format", {{"type", "json_schema"}}}}));
     EXPECT_TRUE(accepts(json{{"response_format", {{"type", "json_schema"}, {"json_schema", {{"name", "x"}}}}}}));
+}
+
+// ---------------------------------------------------------------------------
+// Dialect coverage. validate_constraints() is called once, from
+// validate_sampling_params, which every dialect reaches through
+// parse_chat_request_params. /v1/responses gets there via a shim that BUILDS
+// the response_format, so the validation sees the converted body — asserted
+// here rather than assumed, because a shim that stopped converting (or started
+// converting after validation) would reopen the hole for that dialect only.
+// ---------------------------------------------------------------------------
+
+TEST(ConstraintValidation, ResponsesDialectSchemaReachesValidation) {
+    // What a /v1/responses caller sends: text.format, not response_format.
+    json rsp = {{"model", "m"},
+                {"input", "hi"},
+                {"text", {{"format", {{"type", "json_schema"},
+                                      {"name", "r"},
+                                      {"schema", json::parse(R"({"$ref":"#/definitions/missing"})")}}}}}};
+    const json converted = imp_server::responses::responses_to_openai_body(rsp);
+    ASSERT_TRUE(converted.contains("response_format")) << "the shim must produce a response_format";
+    EXPECT_FALSE(accepts(converted)) << "an unenforceable schema must not survive the shim";
+}
+
+TEST(ConstraintValidation, ResponsesDialectGoodSchemaStillPasses) {
+    json rsp = {{"model", "m"},
+                {"input", "hi"},
+                {"text", {{"format", {{"type", "json_schema"},
+                                      {"name", "r"},
+                                      {"schema", json::parse(
+                                          R"({"type":"object","properties":{"a":{"type":"string"}}})")}}}}}};
+    EXPECT_TRUE(accepts(imp_server::responses::responses_to_openai_body(rsp)));
 }


### PR DESCRIPTION
Follow-up to #1258 / #1259. No production code — it closes a gap in what the
tests *prove*.

## The property at risk

`validate_constraints` is called once, from `validate_sampling_params`. Every
dialect reaches it through `parse_chat_request_params`. But `/v1/responses` gets
there via a shim that **builds** the `response_format` out of `text.format`:

```
POST /v1/responses  { "text": { "format": { "type": "json_schema", ... } } }
        │
        ├─ responses_to_openai_body()   ← the conversion
        │
        └─ parse_chat_request_params() → validate_sampling_params() → validate_constraints()
```

The validation only sees that schema because the conversion happens first. That
ordering is load-bearing and nothing asserted it: a shim that stopped converting,
or started converting *after* validation, would reopen the hole for that dialect
alone — and every OpenAI-route test would still pass.

## What is added

Two tests drive a real `/v1/responses` body through `responses_to_openai_body`
and then through the validator:

- an unresolvable `$ref` must **not** survive the shim
- a good schema must still pass

test-core 913 → **915**.

## Anthropic needs no equivalent, and that is a finding rather than an omission

`/v1/messages` has no `response_format` surface at all. Its constraints arrive as
`tools.input_schema`, which takes `prepare_tool_call` and deliberately falls back
to prompt-hint tool choice when a schema is not enforceable:

```cpp
IMP_LOG_INFO("ConstraintManager: tool schemas not enforceable — keeping prompt-hint tool choice");
```

That looks like the same silent-downgrade shape as #1256, but it is not the same
promise. `response_format` says *"the reply must have this form"*; `tools` says
*"here are capabilities you may use"*. Degrading the second to a prompt hint is a
defensible fallback, and turning it into a 400 would break agent frameworks that
ship loose tool schemas today.

Recorded as a backlog item with that reasoning rather than changed here — the
argument for acting on it is real but weaker, and it deserves its own decision
rather than being swept in behind a test PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8