### PR TITLE
fix(server): reject a content part this server cannot read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A content part this server cannot read is a `400`, not an answer.** A
+  `video_url` part (imp has no video path) produced a 200 replying to a prompt
+  the model never saw, and an `image_url` part with the object missing took the
+  same silent route — indistinguishable, from the caller's side, from a reply
+  that used the input. Only `text` and `image_url` are read, and anything else
+  now says so by name.
+
 - **Constrained decoding now works the same on `/v1/messages` as on
   `/v1/chat/completions`.** `guided_regex`, `guided_grammar`, `grammar` and
   `response_format` were dropped by the Anthropic shim, so the same server

--- a/tests/test_constraint_validation.cpp
+++ b/tests/test_constraint_validation.cpp
@@ -192,3 +192,66 @@ TEST(ConstraintValidation, ResponsesDialectGoodSchemaStillPasses) {
                                           R"({"type":"object","properties":{"a":{"type":"string"}}})")}}}}}};
     EXPECT_TRUE(accepts(imp_server::responses::responses_to_openai_body(rsp)));
 }
+
+// ---------------------------------------------------------------------------
+// Content parts. A part this server cannot read used to fall through the
+// parsing chain in silence: `video_url` (imp has no video path) produced a 200
+// answering a prompt the model never saw. The caller cannot tell that reply
+// apart from one that actually used its input.
+// ---------------------------------------------------------------------------
+
+namespace {
+json parts_body(const json& parts) {
+    return json{{"messages", json::array({{{"role", "user"}, {"content", parts}}})}};
+}
+bool parts_ok(const json& parts) {
+    httplib::Response res;
+    return validate_content_parts(parts_body(parts), res);
+}
+}  // namespace
+
+TEST(ContentParts, TextAndImageAreAccepted) {
+    EXPECT_TRUE(parts_ok(json::array({{{"type", "text"}, {"text", "hi"}}})));
+    EXPECT_TRUE(parts_ok(json::array({{{"type", "image_url"}, {"image_url", {{"url", "data:image/png;base64,AA"}}}}})));
+    EXPECT_TRUE(parts_ok(json::array({{{"type", "text"}, {"text", "what is this"}},
+                                      {{"type", "image_url"}, {"image_url", {{"url", "x"}}}}})));
+}
+
+TEST(ContentParts, UnknownTypeIsRejectedAndNamed) {
+    httplib::Response res;
+    ASSERT_FALSE(validate_content_parts(
+        parts_body(json::array({{{"type", "video_url"}, {"video_url", {{"url", "x"}}}}})), res));
+    EXPECT_EQ(res.status, 400);
+    EXPECT_NE(res.body.find("video_url"), std::string::npos)
+        << "the message must name the part it could not read";
+}
+
+// `{"type":"image_url"}` with the object missing took the same silent path.
+TEST(ContentParts, ImagePartWithoutTheObjectIsRejected) {
+    EXPECT_FALSE(parts_ok(json::array({{{"type", "image_url"}}})));
+}
+
+TEST(ContentParts, MissingTypeIsRejected) {
+    httplib::Response res;
+    ASSERT_FALSE(validate_content_parts(parts_body(json::array({{{"text", "hi"}}})), res));
+    EXPECT_NE(res.body.find("missing type"), std::string::npos);
+}
+
+// A plain string content (the overwhelmingly common shape) must not be touched.
+TEST(ContentParts, StringContentIsUntouched) {
+    httplib::Response res;
+    json body = {{"messages", json::array({{{"role", "user"}, {"content", "plain text"}}})}};
+    EXPECT_TRUE(validate_content_parts(body, res));
+    // ...and so must a request with no messages at all.
+    EXPECT_TRUE(validate_content_parts(json::object(), res));
+}
+
+// Later messages are checked too, not just the first.
+TEST(ContentParts, EveryMessageIsChecked) {
+    json body = {{"messages", json::array({
+        {{"role", "user"}, {"content", "fine"}},
+        {{"role", "assistant"}, {"content", "also fine"}},
+        {{"role", "user"}, {"content", json::array({{{"type", "audio"}, {"audio", "x"}}})}}})}};
+    httplib::Response res;
+    EXPECT_FALSE(validate_content_parts(body, res));
+}

