### PR TITLE
fix(constrain): let the JSON force-close walk out of a state that owes something

### DIFF
--- a/src/compute/json_constrain.cu
+++ b/src/compute/json_constrain.cu
@@ -102,25 +102,82 @@ uint16_t JsonConstrainer::compute_allowed_mask() const {
     // returning unparseable output. Disabled while the budget is unknown (-1).
     force_close_active_ = false;
     if (remaining_budget_ >= 0 && current_state_ != JsonState::DONE) {
-        const bool in_escape = (current_state_ == JsonState::IN_STRING_ESCAPE);
-        const bool in_string = (current_state_ == JsonState::IN_STRING ||
-                                current_state_ == JsonState::OBJECT_KEY);
+        // A closer is not legal in every state, and demanding one where the
+        // grammar forbids it is worse than not narrowing at all: the safety
+        // net below then retries with the ordinary mask, the model carries on
+        // freely, and the document is truncated anyway. Measured on
+        // Qwen3.6-35B-A3B-NVFP4 at max_tokens=40 — the narrowing fired in
+        // ARRAY_NEED_VALUE, where #1096 forbids ']' precisely so `[1,]` cannot
+        // happen, so nothing was allowed and the reply came back unparseable
+        // (#1291).
+        //
+        // So the narrowing first has to walk OUT of a state that owes
+        // something, and the budget has to cover that walk. escape_mask is the
+        // cheapest legal step; escape_cost is how many tokens the whole walk
+        // takes, counted high on purpose — closing early beats not closing.
+        uint16_t escape_mask = 0;
+        int escape_cost = 0;
+        switch (current_state_) {
+            case JsonState::IN_STRING:
+                escape_mask = CAT_QUOTE;  // close it, then AFTER_VALUE takes closers
+                escape_cost = 1;
+                break;
+            case JsonState::OBJECT_KEY:
+                escape_mask = CAT_QUOTE;  // close key → AFTER_KEY still owes ':' + a value
+                escape_cost = 3;
+                break;
+            case JsonState::IN_STRING_ESCAPE:
+                escape_mask = CAT_STRING_CHAR;  // finish the escape, then close the string
+                escape_cost = 2;
+                break;
+            case JsonState::AFTER_KEY:
+                escape_mask = CAT_COLON;  // ':' then a value
+                escape_cost = 2;
+                break;
+            case JsonState::AFTER_COLON:
+            case JsonState::ARRAY_NEED_VALUE:
+                // A number is the only value that both starts and ends in one
+                // token — a string opens another frame, a container opens two.
+                escape_mask = CAT_NUMBER_START;
+                escape_cost = 1;
+                break;
+            case JsonState::OBJECT_NEED_KEY:
+                escape_mask = CAT_QUOTE;  // "…" then ':' then a value
+                escape_cost = 4;
+                break;
+            case JsonState::IN_LITERAL:
+                // A closer ends a *complete* literal; a partial one owes its
+                // tail first. 4 covers the longest ("false").
+                if (target_literal_.empty() || partial_literal_.size() < target_literal_.size()) {
+                    escape_mask = CAT_LITERAL_CONT;
+                    escape_cost = 4;
+                }
+                break;
+            case JsonState::START:
+                escape_mask = CAT_OPEN_BRACE;  // nothing is open yet; open then close
+                escape_cost = 1;
+                break;
+            default:
+                break;  // OBJECT_START / ARRAY_START / *_AFTER_VALUE / IN_NUMBER take a closer
+        }
         // state_stack_ holds only the RETURN states of *nested* values, not the
         // container we are currently inside — at `{"a"` the stack is empty
         // while a '}' is still owed. Count that container explicitly, or the
         // narrowing releases one token too early and the document is truncated
         // anyway (observed: needed=0 in AFTER_KEY with an object still open).
         const bool in_container = (current_state_ != JsonState::START && current_state_ != JsonState::DONE);
-        const int needed = static_cast<int>(state_stack_.size()) + (in_container ? 1 : 0) +
-                           (in_escape   ? 2
-                            : in_string ? 1
-                                        : 0);
+        // +1 margin: the escape step can itself push a frame (a forced number
+        // enters IN_NUMBER inside its container), so an estimate that is exact
+        // at the moment it is taken can still land one token short. Measured
+        // on the #1291 repro: without it the walk emits `-1]` and runs out
+        // before the `}`. Erring high costs a token of content; erring low
+        // costs the whole document.
+        const int needed =
+            static_cast<int>(state_stack_.size()) + (in_container ? 1 : 0) + escape_cost + 1;
         if (remaining_budget_ <= needed) {
             force_close_active_ = true;
-            if (in_escape)
-                return CAT_STRING_CHAR;  // finish the escape, close on the next tick
-            if (in_string)
-                return CAT_QUOTE;  // close the string, then the structures
+            if (escape_mask != 0)
+                return escape_mask;
             return CAT_CLOSE_BRACE | CAT_CLOSE_BRACKET;
         }
     }

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -409,6 +409,83 @@ TEST(JsonConstrainFsm, ForceCloseStillReachesAValidDocument) {
     EXPECT_TRUE(fsm.sim_token_valid("}")) << "grammar rejects the closer the mask offers";
 }
 
+// --- #1291: the force-close has to walk out of a state that owes something ---
+//
+// #1096 forbids a closer straight after a comma so `[1,]` cannot happen. #1104
+// demands a closer once the budget is spent. Where they meet, the narrowing
+// used to leave NOTHING legal, the empty-allow net retried with the ordinary
+// mask, and the reply came back truncated anyway — the exact outcome the
+// force-close exists to prevent. Measured on Qwen3.6-35B-A3B-NVFP4 at
+// max_tokens=40: the mask narrowed to `}`/`]` in ARRAY_NEED_VALUE and the
+// model emitted a quote instead (#1291).
+//
+// The mask must therefore offer the cheapest step OUT of the owing state, and
+// the budget must cover the whole walk.
+
+TEST(JsonConstrainFsm, ForceCloseOffersAValueAfterAnArrayComma) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":[1,");  // ARRAY_NEED_VALUE — ']' is illegal here
+    fsm.set_remaining_budget(1);
+    const uint16_t m = fsm.allowed_categories_for_test();
+    EXPECT_TRUE(m & CAT_NUMBER_START) << "no way out of ARRAY_NEED_VALUE — this is #1291";
+    EXPECT_FALSE(m & CAT_CLOSE_BRACKET) << "offered a closer the grammar forbids after a comma";
+}
+
+TEST(JsonConstrainFsm, ForceCloseOffersAKeyAfterAnObjectComma) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":1,");  // OBJECT_NEED_KEY — '}' is illegal here
+    fsm.set_remaining_budget(1);
+    const uint16_t m = fsm.allowed_categories_for_test();
+    EXPECT_TRUE(m & CAT_QUOTE) << "no way out of OBJECT_NEED_KEY";
+    EXPECT_FALSE(m & CAT_CLOSE_BRACE) << "offered a closer the grammar forbids after a comma";
+}
+
+TEST(JsonConstrainFsm, ForceCloseOffersAColonAfterAKey) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\"");  // AFTER_KEY — the grammar demands ':' next
+    fsm.set_remaining_budget(1);
+    const uint16_t m = fsm.allowed_categories_for_test();
+    EXPECT_TRUE(m & CAT_COLON) << "no way out of AFTER_KEY";
+    EXPECT_FALSE(m & CAT_CLOSE_BRACE) << "offered a closer before the value exists";
+}
+
+// The walk has to actually terminate, not just take one legal step. Follow the
+// mask from the state that broke on the 35B and require a closable document.
+TEST(JsonConstrainFsm, ForceCloseWalksOutOfAnArrayCommaToAClosableDocument) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":[1,");
+    fsm.set_remaining_budget(1);
+    ASSERT_TRUE(fsm.allowed_categories_for_test() & CAT_NUMBER_START);
+    fsm.advance_text("0");  // the value the mask offered
+    EXPECT_TRUE(fsm.sim_token_valid("]")) << "array still not closable after the forced value";
+    fsm.advance_text("]");
+    EXPECT_TRUE(fsm.sim_token_valid("}")) << "object still not closable after the array";
+}
+
+// The walk needs one token more than the states it passes through suggest: the
+// forced value itself enters a frame (a number lands in IN_NUMBER *inside* its
+// container). Without that margin the e2e walk emits `-1]` and runs out before
+// the `}` — measured on the #1291 repro. At `{"a":[1,` the stack owes 1, the
+// array owes 1, the value owes 1, so the narrowing has to be live at 4.
+TEST(JsonConstrainFsm, ForceCloseKeepsAMarginForTheForcedValuesOwnFrame) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":[1,");
+    fsm.set_remaining_budget(4);
+    EXPECT_EQ(fsm.allowed_categories_for_test(), CAT_NUMBER_START)
+        << "narrowing not yet live at 4 — the walk will land one token short";
+}
+
+// The narrowing must stay off while the budget is comfortable, in these states
+// too — otherwise every array in a long reply gets a forced `0`.
+TEST(JsonConstrainFsm, ForceCloseStaysOffInNeedStatesWithBudget) {
+    JsonConstrainer fsm;
+    fsm.advance_text("{\"a\":[1,");
+    fsm.set_remaining_budget(100);
+    const uint16_t m = fsm.allowed_categories_for_test();
+    EXPECT_TRUE(m & CAT_QUOTE) << "a string value is legal here and the budget is ample";
+    EXPECT_TRUE(m & CAT_OPEN_BRACKET) << "a nested array is legal here and the budget is ample";
+}
+
 // #1104: raw control characters must never reach a string. The grammar has
 // always rejected them; apply_mask's in-string fast path skipped the check for
 // any token without a quote or a backslash, which is exactly what a newline


