### PR TITLE
test(constrain): cover GBNF depth and JSON trailing commas

### DIFF
--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -804,3 +804,77 @@ Second pass continues with `I2`. The seams worth re-mining are the ones where
 the first pass found the tests good but the *inputs* narrow — that pattern has
 now produced three findings and is cheaper per finding than anything else this
 campaign has done.
+
+---
+
+## Iteration 9 — 2026-08-08 — focus: constrained decoding — commit: `5a0e3027`
+
+**Mutation score: 90.4 %** (47/52) — prev 90.0 % (45/50). Five mutants written
+(M52–M56); two scored, both killed after one new test, two ruled equivalent,
+one refused by the harness.
+
+| Category | score |
+|---|---|
+| **constrain** (new) | **2/2 = 100 %** |
+| everything else | unchanged |
+
+**Bugs found:** none.
+
+### The point of this iteration was to falsify my own claim
+
+The iteration-1 assertion audit measured the constrained-decoding suites as
+overwhelmingly A0 — `test_json_constrain.cu` 40/44, `test_gbnf_grammar.cpp`
+22/22 — and I softened that in the report: *"for an acceptor, `EXPECT_TRUE
+(accepts(s))` is the value under test, not a smoke check"*. That was an
+argument, not a measurement. Mutating the FSM settles it.
+
+**The claim holds, and for a sharper reason than I gave.** Two mutants re-open
+#1096 in `compute_allowed_mask()` — `ARRAY_NEED_VALUE` admitting `]` again,
+`OBJECT_NEED_KEY` admitting `}` — and nothing fails. That looks damning for
+about ten minutes. It is not: `apply_mask()` uses the mask only as a
+**pre-filter** and then runs `sim_token_valid()` on every candidate that passes
+it (`json_constrain.cu:645-655`), and `advance_char()` enforces the
+trailing-comma rule independently. So M52 and M53 are **equivalent mutants** —
+the mask half of #1096 is defence in depth over the half that decides.
+
+That makes three equivalent mutants found this campaign (M25, M52, M53), all
+three the same shape: a redundant guard layered over a load-bearing one. Worth
+naming as a pattern, because "surviving mutant ⇒ test gap" would have produced
+three wrong issues.
+
+### What was actually missing
+
+| Mutant | Verdict |
+|---|---|
+| M54 — a number ending at whitespace no longer needs a digit (`"1. 1"`, #1104) | KILLED by `JsonConstrainFsm.NumberGrammarMatchesRfc8259` |
+| M55 — GBNF `kMaxStackDepth` cap removed | **SURVIVED** — genuine gap |
+| M56 — schema depth cap | refused: the anchor matched two sites, so the harness declined to mutate an arbitrary one |
+
+`expand()` drops a continuation once it is 128 rule references deep, because a
+self-referential grammar otherwise grows the work list without bound. **No test
+in `test_gbnf_grammar.cpp` nested anything at all**, so removing the cap left
+all 22 green while turning a recursive grammar into a hang.
+
+**Tests added: 2, both verified against the fault they target.**
+
+- `GbnfGrammarTest.DeepSelfRecursionStaysBounded` — `root ::= "[" root "]" | "x"`
+  driven 512 deep. Kills M55.
+- `JsonConstrainPropertyTest.RejectsTrailingCommas` — `[1,]`, `{"a":1,}` and
+  four relatives, cross-checked against `nlohmann::json::accept`. It does **not**
+  kill M52/M53, and its comment says so outright, with the measurement: the
+  generator never produces a trailing comma, so the shape had no coverage, but
+  the path it covers is the one that decides.
+
+Both run in CI.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** No.
+2. **Did every mutant get reverted?** Yes — and M56 never applied, because the
+   harness refuses an ambiguous anchor rather than guessing.
+3. **Did I watch every new test fail before it passed?** For M55, yes. For the
+   trailing-comma test, no — and rather than dress that up, the test's own
+   comment records that the mask mutants do not move it and why.
+4. **Is every bug claim backed by a script I ran twice?** No bugs claimed.
+5. **Did I fix any production code?** No.
+6. **Are all new tests wired into CI?** Yes — both `test-core`.

--- a/tests/test_gbnf_grammar.cpp
+++ b/tests/test_gbnf_grammar.cpp
@@ -42,6 +42,36 @@ std::string compile_error(const std::string& src) {
 }  // namespace
 
 // -----------------------------------------------------------------------------
+// Pathological nesting
+// -----------------------------------------------------------------------------
+
+// expand() drops a continuation once it is kMaxStackDepth (128) rule references
+// deep, because a self-referential grammar otherwise grows the work list without
+// bound. No test in this file nested anything, so removing that cap left the
+// whole suite green while turning a recursive grammar into a hang.
+//
+// A grammar that recurses on every open bracket, driven past the cap: the
+// matcher must stay responsive and simply stop accepting deeper opens, never
+// spin. `would_accept` returning either answer is fine — the assertion is that
+// it returns at all, with a bounded amount of work, and that shallow nesting
+// still behaves.
+TEST(GbnfGrammarTest, DeepSelfRecursionStaysBounded) {
+    GbnfMatcher m = make("root ::= \"[\" root \"]\" | \"x\"\n");
+    ASSERT_TRUE(m.compiled());
+
+    // Well inside the cap: must accept.
+    EXPECT_TRUE(m.would_accept(std::string(8, '[') + "x" + std::string(8, ']')));
+
+    // Well past it: the cap makes this unreachable, and the call must still
+    // return rather than expanding for ever.
+    const std::string deep_open(512, '[');
+    EXPECT_FALSE(m.would_accept(deep_open + "x" + std::string(512, ']')));
+
+    // The matcher is not wedged by the pathological input.
+    EXPECT_TRUE(m.would_accept("x"));
+}
+
+// -----------------------------------------------------------------------------
 // Refusals: a grammar we cannot enforce must be rejected, never approximated.
 // -----------------------------------------------------------------------------
 

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -210,6 +210,28 @@ TEST(JsonConstrainPropertyTest, RejectsSwappedFinalCloser) {
     EXPECT_GT(checked, 0);
 }
 
+// P4c - trailing commas (#1096). gen_document() never produces one, and the two
+// rejection families above (swapped final closer, trailing content after the
+// root) cannot create one either, so this shape had no coverage at all.
+//
+// Measured, so the comment does not overclaim: re-admitting CLOSE_BRACKET in
+// ARRAY_NEED_VALUE and CLOSE_BRACE in OBJECT_NEED_KEY - i.e. undoing #1096 in
+// compute_allowed_mask() - does NOT make this test fail. apply_mask() uses the
+// mask only as a pre-filter and then runs sim_token_valid() on every candidate
+// that passes it, and advance_char() enforces the rule independently. The mask
+// half of #1096 is defence in depth; this test covers the half that decides.
+TEST(JsonConstrainPropertyTest, RejectsTrailingCommas) {
+    static const char* kDocs[] = {
+        "[1,]", "[1, 2,]", "[[1],]", "[{\"a\":1},]",
+        "{\"a\":1,}", "{\"a\":1, \"b\":2,}", "{\"a\":[1],}",
+    };
+    for (const char* d : kDocs) {
+        ASSERT_FALSE(nlohmann::json::accept(d)) << "oracle thinks it is valid: " << d;
+        JsonConstrainer c;
+        EXPECT_FALSE(c.sim_token_valid(d)) << "FSM accepted a trailing comma: " << d;
+    }
+}
+
 TEST(JsonConstrainPropertyTest, RejectsTrailingContentAfterRoot) {
     static const char* kTrailers[] = {"{", "[", "\"", "1", "}", "]", ",", ":", "x"};
     std::mt19937 rng(kSeed + 4);

--- a/tools/mutation/catalogue.json
+++ b/tools/mutation/catalogue.json
@@ -468,6 +468,51 @@
       "focus": "test-core",
       "find": "        if (cached > prompt_tokens)\n            cached = prompt_tokens;",
       "replace": "        // [MUTANT] clamp removed"
+    },
+    {
+      "id": "M52",
+      "category": "constrain",
+      "file": "src/compute/json_constrain.cu",
+      "desc": "ARRAY_NEED_VALUE allows a closing bracket again, so the FSM accepts a trailing comma: [1,]  (#1096).",
+      "focus": "test-core",
+      "find": "        case JsonState::ARRAY_NEED_VALUE:\n            // After , in array: a value is mandatory \u2014 no closer (#1096).\n            mask |= CAT_VALUE_START;",
+      "replace": "        case JsonState::ARRAY_NEED_VALUE:\n            mask |= CAT_VALUE_START | CAT_CLOSE_BRACKET;  // [MUTANT] trailing comma allowed"
+    },
+    {
+      "id": "M53",
+      "category": "constrain",
+      "file": "src/compute/json_constrain.cu",
+      "desc": "OBJECT_NEED_KEY allows a closing brace, so the FSM accepts {\"a\":1,} .",
+      "focus": "test-core",
+      "find": "        case JsonState::OBJECT_NEED_KEY:\n            // After , in object: a key is mandatory \u2014 no closer (#1096).\n            mask |= CAT_QUOTE;",
+      "replace": "        case JsonState::OBJECT_NEED_KEY:\n            mask |= CAT_QUOTE | CAT_CLOSE_BRACE;  // [MUTANT] trailing comma allowed"
+    },
+    {
+      "id": "M54",
+      "category": "constrain",
+      "file": "src/compute/json_constrain.cu",
+      "desc": "A number terminated by whitespace no longer requires a digit, so \"1. 1\" and \"1e \" are accepted (#1104).",
+      "focus": "test-core",
+      "find": "        if (num_need_digit_)\n            return false;  // \"1.\" / \"1e\" / \"-\" cannot end here",
+      "replace": "        // [MUTANT] incomplete number may end at whitespace"
+    },
+    {
+      "id": "M55",
+      "category": "constrain",
+      "file": "src/compute/gbnf_grammar.cpp",
+      "desc": "GBNF stack-depth cap removed, so a deeply nested grammar can overflow the stack.",
+      "focus": "test-core",
+      "find": "        if (static_cast<size_t>(depth) >= kMaxStackDepth)",
+      "replace": "        if (false)  // [MUTANT] depth cap removed"
+    },
+    {
+      "id": "M56",
+      "category": "constrain",
+      "file": "src/compute/schema_constrain.cu",
+      "desc": "Schema stack-depth cap removed at the object-push site.",
+      "focus": "test-core",
+      "find": "                    if (c == '{') {\n                        if (stk.size() >= kMaxSchemaStackDepth)\n                            return false;\n                        f.phase = SchemaPhase::OBJECT_OPEN;",
+      "replace": "                    if (c == '{') {\n                        // [MUTANT] schema depth cap removed\n                        f.phase = SchemaPhase::OBJECT_OPEN;"
     }
   ]
 }


### PR DESCRIPTION
This iteration set out to **falsify a claim I made in iteration 1**. The assertion audit measured the constrained-decoding suites as overwhelmingly A0 (`test_json_constrain.cu` 40/44, `test_gbnf_grammar.cpp` 22/22) and I softened that in the report: *"for an acceptor, a boolean assertion is the value under test, not a smoke check."* That was an argument. Mutating the FSM settles it.

## The claim holds — for a sharper reason than I gave

Two mutants re-open #1096 in `compute_allowed_mask()` (`ARRAY_NEED_VALUE` admitting `]`, `OBJECT_NEED_KEY` admitting `}`) and **nothing fails**. That looks damning for about ten minutes.

It is not. `apply_mask()` uses the mask only as a **pre-filter** and then runs `sim_token_valid()` on every candidate that passes it (`json_constrain.cu:645-655`), while `advance_char()` enforces the trailing-comma rule independently. So both are **equivalent mutants** — the mask half of #1096 is defence in depth over the half that decides.

Third equivalent mutant this campaign (M25, M52, M53), all the same shape: a redundant guard layered over a load-bearing one. Worth naming, because "surviving mutant ⇒ test gap" would have produced three wrong issues.

## What was actually missing

`expand()` drops a continuation once it is 128 rule references deep, because a self-referential grammar otherwise grows the work list without bound. **No test in `test_gbnf_grammar.cpp` nested anything at all** — removing the cap left all 22 green while turning a recursive grammar into a hang.

`GbnfGrammarTest.DeepSelfRecursionStaysBounded` drives `root ::= "[" root "]" | "x"` 512 deep and kills it.

`JsonConstrainPropertyTest.RejectsTrailingCommas` covers a shape `gen_document()` never produces. Its comment states plainly that it does **not** move the mask mutants, and why — a test whose comment overclaims is the same defect as a test with the wrong input.

Both run in CI. One mutant (M56) was **refused by the harness** because its anchor matched two sites; declining to mutate an arbitrary one is the intended behaviour.

Mutation score 90.0 % → **90.4 %** (47/52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8