### PR TITLE
test(kv): cover the prefix-cache content salt and fuzz the manager's invariants

### DIFF
--- a/docs/audit/MUTATION_BASELINE.md
+++ b/docs/audit/MUTATION_BASELINE.md
@@ -4,8 +4,9 @@ Date: 2026-08-08 · Commit `ad067d76` (v0.23.0, `main`) · RTX 5090 / WSL2 / CUD
 Harness: `tools/mutation/run.py` · Catalogue: `tools/mutation/catalogue.json` ·
 Patches: `loop/mutants/M*.patch` · Raw results: `loop/evidence/mutation-results.json`
 
-34 mutants across 10 categories, each a semantically meaningful fault from a
-real bug class in LLM inference — not arithmetic noise. Every mutant: inject →
+42 mutants across 10 categories (34 in iteration 1, eight paging/KV additions
+in iteration 3), each a semantically meaningful fault from a real bug class in
+LLM inference — not arithmetic noise. Every mutant: inject →
 incremental rebuild → run the suite → revert → verify `git status --porcelain`
 is empty. The tree was clean after all 34.
 
@@ -17,6 +18,7 @@ is empty. The tree was clean after all 34.
 |---|---:|
 | **Baseline mutation score, full local suite** | **25 / 33 = 75.8 %** |
 | **After the iteration-2 tests** | **28 / 33 = 84.8 %** |
+| **After iteration 3 (8 paging/KV mutants added)** | **36 / 41 = 87.8 %** |
 | **Mutation score, GitHub CI (`ctest -L unit`)** | **1 / 33 = 3.0 %** (baseline) |
 | Equivalent mutants (excluded from the denominator) | 1 — M25 |
 | Build failures (broken mutants) | 0 |
@@ -51,9 +53,17 @@ binary that only a human on a 5090 ever runs.
 | **sampling** | **0/3** | **0 %** | |
 | **controlflow** | **0/2** | **0 %** | |
 
