### PR TITLE
fix(model): give the final RMSNorm the Qwen3.5/3.6 unit offset it was missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The final RMSNorm missed Qwen3.5/3.6's `gamma = 1 + W` offset (#1287), which
+  is what #1273 actually was.** Every other norm took the offset; the model's
+  output norm went through the no-offset upload, so a Qwen3.5/3.6 SafeTensors
+  checkpoint scaled the last hidden state by `W` instead of `1 + W` — all 32
+  layers correct, only the input to the LM head wrong. Perplexity on
+  `ppl_corpus_45k`: Qwen3.6-27B-Text-NVFP4 **65.13 → 7.53**, Ornith-1.0-35B-NVFP4
+  **16.16 → 7.07**, Qwen3.6-35B-A3B-NVFP4 **13.65 → 6.82** — from 2.1–2.5× their
+  GGUF twins to 1.04–1.09×. GGUF and dense checkpoints are byte-identical before
+  and after. Investigation in [`docs/quantization.md`](docs/quantization.md).
+
 - **`diagnostics.dump_hidden_dir` works on models other than Gemma-4.** The
   per-layer hidden-state dump sat inside the Gemma-4 `layer_out_scale` branch
   *and* behind `debug_forward_enabled()`, so on every Qwen3, every GDN hybrid and

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -117,11 +117,32 @@ the same gap** — both llm-compressor and Modelopt exclude `linear_attn.*` but
 quantize this tensor whole.
 
 That gap used to be offered here as the reason every hybrid NVFP4 checkpoint
-degrades. Treat that as open: #1287 measures the same degradation on a hybrid
-loaded at **BF16**, where no NVFP4 exists to blame, while a dense control on the
-same loader and corpus is correctly ordered. Every degraded checkpoint in #1273
-is a hybrid read from SafeTensors and every healthy twin it is compared against
-is a GGUF, and that confound was never controlled.
+degrades. **It was not the reason.** #1287 found the real one: the model's final
+RMSNorm was the single norm that did not receive Qwen3.5/3.6's `gamma = 1 + W`
+offset, so a SafeTensors checkpoint scaled the last hidden state by `W` instead
+of `1 + W`. Every layer was correct and only the input to the LM head was wrong,
+which is why the model stayed coherent and merely got much worse.
+
+| checkpoint | before | after | its GGUF twin |
+|---|---|---|---|
+| Qwen3.6-27B-Text-NVFP4-MTP | 65.1275 | **7.5302** | none staged |
+| Ornith-1.0-35B-NVFP4 | 16.1630 | **7.0702** | 6.4974 (1.09×) |
+| Qwen3.6-35B-A3B-NVFP4 | 13.6486 | **6.8184** | 6.5465 (1.04×) |
+
+2.1–2.5× their twins before, 1.04–1.09× after — ordinary NVFP4 cost. Dense and
+GGUF checkpoints are byte-identical either way (Qwen3-14B-NVFP4 10.0301,
+Qwen3-8B-NVFP4 11.6677, ornith Q4_K_M 6.4974).
+
+**What made it findable, after a dozen candidates had been ruled out:** the
+degradation was still there at **BF16**, where nothing is quantised, and the
+per-layer hidden states matched an HF `transformers` reference to within 0.4%
+across all 32 layers while perplexity was 41% off. States right, output wrong,
+localises to what happens after the last layer.
+
+**The lesson worth keeping is about the twin comparison.** Every degraded
+checkpoint in #1273 was a hybrid read from SafeTensors, and every healthy twin
+it was measured against was a GGUF. Format and load path were confounded in
+every row of that table, and the conclusion followed the format.
 
 #### What `--calib` does
 

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -926,10 +926,18 @@ static bool upload_embeddings_and_output(Tensor& tok_emb, Tensor& out_norm, Tens
         }
     }
 
