### PR TITLE
feat(quantize): keep fused Q+gate projections out of NVFP4 by default

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -60,6 +60,33 @@ packed nibbles), `.weight_scale` (F8_E4M3 micro-scales), `.weight_scale_2`
 config files, and rebuilds the shard index when the source is sharded.
 Embeddings, norms and (unless `--lm-head`) the LM head stay full precision.
 
+#### Roles that stay full precision, and why
+
+Three weight roles are 2-D and K-aligned — every shape check waves them through
+— and must not be quantized anyway. Each was found by measurement, not by
+reasoning about shapes:
+
+| role | why | found by |
+|---|---|---|
+| MLA latent projections (`kv_a_proj`, `kv_b_proj`) | the runtime slices and reshapes both | bisection on DeepSeek-V2-Lite: quantizing them gave a checkpoint that loaded and emitted cross-script garbage |
+| MoE router (`.gate.weight`) | FP4 across 16 shared-scale values changes the top-k pick | measured separately, with the MLA pair already excluded |
+| **fused Q+gate `q_proj`** (Qwen3.5 / Qwen3-Next `attn_output_gate`) | the gate half feeds a **sigmoid**, and E2M1 is coarsest near zero — exactly where a sigmoid is most sensitive | #1273: rounding *only* that half on a healthy GGUF twin reproduces the real defect (+0.0169 injected divergence per attention block vs +0.0156 for the actual NVFP4 checkpoint); the Q half sits below the noise floor |
+
+The last one is **not** a 4-bit problem: the same half in Q4_K is healthy at
+6.55 perplexity. It is specific to NVFP4/E2M1, which offers 8 magnitudes per
+micro-block.
+
+imp cannot exclude half a tensor, so the whole `q_proj` is kept — 230 MiB on
+Qwen3.6-35B-A3B (10 gated layers of 40) and 552 MiB on the 27B (16 of 64), about
+1% and 4% of the checkpoint, against a 2.08x–6x perplexity penalty.
+`--quantize-attn-gate` opts back in and warns.
+
+A gated `q_proj` is detected from shapes rather than a config flag: it emits
+twice what its own layer's `o_proj` consumes. Note that **published exports have
+the same gap** — both llm-compressor and Modelopt exclude `linear_attn.*` but
+quantize this tensor whole, which is why every hybrid NVFP4 checkpoint tested
+degrades.
+
 #### What `--calib` does
 
 NVFP4's error scales with the magnitude of what it quantizes, so multiplying an

--- a/scripts/bench_longctx_ab.sh
+++ b/scripts/bench_longctx_ab.sh
@@ -33,7 +33,7 @@ CTXS="${3:-2048 8192 32768}"
 MODELS="${4:-/models/Qwen3-8B-Q8_0.gguf /models/Qwen3-30B-A3B-NVFP4-Modelopt}"
 ROUNDS="${LONGCTX_ROUNDS:-3}"
 THRESHOLD="${LONGCTX_THRESHOLD:-3.0}"   # percent; regressions worse than this fail
-MODELS_DIR="${IMP_MODELS_DIR:-/home/kekz/models}"
+MODELS_DIR="${IMP_MODELS_DIR:-$HOME/models}"
 
 # A busy GPU makes every number below meaningless.
 if command -v nvidia-smi >/dev/null 2>&1; then

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -82,6 +82,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <map>
 #include <memory>
 #include <string>
@@ -98,6 +99,11 @@ struct Options {
     // --calib-groups: which AWQ scale groups run, for attributing a bad result.
     std::string calib_groups = awq::kAwqAllGroups;
     bool quantize_lm_head = false;  // imp has its own lm_head NVFP4 policy (#982)
+    // A fused Q+gate q_proj is excluded by default: NVFP4 in the gate half is
+    // the measured root cause of #1273. Costs 230 MiB on Qwen3.6-35B-A3B (10
+    // gated layers of 40) and 552 MiB on the 27B (16 of 64) — ~1% and ~4% of the
+    // checkpoint, against a 2.08x-6x perplexity penalty. This opts back in.
+    bool quantize_attn_gate = false;
     bool dry_run = false;
 };
 
