### PR TITLE
fix(diag): make the per-layer hidden dump fire outside Gemma-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`diagnostics.dump_hidden_dir` works on models other than Gemma-4.** The
+  per-layer hidden-state dump sat inside the Gemma-4 `layer_out_scale` branch
+  *and* behind `debug_forward_enabled()`, so on every Qwen3, every GDN hybrid and
+  everything else it produced no files and said nothing. It now keys off its own
+  switch, writes to the configured directory rather than always `/tmp`, and names
+  the token count so prefill and decode dumps are distinguishable.
+
 ### Reverted
 
 - **The GQA tile split-count boost (#1270) is reverted (#1271).** It measured

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -433,6 +433,33 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 snprintf(rbuf, sizeof(rbuf), "[step=%d] moe_out-%d", decode_step, i);
                 debug_tensor_rows(rbuf, view_tokens(h, n), stream);
             }
+
+            // Binary dump of the full hidden state, for diffing two builds or two
+            // quantizations of the same model layer by layer.
+            //   diagnostics.dump_hidden_dir = "<path>"  -> layers 0/5/15/29
+            //   diagnostics.dump_hidden_dir = "all"     -> every layer
+            //
+            // This used to sit inside the Gemma-4 `layer_out_scale` branch AND
+            // behind debug_forward_enabled(), so on any model without that scale
+            // — every Qwen3, every GDN hybrid — it produced no files at all and
+            // reported nothing. It is a diagnostic, so it keys off its own switch
+            // and nothing else; the default is empty and costs a string check.
+            {
+                const std::string& dh = runtime_config().diagnostics.dump_hidden_dir;
+                if (!dh.empty() && (dh == "all" || i == 0 || i == 5 || i == 15 || i == 29)) {
+                    std::vector<half> h_buf(static_cast<size_t>(n) * cfg.d_model);
+                    cudaStreamSynchronize(stream);
+                    cudaMemcpy(h_buf.data(), view_tokens(h, n).data, h_buf.size() * sizeof(half),
+                               cudaMemcpyDeviceToHost);
+                    char fname[512];
+                    snprintf(fname, sizeof(fname), "%s/imp_L%02d_step%d_n%d.bin",
+                             dh == "all" ? "/tmp" : dh.c_str(), i, decode_step, n);
+                    if (FILE* f = fopen(fname, "wb")) {
+                        fwrite(h_buf.data(), sizeof(half), h_buf.size(), f);
+                        fclose(f);
+                    }
+                }
+            }
         }
 
         // Gemma 4: per-layer output scale (a scalar weight). llama.cpp's
@@ -477,26 +504,6 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                                       decode_step, i, __half2float(h_tmp[0]), __half2float(h_tmp[1]),
                                       __half2float(h_tmp[2]), __half2float(h_tmp[3]), __half2float(h_tmp[4]),
                                       __half2float(h_tmp[5]), __half2float(h_tmp[6]), __half2float(h_tmp[7]));
-                    }
-                    // Binary dump: full hidden state for selected layers.
-                    // [diagnostics] dump_hidden_dir = "<path>"  → layers 0/5/15/29.
-                    // [diagnostics] dump_hidden_dir = "all"     → every layer.
-                    const std::string& dh = runtime_config().diagnostics.dump_hidden_dir;
-                    if (!dh.empty()) {
-                        const bool dump_all = (dh == "all");
-                        bool sel = dump_all || (i == 0 || i == 5 || i == 15 || i == 29);
-                        if (sel) {
-                            std::vector<half> h_buf(n * cfg.d_model);
-                            cudaMemcpy(h_buf.data(), view_tokens(h, n).data, h_buf.size() * sizeof(half),
-                                       cudaMemcpyDeviceToHost);
-                            char fname[256];
-                            snprintf(fname, sizeof(fname), "/tmp/imp_L%02d_step%d.bin", i, decode_step);
-                            FILE* f = fopen(fname, "wb");
-                            if (f) {
-                                fwrite(h_buf.data(), sizeof(half), h_buf.size(), f);
-                                fclose(f);
-                            }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
Found while trying to localise #1273. The instrumentation that campaign needs did
not work on any of the affected models.

## The bug

`diagnostics.dump_hidden_dir` was nested inside the Gemma-4 `layer_out_scale`
branch **and** behind `debug_forward_enabled()`:

```cpp
if (ly.layer_out_scale.data != nullptr && ...) {      // Gemma-4 only
    ...
    if (debug_forward_enabled()) {                     // and a second gate
        ...
        const std::string& dh = ...dump_hidden_dir;    // the actual switch
```

Every Qwen3, every GDN hybrid, everything but Gemma-4 produced **zero files and
no message**. The switch looked broken rather than inapplicable — I spent two
rounds suspecting the dump code before noticing the enclosing branch.

## Changes

- **Hoisted** to the per-layer block every model runs, keyed only off its own setting
- **Writes to the configured directory** instead of hardcoding `/tmp` — the path
  was accepted and then ignored
- **Names the token count**: `imp_L<NN>_step<S>_n<N>.bin`

That last one matters more than it looks. Decode dumps (`n=1`) are captured in a
CUDA graph, so the host-side copy sees only the final buffer state and **every
layer's file is identical**. I hit exactly that: RMS 80.9178 on all 40 layers of
one model and 7.0883 on all 64 of another — impossible values that only stood out
because they matched to four decimals. Prefill dumps (`n>1`) run eager and are the
usable ones; putting `n` in the name is what makes the difference visible instead
of silently yielding 40 copies of one tensor.

- Syncs the stream before the copy.

## Verified

| model | layer files before | after |
|---|---|---|
| Qwen3-14B-NVFP4 | 0 | **320** |
| Qwen3.6-27B-Text-NVFP4-MTP | 0 | **512** |

Prefill profiles are sane on both — RMS 0.218 → 19.2 across 40 layers, 0.326 →
5.45 across 64, no NaN, no Inf.

Cost when unset (the default): one `std::string` emptiness check per layer.

Gate: tg128 **288.60** vs baseline 287.19 (+0.49%, spread 0.07%), `own_peak`
unchanged, CPU lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8