### PR TITLE
test(rope): put the long-context position range under test

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -638,3 +638,90 @@ limitation of the environment, not a decision.
 at and beyond the trained context length, RoPE scaling at the extremes, and the
 sliding-window boundaries that `evict_middle_blocks` already showed are
 delicate.
+
+---
+
+## Iteration 7 — 2026-08-08 — focus: `I7` long context & window boundaries — commit: `2d1d0500`
+
+**Mutation score: unchanged at 88.9 %** — a hunt, no mutants.
+
+**Bugs found:** S1: 0 · S2: 0 · S3: 0 · **S4: 1 (#1316)** · S5: 0
+
+**Escape distribution (new):** E6: 1 — the RoPE tests use a proper CPU-reference
+oracle and are only ever run at positions where the fault is invisible.
+
+### #1316 — the whole long-context RoPE regime was unverified
+
+The hypothesis came from reading, not from a sweep: `rope.cu:101` uses the fast
+intrinsics `__cosf`/`__sinf`, whose argument reduction NVIDIA specifies as
+accurate only for |x| < 48039 — and at `pair_idx == 0` the frequency is exactly
+`1.0f`, so the angle *is* the position. This model family trains to 131072.
+
+Measured against the same CPU reference the existing tests use (which computes
+the angle identically in float, so the comparison isolates the transcendental
+and not the angle's representation):
+
+```
+pos      40   3.0e-6        pos    8000   8.5e-4
+pos     500   5.7e-5        pos   16000   1.6e-3
+pos    1000   9.3e-5        pos   32768   8.9e-4
+pos    2000   2.3e-4        pos  131071   1.0e-2
+```
+
+Every RoPE test in the file stops at position 40:
+
+```
+121:  pos_host = {0, 5}      247:  pos_host(batch*seq_len, 0)
+192:  pos_host = {0, 5}      301:  pos_host = {3, 7}
+373:  pos_host = {0, 1, 2, 3, 10, 20, 30, 40}
+```
+
+The sharp part is not the coverage gap but what it concealed: **the existing
+tolerances are already incompatible with the existing kernel at ordinary context
+lengths.** `RopeBasicFP32` holds itself to `1e-4`, exceeded from about position
+2000; `RopePositionInvariance` holds itself to `1e-5`, exceeded from about
+position 300. Neither has ever had to reconcile its tolerance with the kernel it
+tests, because neither runs there.
+
+**Filed S4, not S1, on purpose.** What is established is numerical drift, not a
+wrong answer — no long-context perplexity measurement was made, and the issue
+says so. Two facts argue against dismissing it: 1e-2 absolute on unit-scale
+activations is well above FP16 noise, and it lands on the lowest-frequency
+rotary pair, which is the one carrying long-range position information.
+
+**Tests added: 1** — `RoPETest.LongContextPositionsMatchCpuReference`, sweeping
+to 131071 with `kTol = 2e-2`. That bound is the **measured envelope with
+headroom, not a specification**: it puts the range under test for the first time
+and catches a regression, without asserting that 1e-2 is acceptable. The test
+and its comment say this explicitly so nobody later reads the tolerance as a
+blessing.
+
+**Not measured:** the YaRN and LongRoPE branches. YaRN's `inv_scaling < 1`
+shrinks the angle so it is probably less exposed — an expectation, not a
+measurement, and labelled as such in #1316.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No. In particular the two
+   tolerances this iteration calls into question (`1e-4`, `1e-5`) were left
+   exactly as they are — they are correct at the positions they run at, and
+   changing them to accommodate a finding would be the precise inversion of the
+   job.
+2. **Did every mutant get reverted?** No mutants this iteration.
+3. **Did I watch every new test fail before it passed?** No — and it would be
+   dishonest to claim otherwise. This test bounds a measured envelope rather
+   than targeting an injected fault; it was written from the sweep, and the
+   sweep is quoted in the source so the numbers can be rechecked.
+4. **Is every bug claim backed by a script I ran twice?** The sweep is a gtest,
+   run repeatedly across two position sets while narrowing the crossing point.
+5. **Did I fix any production code?** No.
+6. **Are all new tests wired into CI?** No — `test-compute` is GPU. Standing
+   finding, #1304.
+
+### Rotation complete
+
+All seven foci have now had a pass: `I1` API surface (it. 4), `I2` paging/KV
+(it. 3), `I3` numerics & quantisation (covered by the iteration-1 mutant
+categories, 100 % across rope/scaling/quantization/numerics), `I4` concurrency
+(it. 6), `I5` ingestion (it. 5), `I6` sampling (it. 2), `I7` long context (this
+one).

--- a/tests/test_rope.cu
+++ b/tests/test_rope.cu
@@ -158,6 +158,72 @@ TEST(RoPETest, RopeBasicFP32) {
 // Test 2 -- RopeBasicFP16
 //   Same small shape but FP16.  Tolerance 1e-2.
 // =========================================================================
+// =========================================================================
+// RoPE across the long-context position range.
+//
+// Every other RoPE test in this file uses positions <= 40; this model family
+// trains to 131072, so the whole long-context regime was unverified. rope.cu
+// uses the fast intrinsics __cosf/__sinf, whose argument reduction NVIDIA
+// specifies as accurate only for |x| < 48039 — and at pair_idx 0 the frequency
+// is exactly 1.0, so the angle IS the position.
+//
+// Measured against the same CPU reference the other tests use (which computes
+// the angle identically in float and then calls the accurate cosf/sinf, so the
+// difference isolates the intrinsic, not the angle's representation):
+//
+//     pos      40   3e-6        pos    8000   8.5e-4
+//     pos     500   5.7e-5      pos   16000   1.6e-3
+//     pos    1000   9.3e-5      pos   32768   8.9e-4
+//     pos    2000   2.3e-4      pos  131071   1.0e-2
+//
+// The envelope grows with position (not monotonically point-to-point, since
+// the error depends on where the angle lands modulo 2*pi). Note what that
+// means for the tests above: RopeBasicFP32 holds itself to 1e-4 and would fail
+// from pos ~2000; RopePositionInvariance holds itself to 1e-5 and would fail
+// from pos ~300. Neither ever runs there.
+//
+// kTol below is the MEASURED ENVELOPE with headroom, not a specification. It
+// exists to catch this getting worse, and to put the range under test at all.
+// Whether 1e-2 at the context limit degrades output quality is not established
+// here — that needs a long-context perplexity measurement. See #1316.
+// =========================================================================
+TEST(RoPETest, LongContextPositionsMatchCpuReference) {
+    const int batch = 1, seq_len = 1, n_heads = 1, n_kv_heads = 1, head_dim = 8;
+    const float theta = 10000.0f, scaling = 1.0f;
+    constexpr float kTol = 2e-2f;
+    const std::vector<int> positions = {0, 40, 500, 1000, 2000, 4000, 8000, 16000, 32768, 131071};
+
+    for (int pos : positions) {
+        const int64_t n = (int64_t)batch * seq_len * n_heads * head_dim;
+        std::vector<float> q_host(n), k_host(n);
+        fill_linear(q_host);
+        fill_linear(k_host);
+        std::vector<float> q_ref(q_host), k_ref(k_host);
+        std::vector<int> pos_host = {pos};
+        cpu_rope(q_ref.data(), k_ref.data(), pos_host.data(), batch, seq_len, n_heads, n_kv_heads,
+                 head_dim, theta, scaling);
+
+        float* q_dev = to_device(q_host.data(), n);
+        float* k_dev = to_device(k_host.data(), n);
+        int* pos_dev = to_device(pos_host.data(), pos_host.size());
+        Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+        Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
+        rope_forward(Q, K, pos_dev, head_dim, theta, scaling);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        auto q_out = to_host(q_dev, n);
+        auto k_out = to_host(k_dev, n);
+        for (int64_t i = 0; i < n; i++) {
+            EXPECT_NEAR(q_out[i], q_ref[i], kTol) << "Q mismatch at pos=" << pos << " index " << i;
+            EXPECT_NEAR(k_out[i], k_ref[i], kTol) << "K mismatch at pos=" << pos << " index " << i;
+        }
+
+        cudaFree(q_dev);
+        cudaFree(k_dev);
+        cudaFree(pos_dev);
+    }
+}
+
 TEST(RoPETest, RopeBasicFP16) {
     const int batch = 1;
     const int seq_len = 2;


### PR DESCRIPTION
Iteration 7, focus long context & window boundaries — the last untouched focus in the rotation.

## The gap

```
$ rg -n 'pos_host' tests/test_rope.cu
121:  pos_host = {0, 5}        247:  pos_host(batch*seq_len, 0)
192:  pos_host = {0, 5}        301:  pos_host = {3, 7}
373:  pos_host = {0, 1, 2, 3, 10, 20, 30, 40}
```

Largest position anywhere: **40**. The model family trains to **131072**.

## What it concealed (#1316)

`rope.cu:101` uses `__cosf`/`__sinf`, whose argument reduction NVIDIA specifies as accurate only for |x| < 48039 — and at `pair_idx == 0` the frequency is exactly `1.0f`, so the angle *is* the position. Measured against the same CPU reference the other tests use (which computes the angle identically in float, so the comparison isolates the transcendental):

| pos | max\|gpu−cpu\| | | pos | max\|gpu−cpu\| |
|---:|---:|---|---:|---:|
| 40 | 3.0e-6 | | 8000 | 8.5e-4 |
| 1000 | 9.3e-5 | | 16000 | 1.6e-3 |
| 2000 | 2.3e-4 | | 131071 | **1.0e-2** |

The sharp part is not the coverage gap. It is that **the existing tolerances are already incompatible with the existing kernel at ordinary context lengths**: `RopeBasicFP32` holds itself to `1e-4` (exceeded from ~pos 2000) and `RopePositionInvariance` to `1e-5` (exceeded from ~pos 300). Neither has ever had to reconcile that, because neither runs there.

**Both are left exactly as they are.** They are correct at the positions they run at, and loosening a tolerance to accommodate a finding would be the precise inversion of this campaign's job.

## The test

`RoPETest.LongContextPositionsMatchCpuReference` sweeps to 131071 at `kTol = 2e-2` — the **measured envelope with headroom, not a specification**. It puts the range under test for the first time and catches a regression, without asserting that 1e-2 is acceptable. The source comment carries the measured table and says this outright, so the tolerance is not later read as a blessing.

Filed **S4, not S1**: what is established is numerical drift, not a wrong answer. No long-context perplexity measurement was made and #1316 says so. Two facts argue against dismissing it — 1e-2 absolute on unit-scale activations is well above FP16 noise, and it lands on the lowest-frequency rotary pair, the one carrying long-range position information.

YaRN and LongRoPE were not measured; YaRN's `inv_scaling < 1` shrinks the angle so it is probably less exposed, which is an expectation and labelled as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8