### PR TITLE
fix(runtime): say it out loud when the KV pool cannot hold the requested context

### DIFF
--- a/src/memory/vram_query.h
+++ b/src/memory/vram_query.h
@@ -113,6 +113,38 @@ struct KvResidualSizing {
 // plan is a projection, the residual is the truth) from "there was nothing
 // left to size from" (always an operator-visible fault), so the caller can
 // be quiet about the first and loud about the second.
+// Blocks one max_seq_len sequence occupies. 0 when either input is unset,
+// which reads as "no requirement to check against".
+inline int kv_blocks_per_sequence(int max_seq_len, int block_size) {
+    if (max_seq_len <= 0 || block_size <= 0)
+        return 0;
+    return (max_seq_len + block_size - 1) / block_size;
+}
+
+// What the operator has to be told about the pool this sizing produced.
+//
+// `Floored` has had its own message since #1251: nothing was left to size
+// from. `ShortOfOneSequence` is the quiet half of the same fault and had
+// none — the pool is a real size, just too small for a single max_seq_len
+// request, so the load reports success and every full-length generation is
+// cancelled at admission instead. Both are operator faults; only the first
+// was audible.
+enum class KvPoolVerdict {
+    Sufficient,          // holds at least one full-length sequence
+    ShortOfOneSequence,  // sized, but no full-length request can be admitted
+    Floored,             // nothing was left to size from
+};
+
+inline KvPoolVerdict kv_pool_verdict(const KvResidualSizing& sizing, int max_seq_len,
+                                     int block_size) {
+    if (sizing.floored)
+        return KvPoolVerdict::Floored;
+    const int need = kv_blocks_per_sequence(max_seq_len, block_size);
+    if (need > 0 && sizing.blocks < need)
+        return KvPoolVerdict::ShortOfOneSequence;
+    return KvPoolVerdict::Sufficient;
+}
+
 inline KvResidualSizing kv_blocks_from_residual(size_t free_bytes, size_t headroom_bytes,
                                                 size_t per_block_bytes, int planned_blocks,
                                                 int floor_blocks) {

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -576,6 +576,12 @@ private:
     std::unique_ptr<LayerOffloadManager> offload_mgr_;
     bool experts_on_host_ = false;
     bool dequant_done_ = false;
+    // max_seq_len came from the operator (--max-seq-len / runtime.max_seq_len /
+    // C-API), not from the auto resolver. The KV pool check needs the two apart:
+    // an auto value is a projection the measured residual is allowed to
+    // undercut, an explicit one is a request that has to be honoured or said
+    // out loud.
+    bool max_seq_len_explicit_ = false;
     // One-shot guard for the resolved-dispatch summary (#1205).
     bool dispatch_dump_done_ = false;
     // Why CUDA graphs were turned off, if they were. First reason wins: a model

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -602,6 +602,11 @@ void Engine::init_compute_max_seq_len_() {
         config_.max_seq_len = v;
         IMP_LOG_INFO("max_seq_len: runtime.max_seq_len=%d", v);
     }
+    // Whoever set it before the auto resolver runs is the operator: the CLI
+    // flag, runtime.max_seq_len, or a C-API embedding. Recorded here because
+    // the value itself no longer says where it came from once auto has filled
+    // it in, and the KV pool check downstream turns on exactly that.
+    max_seq_len_explicit_ = config_.max_seq_len > 0;
     if (config_.max_seq_len <= 0) {
         int model_ctx = mcfg.max_seq_len;  // from GGUF metadata
         size_t free_vram = 0, total_vram = 0;

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -388,6 +388,35 @@ bool Engine::init_kv_cache() {
                 static_cast<double>(sizing.blocks) * kv_bs, max_blocks_planned,
                 static_cast<double>(sizing.blocks) * kv_bs);
         }
+        // The quiet half of the same fault: the pool is a real size — not the
+        // floor — and still holds less than one max_seq_len sequence, so the
+        // load reports success and every full-length request is cancelled at
+        // admission. With an explicit --vram-budget the check below turns this
+        // into a hard failure; without one the path stays best-effort by
+        // design, so it has to at least say so (#1251).
+        //
+        // Only for an operator-set max_seq_len. An AUTO value is a projection
+        // that this clamp is *expected* to undercut — init_compute_max_seq_len_
+        // sizes the GGUF path from raw free VRAM on purpose and leaves the
+        // overshoot for exactly this clamp to absorb. Warning there would fire
+        // on healthy loads and bury the case that is a fault.
+        if (vram_budget_bytes() == 0 && max_seq_len_explicit_ &&
+            kv_pool_verdict(sizing, config_.max_seq_len, kv_bs) ==
+                KvPoolVerdict::ShortOfOneSequence) {
+            const int need_blocks = kv_blocks_per_sequence(config_.max_seq_len, kv_bs);
+            const double need_mib =
+                double(need_blocks) * double(per_block_total_bytes) / (1024.0 * 1024.0);
+            const double have_mib =
+                double(sizing.blocks) * double(per_block_total_bytes) / (1024.0 * 1024.0);
+            IMP_LOG_WARN(
+                "KV cache: the pool ends up at %d blocks (%.0f MiB, %.0f tokens) but the "
+                "requested max_seq_len=%d needs %d blocks (%.0f MiB). Every full-length request "
+                "will be cancelled at admission even though this load reports success. Lower "
+                "--max-seq-len, lower the weight-cache demand (moe.reserve_mib, --kv-fp8), or "
+                "free at least %.0f MiB for the KV pool.",
+                sizing.blocks, have_mib, static_cast<double>(sizing.blocks) * kv_bs,
+                config_.max_seq_len, need_blocks, need_mib, need_mib - have_mib);
+        }
     }
 
     // I6, plan-time half: an explicit --vram-budget that cannot hold one
@@ -400,7 +429,7 @@ bool Engine::init_kv_cache() {
     // Only when a budget is installed. Without one this is the pre-existing
     // best-effort path and must keep its current behaviour.
     if (vram_budget_bytes() > 0 && per_block_total_bytes > 0) {
-        const int blocks_per_seq = (config_.max_seq_len + kv_bs - 1) / kv_bs;
+        const int blocks_per_seq = kv_blocks_per_sequence(config_.max_seq_len, kv_bs);
         if (max_blocks < blocks_per_seq) {
             const double need_mib =
                 double(blocks_per_seq) * double(per_block_total_bytes) / (1024.0 * 1024.0);

--- a/tests/test_kv_residual_sizing.cpp
+++ b/tests/test_kv_residual_sizing.cpp
@@ -95,5 +95,68 @@ TEST(KvResidualSizing, FreeBelowHeadroomDoesNotUnderflow) {
     EXPECT_TRUE(s.floored);
 }
 
+// ── kv_pool_verdict ───────────────────────────────────────────────────────
+//
+// The floor case has been loud since #1251. This covers the case that stayed
+// quiet: a pool that is a real size and still cannot admit one full-length
+// request, which the load reports as success.
+
+TEST(KvPoolVerdict, PoolHoldingAFullSequenceIsSufficient) {
+    // 4096 blocks x 32 tokens = 131072 tokens against a 8192-token request.
+    const auto s = kv_blocks_from_residual(8192 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    EXPECT_EQ(kv_pool_verdict(s, 8192, 32), KvPoolVerdict::Sufficient);
+}
+
+TEST(KvPoolVerdict, ClampedButStillShortOfOneSequenceIsReported) {
+    // 2416 MiB residual - 1630 MiB headroom = 786 MiB -> 1257 blocks, well
+    // above the 16-block floor, so `floored` is false and the pre-#1251 code
+    // said nothing. 1257 x 32 = 40224 tokens; a 65536-token max_seq_len needs
+    // 2048 blocks, so no full-length request can ever be admitted.
+    const auto s = kv_blocks_from_residual(2416 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    ASSERT_TRUE(s.clamped);
+    ASSERT_FALSE(s.floored) << "this case must not be the floor, or it is the other message";
+    EXPECT_EQ(kv_pool_verdict(s, 65536, 32), KvPoolVerdict::ShortOfOneSequence);
+    // Same pool, a request it can serve: nothing to report.
+    EXPECT_EQ(kv_pool_verdict(s, 32768, 32), KvPoolVerdict::Sufficient);
+}
+
+TEST(KvPoolVerdict, FlooredKeepsItsOwnMessage) {
+    // Floored is also short of one sequence, but it has a message of its own
+    // that names the missing residual — reporting both would say it twice.
+    const auto s = kv_blocks_from_residual(1264 * kMiB, 1630 * kMiB, k35bPerBlock, 4096, 16);
+    ASSERT_TRUE(s.floored);
+    EXPECT_EQ(kv_pool_verdict(s, 65536, 32), KvPoolVerdict::Floored);
+}
+
+TEST(KvPoolVerdict, ExactlyOneSequenceIsSufficient) {
+    // The boundary decides whether a pool sized to exactly the request is
+    // called a fault. It is not: one sequence fits.
+    KvResidualSizing s;
+    s.blocks = 64;
+    EXPECT_EQ(kv_pool_verdict(s, 2048, 32), KvPoolVerdict::Sufficient);
+    s.blocks = 63;
+    EXPECT_EQ(kv_pool_verdict(s, 2048, 32), KvPoolVerdict::ShortOfOneSequence);
+}
+
+TEST(KvPoolVerdict, PartialTrailingBlockCounts) {
+    // 2049 tokens at block_size 32 needs 65 blocks, not 64.
+    EXPECT_EQ(kv_blocks_per_sequence(2049, 32), 65);
+    EXPECT_EQ(kv_blocks_per_sequence(2048, 32), 64);
+    KvResidualSizing s;
+    s.blocks = 64;
+    EXPECT_EQ(kv_pool_verdict(s, 2049, 32), KvPoolVerdict::ShortOfOneSequence);
+}
+
+TEST(KvPoolVerdict, UnsetRequirementIsNotAFault) {
+    // No max_seq_len / no block size means there is nothing to check against;
+    // the verdict must not turn that into a warning on every load.
+    KvResidualSizing s;
+    s.blocks = 1;
+    EXPECT_EQ(kv_blocks_per_sequence(0, 32), 0);
+    EXPECT_EQ(kv_blocks_per_sequence(2048, 0), 0);
+    EXPECT_EQ(kv_pool_verdict(s, 0, 32), KvPoolVerdict::Sufficient);
+    EXPECT_EQ(kv_pool_verdict(s, 2048, 0), KvPoolVerdict::Sufficient);
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
#1251 made the floor case loud: when nothing is left to size the pool from, the load warns instead of reporting success and then cancelling every generation at admission. The quiet half stayed quiet — a pool that is a real size, well above the floor, and still smaller than one `max_seq_len` sequence. Same outcome for the operator, no message.

The hard failure that already names this arithmetic only fires with an explicit `--vram-budget`. Without one the sizing stays best-effort by design, so this warns rather than fails.

## Only for an operator-set max_seq_len

An auto value is a projection this clamp is *expected* to undercut — `init_compute_max_seq_len_` sizes the GGUF path from raw free VRAM on purpose and leaves the overshoot "absorbed by the downstream KV clamp". Warning there would fire on healthy loads and bury the case that is a fault. Where the value came from is now recorded rather than inferred, since the value itself no longer says once auto has filled it in.

That distinction is the whole design of this PR; without it the warning is noise.

## Testable without a GPU

`kv_pool_verdict()` carries the decision, for the same reason `kv_blocks_from_residual` moved out of the engine in #1251: inline, nothing could reach it without a GPU and a 22 GB checkpoint. Six tests, including the boundary that decides whether a pool sized to exactly the request counts as a fault (it does not).

Mutation-validated — each mutation caught by exactly the intended test:

| Mutation | Caught by |
|---|---|
| `blocks < need` → `<=` | `ExactlyOneSequenceIsSufficient` |
| `floored` early-return removed | `FlooredKeepsItsOwnMessage` |
| ceiling → floor division | `PartialTrailingBlockCounts` |

`ctest -L unit` green (test-core: 949 tests, 889 passed, 60 GPU-gated skips).

## What this does not cover

The auto path can still advertise a `max_model_len` that admission will cancel — `/v1/models` publishes `max_seq_len`, and the pool is clamped after that value is fixed. That is a separate question (correct the projection vs. advertise the measured capacity) and deliberately not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8