### PR TITLE
fix(server): reject a tool_choice that contradicts the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A `tool_choice` that contradicts the request is a `400`.** Naming a function
+  absent from `tools` had the model invent a call to something the caller never
+  described (a request naming `nonexistent` came back calling `g`), and
+  `"required"` with no tools was answered as an ordinary turn. Distinct from a
+  tool whose *schema* cannot be enforced — that still degrades to prompt-hint
+  choice, because `tools` offers capabilities rather than promising a shape.
+
 - **A content part this server cannot read is a `400`, not an answer.** A
   `video_url` part (imp has no video path) produced a 200 replying to a prompt
   the model never saw, and an `image_url` part with the object missing took the

--- a/tests/test_constraint_validation.cpp
+++ b/tests/test_constraint_validation.cpp
@@ -255,3 +255,64 @@ TEST(ContentParts, EveryMessageIsChecked) {
     httplib::Response res;
     EXPECT_FALSE(validate_content_parts(body, res));
 }
+
+// ---------------------------------------------------------------------------
+// tool_choice contradictions. Distinct from a tool whose SCHEMA cannot be
+// enforced — that legitimately degrades to prompt-hint choice, because `tools`
+// offers capabilities rather than promising a shape. Naming a tool that is not
+// there is not loose, it is self-contradictory, and answering it anyway had the
+// model invent a call to a function the caller never described.
+// ---------------------------------------------------------------------------
+
+namespace {
+json tool(const std::string& name) {
+    return json{{"type", "function"},
+                {"function", {{"name", name}, {"parameters", {{"type", "object"}}}}}};
+}
+bool tc_ok(const json& body) {
+    httplib::Response res;
+    return validate_tool_choice(body, res);
+}
+}  // namespace
+
+TEST(ToolChoice, ConsistentRequestsAreAccepted) {
+    EXPECT_TRUE(tc_ok(json::object())) << "no tool_choice at all";
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", "auto"}}));
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", "none"}})) << "satisfiable without tools";
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", "required"}, {"tools", json::array({tool("f")})}}));
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", {{"type", "function"}, {"function", {{"name", "f"}}}}},
+                           {"tools", json::array({tool("g"), tool("f")})}}))
+        << "named tool present, not necessarily first";
+}
+
+TEST(ToolChoice, RequiredWithoutToolsIsRejected) {
+    httplib::Response res;
+    ASSERT_FALSE(validate_tool_choice(json{{"tool_choice", "required"}}, res));
+    EXPECT_EQ(res.status, 400);
+    EXPECT_NE(res.body.find("required"), std::string::npos);
+
+    // An empty array is the same contradiction as none at all.
+    EXPECT_FALSE(tc_ok(json{{"tool_choice", "required"}, {"tools", json::array()}}));
+}
+
+TEST(ToolChoice, NamedToolMustExistAndIsNamedInTheError) {
+    httplib::Response res;
+    json body = {{"tool_choice", {{"type", "function"}, {"function", {{"name", "nonexistent"}}}}},
+                 {"tools", json::array({tool("f")})}};
+    ASSERT_FALSE(validate_tool_choice(body, res));
+    EXPECT_NE(res.body.find("nonexistent"), std::string::npos)
+        << "the error must name the function that was asked for";
+}
+
+TEST(ToolChoice, NamedToolWithNoToolsAtAllIsRejected) {
+    EXPECT_FALSE(tc_ok(json{{"tool_choice", {{"type", "function"}, {"function", {{"name", "f"}}}}}}));
+}
+
+// Shapes this server does not interpret must pass through rather than 400 —
+// rejecting an unfamiliar dialect would be worse than ignoring it.
+TEST(ToolChoice, UnrecognisedShapesArePassedThrough) {
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", 42}}));
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", {{"type", "function"}}}})) << "no function object";
+    EXPECT_TRUE(tc_ok(json{{"tool_choice", {{"type", "function"}, {"function", {{"name", ""}}}}}}))
+        << "empty name carries no requirement";
+}

--- a/tools/imp-server/constraint_validation.cpp
+++ b/tools/imp-server/constraint_validation.cpp
@@ -139,3 +139,50 @@ bool validate_content_parts(const json& body, httplib::Response& res) {
     }
     return true;
 }
