### PR TITLE
perf(roofline): add a long-context decode shape — tg256 hides the attention cost

### DIFF
--- a/tools/roofline/README.md
+++ b/tools/roofline/README.md
@@ -17,6 +17,23 @@ tools/roofline/roofline issues --run latest     # dry-run; --create files GitHub
 tools/roofline/roofline ab --knob fa2           # unprofiled A/B (FA2 on vs never)
 ```
 
+### Decode shapes: `tg256` is NOT representative of agent workloads
+
+`tg256` prefills 64 tokens, so it profiles decode at a ~320-token context. The
+KV cache is negligible there and `attn_decode_paged` reads almost nothing. Agent
+sessions run 20k-100k. Measured on q8-dense, one restart each:
+
+| kernel class | `tg256` (ctx ~320) | `tg256_ctx8k` (ctx ~8.4k) |
+|---|---|---|
+| `gemv_nvfp4` | 89.0% time, 62.6% roofline | 63.2% time, 39.4% roofline |
+| `attn_decode_paged` | **4.3%** time, 5.0% roofline | **31.0%** time, **10.5%** roofline, occ 17% |
+
+The attention share moves **7.2x** with context, and at long context it is the
+second-largest class running at a tenth of peak bandwidth. Profile `tg256_ctx8k`
+alongside `tg256` before concluding anything about decode for this project's
+target workload — a lever ranked off `tg256` alone is ranked on a context length
+no agent session ever has.
+
 ## Architecture
 
 - **Measurement** (`measure`): per cell (model × shape × restart), two passes in

--- a/tools/roofline/config.json
+++ b/tools/roofline/config.json
@@ -162,6 +162,12 @@
       "bench_pp": 64,
       "bench_reps": 1,
       "max_tokens": 256
+    },
+    "tg256_ctx8k": {
+      "phase": "decode",
+      "bench_pp": 8192,
+      "bench_reps": 1,
+      "max_tokens": 256
     }
   },
   "capture_regex": {


### PR DESCRIPTION
First measurement after opening the perf regime, and it is about the ruler rather
than the thing measured.

## The blind spot

`tg256` prefills **64 tokens**, so it profiles decode at a ~320-token context.
The KV cache is negligible there and `attn_decode_paged` reads almost nothing.

This project targets agent sessions of **20k-100k tokens**. Every decode lever in
the roofline history has therefore been ranked against a context length no such
session ever has.

## Measured

q8-dense, one restart each, same commit:

| kernel class | `tg256` (ctx ~320) | `tg256_ctx8k` (ctx ~8.4k) |
|---|---|---|
| `gemv_nvfp4` | 89.0% time, 62.6% roofline | 63.2% time, 39.4% roofline |
| **`attn_decode_paged`** | **4.3%** time, 5.0% roofline, occ 8% | **31.0%** time, **10.5%** roofline, occ 17% |
| `rmsnorm` | 3.1% | 2.8% |

**`attn_decode_paged` moves 7.2x with context.** At 8k it is the second-largest
class in the decode window and runs at a tenth of peak bandwidth — an Amdahl
headroom of roughly a quarter of the decode window, which `tg256` reports as ~4%
of the time at 5% of roofline, i.e. as noise.

The dispatch that started this run listed "`attn_decode_paged` occupancy" as a
hot candidate to verify. On `tg256` it looks like a rounding error and would
reasonably be dropped. It is not one.

## Why this is a config change and not a kernel change

Without the shape the finding is not reproducible and the next run re-derives it
from scratch. With it, any future attention work has a measurement that shows its
gain — and one that ranks levers by the workload the project is for.

This is the same shape of blind spot as #1251, where the KV pool collapsed under
server defaults while `--bench` reported an honest 243 tok/s: **the measurement
was truthful about what it measured, and what it measured was not the workload.**

## Scope

`tools/roofline/config.json` + README. No engine code, so no perf gate — nothing
measurable moved. The shape is additive; existing runs and pinned baselines are
untouched.

Not claimed here: that the kernel *can* be made faster. That needs its own
hypothesis and A/B. What is claimed is that the cost is real, context-dependent,
and was previously invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8