### PR TITLE
test(mutation): measure whether the perf gate sees a throughput-only mutant

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -274,6 +274,35 @@ to be threaded through with it.
 
 **Blocked on:** unchanged — #1299 still blocks M10 and M22.
 
+### Resolved: the perf gate does see M29
+
+Iteration 1 left this open as a stated limitation — "no *test* catches M29" was
+proven, "nothing catches it" was not, because the real gate
+(`tests/perf_baseline.json` via `make verify-fast`) needs a full `make build`
+per mutant. Measured instead as an alternating A/B on the same tree
+(`tools/mutation/perf_ab.sh`, Qwen3-4B-Q8_0, the gate's own bench invocation):
+
+```
+round 1: clean=450.88  M29=288.12
+round 2: clean=451.12  M29=287.51
+round 3: clean=450.69  M29=287.45
+```
+
+**−36 % decode**, twelve times the gate's 3 % threshold, with the arms
+alternating so drift cancels. So M29 is caught — by the perf gate, not by a
+test. `controlflow` at 0 % measures the test suite, and for M29 that is the
+whole truth: it is a gate-layer responsibility, not a missing test. **M30**
+(the split-K scratch-capacity guard) is still unmeasured; it is a safety check
+whose removal is neither correctness- nor throughput-visible in the shapes the
+suite exercises.
+
+One false alarm worth recording so nobody re-derives it: the M29 arm lands at
+~287.5 tok/s and `tests/perf_baseline.json` pins `tg128: 287.19`, which briefly
+looked like "the baseline is pinned 36 % low and would accept split-K being
+disabled". It is not. The pin is for **Qwen3-8B-Q8_0**; the A/B ran Qwen3-**4B**.
+The same 8B bench on the current tree gives **288.47 tok/s vs the 287.19 pin
+(+0.45 %)** — the baseline is accurate. Two different models, one coincidence.
+
 **Tree clean:** production code untouched.
 
 ### Self-check

--- a/tools/mutation/perf_ab.sh
+++ b/tools/mutation/perf_ab.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Does the performance gate see a mutant that only costs throughput?
+#
+# Usage: perf_ab.sh <MID> [model] [rounds]
+#
+# Iteration 1 recorded "no *test* catches M29" as proven and "nothing catches
+# it" as unproven, because the repo's real perf gate is tests/perf_baseline.json
+# via `make verify-fast` against the imp:test image, and running that per mutant
+# needs a full `make build`. This measures the delta directly instead.
+#
+# Caveat, stated because it matters: this benchmarks the incremental build-dev
+# binary, which the repo forbids for *pinning* a baseline. It is defensible for
+# a *delta*: both arms come from the same tree with one line different, and the
+# arms alternate so drift cancels. The question is only whether the delta clears
+# the gate's 3 % decode threshold.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+MID=${1:-M29}
+MODEL=${2:-$HOME/models/Qwen3-4B-Instruct-2507-Q8_0.gguf}
+ROUNDS=${3:-3}
+OUT=${IMP_AB_LOG:-/tmp/imp-perf-ab.log}
+: >"$OUT"
+
+# Same invocation scripts/verify.sh uses for the decode gate (:386).
+bench() {
+  docker run --rm --gpus all -v "$PWD":/src -v "$(dirname "$MODEL")":/models \
+    -w /src/build-dev imp:toolchain ./imp-cli \
+    --model "/models/$(basename "$MODEL")" --bench --bench-pp 512 --bench-reps 3 \
+    --prefill-chunk-size 0 --max-tokens 128 --temperature 0 \
+    --set speculative.ngram=false 2>&1 \
+    | tee -a "$OUT" | grep -oP '^tg\s+128\s.*\(\s*\K[0-9.]+(?=\s+tok/s)' | head -1
+}
+
+apply() { IMP_AB_MID="$MID" python3 - "$1" <<'PY'
+import json, os, pathlib, sys
+mode = sys.argv[1]
+m = [x for x in json.load(open('tools/mutation/catalogue.json'))['mutants'] if x['id'] == os.environ['IMP_AB_MID']][0]
+p = pathlib.Path(m['file']); t = p.read_text()
+if mode == 'on':
+    assert t.count(m['find']) == 1
+    p.write_text(t.replace(m['find'], m['replace'], 1))
+else:
+    assert t.count(m['replace']) == 1
+    p.write_text(t.replace(m['replace'], m['find'], 1))
+PY
+}
+build() { docker run --rm -v "$PWD":/src -w /src imp:toolchain ninja -C /src/build-dev >/dev/null 2>&1; }
+
+for r in $(seq 1 "$ROUNDS"); do
+  apply off 2>/dev/null || true; build; base=$(bench clean)
+  apply on;  build; mut=$(bench m29)
+  apply off; build
+  echo "round $r: clean=$base  $MID=$mut"
+done
+echo "--- tree ---"
+git status --porcelain | grep -v '^??' || echo CLEAN


### PR DESCRIPTION
Closes the one methodological gap iteration 1 left open and states its own false alarm.

**The gap.** M29 (split-K permanently disabled) survives the whole test suite. Iteration 1 could prove "no *test* catches it" but not "nothing catches it", because the repo's real performance gate — `tests/perf_baseline.json` via `make verify-fast` — needs a full `make build` per mutant.

**The measurement.** `tools/mutation/perf_ab.sh` runs it as an alternating A/B on one tree, using `scripts/verify.sh`'s own bench invocation, so drift cancels between arms:

```
round 1: clean=450.88  M29=288.12
round 2: clean=451.12  M29=287.51
round 3: clean=450.69  M29=287.45
```

**−36 % decode**, twelve times the 3 % threshold, tightly clustered. M29 is caught — by the gate, not by a test. So `controlflow` at 0 % is a statement about the test suite and, for M29, the whole truth: throughput is the gate layer's job.

M30 (the split-K scratch-capacity guard) stays unmeasured; it is a safety check whose removal is neither correctness- nor throughput-visible in the shapes the suite exercises.

**The false alarm, recorded on purpose.** The M29 arm lands at ~287.5 tok/s and `perf_baseline.json` pins `tg128: 287.19`, which briefly read as "the baseline is pinned 36 % low and would accept split-K being switched off". It is not: the pin is **Qwen3-8B-Q8_0** and the A/B ran Qwen3-**4B**. The same 8B bench on the current tree gives **288.47 vs the 287.19 pin (+0.45 %)** — the baseline is accurate. Two models, one coincidence, and it is in the log so nobody re-derives it.

Caveat stated in the script: it benchmarks the incremental `build-dev` binary, which the repo forbids for *pinning* a baseline. That is fine for a *delta* — both arms come from the same tree with one line different — and `imp:test` was cross-checked at 451.07 against build-dev's 450.7–451.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8