### PR TITLE
test(api): assert transport does not change content across truncation points

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -329,3 +329,111 @@ the gate and saying so explicitly.
 
 Remaining survivors overall: M10, M22 (indeterminate, blocked on #1299), M29,
 M30 (perf-only), M31 (#1303, needs an FP8-KV decode with sinks).
+
+---
+
+## Iteration 4 — 2026-08-08 — focus: `I1` API surface & streaming — commit: `ce64a1cb`
+
+**Mutation score: unchanged at 87.8 %** — no mutants were run. This iteration
+was a hunt, and it was pointed at the one surface where a finding is guaranteed
+novel: CI never executes `tools/imp-server/` (#1302), so nothing there has ever
+been under test.
+
+**Bugs found:** S1: 0 · S2: 0 · S3: 0 · S4: 0 · **S5→S1: 1 (#1310)**
+
+**Escape distribution (new):** E5: 1 — the test exists, asserts exactly the
+broken invariant, and runs against a reimplementation that cannot exhibit it.
+
+### Method: differential probe, real server vs the mock CI tests
+
+`tools/mutation/api_diff.py` sends one table of edge-case requests to both a
+real `imp-server` and `tests/api/mock_server.py`, and reports where they
+disagree. 46 cases, five status divergences:
+
+| case | real | mock | |
+|---|---:|---:|---|
+| `n=2` | 200 | 400 | mock rejects `n>1`; the server returns two choices |
+| unknown `model` | 404 | 200 | mock ignores the model field on chat completions |
+| `max_tokens: null` | 200 | crash | `TypeError: '<' not supported between 'int' and 'NoneType'` |
+| JSON array body | 400 | crash | `AttributeError: 'list' object has no attribute 'get'` |
+| JSON scalar body | 400 | crash | `TypeError: argument of type 'int' is not iterable` |
+
+Three are the mock 500-ing where the server answers correctly — the stand-in is
+*weaker* than the thing it stands for. The `n=2` row is the sharper one:
+`tests/api/test_errors.py` asserts a 400 with `"n" must be 1`, so CI encodes a
+constraint the shipping server does not have.
+
+Everything else matched case for case, which is worth stating: the server's
+parameter validation is not the problem.
+
+### #1310 — transport changes content
+
+Comparing *content* rather than status found what the mock structurally cannot.
+The model's third token opens `😊` (`f0 9f 98 8a`); with `max_tokens=3`:
+
+```
+non-streaming bytes: 48656c6c6f2120efbfbd    'Hello! <U+FFFD>'
+streaming     bytes: 48656c6c6f2120          'Hello! '
+```
+
+`Utf8Stitch::feed` (`tools/imp-server/utils.cpp:12`) holds an incomplete tail
+back and is wired into the streaming driver only. On the other path the dangling
+bytes reach `dump_safe` (`utils.cpp:6`), whose `json::error_handler_t::replace`
+substitutes U+FFFD. `stream_pipeline.h:91` already documents that mechanism in a
+comment — the guard was added for one path and not the other. `/v1/messages` is
+affected identically. Reproduced 2/2 (`loop/repro/BUG-3.sh`).
+
+**Tests added: 1, verified to fail against the fault: yes**
+
+`test_stream_nonstream_agree_across_truncation_points` sweeps `max_tokens` 1–8
+and asserts both that the transports agree and that non-streaming introduces no
+U+FFFD. It is the campaign's cleanest single artefact for #1302:
+
+```
+$ IMP_USE_MOCK=1 pytest test_streaming.py -q          # the CI lane
+5 passed in 0.05s
+$ IMP_TEST_URL=<real server> pytest -k truncation -q
+E   AssertionError: max_tokens=3: transports disagree
+```
+
+Green against the mock, red against the server, same test, same commit. It
+therefore does **not** turn CI red; it turns `make test-server` red, which is
+correct until #1310 is fixed.
+
+`tests/api/test_streaming.py:36` already asserted the same invariant and passed,
+for two independent reasons: the mock has no tokenizer and emits whole ASCII
+words, and it pins `max_tokens=16`, which does not truncate mid-character even
+against a real server.
+
+**Attacked and clean:** `max_tokens` at 0 / −1 / 10⁹ / null / missing / string;
+`temperature` and `top_p` bounds and type errors; `top_k` 0 and −1; missing,
+non-array and empty `messages`; empty, whitespace and null content; missing,
+unknown and out-of-order roles; system-only prompts; unknown fields; stop
+sequences empty, empty-list, ten-deep and matching text in the prompt; emoji,
+combining marks, RTL, escaped lone surrogate; a 200 000-character message;
+structured content blocks; malformed, empty, array and scalar request bodies.
+The server answered all of them the way the mock does or better.
+
+**Blocked on:** unchanged — #1299 still blocks M10 and M22.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No — one test added.
+2. **Did every mutant get reverted?** No mutants run this iteration.
+3. **Did I watch every new test fail before it passed?** Yes, against a real
+   server at `max_tokens=3`; and confirmed green against the mock, which is the
+   finding, not an accident.
+4. **Is every bug claim backed by a script I ran twice?** Yes —
+   `loop/repro/BUG-3.sh`, 2/2.
+5. **Did I fix any production code?** No.
+6. **Are all new tests wired into CI?** The new test runs in CI and passes
+   there — against the mock. Making it meaningful in CI is #1302, not something
+   a test can fix.
+
+### Next iteration
+
+`I5` (model ingestion & error paths) is untouched: truncated weight files, a
+missing tensor, wrong shapes, metadata that disagrees with the tensors — all of
+which must produce a clear diagnostic rather than a segfault.
+`tests/test_gguf_fault_injection.cpp` exists (18 cases) and is CPU-only, so
+mutants there would land in the lane that gates a merge.

--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -55,6 +55,50 @@ def test_streaming_content_matches_nonstream(client, model):
     assert content == expected
 
 
+def test_stream_nonstream_agree_across_truncation_points(client, model):
+    """Transport must not change content, at any truncation point.
+
+    test_streaming_content_matches_nonstream above asserts the same invariant
+    but pins max_tokens=16 on "What is 1+1?", which never truncates inside a
+    multi-byte character. Against the mock it cannot: mock_server.py has no
+    tokenizer and emits whole ASCII words, so the assertion passes without
+    exercising the code that fails.
+
+    Sweeping max_tokens walks the truncation point across the generation. When
+    it lands mid-character the non-streaming path emits U+FFFD while the
+    streaming path holds the incomplete bytes back (#1310), so the two
+    transports return different bytes for one request.
+    """
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Hi"}],
+        "temperature": 0,
+        "seed": 123,
+    }
+    for max_tokens in range(1, 9):
+        body = {**payload, "max_tokens": max_tokens}
+
+        r1 = client.post("/v1/chat/completions", json=body)
+        assert r1.status_code == 200
+        nonstream = r1.json()["choices"][0]["message"]["content"]
+
+        r2 = client.post("/v1/chat/completions", json={**body, "stream": True})
+        assert r2.status_code == 200
+        stream = ""
+        for ev in parse_sse(r2.text):
+            stream += (ev["choices"][0].get("delta") or {}).get("content") or ""
+
+        assert stream == nonstream, (
+            f"max_tokens={max_tokens}: transports disagree\n"
+            f"  non-stream: {nonstream!r} ({nonstream.encode('utf-8').hex()})\n"
+            f"  stream:     {stream!r} ({stream.encode('utf-8').hex()})"
+        )
+        assert "\ufffd" not in nonstream, (
+            f"max_tokens={max_tokens}: non-streaming content carries U+FFFD, "
+            f"a character no generated token produced: {nonstream!r}"
+        )
+
+
 def test_streaming_include_usage(client, model):
     r = client.post("/v1/chat/completions", json={
         "model": model,

--- a/tools/mutation/api_diff.py
+++ b/tools/mutation/api_diff.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Differential probe: real imp-server vs the mock CI actually tests.
+
+`Mock API contract` is the only CI job that touches the HTTP API, and it runs
+`tests/api` against `tests/api/mock_server.py` with IMP_USE_MOCK=1 — a Python
+reimplementation of the endpoints. `tools/imp-server/` is never executed there
+(#1302). So every assertion in that suite describes the *mock's* behaviour, and
+nothing checks that the shipping server agrees.
+
+This sends the same table of edge-case requests to both and reports where they
+diverge. A divergence is not automatically a bug in either one — it is a place
+where a green CI run says nothing about the server.
+
+Usage:
+  api_diff.py --real http://127.0.0.1:8099 --model <id>      # starts the mock itself
+"""
+import argparse
+import json
+import sys
+import threading
+
+import httpx
+
+sys.path.insert(0, 'tests/api')
+
+
+def cases(model):
+    """(name, method, path, body_or_raw) — body None means send raw text."""
+    msg = [{"role": "user", "content": "Hi"}]
+    base = {"model": model, "messages": msg, "max_tokens": 1}
+
+    def b(**kw):
+        d = dict(base)
+        d.update(kw)
+        return d
+
+    out = [
+        ("baseline", b()),
+        ("max_tokens=0", b(max_tokens=0)),
+        ("max_tokens=-1", b(max_tokens=-1)),
+        ("max_tokens=10^9", b(max_tokens=10**9)),
+        ("max_tokens=null", b(max_tokens=None)),
+        ("max_tokens missing", {"model": model, "messages": msg}),
+        ("max_tokens as string", b(max_tokens="10")),
+        ("temperature=-0.1", b(temperature=-0.1)),
+        ("temperature=0", b(temperature=0)),
+        ("temperature=2", b(temperature=2.0)),
+        ("temperature=2.5", b(temperature=2.5)),
+        ("temperature as string", b(temperature="hot")),
+        ("top_p=-0.1", b(top_p=-0.1)),
+        ("top_p=0", b(top_p=0)),
+        ("top_p=1.5", b(top_p=1.5)),
+        ("top_k=0", b(top_k=0)),
+        ("top_k=-1", b(top_k=-1)),
+        ("n=2", b(n=2)),
+        ("messages missing", {"model": model, "max_tokens": 1}),
+        ("messages not array", {"model": model, "messages": "nope", "max_tokens": 1}),
+        ("messages empty", {"model": model, "messages": [], "max_tokens": 1}),
+        ("message empty content", b(messages=[{"role": "user", "content": ""}])),
+        ("message whitespace content", b(messages=[{"role": "user", "content": "   "}])),
+        ("message null content", b(messages=[{"role": "user", "content": None}])),
+        ("message no role", b(messages=[{"content": "Hi"}])),
+        ("message unknown role", b(messages=[{"role": "wizard", "content": "Hi"}])),
+        ("system only", b(messages=[{"role": "system", "content": "Be terse"}])),
+        ("two consecutive user turns",
+         b(messages=[{"role": "user", "content": "a"}, {"role": "user", "content": "b"}])),
+        ("assistant first", b(messages=[{"role": "assistant", "content": "hi"}])),
+        ("model missing", {"messages": msg, "max_tokens": 1}),
+        ("model unknown", b(model="no-such-model")),
+        ("unknown field", b(frobnicate=True)),
+        ("stop empty string", b(stop="")),
+        ("stop empty list", b(stop=[])),
+        ("stop list of 10", b(stop=[f"s{i}" for i in range(10)])),
+        ("stop appears in prompt", b(messages=[{"role": "user", "content": "say Hi"}], stop=["Hi"])),
+        ("emoji content", b(messages=[{"role": "user", "content": "👩‍👩‍👧‍👦 x"}])),
+        ("combining marks", b(messages=[{"role": "user", "content": "é́́"}])),
+        ("RTL content", b(messages=[{"role": "user", "content": "مرحبا"}])),
+        ("lone surrogate escape", b(messages=[{"role": "user", "content": "\\ud800"}])),
+        ("very long content", b(messages=[{"role": "user", "content": "x" * 200000}])),
+        ("deeply nested content", b(messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}])),
+    ]
+    return [(n, "/v1/chat/completions", body) for n, body in out]
+
+
+RAW_CASES = [
+    ("malformed json", "/v1/chat/completions", "not json{{{"),
+    ("empty body", "/v1/chat/completions", ""),
+    ("json array body", "/v1/chat/completions", "[1,2,3]"),
+    ("json scalar body", "/v1/chat/completions", "42"),
+]
+
+
+def probe(client, path, body, raw=False):
+    try:
+        if raw:
+            r = client.post(path, content=body, headers={"content-type": "application/json"},
+                            timeout=60)
+        else:
+            r = client.post(path, json=body, timeout=120)
+    except Exception as e:  # noqa: BLE001
+        return {"status": "EXC", "type": type(e).__name__, "msg": str(e)[:60]}
+    out = {"status": r.status_code}
+    try:
+        j = r.json()
+    except Exception:  # noqa: BLE001
+        out["type"] = "<non-json>"
+        out["msg"] = r.text[:60]
+        return out
+    if isinstance(j, dict) and "error" in j and isinstance(j["error"], dict):
+        out["type"] = j["error"].get("type", "?")
+        out["msg"] = str(j["error"].get("message", ""))[:70]
+    elif isinstance(j, dict) and "choices" in j:
+        ch = (j.get("choices") or [{}])[0]
+        out["type"] = "ok"
+        out["msg"] = f"finish={ch.get('finish_reason')} usage={j.get('usage', {})}"
+    else:
+        out["type"] = "?"
+        out["msg"] = json.dumps(j)[:70]
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--real', required=True)
+    ap.add_argument('--model', required=True)
+    ap.add_argument('--mock-port', type=int, default=9099)
+    args = ap.parse_args()
+
+    from mock_server import MOCK_MODEL_ID, run_server
+    srv = run_server(port=args.mock_port, latency_ms=1)
+    threading.Event().wait(0.5)
+
+    real = httpx.Client(base_url=args.real)
+    mock = httpx.Client(base_url=f"http://127.0.0.1:{args.mock_port}")
+
+    rows = []
+    for name, path, body in cases(args.model):
+        r = probe(real, path, body)
+        m = probe(mock, path, dict(body, model=MOCK_MODEL_ID) if isinstance(body, dict) and 'model' in body else body)
+        rows.append((name, r, m))
+    for name, path, raw in RAW_CASES:
+        rows.append((name, probe(real, path, raw, raw=True), probe(mock, path, raw, raw=True)))
+
+    diverged = [(n, r, m) for n, r, m in rows if r["status"] != m["status"]]
+    print(f"{len(rows)} cases, {len(diverged)} status divergences\n")
+    print(f"{'case':<30} {'real':>6} {'mock':>6}  real-type / mock-type")
+    print('-' * 100)
+    for n, r, m in rows:
+        flag = '  <<<' if r["status"] != m["status"] else ''
+        print(f"{n:<30} {str(r['status']):>6} {str(m['status']):>6}  "
+              f"{r.get('type', '')} / {m.get('type', '')}{flag}")
+    print('\n--- divergence detail ---')
+    for n, r, m in diverged:
+        print(f"\n{n}\n  real: {r}\n  mock: {m}")
+    if hasattr(srv, 'shutdown'):
+        srv.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Iteration 4 of the hardening campaign, focus API surface & streaming — the one place where a finding is guaranteed novel, because CI never executes `tools/imp-server/` (#1302).

**Method.** `tools/mutation/api_diff.py` sends one table of edge-case requests to a real `imp-server` and to `tests/api/mock_server.py`, and reports divergences. 46 cases, five status divergences — three of them the mock 500-ing where the server answers correctly, one (`n=2`) a constraint CI asserts that the server does not have. Full table in `docs/audit/TEST_HARDENING_LOG.md` and on #1302.

**The finding (#1310).** Comparing *content* rather than status found what the mock cannot produce. With `max_tokens=3` on a generation whose third token opens `😊`:

```
non-streaming bytes: 48656c6c6f2120efbfbd    'Hello! <U+FFFD>'
streaming     bytes: 48656c6c6f2120          'Hello! '
```

`Utf8Stitch::feed` (`tools/imp-server/utils.cpp:12`) holds the incomplete tail back and is wired into the streaming driver only; on the other path the dangling bytes reach `dump_safe`, whose `json::error_handler_t::replace` substitutes U+FFFD. `stream_pipeline.h:91` documents that exact mechanism in a comment — the guard was added for one path and not the other. `/v1/messages` is affected identically.

**The test.** Sweeps `max_tokens` 1–8, asserting both that the transports agree and that non-streaming introduces no U+FFFD.

```
$ IMP_USE_MOCK=1 pytest test_streaming.py -q          # the CI lane
5 passed in 0.05s
$ IMP_TEST_URL=<real server> pytest -k truncation -q
E   AssertionError: max_tokens=3: transports disagree
```

Green against the mock, red against the server, same test, same commit. **CI does not change colour**; `make test-server` goes red, which is correct until #1310 is fixed. No production code touched — this campaign files findings, it does not patch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8