### PR TITLE
fix(quantize): stop excluding the gate half by default — it measured worse

### DIFF
--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -70,16 +70,39 @@ reasoning about shapes:
 |---|---|---|
 | MLA latent projections (`kv_a_proj`, `kv_b_proj`) | the runtime slices and reshapes both | bisection on DeepSeek-V2-Lite: quantizing them gave a checkpoint that loaded and emitted cross-script garbage |
 | MoE router (`.gate.weight`) | FP4 across 16 shared-scale values changes the top-k pick | measured separately, with the MLA pair already excluded |
-| **fused Q+gate `q_proj`** (Qwen3.5 / Qwen3-Next `attn_output_gate`) | the gate half feeds a **sigmoid**, and E2M1 is coarsest near zero — exactly where a sigmoid is most sensitive | #1273: rounding *only* that half on a healthy GGUF twin reproduces the real defect (+0.0169 injected divergence per attention block vs +0.0156 for the actual NVFP4 checkpoint); the Q half sits below the noise floor |
+| **fused Q+gate `q_proj`** (Qwen3.5 / Qwen3-Next `attn_output_gate`) | reported, **not excluded** — see below | #1273 |
 
-The last one is **not** a 4-bit problem: the same half in Q4_K is healthy at
-6.55 perplexity. It is specific to NVFP4/E2M1, which offers 8 magnitudes per
-micro-block.
+The last row is a correction. The gate half feeds a **sigmoid**, and E2M1 is
+coarsest near zero — exactly where a sigmoid is most sensitive — so it is where
+#1273's divergence is created: rounding *only* that half on a healthy GGUF twin
+reproduces the real defect (+0.0169 injected divergence per attention block
+against +0.0156 for the actual NVFP4 checkpoint), while the Q half sits below
+the noise floor. The same half in Q4_K is healthy, so this is specific to E2M1.
 
-imp cannot exclude half a tensor, so the whole `q_proj` is kept — 230 MiB on
-Qwen3.6-35B-A3B (10 gated layers of 40) and 552 MiB on the 27B (16 of 64), about
-1% and 4% of the checkpoint, against a 2.08x–6x perplexity penalty.
-`--quantize-attn-gate` opts back in and warns.
+**That divergence does not translate into a quality win for excluding it**, and
+this briefly shipped asserting it did. Measured end to end on Qwen3.5-4B (8
+gated layers of 32), perplexity over `ppl_corpus_45k.txt`, three runs each:
+
+| arm | runs | spread |
+|---|---|---|
+| gate quantized (default) | **14.6665 / 14.6476 / 14.6716** | 0.16% |
+| gate excluded | 14.8672 / 14.9339 / 14.8672 | 0.45% |
+| BF16 reference | 12.6735 | — |
+
+Excluding it is **~1.5% worse**, consistently, with non-overlapping spreads —
+and it costs 1-4% of the checkpoint on top. Divergence measured against a twin
+and quality measured against a corpus are different questions, and only the
+second one decides this.
+
+`--keep-attn-gate` keeps the option available: the one checkpoint that could be
+measured has a lower gate share than the worst #1273 offender (8/32 against
+16/64), so the trade may still turn on a model with more of them. imp cannot
+exclude half a tensor, so the flag keeps the whole `q_proj`.
+
+A gated `q_proj` is detected from shapes rather than a config flag: it emits
+twice what its own layer's `o_proj` consumes. Note that **published exports
+quantize it too** — both llm-compressor and Modelopt exclude `linear_attn.*`
+but not this tensor.
 
 A gated `q_proj` is detected from shapes rather than a config flag: it emits
 twice what its own layer's `o_proj` consumes. Note that **published exports have

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -160,6 +160,35 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
              &logits_, &fp32_accum_buf_, &fp32_hidden_);
 
     // Compute shared workspace sizes (no allocation — deferred to allocate_workspaces()).
+    // Detect GDN layers (Gated DeltaNet, e.g., Qwen3.5) BEFORE the shared sizes
+    // are computed. GDN carries its input projection in FP32 for precision, so
+    // compute_shared_sizes() charges 4 bytes/elem for it — but only if it knows
+    // the model is GDN. Reading has_gdn_ while it is still false reserved HALF
+    // the bytes the pointer carve then handed out, and configure_ssm_workspace()
+    // ran later, when the flag WAS set, so the two disagreed by exactly 2x.
+    //
+    // On a GDN+MoE model the MoE phase dominates the shared arena and hid this;
+    // on a GDN+dense model (Qwen3.5-4B) the SSM phase is the maximum, and the
+    // overrun corrupted every token past the halfway point — NaN from the first
+    // recurrent layer whose block exceeded it, silently and prefill-only (#1282).
+    //
+    // Deliberately placed AFTER the max_tokens cap above, which reads has_gdn_
+    // while it is still false. That is the AS-BUILT behaviour the T2 reservation
+    // replicates on purpose (AUDIT B18) — moving this any earlier would change
+    // the cap and under-reserve the arena by 2x instead.
+    {
+        int gdn_idx = 0;
+        for (int i = 0; i < cfg.n_layers; i++) {
+            if (model_->layer(i).gdn_gate.data != nullptr) {
+                gdn_idx++;
+            }
+        }
+        if (gdn_idx > 0) {
+            has_gdn_ = true;
+            IMP_LOG_INFO("GDN layers: %d out of %d total", gdn_idx, cfg.n_layers);
+        }
+    }
+
     // Deferring GPU allocation maximizes VRAM available for expert weight upload.
     ws_.compute_shared_sizes(max_tokens_);
 