+
+// `tool_choice` naming a tool that is not in `tools`, or demanding a tool call
+// with no tools at all, is a CONTRADICTORY request rather than a loose one —
+// unlike a tool whose schema simply cannot be enforced, which legitimately
+// degrades to prompt-hint choice. Answering it anyway produced a model
+// inventing a call to a function the caller never described (measured: a
+// request naming "nonexistent" came back with a call to "g"). OpenAI answers
+// 400 for both.
+bool validate_tool_choice(const json& body, httplib::Response& res) {
+    if (!body.contains("tool_choice"))
+        return true;
+
+    auto reject = [&res](const std::string& message) {
+        res.status = 400;
+        json err = {{"error", {{"message", message}, {"type", "invalid_request_error"}}}};
+        res.set_content(dump_safe(err), "application/json");
+        return false;
+    };
+
+    const json& tc = body["tool_choice"];
+    const bool has_tools = body.contains("tools") && body["tools"].is_array() && !body["tools"].empty();
+
+    // "none" is satisfiable without tools; "auto" is a no-op there.
+    if (tc.is_string()) {
+        const std::string s = tc.get<std::string>();
+        if (s == "required" && !has_tools)
+            return reject("\"tool_choice\": \"required\" needs a non-empty \"tools\" array");
+        return true;
+    }
+
+    if (!tc.is_object() || !tc.contains("function") || !tc["function"].is_object())
+        return true;  // shapes this server does not interpret are left alone
+    const std::string want = tc["function"].value("name", "");
+    if (want.empty())
+        return true;
+    if (!has_tools)
+        return reject("\"tool_choice\" names the function \"" + want +
+                      "\" but the request carries no \"tools\"");
+    for (const auto& t : body["tools"]) {
+        if (!t.is_object() || !t.contains("function") || !t["function"].is_object())
+            continue;
+        if (t["function"].value("name", "") == want)
+            return true;
+    }
+    return reject("\"tool_choice\" names the function \"" + want +
+                  "\", which is not among the tools in this request");
+}

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -711,6 +711,9 @@ bool validate_sampling_params(const json& body, httplib::Response& res) {
     if (!validate_content_parts(body, res))
         return false;
 
+    if (!validate_tool_choice(body, res))
+        return false;
+
     return true;
 }
 

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -222,6 +222,10 @@ bool validate_constraints(const json& body, httplib::Response& res);
 // image_url part) instead of answering as if it had been understood.
 bool validate_content_parts(const json& body, httplib::Response& res);
 
+// Rejects a tool_choice that contradicts the request (names a tool that is not
+// there, or demands a call with no tools).
+bool validate_tool_choice(const json& body, httplib::Response& res);
+
 // Defined in handlers_chat_core.cpp.
 void log_request_jsonl(ServerState& state, bool skip, const std::chrono::system_clock::time_point& t_start,
                        const std::string& req_id, const std::string& endpoint, const std::string& client_ip,


### PR DESCRIPTION
Found probing tool-calling error paths — the last untested surface in this run.

## Two contradictions that were answered anyway

| request | before |
|---|---|
| `tool_choice: {function:{name:"nonexistent"}}` with `tools: [f]` | **200**, and the model invented a call to **`g`** |
| `tool_choice: "required"` with no `tools` | **200**, an ordinary assistant turn |

The first is the worse one: a request that named a function which does not exist
came back with a call to a *different* function the caller never described. A
client parsing that reply gets a plausible-looking tool call for something it
cannot dispatch.

## Why this is a fix and the neighbouring case is not

A tool whose **schema** cannot be enforced still degrades to prompt-hint tool
choice, and that stays:

```cpp
IMP_LOG_INFO("ConstraintManager: tool schemas not enforceable — keeping prompt-hint tool choice");
```

`tools` offers *capabilities*; it does not promise an output shape, so a fallback
there is defensible — and turning it into a 400 would break agent frameworks that
ship loose schemas. Being unable to **satisfy "call exactly this function"** is a
different thing from being unable to **constrain its arguments**. The first is
unsatisfiable; the second is merely unconstrained.

That line is why this PR exists and the neighbouring one (filed in #1262) does not.

## Deliberately still permissive

Shapes this server does not interpret pass through: a non-object `tool_choice`,
one without a `function` object, an empty name. A 400 on an unfamiliar dialect
would be worse than ignoring it — the target is contradictions, not strictness.

## Verified

```
named tool missing  -> 400  "tool_choice" names the function "nonexistent", which is
                            not among the tools in this request
required, no tools  -> 400  "tool_choice": "required" needs a non-empty "tools" array
named tool present  -> 200  (unchanged)
auto                -> 200  (unchanged)
```

5 tests, test-core 930 → **935**.

| mutation | tests killed |
|---|---|
| skip the `required` check | 1 |
| match any tool instead of the named one | 1 |
| count an empty `tools` array as tools | 1 |
| reject `"none"` as well | 1 |

The last one guards the permissiveness above: `"none"` is satisfiable without
tools and must not start failing.

Gate: tg128 **288.51** vs baseline 287.19 (+0.46%, spread 0.06% over 3
processes), own_peak 20718 MiB (+0.01%), degeneration smoke PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8