-    // Upload output norm
+    // Upload output norm — with ctx.arch_norm_offset, like every other norm.
+    //
+    // This is the model's final RMSNorm, the one that feeds the LM head. It
+    // used to go through the no-offset path while attn_norm, ffn_norm, the QK
+    // norms and even the MTP head's norms all took the offset, so on a
+    // Qwen3.5/3.6 SafeTensors checkpoint it ran with gamma = W instead of
+    // gamma = 1 + W. Every layer was correct and only the last scaling before
+    // the logits was wrong, which is why the damage never looked like a load
+    // bug: the model stayed coherent and merely got much worse.
     if (out_norm.data && !out_norm.on_device) {
-        if (!upload_unquantized_weight(out_norm, out_norm.qtype, ctx.compute_dtype, ctx.stream,
-                                       ctx.gpu_allocs, true, "out_norm")) {
+        if (!upload_weight(out_norm, out_norm.qtype, ctx.compute_dtype, ctx.stream, ctx.gpu_allocs,
+                           /*raw_quant=*/true, ctx.arch_norm_offset, "out_norm")) {
             IMP_LOG_ERROR("Failed to upload output norm");
             return false;
         }


### PR DESCRIPTION
**This is #1273.** One line, and the three checkpoints that issue was opened about go from 2.1–2.5× their GGUF twins to 1.04–1.09×.

Qwen3.5/3.6 SafeTensors stores RMSNorm gammas as deltas — the actual gamma is `1 + W` — and `ctx.arch_norm_offset` bakes the +1 in during the BF16→FP16 upload. Every norm took it: `attn_norm`, `ffn_norm`, the QK norms, even the MTP head's seven. The model's own output norm did not — it went through `upload_unquantized_weight`, which has no offset parameter.

So the last hidden state was scaled by `W` instead of `1 + W` before reaching the LM head. **All 32 layers were correct; only the input to the logits was wrong.** That is why it never looked like a load bug — the model stayed coherent and merely got much worse.

## Effect

`ppl_corpus_45k.txt`:

| checkpoint | before | after | its GGUF twin |
|---|---|---|---|
| Qwen3.6-27B-Text-NVFP4-MTP | 65.1275 | **7.5302** | none staged |
| Ornith-1.0-35B-NVFP4 | 16.1630 | **7.0702** | 6.4974 → 2.49× becomes **1.09×** |
| Qwen3.6-35B-A3B-NVFP4 | 13.6486 | **6.8184** | 6.5465 → 2.08× becomes **1.04×** |
| Qwen3.5-4B BF16 | 12.6794 | **9.2624** | its own mxfp4 GGUF: 9.3793 |

## How it was found

The last row is the one that cracked it. A **BF16** checkpoint scoring worse than its own **4-bit** quantisation is impossible — 4 bits add no information. So the defect could not be about the quant format, which is what #1273 had concluded. Every degraded checkpoint there was a hybrid read from SafeTensors and every healthy twin it was measured against was a GGUF: **format and load path were confounded in every row of that table.**

Localising it took a reference implementation, because the two imp paths agree on every input that can be inspected. HF `transformers`, same checkpoint, same tokens, same BF16 precision:

| implementation | precision | PPL |
|---|---|---|
| HF transformers | BF16 | **4.6990** |
| imp GGUF mxfp4 | 4-bit | 5.0928 (+8.4%, what 4-bit costs) |
| imp SafeTensors | BF16 | 6.6238 (**+41%**, at the reference's own precision) |

Per-layer hidden-state RMS against that reference matched **within 0.4% across all 32 layers** while perplexity was 41% off. States right, output wrong → the error is after the last layer. From there it was one comparison: the final norm needs the offset (`max|gguf − (hf+1)| = 0.0000`) and was the one norm not getting it.

A dozen candidates were ruled out first, each by making its switch *worse* rather than by inspection — head layout (654.27), v-head reorder (88974), the fused Q+gate split (79026 / 474573), all three GDN scan kernels, cuBLAS FP16-accumulate, tokenisation, multimodality and M-RoPE. Full list in #1287.

## No regression

The offset only applies on the BF16-source path, so GGUF norms (already F32 with the +1 baked in at conversion) and dense architectures (`arch_norm_offset = 0`) are untouched. Byte-identical before and after:

| control | PPL |
|---|---|
| Qwen3-14B-NVFP4 (dense) | 10.0301 |
| Qwen3-8B-NVFP4 (dense) | 11.6677 |
| ornith-1.0-35b Q4_K_M (GGUF hybrid) | 6.4974 |
| Qwen3.5-4B mxfp4 (GGUF hybrid) | 9.3793 |

`ctest -L unit` green.

Closes #1273. Closes #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8