### PR DESCRIPTION
Two guarantees in the JSON constrainer contradicted each other, and the one that lost is the one that keeps replies parseable.

- **#1096** forbids a closer straight after a comma, so `[1,]` cannot happen.
- **#1104** narrows the mask to closers once the token budget is spent, so a reply that hits `max_tokens` still ends well-formed.

Where they meet, the narrowing leaves **nothing** legal. The empty-allow safety net then retries with the ordinary mask — deliberately, "force-close must never make the outcome worse" — the model carries on freely, and the document is truncated anyway.

## Measured

Qwen3.6-35B-A3B-NVFP4, `json_object`, `max_tokens=40`, greedy, thinking off. Instrumented mask sequence:

```
b=3 stack=1 mask=0x1f45     ordinary — the net had already retried
b=2 stack=1 mask=0x000a     closers only
b=1 stack=1 mask=0x000a     closers only
content ends: ..."camera quality",\n\t\t"
```

The narrowing fires and is released again, because at that point the FSM sits in `ARRAY_NEED_VALUE` where `]` is illegal by #1096. **0 of 12 replies parsed.**

## The fix

The narrowing now offers the cheapest legal step **out** of the owing state instead of a closer the grammar refuses, and the budget covers the whole walk:

| state | offered | cost | why |
|---|---|---|---|
| `IN_STRING` | `"` | 1 | close it; `AFTER_VALUE` then takes a closer |
| `OBJECT_KEY` | `"` | 3 | close key, then `:` and a value |
| `IN_STRING_ESCAPE` | char | 2 | finish the escape, then close the string |
| `AFTER_KEY` | `:` | 2 | `:` then a value |
| `AFTER_COLON` | `0-9 -` | 1 | a number is the only value that starts **and** ends in one token |
| `ARRAY_NEED_VALUE` | `0-9 -` | 1 | " |
| `OBJECT_NEED_KEY` | `"` | 4 | `"…"` then `:` then a value |
| `IN_LITERAL` (partial) | cont | 4 | a closer only ends a *complete* literal |
| `START` | `{` | 1 | nothing open yet; open then close |

Plus **one token of margin**: the forced value enters a frame of its own — a number lands in `IN_NUMBER` inside its container — so an estimate that is exact when taken still lands one short. Without it the walk emits `-1]` and runs out before the `}`, which is exactly what the intermediate build did.

## Result

| model | before | after |
|---|---|---|
| Qwen3.6-35B-A3B-NVFP4 | **0/12** valid | **6/6** valid, ending `..."camera quality",2]}` |
| Qwen3-14B-NVFP4 (force-close already worked) | 4/5 | **4/5**, unchanged |

## Tests

Six FSM tests on the CPU lane, mutation-validated — each mutation caught by its own test and nothing else:

| mutation | caught by |
|---|---|
| margin removed | `ForceCloseKeepsAMarginForTheForcedValuesOwnFrame` |
| `ARRAY_NEED_VALUE` escape removed | `ForceCloseOffersAValueAfterAnArrayComma` |
| `OBJECT_NEED_KEY` escape removed | `ForceCloseOffersAKeyAfterAnObjectComma` |

The pre-existing #1104 force-close tests still pass, and one new test pins that the narrowing stays **off** while the budget is comfortable — otherwise every array in a long reply would collect a forced `0`.

`ctest -L unit` green.

Closes #1291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8