@@ -175,19 +204,6 @@ bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, 
         IMP_LOG_INFO("SSM layers: %d out of %d total", ssm_idx, cfg.n_layers);
     }
 
-    // Detect GDN layers (Gated DeltaNet, e.g., Qwen3.5)
-    {
-        int gdn_idx = 0;
-        for (int i = 0; i < cfg.n_layers; i++) {
-            if (model_->layer(i).gdn_gate.data != nullptr) {
-                gdn_idx++;
-            }
-        }
-        if (gdn_idx > 0) {
-            has_gdn_ = true;
-            IMP_LOG_INFO("GDN layers: %d out of %d total", gdn_idx, cfg.n_layers);
-        }
-    }
 
     // Enable Programmatic Dependent Launch on custom kernels if requested.
     if (use_pdl_ && pdl::is_available()) {

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -1402,7 +1402,6 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
     for (Tensor* t : {&L.ssm_a, &L.ssm_d, &L.ssm_dt_b}) {
         if (!t->data || t->on_device)
             continue;
-        const bool is_ssm_a_hf = (t == &L.ssm_a) && (t->qtype == QType::BF16 || t->qtype == QType::F16);
         const int64_t n_elem = t->numel();
         const size_t fp32_bytes = static_cast<size_t>(n_elem) * sizeof(float);
         void* d_data = nullptr;
@@ -1414,13 +1413,7 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
 
         std::vector<float> h_fp32(static_cast<size_t>(n_elem));
         if (t->qtype == QType::F32 || t->qtype == QType::NONE) {
-            // GGUF path — already FP32, ssm_a already pre-transformed by converter.
-            h2d_copy(d_data, t->data, fp32_bytes, ctx.stream);
-            ctx.gpu_allocs.push_back(d_data);
-            t->data = d_data;
-            t->qtype = QType::F32;
-            t->on_device = true;
-            continue;
+            std::memcpy(h_fp32.data(), t->data, fp32_bytes);
         } else if (t->qtype == QType::BF16) {
             const uint16_t* src = static_cast<const uint16_t*>(t->data);
             for (int64_t k = 0; k < n_elem; ++k) {
@@ -1439,7 +1432,30 @@ static bool upload_layer_ssm_weights(TransformerLayer& L, int i, const UploadCtx
         }
 
         // Apply HF-to-GGUF A_log transform: A_log_GGUF = -exp(A_log_HF).
-        // Only for ssm_a, only when source is BF16/F16 (= HF SafeTensors path).
+        //
+        // Deciding this from the dtype does NOT work. It used to read "F32 means
+        // GGUF, already transformed" and skip — but an HF checkpoint may store
+        // A_log as F32, and Qwen3.5-4B does. Its raw A_log then reached the scan
+        // as a positive decay rate (up to +2.05), so the state grew instead of
+        // decaying: per-token absmax 0.04, 0.06, 0.40, 2.51, 110, 31680, inf.
+        // FP16 overflows between token 5 and 6, rmsnorm(inf) makes NaN, and the
+        // model emitted one token forever (#1282).
+        //
+        // Decide from the VALUES, which is decidable: -exp(x) is strictly
+        // negative for every real x, so any value >= 0 can only be a raw HF
+        // A_log. The dtype signal is kept as an OR because BF16/F16 storage is
+        // HF-only regardless of sign — a GGUF file never gets here in those
+        // types. When every value is negative AND the source is F32, this stays
+        // a no-op, exactly as before, so no existing GGUF model changes.
+        bool has_nonnegative = false;
+        for (int64_t k = 0; k < n_elem; ++k) {
+            if (h_fp32[k] >= 0.0f) {
+                has_nonnegative = true;
+                break;
+            }
+        }
+        const bool is_ssm_a_hf = (t == &L.ssm_a) &&
+                                 (t->qtype == QType::BF16 || t->qtype == QType::F16 || has_nonnegative);
         if (is_ssm_a_hf) {
             for (int64_t k = 0; k < n_elem; ++k) {
                 h_fp32[k] = -std::exp(h_fp32[k]);

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -99,11 +99,12 @@ struct Options {
     // --calib-groups: which AWQ scale groups run, for attributing a bad result.
     std::string calib_groups = awq::kAwqAllGroups;
     bool quantize_lm_head = false;  // imp has its own lm_head NVFP4 policy (#982)
-    // A fused Q+gate q_proj is excluded by default: NVFP4 in the gate half is
-    // the measured root cause of #1273. Costs 230 MiB on Qwen3.6-35B-A3B (10
-    // gated layers of 40) and 552 MiB on the 27B (16 of 64) — ~1% and ~4% of the
-    // checkpoint, against a 2.08x-6x perplexity penalty. This opts back in.
-    bool quantize_attn_gate = false;
+    // Keep a fused Q+gate q_proj out of NVFP4. OFF by default: the gate half
+    // demonstrably carries the #1273 divergence, but excluding it did NOT
+    // improve perplexity when measured end to end — it cost ~1.5% (see the
+    // header). Kept as an opt-in so the trade stays available on models where
+    // the gate share is higher than the one checkpoint that could be measured.
+    bool keep_attn_gate = false;
     bool dry_run = false;
 };
 
@@ -130,12 +131,12 @@ void usage() {
         "                docs/quantization.md.\n"
         "  --lm-head     also quantize lm_head (default: excluded, imp applies its\n"
         "                own measured lm_head policy at runtime)\n"
-        "  --quantize-attn-gate\n"
-        "                also quantize a fused Q+gate q_proj (Qwen3.5 / Qwen3-Next\n"
-        "                `attn_output_gate`). Excluded by default: NVFP4 in the gate\n"
-        "                half is the measured root cause of #1273 and costs 2.08x-6x\n"
-        "                perplexity. Keeping it full precision costs ~1-4% of the\n"
-        "                checkpoint (230 MiB on Qwen3.6-35B-A3B, 552 on the 27B).\n"
+        "  --keep-attn-gate\n"
+        "                keep a fused Q+gate q_proj (Qwen3.5 / Qwen3-Next\n"
+        "                `attn_output_gate`) out of NVFP4. OFF by default: the gate\n"
+        "                half carries #1273's divergence, but excluding it measured\n"
+        "                ~1.5%% WORSE on perplexity, not better, and costs 1-4% of\n"
+        "                the checkpoint. Kept for models with a higher gate share.\n"
         "  --dry-run     report what would be quantized, write nothing\n");
 }
 
@@ -294,8 +295,8 @@ int main(int argc, char** argv) {
             opt.out_dir = next();
         else if (a == "--lm-head")
             opt.quantize_lm_head = true;
-        else if (a == "--quantize-attn-gate")
-            opt.quantize_attn_gate = true;
+        else if (a == "--keep-attn-gate")
+            opt.keep_attn_gate = true;
         else if (a == "--calib")
             opt.calib_file = next();
         else if (a == "--calib-groups") {
@@ -393,18 +394,27 @@ int main(int argc, char** argv) {
         }
     }
 
-    // Fused Q+gate projections stay full precision by default. NVFP4 in the gate
-    // half is the measured root cause of #1273: rounding ONLY that half on a
-    // healthy GGUF twin reproduces the real defect (+0.0169 divergence injected
-    // per attention block against the +0.0156 the actual NVFP4 checkpoint
-    // injects), while the Q half sits below the noise floor. Not a 4-bit
-    // problem — the same half in Q4_K is healthy; E2M1 is coarsest near zero,
-    // where a sigmoid is most sensitive.
+    // Fused Q+gate projections are quantized like anything else. They are
+    // reported because the gate half is where #1273's divergence is created:
+    // rounding ONLY that half on a healthy GGUF twin reproduces the real defect
+    // (+0.0169 injected per attention block vs +0.0156 for the actual NVFP4
+    // checkpoint), while the Q half sits below the noise floor.
     //
-    // imp cannot exclude half a tensor, so the whole q_proj is kept. That costs
-    // 230 MiB on Qwen3.6-35B-A3B and 552 MiB on the 27B (~1% and ~4%) against a
-    // 2.08x-6x perplexity penalty, which is why it is the default rather than a
-    // flag the user has to know about.
+    // That divergence is real. What does NOT follow from it is a quality win
+    // for excluding the tensor, and this shipped briefly asserting one. Measured
+    // end to end on Qwen3.5-4B (8 gated layers of 32), perplexity over
+    // ppl_corpus_45k, three runs each:
+    //
+    //   gate quantized  14.6665 / 14.6476 / 14.6716   (spread 0.16%)
+    //   gate excluded   14.8672 / 14.9339 / 14.8672   (spread 0.45%)
+    //   BF16 reference  12.6735
+    //
+    // Excluding it is ~1.5% WORSE, consistently, with non-overlapping spreads —
+    // so it also costs 1-4% of the checkpoint for nothing. Divergence against a
+    // twin is not the same measurement as quality, and only the latter decides
+    // this. `--keep-attn-gate` retains the option: the one checkpoint that could
+    // be measured has a lower gate share than the worst #1273 offender (8/32
+    // against 16/64), so the trade may still turn on a model with more of them.
     std::set<std::string> gated_q_proj;
     {
         std::vector<const RawTensor*> gated;
@@ -418,17 +428,17 @@ int main(int argc, char** argv) {
                 // What keeping it full precision costs over quantizing it.
                 const size_t nvfp4 = t->numel() / 2 + t->numel() / 16;
                 extra_bytes += t->nbytes > nvfp4 ? t->nbytes - nvfp4 : 0;
-                if (!opt.quantize_attn_gate)
+                if (opt.keep_attn_gate)
                     gated_q_proj.insert(t->name);
             }
             printf("%s %zu fused Q+gate projection(s), %.0f MiB %s (#1273)\n",
-                   opt.quantize_attn_gate ? "  QUANTIZING" : "  KEEPING", gated.size(),
+                   opt.keep_attn_gate ? "  KEEPING" : "  QUANTIZING", gated.size(),
                    double(extra_bytes) / (1024.0 * 1024.0),
-                   opt.quantize_attn_gate ? "saved, at a 2.08x-6x perplexity penalty" : "larger");
-            if (opt.quantize_attn_gate)
+                   opt.keep_attn_gate ? "larger (--keep-attn-gate)" : "saved");
+            if (opt.keep_attn_gate)
                 fprintf(stderr,
-                        "warning: --quantize-attn-gate puts the attention gate half in NVFP4, which\n"
-                        "is the measured root cause of #1273. Expect 2.08x-6x worse perplexity.\n");
+                        "note: --keep-attn-gate excludes the gate half. On the one checkpoint this\n"
+                        "could be measured on it cost ~1.5%% perplexity rather than gaining any.\n");
         }
     }
 
@@ -495,8 +505,7 @@ int main(int argc, char** argv) {
             // know a q_proj is gated — that needs the layer's o_proj too.
             const bool gated = gated_q_proj.count(t.name) != 0;
             if (gated)
-                why = "fused Q+gate projection — NVFP4 in the gate half is #1273 "
-                      "(use --quantize-attn-gate to include it anyway)";
+                why = "fused Q+gate projection (--keep-attn-gate)";
             if (gated || !quantize::should_quantize(t, opt.quantize_lm_head, why)) {
                 if (contains(why, "3-D stacked")) {
                     n_moe_skipped++;


### PR DESCRIPTION
Reverts the default introduced in #1281.

## What stands

The divergence measurement is unchanged: rounding **only** the gate half of a fused `q_proj` on a healthy GGUF twin reproduces #1273's defect — +0.0169 injected divergence per attention block against +0.0156 for the real NVFP4 checkpoint — while the Q half sits below the noise floor.

## What did not

The step I never checked: that this divergence is a quality loss worth 1-4% of the checkpoint. Measured end to end on Qwen3.5-4B (8 gated layers of 32), perplexity over `ppl_corpus_45k.txt`, three runs each:

| arm | runs | spread |
|---|---|---|
| **gate quantized** (this PR's default) | **14.6665 / 14.6476 / 14.6716** | 0.16% |
| gate excluded (#1281's default) | 14.8672 / 14.9339 / 14.8672 | 0.45% |
| BF16 reference | 12.6735 | — |

Excluding it is **~1.5% worse**, consistently, with **non-overlapping spreads**. It cost size *and* quality.

## Why it could not be caught earlier

This model produced uniform logits until #1284 fixed the `A_log` transform, so no perplexity number from it meant anything. Every gated checkpoint already staged was pre-quantized, so no forward measurement existed at all. Filing the exclusion before one was possible is the actual error — the divergence result had felt like enough evidence, and divergence against a twin and quality against a corpus are simply different questions.

## What this keeps

- **The detection and its four tests.** Correct, and it found that the MTP layer carries the same gate.
- **The reporting line**, now stating what is being quantized rather than skipped.
- **`--keep-attn-gate`** (was `--quantize-attn-gate`, inverted). The trade stays available: this checkpoint has a lower gate share than the worst #1273 offender — 8/32 against 16/64 — so one measurement is not proof for the family.

## Verification

- Both paths exercised on the synthetic gated checkpoint: default quantizes both `q_proj`s, `--keep-attn-gate` skips the gated one and keeps the dense one.
- `make dev-test` green (939 tests). `verify-fast` green: decode tg128 287.03 (-0.06% vs pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8