### PR TITLE
test(gguf): pin the semantic-validation gap and stop the harness flattering itself

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -437,3 +437,107 @@ missing tensor, wrong shapes, metadata that disagrees with the tensors — all o
 which must produce a clear diagnostic rather than a segfault.
 `tests/test_gguf_fault_injection.cpp` exists (18 cases) and is CPU-only, so
 mutants there would land in the lane that gates a merge.
+
+---
+
+## Iteration 5 — 2026-08-08 — focus: `I5` model ingestion & error paths — commit: `cda991a6`
+
+**Mutation score: 88.9 %** (40/45) — prev 87.8 % (36/41). Four new loader
+mutants (M43–M46), all killed.
+
+| Category | score |
+|---|---|
+| **ingestion** (new) | **4/4 = 100 %** |
+| everything else | unchanged |
+
+**Bugs found:** S1: 0 · S2: 0 · **S3: 1 (#1312)** · S4: 0 · S5: 0
+
+**Escape distribution (new):** E1: 1 (#1312 — no test covers the semantic layer)
+
+### The GGUF container layer is genuinely well defended
+
+`tests/test_gguf_fault_injection.cpp` has 18 cases and they hold:
+
+| Mutant | Killed by |
+|---|---|
+| M43 per-tensor bounds guard removed | `TensorOffsetPastEof`, `TensorOffsetMaxU64`, `TensorDimOverflow`, `TensorDimNegative`, `NonexistentTensorType` — five at once |
+| M44 magic unchecked | `BadMagic` |
+| M45 version gate widened | `GgufLoaderTest.UnsupportedVersion`, `BadVersion` |
+| M46 zero-alignment guard removed | `ZeroAlignmentMetadata` — by SIGFPE, see below |
+
+All four land in `test-core`, i.e. **the lane that gates a merge**. This is the
+one area of the codebase where CI genuinely protects against the fault class.
+
+### #1312 — the semantic layer has no tests at all
+
+Every one of those 18 cases attacks the binary container. None checks whether
+the tensors present match what the metadata claims. So:
+
+```
+GGUF declaring llama.block_count = 2, shipping no layer tensor
+  -> load_gguf returns a Model, n_layers=2
+  -> layer 0: wq=(nil) wk=(nil) ffn_down=(nil)
+  -> layer 1: wq=(nil) wk=(nil) ffn_down=(nil)
+  -> the only log line is an unrelated "No tokenizer data found"
+```
+
+`n_attn` is counted (`gguf_loader.cpp:730`) and printed next to `cfg.n_layers`
+in one format string (`:769`) but never compared. All three consistency checks
+in the file are `WARN` (`:855`, `:862`, `:866`) and none covers this case.
+`engine_weight_upload.cpp:145-149` then papers over it: `if (n_attn == 0)
+n_attn = mcfg.n_layers;`.
+
+**Scope discipline:** verified at the loader boundary only. No forward pass was
+run on such a model, so no IMA or wrong-output claim is made — S3, not S1. The
+same class has shipped here before in a different loader (Qwen3-VL: 247/316
+tensors, `nullptr` into `vision_gemm`).
+
+The committed test is a **characterisation** test, not the invariant. This file
+runs in the CI lane, and a red required check blocks every merge in the repo —
+that call belongs to the owner. #1312 carries the strict version, which is the
+same test with its assertions inverted.
+
+### A defect in this harness, found by a mutant that should have died
+
+M46 first scored SURVIVED. It does not survive: removing the zero-alignment
+guard makes `align()` execute `pos_ % 0`, and the binary dies with **rc=136
+(SIGFPE)**. A crashed gtest binary prints no `[  FAILED  ]` line, and `run.py`
+only looked for those — so a kill-by-crash read as "no failures" and scored as a
+survival. That is precisely the shape of a harness that flatters the suite it
+measures.
+
+Fixed: `crashed(rc, output)` now treats "neither exited 0 nor named a failing
+test" as a kill, on every lane including the CI ones, and a crash is never
+discounted as pre-existing (the baseline ran clean). Re-scored: **M46 KILLED,
+`test-core: crashed (rc=136)`**.
+
+**Audited every earlier run for the same mistake** — `rc != 0` with an empty
+failure list across all `loop/evidence/mutation-results*.json`: M46 is the only
+occurrence. All previously reported scores stand.
+
+**Attacked and clean:** magic, version, three truncation points, KV and tensor
+count overflows, string length past EOF and overflowing, unknown array element
+type with a huge count, tensor offset past EOF and at U64 max, dim overflow and
+negative dims, nonexistent tensor type, zero alignment.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No — one added.
+2. **Did every mutant get reverted?** Yes; and the one manual apply/restore
+   outside the harness was byte-restored from a saved copy and verified with
+   `git status`.
+3. **Did I watch every new test fail before it passed?** The committed test is a
+   characterisation test, so this does not apply; it is labelled as such in the
+   source and in #1312.
+4. **Is every bug claim backed by a script I ran twice?** Yes — the probe ran
+   2/2 from fresh processes before anything was written down.
+5. **Did I fix any production code?** No. The only fix was to my own harness.
+6. **Are all new tests wired into CI?** Yes — `test-core`.
+
+### Next iteration
+
+Untouched foci: `I4` (concurrency, cancellation, VRAM pressure) and `I7` (long
+context & window boundaries). `I4` is the one with a documented history on this
+box — #1044/#1045 was cross-request KV corruption under load — and the dispatch's
+cancel-storm and eviction-under-pressure cases have no equivalent anywhere in
+the suite.

--- a/tests/test_gguf_fault_injection.cpp
+++ b/tests/test_gguf_fault_injection.cpp
@@ -47,6 +47,7 @@ struct GgufBytes {
     size_t off_tensor_dim0 = 0;       // u64 ne[0] of the tensor
     size_t off_tensor_type = 0;       // u32 ggml type of the tensor
     size_t off_tensor_data_offset = 0;  // u64 data-section-relative offset
+    size_t off_block_count = 0;         // u32 value of llama.block_count
 };
 
 class Writer {
@@ -105,6 +106,7 @@ GgufBytes build_valid_gguf() {
     // llama.block_count = 0  (no layers — keeps the model trivially small)
     w.str("llama.block_count");
     w.u32(T_UINT32);
+    g.off_block_count = w.pos();
     w.u32(0);
 
     // --- tensor info ---
@@ -200,6 +202,41 @@ TEST(GgufFaultInjection, ValidBaselineLoads) {
     auto model = load_gguf(path);
     EXPECT_NE(model, nullptr) << "baseline GGUF must load, else corruption tests are meaningless";
     unlink(path.c_str());
+}
+
+// ---- Config vs tensors ----
+//
+// CHARACTERISATION, not an invariant. A GGUF whose metadata declares N
+// transformer blocks but ships no layer tensor at all loads *successfully*:
+// load_gguf returns a Model reporting n_layers == N with every layer weight
+// null, and emits no diagnostic about it. That is #1312.
+//
+// This test pins the behaviour that exists so the change is visible when it is
+// fixed — it deliberately does NOT assert the invariant the loader ought to
+// enforce ("declared layers must have weights, or the load fails"), because
+// this file runs in the CI lane and a red required check blocks every merge.
+// The strict version is one edit away and is written out in #1312.
+//
+// Every config/tensor consistency check in the loader is a WARN
+// (gguf_loader.cpp:855, :862, :866) and none covers this case: n_attn is
+// counted at :730 and printed at :769, never compared against cfg.n_layers.
+TEST(GgufFaultInjection, DeclaredLayersWithoutTensorsLoadWithNullWeights) {
+    GgufBytes g = build_valid_gguf();
+    patch_u32(g.buf, g.off_block_count, 2);
+    auto model = load_buf(g.buf);
+
+    ASSERT_NE(model, nullptr) << "documenting today's behaviour: the load succeeds";
+    EXPECT_EQ(model->config().n_layers, 2);
+    ASSERT_EQ(model->layers_.size(), 2u);
+    for (size_t i = 0; i < model->layers_.size(); ++i) {
+        EXPECT_EQ(model->layers_[i].wq.data, nullptr)
+            << "layer " << i << ": if this is now non-null the loader changed — see #1312";
+        EXPECT_EQ(model->layers_[i].wk.data, nullptr) << "layer " << i;
+        EXPECT_EQ(model->layers_[i].w_down.data, nullptr) << "layer " << i;
+    }
+    // The one thing the file did supply is present, so the null layers above
+    // are a missing-tensor consequence and not a wholesale load failure.
+    EXPECT_NE(model->token_embedding().data, nullptr);
 }
 
 // ---- Magic / version ----

--- a/tools/mutation/catalogue.json
+++ b/tools/mutation/catalogue.json
@@ -387,6 +387,42 @@
       "focus": "test-kv",
       "find": "    if (sink_end_block > already)\n        pin_prefix(seq_id, sink_end_block);",
       "replace": "    (void)already;  // [MUTANT] sink blocks left unpinned"
+    },
+    {
+      "id": "M43",
+      "category": "ingestion",
+      "file": "src/model/gguf_loader.cpp",
+      "desc": "Per-tensor bounds guard removed: a corrupt offset yields a wild pointer into the mmap instead of a skip.",
+      "focus": "test-core",
+      "find": "        if (!gguf_tensor_in_bounds(info)) {",
+      "replace": "        if (false && !gguf_tensor_in_bounds(info)) {  // [MUTANT] bounds guard removed"
+    },
+    {
+      "id": "M44",
+      "category": "ingestion",
+      "file": "src/model/gguf_loader.cpp",
+      "desc": "GGUF magic is no longer checked, so any file is parsed with v3 field-layout assumptions.",
+      "focus": "test-core",
+      "find": "    if (magic != GGUF_MAGIC) {\n        IMP_LOG_ERROR(\"Invalid GGUF magic: 0x%08x\", magic);",
+      "replace": "    if (false) {  // [MUTANT] magic unchecked\n        IMP_LOG_ERROR(\"Invalid GGUF magic: 0x%08x\", magic);"
+    },
+    {
+      "id": "M45",
+      "category": "ingestion",
+      "file": "src/model/gguf_loader.cpp",
+      "desc": "Version gate widened to accept v1 and v4+, whose field layout differs from v2/v3.",
+      "focus": "test-core",
+      "find": "    if (version < 2 || version > 3) {",
+      "replace": "    if (version < 0) {  // [MUTANT] any version accepted"
+    },
+    {
+      "id": "M46",
+      "category": "ingestion",
+      "file": "src/model/gguf_loader.cpp",
+      "desc": "A declared alignment of 0 is no longer replaced by the default, so align() divides by zero.",
+      "focus": "test-core",
+      "find": "        if (alignment == 0)\n            alignment = GGUF_DEFAULT_ALIGNMENT;",
+      "replace": "        // [MUTANT] zero alignment accepted"
     }
   ]
 }

--- a/tools/mutation/run.py
+++ b/tools/mutation/run.py
@@ -112,6 +112,20 @@ def run_binary(name, timeout=1800, extra_args=None):
     return rc, out
 
 
+def crashed(rc, output):
+    """True when the binary died instead of reporting failures.
+
+    A SIGFPE/SIGSEGV leaves no `[  FAILED  ]` line, so a kill-by-crash reads as
+    "no failures" and the mutant is scored SURVIVED. That happened once (M46,
+    rc=136 = SIGFPE from `pos_ % 0` after removing the zero-alignment guard) and
+    is exactly the shape of a harness that flatters the suite. A run that neither
+    exits 0 nor names a failing test did not pass.
+    """
+    if rc in (0, 124):
+        return False
+    return not failing_tests(output)
+
+
 def failing_tests(output):
     """gtest names reported as FAILED, in order."""
     names = []
@@ -192,9 +206,12 @@ def run_one(m, log_dir, full_timeout):
             tag = b + ('-ci' if extra else '')
             (log_dir / f"{m['id']}-{tag}.log").write_text(out[-200000:])
             fails = failing_tests(out)
-            res['lanes'].append({'binary': tag, 'rc': rc, 'failed': fails, 'ci': True})
-            if fails and res['ci_killed_by'] is None:
-                res['ci_killed_by'] = f"{tag}: " + ', '.join(fails[:5])
+            crash = crashed(rc, out)
+            res['lanes'].append({'binary': tag, 'rc': rc, 'failed': fails,
+                                 'crashed': crash, 'ci': True})
+            if (fails or crash) and res['ci_killed_by'] is None:
+                res['ci_killed_by'] = (f"{tag}: " + ', '.join(fails[:5])) if fails \
+                    else f"{tag}: crashed (rc={rc})"
 
         if res['ci_killed_by']:
             res['status'] = 'KILLED'
@@ -211,13 +228,15 @@ def run_one(m, log_dir, full_timeout):
             rc, out = run_binary(b, timeout=full_timeout)
             (log_dir / f"{m['id']}-{b}.log").write_text(out[-200000:])
             fails = failing_tests(out)
-            res['lanes'].append({'binary': b, 'rc': rc, 'failed': fails})
+            crash = crashed(rc, out)
+            res['lanes'].append({'binary': b, 'rc': rc, 'failed': fails, 'crashed': crash})
             if rc == 124:
                 res['status'] = 'TIMEOUT'
                 return res
-            if fails:
+            if fails or crash:
                 res['status'] = 'KILLED'
-                res['killed_by'] = f"{b}: " + ', '.join(fails[:5])
+                res['killed_by'] = (f"{b}: " + ', '.join(fails[:5])) if fails \
+                    else f"{b}: crashed (rc={rc})"
                 return res
         res['status'] = 'SURVIVED'
         return res
@@ -278,7 +297,8 @@ def main():
         rc, out = run_binary(b, timeout=args.timeout, extra_args=extra)
         tag = b + ('-ci' if extra else '')
         (log_dir / f'baseline-{tag}.log').write_text(out[-200000:])
-        baseline[tag] = {'rc': rc, 'failed': failing_tests(out)}
+        baseline[tag] = {'rc': rc, 'failed': failing_tests(out),
+                         'crashed': crashed(rc, out)}
         print(f'  baseline {tag}: rc={rc} failed={baseline[tag]["failed"]}', flush=True)
     (REPO / 'loop' / 'evidence' / 'mutation-baseline.json').write_text(
         json.dumps(baseline, indent=1))
@@ -293,6 +313,8 @@ def main():
         # Discount tests that were already red on the clean tree.
         if r['status'] == 'KILLED':
             for lane in r['lanes']:
+                if lane.get('crashed'):
+                    continue  # a crash is never "pre-existing" — the baseline ran clean
                 pre = set(baseline.get(lane['binary'], {}).get('failed', []))
                 new = [f for f in lane['failed'] if f not in pre]
                 if lane['failed'] and not new:


### PR DESCRIPTION
Iteration 5, focus model ingestion & error paths — chosen because it is CPU-only, so mutants land in the lane that gates a merge.

## The container layer holds

Four loader mutants, all killed, all by `test-core`:

| Mutant | Killed by |
|---|---|
| per-tensor bounds guard removed | `TensorOffsetPastEof`, `TensorOffsetMaxU64`, `TensorDimOverflow`, `TensorDimNegative`, `NonexistentTensorType` — five at once |
| magic unchecked | `BadMagic` |
| version gate widened | `UnsupportedVersion`, `BadVersion` |
| zero-alignment guard removed | `ZeroAlignmentMetadata` |

This is the one area of the codebase where CI genuinely protects against the fault class.

## The semantic layer has none (#1312)

All 18 existing cases attack the binary container. None checks whether the tensors present match what the metadata claims:

```
GGUF declaring llama.block_count = 2, shipping no layer tensor
  -> load_gguf returns a Model, n_layers=2
  -> layer 0: wq=(nil) wk=(nil) ffn_down=(nil)
  -> layer 1: wq=(nil) wk=(nil) ffn_down=(nil)
  -> only log line: an unrelated "No tokenizer data found"
```

`n_attn` is counted (`gguf_loader.cpp:730`) and printed next to `cfg.n_layers` in one format string (`:769`) but never compared; the three consistency checks in the file are all `WARN` and none covers this. `engine_weight_upload.cpp:145-149` then papers over it with `if (n_attn == 0) n_attn = mcfg.n_layers;`.

Verified at the loader boundary only — no forward pass was run on such a model, so this is filed S3, not S1.

**The committed test characterises the behaviour; it does not assert the invariant.** This file is behind the required `Build` check and red-lining it blocks every merge in the repo. That is the owner's call, so #1312 carries the strict version — the same test with its assertions inverted.

## A defect in the harness, found by a mutant that should have died

M46 first scored SURVIVED. It does not: removing the zero-alignment guard makes `align()` execute `pos_ % 0` and the binary dies with **rc=136 (SIGFPE)**. A crashed gtest prints no `[ FAILED ]` line, and `run.py` only looked for those — so a kill-by-crash read as a survival. Exactly the shape of a harness that flatters the suite it measures.

Fixed, and **every earlier run audited** for `rc != 0` with an empty failure list: M46 is the only occurrence, so all previously reported scores stand.

Mutation score 87.8 % → **88.9 %** (40/45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8