### PR TITLE
fix(sampling): order-preserving float atomicMax, so top_k>128 works on negative logits

### DIFF
--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -12,6 +12,7 @@
 //   token     = argmax(logits)
 // =============================================================================
 
+#include "compute/warp_reduce.cuh"
 #include "compute/mtp_forward.h"
 #include "compute/activation.h"     // swiglu, shared_expert_gate_scale
 #include "compute/embedding.h"      // embedding_lookup (handles quantized tables)
@@ -257,7 +258,7 @@ __global__ void mtp_attn_kv_scan_kernel(
     __shared__ float s_block_max;
     if (tid == 0) s_block_max = -1.0e30f;
     __syncthreads();
-    atomicMax(reinterpret_cast<int*>(&s_block_max), __float_as_int(max_score));
+    atomic_max_float(&s_block_max, max_score);
     __syncthreads();
     float gmax = s_block_max;
 

--- a/src/compute/sampling_topk_topp.cu
+++ b/src/compute/sampling_topk_topp.cu
@@ -394,7 +394,7 @@ __global__ void softmax_max_kernel(const float* __restrict__ logits, int vocab_s
         for (int w = 0; w < BLOCK_SIZE / WARP_SIZE; w++)
             if (s_max[w] > mx)
                 mx = s_max[w];
-        atomicMax(reinterpret_cast<int*>(d_max), __float_as_int(mx));
+        atomic_max_float(d_max, mx);
     }
 }
 

--- a/src/compute/warp_reduce.cuh
+++ b/src/compute/warp_reduce.cuh
@@ -7,6 +7,27 @@ namespace imp {
 
 static constexpr int kWarpSize = 32;
 
+// Order-preserving atomic max on a float stored as raw bits (#1305).
+//
+// `atomicMax((int*)addr, __float_as_int(v))` is only correct when every
+// candidate is non-negative. IEEE-754 negatives have the sign bit set, so
+// larger magnitude means larger unsigned pattern and MORE negative as int32:
+// a signed atomicMax over negatives selects the float MINIMUM, and the usual
+// -FLT_MAX sentinel (0xFF7FFFFF -> -9 437 185 as int32) beats every ordinary
+// negative logit (-20.7f -> -1 046 326 805) and survives the reduction. The
+// sampler's softmax then computed expf(x - (-FLT_MAX)) = inf for every entry.
+//
+// The standard fix: signed atomicMax for non-negative candidates, unsigned
+// atomicMin for negative ones. The two are safe against each other because a
+// negative float is >= 0x80000000 unsigned while a positive float is below it,
+// so a negative can never displace a positive and vice versa.
+__device__ __forceinline__ void atomic_max_float(float* addr, float value) {
+    if (value >= 0.0f)
+        atomicMax(reinterpret_cast<int*>(addr), __float_as_int(value));
+    else
+        atomicMin(reinterpret_cast<unsigned int*>(addr), __float_as_uint(value));
+}
+
 __device__ __forceinline__ float warp_reduce_sum(float val) {
 #pragma unroll
     for (int offset = kWarpSize / 2; offset > 0; offset >>= 1)


### PR DESCRIPTION
Closes #1305.

`softmax_max_kernel` reduced the global max with `atomicMax((int*)d_max, __float_as_int(mx))`. That ordering only holds for non-negative candidates: IEEE-754 negatives have the sign bit set, so larger magnitude means larger unsigned pattern and *more* negative as `int32`. A signed `atomicMax` over negatives therefore selects the float **minimum**, and the `-FLT_MAX` sentinel (`0xFF7FFFFF` → −9 437 185) beats every ordinary negative logit (`-20.7f` → −1 046 326 805) and survives the reduction.

Downstream every probability became `expf(x - (-FLT_MAX))` = inf, the sort keys were all equal, and `topp_sample_from_sorted_kernel` fell through to its `chosen = sorted_indices[0]` initialiser. Trigger: `top_k > SAMPLE_MAX_TOP_K` **and** every logit negative. Result: **token 0 emitted for every seed, silently.**

`atomic_max_float()` in `warp_reduce.cuh` uses the standard split — signed `atomicMax` for non-negative candidates, unsigned `atomicMin` for negative ones. The two are safe against each other because a negative float is ≥ `0x80000000` unsigned while a positive one is below it, so neither can displace the other.

The same pattern sat at `mtp_forward.cu:260` on attention scores, which are routinely negative; rewired to the same helper.

## Verification

- `SamplingTest.TopPTruncatesCubPath` has been red since it was added and is now **green**, along with all four shift-invariance variants.
- **Identical failure sets with and without the change**, run under the same environment: `test-e2e`'s 61 failures are the documented single-process VRAM capacity limit and appear in both arms; every other binary is green (`test-core` 962, `test-compute` 209, `test-attention` 201, `test-quant` 199, `test-kv` 61, `test-moe-gdn` 143).
- CI lane green; `clang-format` clean on the changed lines.
- Perf gate unmoved. The changed kernels are not on the greedy decode path it measures, so the honest claim is "structurally cannot regress it", and the measurement agrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8