-After iteration 2 (`docs/audit/TEST_HARDENING_LOG.md`): sampling 2/3 = 67 %
-(M20, M21 killed by the new `TopPTruncates*` tests), kvcache 2/2 = 100 %
-(M23 killed by `BlockHashDiscriminatesEveryTokenPosition`, which runs in CI).
+After iterations 2–3 (`docs/audit/TEST_HARDENING_LOG.md`): sampling 2/3 = 67 %
+(M20, M21 killed by the new `TopPTruncates*` tests), **kvcache 8/8 = 100 %**
+(M23 by `BlockHashDiscriminatesEveryTokenPosition`, which runs in CI; M35 by
+`ContentSaltSeparatesIdenticalTokenPrefixes`; M36–M42 by tests that already
+existed), masking 6/7, indexing 5/6.
+
+The eight iteration-3 mutants (M35–M42) targeted the KV manager, the prefix hash
+chain and StreamingLLM eviction. Seven were killed by tests that were already
+there — including both halves of the #963 boundary-block fix — which is the
+strongest single piece of evidence in this campaign that the KV subsystem's
+*tests* are good and its problem is only that CI cannot run them.
 
 Attention numerics, RoPE and dequantisation are genuinely well covered — the
 kills come from real oracle tests (a CPU reference, an FP16 reference, an fp64

--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -207,3 +207,96 @@ exists at `mtp_forward.cu:260`.
 Stopping criteria still not met: score 84.8 % (< 85 %), `controlflow` at 0 %,
 one new S1 this round. Focus `I2` (paging / KV / prefix cache) and the two
 indeterminate mutants, which unblock as soon as #1299 lands.
+
+---
+
+## Iteration 3 — 2026-08-08 — focus: `I2` paging / KV / prefix cache — commit: `d1906167`
+
+**Mutation score: 87.8 %** (36/41) — prev 84.8 % (28/33). Eight new mutants
+(M35–M42) aimed at the KV manager, the prefix hash chain and StreamingLLM
+eviction; the denominator grows with them.
+
+| Category | now | was |
+|---|---|---|
+| **kvcache** | **8/8 = 100 %** | 2/2 |
+| masking | 6/7 = 86 % | 5/6 = 83 % |
+| indexing | 5/6 = 83 % | 4/5 = 80 % |
+| sampling | 2/3 = 67 % | unchanged |
+| controlflow | 0/2 = 0 % | unchanged |
+| rope / scaling / quantization / memory / numerics | 100 % | unchanged |
+
+**Bugs found:** none. S1: 0 · S2: 0 · S3: 0 · S4: 0 · S5: 0
+
+**Escape distribution (new):** E1: 1 (M35 — no test ever passed a `content_salt`)
+
+**Tests added: 2, both verified against the fault they target: yes**
+
+| Test | Binary | Kills |
+|---|---|---|
+| `PrefixEquivTest.ContentSaltSeparatesIdenticalTokenPrefixes` | test-kv | M35 |
+| `PrefixEquivTest.RandomisedWorkloadKeepsProbeAllocationAndPoolConsistent` | test-kv | M38 |
+
+The randomised one is a property harness rather than a scenario: a seeded
+workload of overlapping prefixes, frees and evictions, with sequence lengths
+sitting on and either side of the block boundary, asserting three invariants in
+every state — probe equals actual reuse, no block appears twice in one
+sequence's table, and the pool comes back whole once everything is freed and the
+cache drained (the shape of #1115). It earned its place immediately by killing
+M38 alongside the existing `LongestCachedPrefixProbe`.
+
+**The one survivor was a genuine hole and is now closed.** M35 drops
+`content_salt`, the seed that keeps two multimodal prompts with identical token
+ids but different images from sharing KV. Both production call sites pass
+`req->vision_content_hash` (`engine_scheduler.cpp:598`, `scheduler.cpp:88`), and
+**no test in the suite passed a non-zero salt** — so the parameter could be
+deleted outright and everything stayed green, while the second request answered
+about the first request's picture.
+
+**Attacked and clean — do not re-mine:**
+
+- Prefix reuse contiguity after a miss (`ChainHoleStopsReuse` kills it).
+- Partial trailing blocks registered as cacheable, and block-count rounding
+  (`PrefixCachingWithPartialLastBlock` kills both).
+- Stale hash entries on cached-block reclaim (`EvictionThenRefillIsNewNotStaleHit`).
+- StreamingLLM: the extra boundary block from #963, and sink pinning.
+  `EvictMiddleBlocksRetainsKernelWindowStart` is the #963 regression test and it
+  still bites; sink pinning is covered by `EvictMiddleBlocksKeepsSinksAndWindow`.
+- The SWA snapshot suite writes real byte patterns to device memory and asserts
+  exact block indices — A4-grade, left alone.
+
+**A source-level inconsistency that is not a bug.** `longest_cached_prefix_blocks`
+is called without a `content_salt` at `engine_sampling_stop.cpp:337` and `:405`
+while the allocator is called with one, so the two hash chains would diverge for
+a multimodal request. It cannot fire: `hybrid_prefix_reuse_limit_` returns 0 for
+any vision request twelve lines earlier (`:329`). Recorded so the next reader
+does not re-derive it — and so that if that guard is ever relaxed, the salt has
+to be threaded through with it.
+
+**Blocked on:** unchanged — #1299 still blocks M10 and M22.
+
+**Tree clean:** production code untouched.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No.
+2. **Did every mutant get reverted?** Yes — 8 mutants, tree checked after each.
+3. **Did I watch every new test fail before it passed?** Yes: M35 against
+   `ContentSaltSeparatesIdenticalTokenPrefixes`, M38 against the randomised
+   harness.
+4. **Is every bug claim backed by a script I ran twice?** No bugs claimed this
+   iteration.
+5. **Did I fix any production code?** No.
+6. **Are all new tests wired into CI?** No — both are `test-kv` (GPU). The
+   manager's own bookkeeping is CUDA-gated because the fixture allocates a real
+   pool, which is the standing finding in #1304.
+
+### Next iteration
+
+87.8 % is above the 85 % bar, but `controlflow` sits at 0 % (< 70 %), so the
+stopping criteria are still not met. That category is M29/M30 — both
+perf-only, and the suite has no perf oracle at all; closing it means either a
+kernel-level timing assertion or accepting that `tests/perf_baseline.json` is
+the gate and saying so explicitly.
+
+Remaining survivors overall: M10, M22 (indeterminate, blocked on #1299), M29,
+M30 (perf-only), M31 (#1303, needs an FP8-KV decode with sinks).

--- a/tests/test_prefix_cache_equiv.cpp
+++ b/tests/test_prefix_cache_equiv.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <cstdio>
 #include <numeric>
+#include <unordered_set>
 #include <vector>
 
 #include "test_cuda_skip.h"
@@ -431,6 +432,158 @@ TEST(PrefixEquivTest, RollbackOfPartialAllocationDropsItsHashes) {
         << "rolled-back prefix falsely re-hit a block that went back to the free pool "
            "— STALE-HASH BUG";
     mgr->free_sequence(2);
+}
+
+// ── (9d) content_salt separates prompts that share token ids ──────────────
+// A multimodal prompt's image is not in its token ids — every image token
+// carries the same placeholder id — so two requests with the same text and
+// DIFFERENT pictures produce byte-identical token sequences. `content_salt`
+// seeds the hash chain with the image content so the two chains diverge at
+// block 0; both production call sites pass `req->vision_content_hash`
+// (engine_scheduler.cpp:598, scheduler.cpp:88).
+//
+// Nothing exercised it: no test in the suite passed a non-zero salt, so the
+// parameter could be dropped entirely and the suite stayed green — the second
+// request would have inherited the first one's KV, i.e. answered about the
+// wrong picture.
+TEST(PrefixEquivTest, ContentSaltSeparatesIdenticalTokenPrefixes) {
+    SKIP_IF_NO_CUDA();
+    auto mgr = MakeManager(16);
+    mgr->set_prefix_caching_enabled(true);
+
+    constexpr size_t kImageA = 0xA11CE;
+    constexpr size_t kImageB = 0xB0B;
+    std::vector<int32_t> tokens(32);  // 2 full blocks, identical for both requests
+    std::iota(tokens.begin(), tokens.end(), 500);
+
+    // Request 1 carries image A. Cache it, then free so the blocks are cached.
+    ASSERT_EQ(mgr->allocate_blocks_with_prefix(0, tokens, /*max_reuse_blocks=*/-1, kImageA), 0);
+    mgr->register_block_hashes(0, tokens, kImageA);
+    mgr->free_sequence(0);
+    ASSERT_EQ(mgr->num_cached_blocks(), 2);
+
+    // Same tokens, different image: must NOT hit.
+    std::vector<size_t> chain_b;
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, chain_b, kImageB), 0)
+        << "probe matched a prefix cached under a different image";
+    const int reused_b = mgr->allocate_blocks_with_prefix(1, tokens, /*max_reuse_blocks=*/-1, kImageB);
+    ASSERT_GE(reused_b, 0);
+    EXPECT_EQ(reused_b, 0) << "a different image reused the first image's KV blocks";
+    mgr->free_sequence(1);
+
+    // Same tokens, same image: must hit, or the salt has broken caching outright.
+    std::vector<size_t> chain_a;
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, chain_a, kImageA), 2);
+    const int reused_a = mgr->allocate_blocks_with_prefix(2, tokens, /*max_reuse_blocks=*/-1, kImageA);
+    EXPECT_EQ(reused_a, 2) << "same image failed to reuse its own cached prefix";
+    mgr->free_sequence(2);
+
+    // And a text prompt (salt 0) is a third, distinct chain.
+    std::vector<size_t> chain_text;
+    EXPECT_EQ(mgr->longest_cached_prefix_blocks(tokens, chain_text, /*content_salt=*/0), 0);
+    EXPECT_NE(chain_a[0], chain_b[0]);
+    EXPECT_NE(chain_a[0], chain_text[0]);
+}
+
+// ── (9c) randomised invariants over the whole manager ─────────────────────
+// The cases above each pin one hand-built scenario. This one hammers the
+// manager with a seeded pseudo-random workload — overlapping prefixes, frees,
+// evictions, sequences sized around the block boundary — and asserts three
+// invariants that must hold in EVERY state:
+//
+//   (a) probe == reuse. longest_cached_prefix_blocks() is a read-only oracle
+//       the hybrid snapshot lookup uses to pick a restore boundary BEFORE
+//       allocating (engine_sampling_stop.cpp:337/405). It checks only the hash
+//       table; allocate_blocks_with_prefix() additionally rejects an entry
+//       whose block is ref-0-and-not-cached (:509). If those two ever disagree,
+//       the snapshot boundary is chosen for a prefix that is not actually
+//       reused.
+//   (b) no double ownership. A physical block may appear in two live
+//       sequences only when it was legitimately shared as a prefix; it must
+//       never appear twice within ONE sequence's table.
+//   (c) no leak. Free every sequence, drain the cache, and the pool must be
+//       whole again — the shape of #1115, where exactly one block per request
+//       never came back.
+//
+// Seeded and fixed-iteration, so a failure reproduces exactly.
+TEST(PrefixEquivTest, RandomisedWorkloadKeepsProbeAllocationAndPoolConsistent) {
+    SKIP_IF_NO_CUDA();
+    constexpr int kPool = 12;
+    constexpr int kBlock = 16;  // kKVBlockSize
+    auto mgr = MakeManager(kPool);
+    mgr->set_prefix_caching_enabled(true);
+
+    // Deterministic LCG — no <random> engine differences across toolchains.
+    uint32_t rng = 0xC0FFEEu;
+    auto next = [&rng](int n) {
+        rng = rng * 1664525u + 1013904223u;
+        return static_cast<int>((rng >> 16) % static_cast<uint32_t>(n));
+    };
+
+    // A handful of shared roots so prefixes actually collide, and lengths that
+    // sit on, just below and just above block boundaries.
+    const int kRoots[4] = {1000, 2000, 3000, 4000};
+    const int kLens[6] = {kBlock - 1, kBlock, kBlock + 1, 2 * kBlock, 3 * kBlock - 1, 3 * kBlock + 1};
+
+    std::vector<int> live;
+    int next_seq = 0;
+
+    for (int round = 0; round < 300; ++round) {
+        if (!live.empty() && next(100) < 35) {
+            const int idx = next(static_cast<int>(live.size()));
+            mgr->free_sequence(live[idx]);
+            live.erase(live.begin() + idx);
+            continue;
+        }
+        if (next(100) < 10) {
+            mgr->evict_cached_block();
+            continue;
+        }
+
+        const int root = kRoots[next(4)];
+        const int len = kLens[next(6)];
+        std::vector<int32_t> tokens(static_cast<size_t>(len));
+        std::iota(tokens.begin(), tokens.end(), root);
+
+        std::vector<size_t> chain;
+        const int probed = mgr->longest_cached_prefix_blocks(tokens, chain);
+        ASSERT_EQ(static_cast<int>(chain.size()), len / kBlock)
+            << "round " << round << ": probe must hash every FULL block";
+
+        const int seq = next_seq++;
+        const int reused = mgr->allocate_blocks_with_prefix(seq, tokens);
+        if (reused < 0)
+            continue;  // pool could not fit it; rollback is covered separately
+
+        // (a)
+        EXPECT_EQ(reused, probed)
+            << "round " << round << ": probe said " << probed << " cached blocks, allocation reused "
+            << reused << " — the snapshot restore boundary would be wrong";
+
+        // (b)
+        const std::vector<int>& table = mgr->block_table(seq);
+        EXPECT_EQ(static_cast<int>(table.size()), (len + kBlock - 1) / kBlock) << "round " << round;
+        std::unordered_set<int> seen_in_seq;
+        for (int id : table) {
+            ASSERT_GE(id, 0) << "round " << round;
+            ASSERT_LT(id, kPool) << "round " << round;
+            EXPECT_TRUE(seen_in_seq.insert(id).second)
+                << "round " << round << ": block " << id << " appears twice in one sequence";
+        }
+
+        mgr->register_block_hashes(seq, tokens);
+        live.push_back(seq);
+    }
+
+    // (c)
+    for (int seq : live)
+        mgr->free_sequence(seq);
+    live.clear();
+    while (mgr->evict_cached_block()) {
+    }
+    EXPECT_EQ(mgr->num_cached_blocks(), 0);
+    EXPECT_EQ(mgr->num_free_blocks(), kPool)
+        << "pool did not come back whole after every sequence was freed and the cache drained";
 }
 
 // ── (10) longest_cached_prefix_blocks probe ───────────────────────────────

