### PR TITLE
Revert "perf(attention): more split-K for the GQA tile kernel past a context threshold"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,13 @@ there instead of retelling it.
 
 ## [Unreleased]
 
-### Performance
+### Reverted
 
-- **Long-context decode is up to 10% faster.** The GQA tile attention kernel is
-  grid-limited, not resource-limited, so past a context threshold it takes
-  `4*SMs` blocks instead of `2*SMs`. Qwen3-8B-Q8_0, Spec-OFF, median of 3
-  alternating rounds: **8k +1.3%, 16k +4.8%, 32k +10.0%**, and 512/2048/4096
-  unchanged (the boost declines below the crossover). Greedy output changes
-  where it engages — the reduce sums in a different order — but stays
-  deterministic per build.
+- **The GQA tile split-count boost (#1270) is reverted (#1271).** It measured
+  +1.3/+4.8/+10.0% at 8k/16k/32k on Qwen3-8B-Q8_0 and **−7.30% at 32k on
+  Qwen3-30B-A3B-NVFP4**, a pinned hero. One model is not a heuristic. The
+  mechanism is real and the measurements are kept in the issue; the condition
+  separating the two cases is not established, so the change does not ship.
 
 The 2026-08-06 error-path campaign (#1252-#1265) is written up in
 [`docs/MISSION_JOURNAL.md`](docs/MISSION_JOURNAL.md) — the KV-floor mechanism, the

--- a/src/compute/attention_paged_fp8_tile.cu
+++ b/src/compute/attention_paged_fp8_tile.cu
@@ -536,28 +536,6 @@ int paged_attention_splitk_fp8_tile_gqa_splits(int batch_size, int n_heads, int 
     const int num_ctx_blocks = (max_context_len + block_size - 1) / block_size;
     const int bh_kv = batch_size * n_kv_heads;
     int s = (2 * sms + bh_kv - 1) / bh_kv;
-
-    // Long context: aim for 4*SMs blocks instead of 2*SMs. This kernel is
-    // GRID-limited rather than resource-limited — 9 KB of static smem and
-    // WARP_SIZE*g threads leave room for several blocks per SM — so past a
-    // point the extra parallelism outruns the extra reduce.
-    //
-    // Only past that point. Each split must keep enough KV blocks for the
-    // reduce to amortise, and measured on Qwen3-8B-Q8_0 (Spec-OFF, 3 alternating
-    // rounds per context, spreads all <0.5%) the crossover is sharp:
-    //
-    //   ctx  2048  -0.02%   4096  -0.35%   8192  +1.26%   16384  +4.75%   32768  +9.96%
-    //
-    // `num_ctx_blocks >= 4 * s4` reproduces that split. On this model
-    // (n_kv_heads=8 -> kv_block_size 16, sms=170, s4=85 -> threshold 340) it
-    // declines the boost at 4096 (256 blocks) and takes it from 8192 (512)
-    // upward. A threshold of 3 was tried first and measured -0.35% at 4096,
-    // because 256 clears 255 by one block — the boost has to start after the
-    // crossover, not on it.
-    const int s4 = (4 * sms + bh_kv - 1) / bh_kv;
-    if (num_ctx_blocks >= 4 * s4)
-        s = s4;
-
     s = min(s, num_ctx_blocks);
     void* sk_ptr = nullptr;
     size_t sk_size = 0;


### PR DESCRIPTION
Reverts #1270. It was measured on one model and regresses another.

| model | shape | 32k delta |
|---|---|---|
| Qwen3-8B-Q8_0 | `n_kv_heads=8`, `g=4` | **+10.00%** |
| **Qwen3-30B-A3B-NVFP4** | `n_kv_heads=4`, `g=8` | **−7.30%** ← pinned hero |

Both Spec-OFF, 3 alternating rounds, spreads 0.06–0.28 tok/s. **The regression is
as clean as the win was** — this is not a noise call.

## Why not patch it instead

The difference is visible but not established. With `n_kv_heads=4` the threshold
`4*s4` is 680 blocks, so the boost engages only past ~22k context, and it then
asks for **170 splits** against the 8B's 85 — twice the reduce work — with
**256-thread blocks** (`g=8`) instead of 128.

Any of those could be paying the −7.30%. Picking one and gating on it would be a
second heuristic stacked on a first that already failed to generalise, justified
by an argument I have not measured. The honest response to *"my heuristic helps
model A and hurts model B"* is to withdraw it, not to narrow it until the two
models I happen to own are both green.

## What stands

- **#1268 is untouched and still open**: attention holds 31% of the decode window
  at 8k while sustaining 192 GB/s, against a GEMV at 711 in the same window.
- The observation that this kernel's split count targets `2*SMs` — the figure for
  a one-block-per-SM kernel, which this one is not — also stands.
- What is retracted is only that **doubling it is safe across shapes**.

The measurements are kept in #1268 so the next attempt starts from a two-model
picture rather than re-deriving the 8B curve.

## The process failure, since it is the reusable part

I measured **six context lengths on one model**, saw a clean monotone curve with
sub-0.5% spreads, and shipped. The gate could not catch it — it runs `pp512`,
where the boost is inactive by construction, so it passed at +0.33%.

Checking the second model took **twenty minutes**. The care went into the
precision of a single-model measurement instead of into its breadth, and
precision is not coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8