@@ -124,6 +130,12 @@ void usage() {
         "                docs/quantization.md.\n"
         "  --lm-head     also quantize lm_head (default: excluded, imp applies its\n"
         "                own measured lm_head policy at runtime)\n"
+        "  --quantize-attn-gate\n"
+        "                also quantize a fused Q+gate q_proj (Qwen3.5 / Qwen3-Next\n"
+        "                `attn_output_gate`). Excluded by default: NVFP4 in the gate\n"
+        "                half is the measured root cause of #1273 and costs 2.08x-6x\n"
+        "                perplexity. Keeping it full precision costs ~1-4% of the\n"
+        "                checkpoint (230 MiB on Qwen3.6-35B-A3B, 552 on the 27B).\n"
         "  --dry-run     report what would be quantized, write nothing\n");
 }
 
@@ -282,6 +294,8 @@ int main(int argc, char** argv) {
             opt.out_dir = next();
         else if (a == "--lm-head")
             opt.quantize_lm_head = true;
+        else if (a == "--quantize-attn-gate")
+            opt.quantize_attn_gate = true;
         else if (a == "--calib")
             opt.calib_file = next();
         else if (a == "--calib-groups") {
@@ -379,8 +393,19 @@ int main(int argc, char** argv) {
         }
     }
 
-    // Warn, do not refuse: this is a quality trade the caller owns, and the
-    // checkpoint still works — it is measurably worse, not broken on load.
+    // Fused Q+gate projections stay full precision by default. NVFP4 in the gate
+    // half is the measured root cause of #1273: rounding ONLY that half on a
+    // healthy GGUF twin reproduces the real defect (+0.0169 divergence injected
+    // per attention block against the +0.0156 the actual NVFP4 checkpoint
+    // injects), while the Q half sits below the noise floor. Not a 4-bit
+    // problem — the same half in Q4_K is healthy; E2M1 is coarsest near zero,
+    // where a sigmoid is most sensitive.
+    //
+    // imp cannot exclude half a tensor, so the whole q_proj is kept. That costs
+    // 230 MiB on Qwen3.6-35B-A3B and 552 MiB on the 27B (~1% and ~4%) against a
+    // 2.08x-6x perplexity penalty, which is why it is the default rather than a
+    // flag the user has to know about.
+    std::set<std::string> gated_q_proj;
     {
         std::vector<const RawTensor*> gated;
         for (const auto& src : opened) {
@@ -388,19 +413,22 @@ int main(int argc, char** argv) {
             gated.insert(gated.end(), found.begin(), found.end());
         }
         if (!gated.empty()) {
-            fprintf(stderr,
-                    "warning: %zu q_proj tensor(s) carry a fused attention output GATE alongside Q\n"
-                    "(Qwen3.5 / Qwen3-Next `attn_output_gate`). The gate half feeds a sigmoid, and\n"
-                    "NVFP4 there is the measured root cause of #1273 — hybrid checkpoints degrade\n"
-                    "2.08x-6x on perplexity while dense ones cost 1.05x. The same half in Q4_K is\n"
-                    "healthy, so this is specific to E2M1: 8 magnitudes per micro-block, coarsest\n"
-                    "near zero, which is where a sigmoid is most sensitive.\n"
-                    "imp cannot exclude half a tensor yet, so these are quantized whole.\n",
-                    gated.size());
-            for (size_t i = 0; i < gated.size() && i < 3; ++i)
-                fprintf(stderr, "  %s\n", gated[i]->name.c_str());
-            if (gated.size() > 3)
-                fprintf(stderr, "  ... and %zu more\n", gated.size() - 3);
+            size_t extra_bytes = 0;
+            for (const RawTensor* t : gated) {
+                // What keeping it full precision costs over quantizing it.
+                const size_t nvfp4 = t->numel() / 2 + t->numel() / 16;
+                extra_bytes += t->nbytes > nvfp4 ? t->nbytes - nvfp4 : 0;
+                if (!opt.quantize_attn_gate)
+                    gated_q_proj.insert(t->name);
+            }
+            printf("%s %zu fused Q+gate projection(s), %.0f MiB %s (#1273)\n",
+                   opt.quantize_attn_gate ? "  QUANTIZING" : "  KEEPING", gated.size(),
+                   double(extra_bytes) / (1024.0 * 1024.0),
+                   opt.quantize_attn_gate ? "saved, at a 2.08x-6x perplexity penalty" : "larger");
+            if (opt.quantize_attn_gate)
+                fprintf(stderr,
+                        "warning: --quantize-attn-gate puts the attention gate half in NVFP4, which\n"
+                        "is the measured root cause of #1273. Expect 2.08x-6x worse perplexity.\n");
         }
     }
 
@@ -463,7 +491,13 @@ int main(int argc, char** argv) {
         for (const auto& t : src.tensors()) {
             bytes_in += t.nbytes;
             std::string why;
-            if (!quantize::should_quantize(t, opt.quantize_lm_head, why)) {
+            // Checked before should_quantize, which sees one tensor and cannot
+            // know a q_proj is gated — that needs the layer's o_proj too.
+            const bool gated = gated_q_proj.count(t.name) != 0;
+            if (gated)
+                why = "fused Q+gate projection — NVFP4 in the gate half is #1273 "
+                      "(use --quantize-attn-gate to include it anyway)";
+            if (gated || !quantize::should_quantize(t, opt.quantize_lm_head, why)) {
                 if (contains(why, "3-D stacked")) {
                     n_moe_skipped++;
                     printf("  SKIP  %-58s %s\n", t.name.c_str(), why.c_str());


### PR DESCRIPTION
#1280 detected these and warned. This **excludes** them — because the cost of keeping them is far smaller than I claimed when I deferred the decision.

## The number that changed my mind

I said "~1.3 GB" and deferred. That was a guess, and measuring it from the actual checkpoint shapes makes it 5–6x too high:

| checkpoint | gated layers | cost of keeping `q_proj` full precision | share |
|---|---|---|---|
| Qwen3.6-35B-A3B | 10 of 40 | **230 MiB** | ~1% |
| Qwen3.6-27B-Text | 16 of 64 | **552 MiB** | ~4% |

Against a **2.08x–6x perplexity penalty**. At 1–4% this is not a trade-off worth making the user discover, so it is the default; `--quantize-attn-gate` opts back in and warns.

## Why the whole tensor

imp cannot exclude half a tensor. The gate half is what matters — rounding *only* it on a healthy GGUF twin reproduces the real defect (+0.0169 injected divergence per attention block against +0.0156 for the actual NVFP4 checkpoint), while the Q half sits below the noise floor. Keeping both is the conservative version of the right fix.

## Verification without a BF16 hybrid

The blocker on proving this end to end was that every gated checkpoint on this box is already quantized. A synthetic BF16 checkpoint removes that dependency — one gated layer (`q_proj` 64x32, `o_proj` 32x32) and one dense layer (32x32):

```
default                 KEEPING 1 fused Q+gate projection(s), ... (#1273)
                        QUANT  model.layers.1.self_attn.q_proj.weight  [32,32]
                        (layers.0 q_proj absent — kept)

--quantize-attn-gate    QUANTIZING 1 fused Q+gate projection(s), ...
                        QUANT  model.layers.0.self_attn.q_proj.weight  [64,32]
                        QUANT  model.layers.1.self_attn.q_proj.weight  [32,32]
                        warning: ... expect 2.08x-6x worse perplexity
```

Both paths exercised, including that a **dense** `q_proj` is still quantized — the failure mode that would make this fix worse than the bug.

## Docs

`docs/quantization.md` now lists all three full-precision roles side by side (MLA latent projections, MoE router, fused Q+gate) with what each was found by, since "2-D and K-aligned" waves all three through. It also records that **published exports have the same gap**: both llm-compressor and Modelopt exclude `linear_attn.*` but quantize this tensor whole, which is why every hybrid NVFP4 checkpoint tested degrades.

## Perf

`verify-fast` **green**: decode tg128 **287.47** (+0.10% against the 287.19 pin). Worth noting after three red gates earlier today on the same box — those were host load, as the alternating A/B against `main` showed each time (main 277.51 / 277.62 under load, 281–287 quiet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8