### PR TITLE
fix(server): drop an incomplete UTF-8 tail from the non-streaming reply

### DIFF
--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -834,6 +834,10 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
         total_output_tokens += n_output_tokens;
         std::string content = !ctx.params.stop_sequences.empty() ? output_text
                                                                  : ctx.snap.tok->decode(output_ids);
+        // max_tokens can stop mid-codepoint; the streaming path holds those
+        // bytes back, so this one must drop them or the two transports return
+        // different text for the same request (#1310).
+        drop_incomplete_utf8_tail(content);
 
         // Extract reasoning content (DeepSeek format) or strip think blocks.
         // enable_thinking also covers text-level thinkers (Nemotron) whose

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -9,6 +9,24 @@ std::string dump_safe(const json& j) {
     return j.dump(-1, ' ', false, json::error_handler_t::replace);
 }
 
+// Drop an incomplete trailing UTF-8 sequence from a FINISHED string (#1310).
+//
+// Utf8Stitch carries such a tail forward to the next piece, which is right for
+// a stream. At the end of a generation there is no next piece: max_tokens can
+// stop mid-codepoint, and those bytes then reach dump_safe(), whose
+// error_handler_t::replace substitutes U+FFFD - so `message.content` carries a
+// character no generated token produced. The streaming path never showed this
+// because the stitcher simply never releases the tail.
+//
+// Same 3-byte bound as Utf8Stitch::feed: a split codepoint is at most 3 bytes
+// short, and a longer tail is genuinely ill-formed input rather than a
+// truncation, so it is left alone for dump_safe to handle.
+void drop_incomplete_utf8_tail(std::string& s) {
+    const size_t complete = imp::stream::utf8_complete_len(s);
+    if (complete < s.size() && s.size() - complete <= 3)
+        s.resize(complete);
+}
+
 std::string Utf8Stitch::feed(const std::string& piece) {
     std::string buf = carry_ + piece;
     carry_.clear();

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -67,6 +67,9 @@ bool api_key_matches(const std::string& authorization, const std::string& x_api_
 json safe_token_json(const std::string& text);
 json token_bytes_json(const std::string& text);
 size_t utf8_complete_len(const std::string& s);
+
+// Trim a trailing incomplete UTF-8 sequence from a finished string (#1310).
+void drop_incomplete_utf8_tail(std::string& s);
 void json_escape_into(std::string& out, const char* s, size_t len);
 
 int b64_val(unsigned char c);


### PR DESCRIPTION
Closes #1310.

When `max_tokens` stopped generation mid-codepoint, the non-streaming reply carried **U+FFFD** while the streaming reply for the identical request did not — so transport changed content:

```
max_tokens=3  non-streaming: 'Hello! <U+FFFD>'  48656c6c6f2120efbfbd
max_tokens=3  streaming:     'Hello! '          48656c6c6f2120
```

`Utf8Stitch::feed` holds an incomplete tail back and is wired into the streaming driver only. On the other path the dangling bytes reached `dump_safe()`, whose `json::error_handler_t::replace` substitutes U+FFFD — so `message.content` carried a character no generated token produced.

`drop_incomplete_utf8_tail()` applies the same rule where a stream cannot: at the end of a generation there is no next piece, so the tail is dropped rather than carried. Same 3-byte bound as the stitcher, for the same reason — a longer tail is ill-formed input rather than a truncation, and is left for `dump_safe`.

`/v1/messages` is fixed by the same change; it transforms this reply rather than building its own, which the measurement confirms.

## Verification

- `loop/repro/BUG-3.sh` no longer reproduces — both transports return `48656c6c6f2120`.
- `test_streaming.py` **5/5**, including `test_stream_nonstream_agree_across_truncation_points`, which has been red since it was added.
- `tests/api` against a real server: 85 passed, 1 skipped. The single failure (`test_n_greater_than_1`) is the pre-existing mock/server disagreement documented on #1302 — the mock asserts 400 for `n>1`, the server returns 200 with two choices — and is outside the three files touched here.
- Mock lane unchanged (73 passed / 10 skipped), `test-core` 903 passed, CI lane green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8
