### PR TITLE
fix(anthropic): carry the constrained-decoding fields through the shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Constrained decoding now works the same on `/v1/messages` as on
+  `/v1/chat/completions`.** `guided_regex`, `guided_grammar`, `grammar` and
+  `response_format` were dropped by the Anthropic shim, so the same server
+  honoured a constraint on one route and ignored it on the other (measured:
+  `'ZZZ6'` vs free-form prose) — and a malformed one was not rejected there
+  either, because the admission check never saw the field. Both halves close
+  together.
+
 - **A `"system"` message on `/v1/messages` now acts as a system prompt.** The
   Messages API has no `system` role, so imp fell through to its
   not-assistant branch and rendered it as a **user** turn — the text reached the

--- a/tests/test_anthropic_transform.cpp
+++ b/tests/test_anthropic_transform.cpp
@@ -676,3 +676,45 @@ TEST(AnthropicSystemRole, NoSystemRoleIsUnchanged) {
     EXPECT_EQ(oai["messages"][1]["role"], "assistant");
     EXPECT_EQ(oai["messages"][2]["role"], "user");
 }
+
+// ---------------------------------------------------------------------------
+// Constrained-decoding extensions have no Anthropic equivalent, and the shim
+// used to drop them: the same server honoured guided_regex on
+// /v1/chat/completions and ignored it on /v1/messages (measured: 'ZZZ6' vs
+// free-form prose). The silence was total — a malformed pattern was not
+// rejected either, because the admission check never saw the field.
+// ---------------------------------------------------------------------------
+
+TEST(AnthropicGuidedPassthrough, GuidedFieldsSurviveTheShim) {
+    for (const char* key : {"guided_regex", "guided_grammar", "grammar"}) {
+        json req = {{"model", "m"},
+                    {"max_tokens", 16},
+                    {"messages", json::array({{{"role", "user"}, {"content", "hi"}}})}};
+        req[key] = "ZZZ[0-9]";
+        json oai = anthropic_to_openai_body(req);
+        ASSERT_TRUE(oai.contains(key)) << "dropped by the shim: " << key;
+        EXPECT_EQ(oai[key], "ZZZ[0-9]");
+    }
+}
+
+TEST(AnthropicGuidedPassthrough, ResponseFormatSurvivesTheShim) {
+    json req = {{"model", "m"},
+                {"max_tokens", 16},
+                {"messages", json::array({{{"role", "user"}, {"content", "hi"}}})},
+                {"response_format", {{"type", "regex"}, {"regex", "[0-9]{3}"}}}};
+    json oai = anthropic_to_openai_body(req);
+    ASSERT_TRUE(oai.contains("response_format"));
+    EXPECT_EQ(oai["response_format"]["regex"], "[0-9]{3}");
+}
+
+// A request carrying none of them must not grow the fields.
+TEST(AnthropicGuidedPassthrough, AbsentFieldsAreNotInvented) {
+    json req = {{"model", "m"},
+                {"max_tokens", 16},
+                {"messages", json::array({{{"role", "user"}, {"content", "hi"}}})}};
+    json oai = anthropic_to_openai_body(req);
+    EXPECT_FALSE(oai.contains("guided_regex"));
+    EXPECT_FALSE(oai.contains("guided_grammar"));
+    EXPECT_FALSE(oai.contains("grammar"));
+    EXPECT_FALSE(oai.contains("response_format"));
+}

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -340,6 +340,18 @@ json anthropic_to_openai_body(const json& anth) {
     if (anth.contains("stop_sequences"))
         oai["stop"] = anth["stop_sequences"];
 
+    // Constrained decoding. These are imp/vLLM/llama.cpp extensions with no
+    // Anthropic equivalent, and the shim used to leave them behind — so the
+    // SAME server honoured `guided_regex` on /v1/chat/completions and ignored
+    // it on /v1/messages (measured: 'ZZZ6' vs free-form prose). Nothing
+    // documented was violated, but one server answering the same extension two
+    // ways is a trap, and the silence was total: a malformed pattern was not
+    // rejected here either, because the admission check never saw the field.
+    // Carrying them through fixes both halves at once.
+    for (const char* key : {"guided_regex", "guided_grammar", "grammar", "response_format"})
+        if (anth.contains(key))
+            oai[key] = anth[key];
+
     // Extended-thinking control. Anthropic uses a `thinking` object:
     //   {"type":"enabled","budget_tokens":N}  |  {"type":"disabled"}
     // imp's orchestrator (handlers.cpp) reads `enable_thinking` (bool) and


### PR DESCRIPTION
Closes #1262 §2.

## The inconsistency

`guided_regex`, `guided_grammar`, `grammar` and `response_format` have no
Anthropic equivalent, and `anthropic_to_openai_body` left them behind. The same
server, the same constraint, one request each:

| route | reply |
|---|---|
| `/v1/chat/completions` | `'ZZZ6'` |
| `/v1/messages` | `'How about I start a conversation with you? What'` |

Nothing documented was violated — Anthropic has no such field. But a client using
both routes of one server has no way to see why its constraint holds on one and
evaporates on the other.

## The part that makes it worth fixing rather than documenting

**The silence was total.** A *malformed* pattern was not rejected on
`/v1/messages` either, because the admission check from #1258 never saw the
field. So the route that ignored your constraint was also the route that could
not tell you it was broken — the exact combination #1256 was about, reachable
through a different door.

Carrying the fields through closes both halves at once:

| request on `/v1/messages` | before | after |
|---|---|---|
| `guided_regex "ZZZ[0-9]"` | free-form prose | **`'ZZZ7'`** — same as the OpenAI route |
| `guided_regex "(?=x)y"` | 200, unconstrained | **400** — same as the OpenAI route |

## Tests

3 added: each `guided_*` spelling survives the shim, `response_format` survives,
and a request carrying none of them does not grow the fields (a passthrough that
invents keys would be its own bug). test-core 921 → **924**.

Gate: tg128 **288.68** vs baseline 287.19 (+0.52%, spread 0.27% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

## Still deferred from #1262

§1 — `max_tokens` is required by the spec and imp accepts its absence. That is
imp being *more permissive* than the reference rather than meaning something
different by the input, so a 400 would break working clients for a portability
argument. Left as filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8