### PR TITLE
perf(attention): more split-K for the GQA tile kernel past a context threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Performance
+
+- **Long-context decode is up to 10% faster.** The GQA tile attention kernel is
+  grid-limited, not resource-limited, so past a context threshold it takes
+  `4*SMs` blocks instead of `2*SMs`. Qwen3-8B-Q8_0, Spec-OFF, median of 3
+  alternating rounds: **8k +1.3%, 16k +4.8%, 32k +10.0%**, and 512/2048/4096
+  unchanged (the boost declines below the crossover). Greedy output changes
+  where it engages — the reduce sums in a different order — but stays
+  deterministic per build.
+
 The 2026-08-06 error-path campaign (#1252-#1265) is written up in
 [`docs/MISSION_JOURNAL.md`](docs/MISSION_JOURNAL.md) — the KV-floor mechanism, the
 ordering constraint behind the constrained-decoding fixes, and the measurement traps.

--- a/src/compute/attention_paged_fp8_tile.cu
+++ b/src/compute/attention_paged_fp8_tile.cu
@@ -536,6 +536,28 @@ int paged_attention_splitk_fp8_tile_gqa_splits(int batch_size, int n_heads, int 
     const int num_ctx_blocks = (max_context_len + block_size - 1) / block_size;
     const int bh_kv = batch_size * n_kv_heads;
     int s = (2 * sms + bh_kv - 1) / bh_kv;
+
+    // Long context: aim for 4*SMs blocks instead of 2*SMs. This kernel is
+    // GRID-limited rather than resource-limited — 9 KB of static smem and
+    // WARP_SIZE*g threads leave room for several blocks per SM — so past a
+    // point the extra parallelism outruns the extra reduce.
+    //
+    // Only past that point. Each split must keep enough KV blocks for the
+    // reduce to amortise, and measured on Qwen3-8B-Q8_0 (Spec-OFF, 3 alternating
+    // rounds per context, spreads all <0.5%) the crossover is sharp:
+    //
+    //   ctx  2048  -0.02%   4096  -0.35%   8192  +1.26%   16384  +4.75%   32768  +9.96%
+    //
+    // `num_ctx_blocks >= 4 * s4` reproduces that split. On this model
+    // (n_kv_heads=8 -> kv_block_size 16, sms=170, s4=85 -> threshold 340) it
+    // declines the boost at 4096 (256 blocks) and takes it from 8192 (512)
+    // upward. A threshold of 3 was tried first and measured -0.35% at 4096,
+    // because 256 clears 255 by one block — the boost has to start after the
+    // crossover, not on it.
+    const int s4 = (4 * sms + bh_kv - 1) / bh_kv;
+    if (num_ctx_blocks >= 4 * s4)
+        s = s4;
+
     s = min(s, num_ctx_blocks);
     void* sk_ptr = nullptr;
     size_t sk_size = 0;


### PR DESCRIPTION
Acts on #1268 — the first measured win of this run's perf phase.

## Mechanism

That issue found paged attention holding **31% of the decode window at 8k
context** while sustaining 192 GB/s, against a GEMV in the same window at 711.

The GQA tile kernel is **grid-limited, not resource-limited**: 9 KB of static
smem and `WARP_SIZE*g` threads leave room for several blocks per SM. Its split
count nevertheless targets `2*SMs` blocks — the figure appropriate for a kernel
capped at one block per SM.

The neighbouring *token-tiled* variant **is** so capped and documents it. I first
read that comment as applying here and withdrew part of #1268 on the strength of
it; it does not apply to this kernel. Correcting that misreading is what led to
this patch.

## Measured

Qwen3-8B-Q8_0, Spec-OFF, 3 alternating rounds per point, all spreads < 0.8 tok/s:

| ctx | 512 | 2048 | 4096 | 8192 | 16384 | 32768 |
|---|---|---|---|---|---|---|
| delta | −0.05% | −0.02% | +0.13% | **+1.32%** | **+4.83%** | **+10.00%** |

**Spec-ON was tried first and abandoned as a measurement vehicle.** n-gram
speculation put **14–17% spread** on the short-context points — enough to hide a
1% effect entirely, and enough to make a −11% median look real when it was not.
Spec-OFF (what the gate measures) drops the spread below 0.5% and the curve is
unambiguous. That is the whole difference between this table and my first pass.

## Calibrating the threshold

`num_ctx_blocks >= 4 * s4`. A factor of **3** was tried first and measured
**−0.35% at 4096**: with `n_kv_heads=8` the KV block size is 16, so 4096 tokens
is 256 blocks and clears `3*85 = 255` **by a single block**. The boost has to
start *after* the crossover, not on it — off-by-one in a heuristic threshold is
still off-by-one.

## Gate and correctness

- tg128 **288.13** vs baseline 287.19 (+0.33%, spread 0.02%) — short contexts are
  untouched, so the gate is structurally unmoved
- `own_peak` 20718 MiB (+0.01%), prefill and graphs gates PASS, CPU lane green

**Behaviour note, stated plainly:** where the boost engages, **greedy output
changes**. The split reduce sums in a different order and that flips near-tie
logits — the same class as any kernel change touching reduction order. Verified:

- **deterministic per build** — 3/3 byte-identical on a 9644-token prompt
- **non-degenerate under sampling** at 15553 prompt tokens: distinct/total 0.74,
  longest repeat run 2, coherent content

## Scope

One heuristic, 22 lines with the measurement table in the comment. It does not
touch the kernel itself — the 192 GB/s question in #1268 stands, and this only
buys back some of the grid-occupancy half of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8