### PR TITLE
test(concurrency): probe for cancel-storm and batch-composition effects

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -541,3 +541,100 @@ context & window boundaries). `I4` is the one with a documented history on this
 box — #1044/#1045 was cross-request KV corruption under load — and the dispatch's
 cancel-storm and eviction-under-pressure cases have no equivalent anywhere in
 the suite.
+
+---
+
+## Iteration 6 — 2026-08-08 — focus: `I4` concurrency, cancellation, VRAM pressure — commit: `863df810`
+
+**Mutation score: unchanged at 88.9 %** — a hunt, no mutants. Chosen because
+this is the focus with history on this box (#1044/#1045 was cross-request KV
+corruption under load) and because the dispatch's cancel-storm and
+eviction-under-pressure cases have no equivalent anywhere in the suite.
+
+**Bugs found:** **S1: 1 (#1314)** · S2: 0 · S3: 0 · S4: 0 · S5: 0
+
+**Escape distribution (new):** E1: 1 — no test asserts batch invariance in any
+form.
+
+### #1314 — greedy output depends on who else is in the batch
+
+`tools/mutation/cancel_storm.py` runs five survivor prompts alone, then
+alongside 45 unrelated 512-token requests, and compares byte for byte.
+
+```
+solo, 5 runs each:                 distinct outputs
+  List the first five prime numbers.        1
+  Name three primary colours.               1
+  What is the capital of France?            1
+  Count from one to seven.                  1
+
+under 45 concurrent requests:
+  DIVERGED 'Name three primary colours.'
+    alone: '... primary colors are red, blue, and yellow.'
+    storm: '... primary colours are red, blue, and yellow.'
+  DIVERGED 'List the first five prime numbers.'
+    alone: '**2, 3, 5, 7, 11**\n\nA prime number is a natural number greater ...'
+    storm: '**2, 3, 5, 7, 11**. ✅'
+```
+
+One greedy argmax flip (`colors` → `colours`) is enough to redirect the whole
+continuation, which is what the second case shows.
+
+### Four hypotheses, separated by experiment
+
+| | result |
+|---|---|
+| the prompts are simply unstable | **no** — 5/5 identical solo runs each |
+| cancellation corrupts survivors (#1044/#1045 class) | **no** — victims run to completion, same divergence |
+| cancel → resubmit serves a half-evicted prefix | **no** — clean in every round |
+| `IMP_DETERMINISTIC=1` prevents it | **no** — same two prompts, both rounds |
+
+So cancellation is exonerated, the prefix cache is exonerated, and the remaining
+variable is batch composition — which survives the strongest reproducibility
+switch the engine has. Reproduced 2/2 with `loop/repro/BUG-5.sh`, 4/4 counting
+the deterministic-mode rounds.
+
+Distinct from #1299: these prompts are byte-stable back-to-back on one context
+here, which is precisely what #1299 shows failing elsewhere. Same symptom class,
+different trigger, different fix surface.
+
+`docs/determinism.md` and #554 list the documented boundaries — dense greedy
+logit ties, CUB top-k > 128, `typical_p` atomicAdd, GDN cross-context. Batch
+invariance appears in neither the guarantees nor the exclusions.
+
+**Tests added: 0.** The right oracle for this is logit-level, not text-level:
+run a sequence alone, run it batched with unrelated padding sequences of
+different lengths, assert the logits match within a stated tolerance and the
+argmax is identical at every step. That belongs in `test-e2e` next to the
+executor, needs no server, and localises the fault to a kernel instead of a text
+diff. Writing it against a fault I have localised only to "batch composition"
+would be guessing at the seam; #1314 carries the recipe.
+
+**Attacked and clean:** cancel storm with 45 abortive clients (survivors
+unaffected); cancel → immediate resubmit of the same prompt (prefix cache
+serves correctly); 50 concurrent requests against a server whose max batch is
+smaller (queueing does not corrupt state — the three non-diverging survivors are
+byte-identical in every round).
+
+**Not attacked:** deliberate VRAM exhaustion and the allocation-failure path.
+`compute-sanitizer` is unusable on WSL2 (recorded previously), so racecheck /
+initcheck /synccheck remain out of reach on this box; that is a standing
+limitation of the environment, not a decision.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No.
+2. **Did every mutant get reverted?** No mutants this iteration.
+3. **Did I watch every new test fail before it passed?** No tests added — and
+   the reason is stated above rather than papered over.
+4. **Is every bug claim backed by a script I ran twice?** Yes —
+   `loop/repro/BUG-5.sh`, 2/2, plus two deterministic-mode rounds.
+5. **Did I fix any production code?** No.
+6. **Are all new tests wired into CI?** N/A.
+
+### Next iteration
+
+`I7` (long context & window boundaries) is the last untouched focus: behaviour
+at and beyond the trained context length, RoPE scaling at the extremes, and the
+sliding-window boundaries that `evict_middle_blocks` already showed are
+delicate.

--- a/tools/mutation/cancel_storm.py
+++ b/tools/mutation/cancel_storm.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Cancel-storm probe: does aborting requests mid-flight change the survivors?
+
+The invariant: greedy generation is a pure function of its prompt. A request
+that runs alongside 45 others which are cancelled mid-decode must produce the
+same bytes as the same request run by itself. If it does not, cancellation is
+leaking state across sequences — the shape of #1044/#1045, where a stale prefix
+hash silently corrupted another request's KV.
+
+Nothing in the suite covers this: `tests/api/test_concurrency.py` runs against
+the mock in CI (#1302), and the C++ scheduler tests exercise `HandlesCancel` at
+the bookkeeping level, never end to end under load.
+
+Phases:
+  A  each survivor prompt alone, greedy      -> reference bytes
+  B  survivors + N victims launched together, victims aborted mid-stream
+  C  compare survivors against their references, byte for byte
+
+Also probes the prefix-cache half-eviction case: submit, cancel, immediately
+resubmit the same prompt, and check the resubmission matches its reference.
+
+Usage: cancel_storm.py --base http://127.0.0.1:8099 --model <id> [--victims 45]
+"""
+import argparse
+import concurrent.futures as cf
+import json
+import sys
+import time
+
+import httpx
+
+SURVIVORS = [
+    "List the first five prime numbers.",
+    "What is the capital of France?",
+    "Name three primary colours.",
+    "Write the word banana five times.",
+    "Count from one to seven.",
+]
+
+
+def stream_once(base, model, prompt, max_tokens, abort_after=None, timeout=120):
+    """Stream a completion. If abort_after is set, drop the connection after
+    that many seconds and return None."""
+    body = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "seed": 1234,
+        "stream": True,
+    }
+    out = []
+    t0 = time.monotonic()
+    try:
+        with httpx.Client(base_url=base, timeout=timeout) as c:
+            with c.stream("POST", "/v1/chat/completions", json=body) as r:
+                for line in r.iter_lines():
+                    if abort_after is not None and time.monotonic() - t0 > abort_after:
+                        return None  # closes the connection on the way out
+                    line = line.strip()
+                    if not line.startswith("data: "):
+                        continue
+                    payload = line[6:]
+                    if payload == "[DONE]":
+                        break
+                    delta = (json.loads(payload)["choices"][0].get("delta") or {})
+                    out.append(delta.get("content") or "")
+    except Exception:  # noqa: BLE001 — an aborted stream is the point
+        return None
+    return "".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--victims", type=int, default=45)
+    ap.add_argument("--max-tokens", type=int, default=48)
+    ap.add_argument("--rounds", type=int, default=2)
+    ap.add_argument("--no-cancel", action="store_true",
+                    help="let the victims run to completion — isolates concurrency from cancellation")
+    args = ap.parse_args()
+
+    print("phase A: reference runs, one at a time")
+    ref = {}
+    for p in SURVIVORS:
+        ref[p] = stream_once(args.base, args.model, p, args.max_tokens)
+        assert ref[p], f"reference run produced nothing for {p!r}"
+        print(f"  {p[:34]:<34} {len(ref[p]):4d} chars")
+
+    bad = 0
+    for rnd in range(1, args.rounds + 1):
+        print(f"\nphase B round {rnd}: {len(SURVIVORS)} survivors + {args.victims} victims"
+              f"{' (no cancel)' if args.no_cancel else ''}")
+        with cf.ThreadPoolExecutor(max_workers=args.victims + len(SURVIVORS)) as ex:
+            futs = {}
+            for i in range(args.victims):
+                futs[ex.submit(stream_once, args.base, args.model,
+                               f"Tell me a long story about topic number {i}.",
+                               512, None if args.no_cancel else 0.35)] = ("victim", i)
+            for p in SURVIVORS:
+                futs[ex.submit(stream_once, args.base, args.model, p,
+                               args.max_tokens)] = ("survivor", p)
+
+            got = {}
+            for f in cf.as_completed(futs):
+                kind, key = futs[f]
+                if kind == "survivor":
+                    got[key] = f.result()
+
+        for p in SURVIVORS:
+            g = got.get(p)
+            if g != ref[p]:
+                bad += 1
+                print(f"  DIVERGED {p!r}\n    alone: {ref[p]!r}\n    storm: {g!r}")
+            else:
+                print(f"  ok       {p[:34]:<34} {len(g or ''):4d} chars")
+
+    print("\nphase C: cancel then immediately resubmit the same prompt")
+    for p in SURVIVORS[:3]:
+        stream_once(args.base, args.model, p, 512, abort_after=0.25)
+        again = stream_once(args.base, args.model, p, args.max_tokens)
+        if again != ref[p]:
+            bad += 1
+            print(f"  DIVERGED after cancel+resubmit {p!r}\n    alone: {ref[p]!r}\n    after: {again!r}")
+        else:
+            print(f"  ok       {p[:34]:<34} (cancel -> resubmit matches)")
+
+    print(f"\n{bad} divergence(s)")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Iteration 6, focus concurrency / cancellation / VRAM pressure. Adds `tools/mutation/cancel_storm.py` and records what it found.

## What it exonerates

The probe was aimed at the #1044/#1045 class — cancellation leaking state across sequences. It does not reproduce:

| hypothesis | result |
|---|---|
| the prompts are simply unstable | **no** — 5/5 identical solo runs each |
| cancellation corrupts survivors | **no** — victims run to completion, same divergence |
| cancel → resubmit serves a half-evicted prefix | **no** — clean in every round |
| 50 concurrent requests over max batch corrupt state | **no** — the three non-diverging survivors are byte-identical every round |

## What it found instead (#1314)

Greedy output depends on which unrelated requests share the batch, and `IMP_DETERMINISTIC=1` does not prevent it.

```
solo, 5 runs each:                        distinct outputs
  Name three primary colours.                    1
  List the first five prime numbers.             1

under 45 concurrent requests:
  DIVERGED 'Name three primary colours.'
    alone: '... primary colors are red, blue, and yellow.'
    storm: '... primary colours are red, blue, and yellow.'
```

One argmax flip redirects the whole continuation — the prime-numbers prompt loses its entire explanatory paragraph. Reproduced 2/2, 4/4 counting the deterministic-mode rounds.

Distinct from #1299: these prompts are byte-stable back-to-back on one context here, which is exactly what #1299 shows failing elsewhere. `docs/determinism.md` and #554 list the documented boundaries — dense greedy logit ties, CUB top-k, `typical_p` atomicAdd, GDN cross-context. Batch invariance appears in neither the guarantees nor the exclusions.

## No test added, on purpose

The right oracle is logit-level, not text-level: run a sequence alone, run it batched with unrelated padding sequences of different lengths, assert the logits match within a stated tolerance and the argmax is identical at every step. That belongs next to the executor, needs no server, and localises the fault to a kernel instead of a text diff. Writing it against a fault I have localised only to "batch composition" would be guessing at the seam — #1314 carries the recipe.

**Not attacked:** deliberate VRAM exhaustion and the allocation-failure path. `compute-sanitizer` is unusable on WSL2, so racecheck/initcheck/synccheck stay out of reach here — an environment limitation, not a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8