### PR TITLE
fix(exec): size the SSM z buffer for the attention gate that borrows it

### DIFF
--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -704,6 +704,11 @@ private:
     // Max expert FFN hidden dim from actual packed tensor shapes (may differ from cfg.expert_d_ff)
     int max_expert_eff_ = 0;
 
+    // Columns of the SSM z buffer, which the attention output gate borrows
+    // (exec_ssm_z_cols). Cached at init: configure_ssm_workspace() runs on every
+    // recurrent layer of every forward, and computing it scans all layers.
+    int ssm_z_cols_ = 0;
+
     // The dual prefill/decode workspace swap state (decode_workspace_,
     // decode_shared_workspace_, the sizes, decode_max_batch_, active_workspace_,
     // SavedWorkspace saved_prefill_ws_) moved into ws_ (exec/workspace.h).

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -1,5 +1,6 @@
 #include "exec/executor.h"
 #include "exec/workspace.h"
+#include "exec/workspace_sizes.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "memory/mem_account.h"
@@ -82,6 +83,9 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
     has_ssm_ = (cfg.ssm_inner_size > 0);
     has_gdn_ = false;  // detected from tensor presence below
     has_dense_ffn_ = (cfg.d_ff > 0);
+    // Scans all layers, so it is taken once here rather than per recurrent layer
+    // in configure_ssm_workspace().
+    ssm_z_cols_ = exec_ssm_z_cols(model);
 
     // Compute max expert FFN hidden dim from actual packed tensor shapes.
     // cfg.expert_d_ff may not match the actual tensor dimensions (e.g. Nemotron-H).
@@ -438,11 +442,15 @@ void Workspace::compute_shared_sizes(int max_tokens) {
 
         size_t proj_elem_size = *has_gdn_ ? sizeof(float) : es;
         int fused_total_out = conv_channels + inner + 2 * n_heads;
+        // z serves two tenants: the recurrent gate and the attention output
+        // gate, which borrows it. Charge the wider one, or the borrow overruns
+        // the neighbouring buffer on any model where the gate is wider.
+        int z_cols = exec_ssm_z_cols(*model_);
         ssm_shared_size_ = align256(static_cast<size_t>(max_tokens) * ssm_in_dim *
                                     proj_elem_size)  // proj (FP32 for GDN)
                            + align256(static_cast<size_t>(max_tokens) * conv_channels * es)  // xBC
                            + align256(static_cast<size_t>(max_tokens) * inner * es)          // y
-                           + align256(static_cast<size_t>(max_tokens) * inner * es)          // z
+                           + align256(static_cast<size_t>(max_tokens) * z_cols * es)         // z
                            + align256(static_cast<size_t>(max_tokens) * d * es)              // out
                            + align256(static_cast<size_t>(max_tokens) * n_heads * (*has_gdn_ ? 2 : 1) *
                                       es)  // dt (2x for GDN: alpha + beta)

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -1,4 +1,5 @@
 #include "exec/executor.h"
+#include "exec/workspace_sizes.h"
 #include "exec/workspace.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
@@ -112,8 +113,11 @@ void GraphExecutor::configure_ssm_workspace(int max_tokens) {
                                          align256(static_cast<size_t>(max_tokens) * conv_channels * es));
     ssm_y_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
                                        align256(static_cast<size_t>(max_tokens) * inner * es));
-    ssm_z_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, inner,
-                                       align256(static_cast<size_t>(max_tokens) * inner * es));
+    // The attention output gate borrows this buffer, so it is sized for the
+    // wider of the two tenants (exec_ssm_z_cols) — not for `inner` alone.
+    const int z_cols = ssm_z_cols_ > 0 ? ssm_z_cols_ : inner;
+    ssm_z_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, z_cols,
+                                       align256(static_cast<size_t>(max_tokens) * z_cols * es));
     ssm_out_buf_ = make_workspace_tensor(ptr, compute_dtype_, max_tokens, d,
                                          align256(static_cast<size_t>(max_tokens) * d * es));
     // GDN layers store BOTH alpha and beta projections in ssm_dt_buf_ (sequentially).