--- a/tools/imp-server/constraint_validation.cpp
+++ b/tools/imp-server/constraint_validation.cpp
@@ -103,3 +103,39 @@ bool validate_constraints(const json& body, httplib::Response& res) {
 
     return true;
 }
+
+// A content part this server cannot read used to fall through the parsing chain
+// in silence: `video_url` (imp has no video path at all) produced a 200
+// answering a prompt the model never saw, and an `image_url` part with the
+// object missing did the same. Answering as if the input had been understood is
+// worse than refusing it — the caller cannot tell that reply apart from one that
+// actually used its picture.
+//
+// Checked at admission alongside the constraints, and in this TU for the same
+// reason: the CPU lane compiles it, so the rule runs in CI.
+bool validate_content_parts(const json& body, httplib::Response& res) {
+    if (!body.contains("messages") || !body["messages"].is_array())
+        return true;
+    for (const auto& msg : body["messages"]) {
+        if (!msg.is_object() || !msg.contains("content") || !msg["content"].is_array())
+            continue;
+        for (const auto& part : msg["content"]) {
+            if (!part.is_object())
+                continue;
+            const std::string type = part.value("type", "");
+            if (type == "text")
+                continue;
+            if (type == "image_url" && part.contains("image_url"))
+                continue;
+            res.status = 400;
+            json err = {{"error",
+                         {{"message", "unsupported content part \"" +
+                                          (type.empty() ? std::string("(missing type)") : type) +
+                                          "\": this endpoint reads \"text\" and \"image_url\" parts"},
+                          {"type", "invalid_request_error"}}}};
+            res.set_content(dump_safe(err), "application/json");
+            return false;
+        }
+    }
+    return true;
+}

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -708,6 +708,9 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
     if (!validate_constraints(body, res))
         return false;
 
+    if (!validate_content_parts(body, res))
+        return false;
+
     return true;
 }
 

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -218,6 +218,10 @@ bool validate_sampling_params(const json& body, httplib::Response& res);
 // unconstrained (#1256). Called from validate_sampling_params.
 bool validate_constraints(const json& body, httplib::Response& res);
 
+// Rejects a content part this server cannot read (video_url, a malformed
+// image_url part) instead of answering as if it had been understood.
+bool validate_content_parts(const json& body, httplib::Response& res);
+
 // Defined in handlers_chat_core.cpp.
 void log_request_jsonl(ServerState& state, bool skip, const std::chrono::system_clock::time_point& t_start,
                        const std::string& req_id, const std::string& endpoint, const std::string& client_ip,


### PR DESCRIPTION
Found probing vision error paths. Same shape as #1256, reached through a
different door: input accepted, quietly not used, answered anyway.

## What happened

The multimodal parsing loop handles `text` and `image_url` and has **no else
branch**. Measured against a running Qwen3-VL-4B:

| request | before |
|---|---|
| `{"type":"video_url", …}` | **200** — `"It appears to be an error or incomplete"` |
| `{"type":"image_url"}` (object missing) | **200** |

imp has no video path at all — *"no video"* is a documented limitation in
`roadmap.md` — so the first request could never have worked. What it got instead
of an error was a model answering a prompt containing **none of its input**. From
the caller's side that is indistinguishable from a reply that used the picture.

The rest of the vision error surface is in good shape, which is what made this
one stand out: base64 garbage, an empty data URI, a missing `url` and an
unreachable `http://` URL all already return typed 400s.

## After

```
video_url             -> 400  unsupported content part "video_url": this endpoint
                              reads "text" and "image_url" parts
image_url (no object) -> 400
real image            -> 200  'The color is **red**.'    (unchanged)
plain string content  -> 200                              (unchanged)
```

## Placement

In `constraint_validation.cpp`, for the reason that TU exists: the CPU lane
compiles it and `handlers_chat_params.cpp` it does not. Written inside the
parsing loop, the rule would have been untestable in CI — which is how the
original gap survived.

## Tests

6 added: text/image accepted, unknown type rejected **and named**, image part
without its object, missing `type`, plain string content untouched, and later
messages checked as well as the first. test-core 924 → **930**.

| mutation | tests killed |
|---|---|
| accept everything | 4 |
| check only the first message | 1 |
| allow an image part without its object | 1 |
| default a missing `type` to `"text"` | 1 |

Gate: tg128 **288.45** vs baseline 287.19 (+0.44%, spread 0.15% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8