--- a/tools/mutation/catalogue.json
+++ b/tools/mutation/catalogue.json
@@ -315,6 +315,78 @@
       "focus": "test-attention",
       "find": "    return (softcap > 0.0f) ? (softcap * tanhf(dot / softcap)) : dot;",
       "replace": "    return (softcap > 0.0f) ? dot : dot;"
+    },
+    {
+      "id": "M35",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "content_salt is ignored, so two prompts with identical token ids but different images share KV.",
+      "focus": "test-kv",
+      "find": "    auto& hashes = seq_block_hashes_[seq_id];\n    int reused_blocks = 0;\n    size_t parent_hash = content_salt;",
+      "replace": "    auto& hashes = seq_block_hashes_[seq_id];\n    int reused_blocks = 0;\n    size_t parent_hash = 0;  // [MUTANT] content_salt dropped"
+    },
+    {
+      "id": "M36",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "Prefix reuse is no longer forced to be contiguous: a hit after a miss is shared, leaving uncomputed KV in the skipped range.",
+      "focus": "test-kv",
+      "find": "            // No cache hit (or reuse closed) \u2014 allocate a fresh block.\n            reuse_open = false;",
+      "replace": "            // No cache hit (or reuse closed) \u2014 allocate a fresh block.\n            // [MUTANT] reuse stays open across a miss"
+    },
+    {
+      "id": "M37",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "Partial (non-full) trailing blocks are registered in the prefix hash table as if they were full.",
+      "focus": "test-kv",
+      "find": "        if (block_tokens < cache_->block_size())\n            break;  // Only full blocks are cacheable.",
+      "replace": "        if (block_tokens < 0)\n            break;  // [MUTANT] partial blocks registered too"
+    },
+    {
+      "id": "M38",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "The probe reports a cached prefix one block longer than the chain actually reaches.",
+      "focus": "test-kv",
+      "find": "        if (chain_intact && block_hash_to_id_.find(h) != block_hash_to_id_.end())\n            cached = b + 1;",
+      "replace": "        if (chain_intact && block_hash_to_id_.find(h) != block_hash_to_id_.end())\n            cached = b + 2;  // [MUTANT] off by one"
+    },
+    {
+      "id": "M39",
+      "category": "indexing",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "Block count rounds down, so a sequence whose length is not a block multiple loses its trailing partial block.",
+      "focus": "test-kv",
+      "find": "    int total_blocks = (num_tokens + cache_->block_size() - 1) / cache_->block_size();\n    auto& blocks = seq_blocks_[seq_id];",
+      "replace": "    int total_blocks = num_tokens / cache_->block_size();  // [MUTANT] rounds down\n    auto& blocks = seq_blocks_[seq_id];"
+    },
+    {
+      "id": "M40",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "Reclaiming a cached block no longer removes its prefix-hash entry, so the table points at a free block.",
+      "focus": "test-kv",
+      "find": "    auto hash_it = block_id_to_hash_.find(block_id);\n    if (hash_it != block_id_to_hash_.end()) {\n        block_hash_to_id_.erase(hash_it->second);\n        block_id_to_hash_.erase(hash_it);\n    }\n\n    // Dropping the cache's reference is what returns the block to the pool \u2014",
+      "replace": "    // [MUTANT] stale hash entry left behind on reclaim\n\n    // Dropping the cache's reference is what returns the block to the pool \u2014"
+    },
+    {
+      "id": "M41",
+      "category": "masking",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "StreamingLLM drops the extra boundary block (#963), so the kernels' floor-aligned window start reads a -1 sentinel.",
+      "focus": "test-kv",
+      "find": "    const int window_start_block = std::max(0, total_blocks - window_block_count - 1);",
+      "replace": "    const int window_start_block = std::max(0, total_blocks - window_block_count);  // [MUTANT] no boundary block"
+    },
+    {
+      "id": "M42",
+      "category": "kvcache",
+      "file": "src/memory/kv_cache_manager.cpp",
+      "desc": "StreamingLLM sink blocks are no longer pinned, so LRU reclaim can take them while the sequence is live.",
+      "focus": "test-kv",
+      "find": "    if (sink_end_block > already)\n        pin_prefix(seq_id, sink_end_block);",
+      "replace": "    (void)already;  // [MUTANT] sink blocks left unpinned"
     }
   ]
 }


