### PR TITLE
test(mutation): make the harness path-portable

### DIFF
--- a/tools/mutation/recheck.sh
+++ b/tools/mutation/recheck.sh
@@ -12,12 +12,13 @@
 set -uo pipefail
 cd "$(dirname "$0")/../.."
 MID=$1 BIN=$2 FILTER=$3 REPEATS=${4:-1}
+MODELS=${IMP_MODELS_DIR:-$HOME/models}
 CAT=tools/mutation/catalogue.json
 OUT=loop/evidence/recheck
 mkdir -p "$OUT"
 
 run() {
-  docker run --rm --gpus all -v "$PWD":/src -v /home/kekz/models:/models \
+  docker run --rm --gpus all -v "$PWD":/src -v "$MODELS":/models \
     -w /src/build-dev \
     -e IMP_TEST_MODEL=/models/Qwen3-8B-Q8_0.gguf \
     -e IMP_TEST_MOE_MODEL=/models/gpt-oss-20b-mxfp4.gguf \
@@ -28,12 +29,13 @@ run() {
 build() { docker run --rm -v "$PWD":/src -w /src imp:toolchain ninja -C /src/build-dev 2>&1; }
 
 python3 - "$MID" <<'PY'
-import json, sys, pathlib
+import json, os, sys, pathlib
 mid = sys.argv[1]
 m = [x for x in json.load(open('tools/mutation/catalogue.json'))['mutants'] if x['id'] == mid][0]
 p = pathlib.Path(m['file']); t = p.read_text()
 assert t.count(m['find']) == 1, f'{mid}: anchor not unique'
-pathlib.Path('/tmp/imp_recheck_orig').write_text(t)
+orig = pathlib.Path(os.environ.get('TMPDIR', '/tmp')) / 'imp_recheck_orig'
+orig.write_text(t)
 p.write_text(t.replace(m['find'], m['replace'], 1))
 print(f'{mid} applied to {m["file"]}')
 PY
@@ -48,10 +50,11 @@ done
 cp "$OUT/$MID-mutant-r1.log" "$OUT/$MID-mutant.log"
 
 python3 - "$MID" <<'PY'
-import json, sys, pathlib
+import json, os, sys, pathlib
 mid = sys.argv[1]
 m = [x for x in json.load(open('tools/mutation/catalogue.json'))['mutants'] if x['id'] == mid][0]
-pathlib.Path(m['file']).write_text(pathlib.Path('/tmp/imp_recheck_orig').read_text())
+orig = pathlib.Path(os.environ.get('TMPDIR', '/tmp')) / 'imp_recheck_orig'
+pathlib.Path(m['file']).write_text(orig.read_text())
 print(f'{mid} reverted')
 PY
 build > "$OUT/$MID-rebuild.log" 2>&1

--- a/tools/mutation/run.py
+++ b/tools/mutation/run.py
@@ -32,16 +32,17 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 DEV_IMG = os.environ.get('IMP_DEV_IMG', 'imp:toolchain')
 DEV_DIR = os.environ.get('IMP_DEV_DIR', 'build-dev')
-MODELS = os.environ.get('IMP_MODELS', '/home/kekz/models')
-BACKUP = Path(os.environ.get(
-    'IMP_MUT_BACKUP',
-    '/tmp/claude-1000/-home-kekz-github-com-kekzl-imp/mutation-backup'))
+MODELS = os.environ.get('IMP_MODELS_DIR',
+                        os.path.join(os.path.expanduser('~'), 'models'))
+BACKUP = Path(os.environ.get('IMP_MUT_BACKUP',
+                             os.path.join(tempfile.gettempdir(), 'imp-mutation-backup')))
 
 # Model env for the GPU lanes — without these ~63 tests skip silently and the
 # run looks green for the wrong reason (see loop/run_gpu_suite.sh).
@@ -52,7 +53,7 @@ MODEL_ENV = {
     'IMP_TEST_MODEL_LLAMA': '/models/Llama-3.2-3B-Instruct-Q8_0.gguf',
     'IMP_TEST_MODEL_GDN': '/models/Qwen3.5-4B-mxfp4.gguf',
     'IMP_TEST_MODEL_GEMMA4': '/models/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf',
-    'IMP_TEST_MOE_MODEL': '/models/Qwen3-30B-A3B-Q4_K_M.gguf',
+    'IMP_TEST_MOE_MODEL': '/models/gpt-oss-20b-mxfp4.gguf',
     'IMP_TEST_MODEL_DEEPSEEK': '/models/DeepSeek-V2-Lite',
     'IMP_TEST_MODEL_QWEN3VL': '/models/Qwen3-VL-4B-GGUF/Qwen3-VL-4B-Instruct-Q4_K_M.gguf',
     'IMP_TEST_MMPROJ': '/models/Qwen3-VL-4B-GGUF/mmproj-F16.gguf',


### PR DESCRIPTION
The `Release hygiene` gate on #1306 was correct and I did not get the fix in before auto-merge squashed it, so `main` currently fails that check.

`tools/mutation/run.py` and `recheck.sh` hardcoded one box's models directory and a session-specific backup path. Both now come from env vars — `IMP_MODELS_DIR` (default `$HOME/models`) and `IMP_MUT_BACKUP` (default the platform temp dir) — and `IMP_TEST_MOE_MODEL` points at a model that actually exists rather than a path that is one directory off, which in the audit produced 20 hard failures where the suite should have skipped.

`bash scripts/check-release.sh` → all gates passed. Harness re-smoke-tested: `recheck.sh M23 test-core 'KVCacheManagerTest.BlockHash*'` still kills M23 and leaves the tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8