--- a/src/exec/workspace_sizes.cpp
+++ b/src/exec/workspace_sizes.cpp
@@ -87,6 +87,7 @@ ExecShape exec_shape_of(const Model& model) {
     s.ssm_inner_size = cfg.ssm_inner_size;
     s.ssm_conv_channels = cfg.ssm_inner_size > 0 ? cfg.ssm_conv_channels() : 0;
     s.ssm_dt_rank = cfg.ssm_dt_rank;
+    s.attn_gate_cols = exec_attn_gate_cols(model);
     s.n_experts_active = cfg.n_experts_active;
     s.n_layers = cfg.n_layers;
     // Per-layer maxima for the chunk-capture scratch — see ExecShape.
@@ -176,6 +177,30 @@ int exec_max_weight_k(const ExecShape& shape) {
         max_k = std::max(max_k, k);
     }
     return static_cast<int>(max_k);
+}
+
+int exec_ssm_z_cols(const ExecShape& shape) { return std::max(shape.ssm_inner_size, shape.attn_gate_cols); }
+
+int exec_attn_gate_cols(const Model& model) {
+    const auto& cfg = model.config();
+    const int q_cols = cfg.n_heads * cfg.head_dim;
+    if (q_cols <= 0)
+        return 0;
+    // The gate exists when a layer's q_proj is wider than Q alone; the gate half
+    // it is split into is exactly q_cols wide (executor_attention.cu).
+    for (int i = 0; i < cfg.n_layers; i++) {
+        const auto& ly = model.layer(i);
+        if (ly.wq.data && static_cast<int>(ly.wq.shape[0]) > q_cols)
+            return q_cols;
+    }
+    return 0;
+}
+
+int exec_ssm_z_cols(const Model& model) {
+    ExecShape s;
+    s.ssm_inner_size = model.config().ssm_inner_size;
+    s.attn_gate_cols = exec_attn_gate_cols(model);
+    return exec_ssm_z_cols(s);
 }
 
 ImmaScratchShape exec_imma_scratch_shape(const ExecShape& shape, int max_seq_len) {

--- a/src/exec/workspace_sizes.h
+++ b/src/exec/workspace_sizes.h
@@ -56,6 +56,11 @@ struct ExecShape {
     int ssm_inner_size = 0;
     int ssm_conv_channels = 0;
     int ssm_dt_rank = 0;
+    // Columns the Qwen3.5-style attention output gate writes. The gate half of a
+    // fused q_proj is split out into a buffer BORROWED from the SSM z buffer
+    // (executor_attention.cu), so the two sizings are coupled. 0 when the model
+    // has no gate, i.e. when no layer's q_proj is wider than n_heads * head_dim.
+    int attn_gate_cols = 0;
     // (N, logical K) of every weight the MMVQ / dequant paths can see. Logical
     // K means NVFP4's packed byte dim already doubled.
     std::vector<std::pair<int64_t, int64_t>> weights;
@@ -207,6 +212,20 @@ ExecShape exec_shape_of(const Model& model);
 int exec_max_tokens(const ExecShape& shape, int max_seq_len);
 int exec_max_weight_k(const ExecShape& shape);
 ExecT2Demand exec_t2_demand(const ExecShape& shape, int max_seq_len);
+
+// Columns the SSM z buffer must hold. It serves two tenants: the recurrent z /
+// gate projection (ssm_inner_size) and the attention output gate, which borrows
+// the same allocation. On every hybrid staged today the two are exactly equal
+// (4096 == 4096 on Qwen3.6-35B-A3B and Ornith-35B, 6144 == 6144 on the 27B), so
+// the borrow currently fits by arithmetic coincidence rather than by
+// construction — a checkpoint whose recurrent inner size is narrower than
+// n_heads * head_dim would overrun it, silently and only in prefill.
+int exec_ssm_z_cols(const ExecShape& shape);
+int exec_ssm_z_cols(const Model& model);
+
+// Width of the attention output gate, 0 when the model has no gate. Both SSM z
+// sizings call this so the buffer and its charge cannot drift apart.
+int exec_attn_gate_cols(const Model& model);
 
 // The (rows, K) pair the `imma_scratch` charge was computed from — the larger
 // of the dense and MoE routes. engine.cpp hands it to

--- a/tests/test_workspace_sizes.cpp
+++ b/tests/test_workspace_sizes.cpp
@@ -459,3 +459,61 @@ TEST(ExecT2Demand, SampleScratchFollowsTheBATCHNotTheContext) {
     // Sanity on the order of magnitude that made the wrong call wrong.
     EXPECT_LT(exec_t2_demand(long_ctx, 131072).sample_scratch, 4ull * 1024 * 1024);
 }
+
+// ── exec_ssm_z_cols ──────────────────────────────────────────────────
+//
+// The Qwen3.5-style attention output gate does not own a buffer. It splits the
+// gate half out of the fused q_proj into an allocation BORROWED from the SSM z
+// buffer, which is sized from ssm_inner_size alone. Every hybrid staged today
+// makes the two exactly equal — 4096 == 4096 on Qwen3.6-35B-A3B and
+// Ornith-1.0-35B, 6144 == 6144 on Qwen3.6-27B — so the borrow fits by
+// arithmetic coincidence rather than by construction. These pin the coupling so
+// the next checkpoint with a narrower recurrent path fails a test instead of
+// overrunning the neighbouring buffer, silently and only in prefill.
+
+// A gated hybrid: recurrent layers plus full-attention layers whose q_proj is
+// twice n_heads * head_dim (Q and gate fused).
+ExecShape gated_hybrid_shape() {
+    ExecShape s;
+    s.max_seq_len_cfg = 4096;
+    s.d_model = 2048;
+    s.d_ff = 6144;
+    s.is_ssm = true;
+    s.n_heads = 16;
+    s.head_dim = 256;         // gate needs 16 * 256 = 4096 columns
+    s.ssm_inner_size = 4096;  // what every staged checkpoint happens to have
+    s.attn_gate_cols = 4096;
+    s.weights = {{4096, 2048}};
+    return s;
+}
+
+TEST(ExecSsmZCols, CoversTheAttentionGateWhenTheRecurrentInnerIsNarrower) {
+    ExecShape s = gated_hybrid_shape();
+    s.ssm_inner_size = 2048;  // a narrower recurrent path than the gate needs
+    EXPECT_EQ(exec_ssm_z_cols(s), 4096) << "the attention gate borrows this buffer and would overrun it";
+}
+
+TEST(ExecSsmZCols, KeepsTheRecurrentInnerWhenItIsTheLargerTenant) {
+    ExecShape s = gated_hybrid_shape();
+    s.ssm_inner_size = 8192;
+    EXPECT_EQ(exec_ssm_z_cols(s), 8192);
+}
+
+TEST(ExecSsmZCols, ChargesNothingExtraForAModelWithoutAGate) {
+    ExecShape s = gated_hybrid_shape();
+    s.attn_gate_cols = 0;  // no layer's q_proj is wider than n_heads * head_dim
+    EXPECT_EQ(exec_ssm_z_cols(s), s.ssm_inner_size);
+}
+
+TEST(ExecSsmZCols, MatchesTheRecurrentInnerOnEveryHybridStagedToday) {
+    // The coincidence itself, pinned: if a future change moves either sizing,
+    // this is the test that says the two were equal on purpose-by-accident.
+    ExecShape s = gated_hybrid_shape();
+    EXPECT_EQ(exec_ssm_z_cols(s), 4096);
+
+    ExecShape wide = gated_hybrid_shape();  // the 27B: 24 heads x 256
+    wide.n_heads = 24;
+    wide.attn_gate_cols = 6144;
+    wide.ssm_inner_size = 6144;
+    EXPECT_EQ(exec_ssm_z_cols(wide), 6144);
+}


### PR DESCRIPTION
## What

The Qwen3.5-style attention output gate does not own a buffer. It splits the gate half out of the fused `q_proj` into an allocation **borrowed from the SSM z buffer** (`executor_attention.cu`), which was sized from `ssm_inner_size` alone.

Every hybrid staged today makes the two exactly equal:

| model | `ssm_inner_size` | gate needs (`n_heads * head_dim`) |
|---|---|---|
| Qwen3.6-35B-A3B | 4096 | 4096 |
| Ornith-1.0-35B | 4096 | 4096 |
| Qwen3.6-27B-Text | 6144 | 6144 |

So the borrow fits by arithmetic coincidence rather than by construction. A checkpoint whose recurrent inner size is narrower than `n_heads * head_dim` would overrun the neighbouring buffer — silently, and only in prefill.

## How

`exec_ssm_z_cols()` charges the wider of the two tenants, and **both** sizings go through it — the shared-size charge (`executor_workspace.cu`) and the pointer carve (`executor_workspace_config.cu`) — so they cannot drift apart. The value is cached at init because `configure_ssm_workspace()` runs on every recurrent layer of every forward and computing it scans all layers.

## Behaviour

Unchanged on every current checkpoint: `max(inner, gate) == inner` where the two are equal, and `attn_gate_cols` is 0 on models without a gate.

Verified on Qwen3.5-4B-mxfp4 (GDN + `attn_output_gate`, the path this touches), greedy, 24 tokens: **byte-identical token IDs** before and after.

## Tests

Four tests in `tests/test_workspace_sizes.cpp` (CPU lane, `test-core` 935 → 939). Mutation-checked: flipping `max` to `min` fails three of them and turns `make dev-test` red, which also confirms the CI lane actually runs them.

## Perf

Not a perf change — no hot-path code is touched, and the gate model (Qwen3-8B-Q8_0) has `ssm_inner_size = 0`, so `configure_ssm_workspace()` is never called on it.

`verify-fast` was red on the first run (277.09, -3.5%) under host load from unrelated containers. Alternating A/B against `main` on the same box: main 281.25 / 286.61, this branch 277.09 / 277.22 / 282.16 / **280.64 PASS**. The distributions overlap fully — this branch's round 2 (282.16) beats main's round 1 (281.25) — and `main` itself came in under the pin twice. Baseline not touched.

## Context

Found while narrowing #1273, which is what put the gate path under the microscope. It is **not** that bug — it is an unasserted coupling next to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8