### PR DESCRIPTION
Iteration 3 of the test-hardening campaign, focus paging / KV / prefix cache. Eight new mutants (M35–M42) against the KV manager, the prefix hash chain and StreamingLLM eviction.

**Seven were killed by tests that already existed**, including both halves of the #963 boundary-block fix (`EvictMiddleBlocksRetainsKernelWindowStart` still bites) and the contiguity guard (`ChainHoleStopsReuse`). That is the strongest evidence in this campaign that the KV subsystem's *tests* are good and its problem is only that CI cannot run them — they are CUDA-gated because the fixture allocates a real pool (#1304).

**One survived, and it was real.** `content_salt` could be deleted outright with the suite green. It is the seed that keeps two multimodal prompts with identical token ids but different images from sharing KV — every image token carries the same placeholder id, so two requests with the same text and different pictures produce byte-identical token sequences. Both production call sites pass `req->vision_content_hash` (`engine_scheduler.cpp:598`, `scheduler.cpp:88`); no test passed a non-zero salt. Closed by `PrefixEquivTest.ContentSaltSeparatesIdenticalTokenPrefixes`, verified to fail against the mutant.

Also adds `PrefixEquivTest.RandomisedWorkloadKeepsProbeAllocationAndPoolConsistent`: a seeded property harness over the manager — overlapping prefixes, frees, evictions, lengths on and either side of the block boundary — asserting in every state that

- the read-only prefix probe agrees with what allocation actually reuses (the probe picks the hybrid snapshot restore boundary *before* allocating, and only the allocator rejects stale entries),
- no physical block appears twice in one sequence's table,
- the pool comes back whole once every sequence is freed and the cache drained — the shape of #1115.

It killed M38 on its first run.

**No bug filed this iteration**, and one near-miss recorded rather than reported: `longest_cached_prefix_blocks` is called without a salt at `engine_sampling_stop.cpp:337/405` while the allocator gets one, but `hybrid_prefix_reuse_limit_` returns 0 for any vision request twelve lines earlier, so the chains can never disagree in practice. Noted in the log so that if that guard is relaxed, the salt gets threaded through with it.

Mutation score 84.8 % → **87.8 %** (36/41). Full scorecard in `docs/audit/TEST_HARDENING_LOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8