### PR TITLE
fix(gguf): reject a file that declares layers it has no tensors for

### DIFF
--- a/src/model/gguf_loader.cpp
+++ b/src/model/gguf_loader.cpp
@@ -719,12 +719,28 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
     {
         int n_attn = 0, n_moe = 0, n_dense_ffn = 0, n_shared_exp = 0;
         int n_qk_norm = 0, n_ssm = 0, n_gdn = 0, n_remapped = 0;
+        int n_empty = 0;
+        int first_empty = -1;
 
         for (int i = 0; i < cfg.n_layers; i++) {
             auto& ly = model->layers_[i];
             bool has_moe = (ly.moe_gate.data != nullptr);
             bool has_dense = (ly.w_up.data != nullptr);
             bool has_shared = (ly.w_up_shared.data != nullptr);
+
+            // A declared block must carry SOMETHING. Every architecture here
+            // mixes attention, GDN and SSM blocks freely, so no single tensor
+            // is universally required — but a block with none of them and no
+            // FFN either cannot be executed (#1312). Before this check a
+            // truncated download or an interrupted conversion produced a Model
+            // reporting n_layers=N with every weight null and no diagnostic
+            // beyond an unrelated tokenizer warning.
+            if (ly.wq.data == nullptr && ly.gdn_gate.data == nullptr && ly.ssm_in.data == nullptr &&
+                !has_moe && !has_dense && !has_shared) {
+                if (first_empty < 0)
+                    first_empty = i;
+                n_empty++;
+            }
 
             if (ly.wq.data != nullptr)
                 n_attn++;
@@ -767,6 +783,15 @@ std::unique_ptr<Model> load_gguf(const std::string& path) {
             "Layer census: %d attn, %d GDN, %d MoE, %d dense FFN, %d shared expert, "
             "%d QK-norm, %d SSM  (of %d layers)",
             n_attn, n_gdn, n_moe, n_dense_ffn, n_shared_exp, n_qk_norm, n_ssm, cfg.n_layers);
+
+        if (n_empty > 0) {
+            IMP_LOG_ERROR(
+                "GGUF declares %d layers but %d of them carry no attention, GDN, SSM or FFN "
+                "tensors at all (first: layer %d) — the file is incomplete or truncated",
+                cfg.n_layers, n_empty, first_empty);
+            munmap(mmap_base, file_size);
+            return nullptr;
+        }
 
         if (n_remapped > 0) {
             IMP_LOG_INFO("Remapped %d layers: dense FFN tensors -> shared expert", n_remapped);

--- a/tests/test_gguf_fault_injection.cpp
+++ b/tests/test_gguf_fault_injection.cpp
@@ -206,36 +206,32 @@ TEST(GgufFaultInjection, ValidBaselineLoads) {
 
 // ---- Config vs tensors ----
 //
-// CHARACTERISATION, not an invariant. A GGUF whose metadata declares N
-// transformer blocks but ships no layer tensor at all loads *successfully*:
-// load_gguf returns a Model reporting n_layers == N with every layer weight
-// null, and emits no diagnostic about it. That is #1312.
+// A GGUF whose metadata declares N transformer blocks but ships no layer tensor
+// must not load. Before #1312 it did: load_gguf returned a Model reporting
+// n_layers == N with every layer weight null, and the only log line was an
+// unrelated tokenizer warning, so a truncated download was indistinguishable
+// from a complete file at the API boundary.
 //
-// This test pins the behaviour that exists so the change is visible when it is
-// fixed — it deliberately does NOT assert the invariant the loader ought to
-// enforce ("declared layers must have weights, or the load fails"), because
-// this file runs in the CI lane and a red required check blocks every merge.
-// The strict version is one edit away and is written out in #1312.
-//
-// Every config/tensor consistency check in the loader is a WARN
-// (gguf_loader.cpp:855, :862, :866) and none covers this case: n_attn is
-// counted at :730 and printed at :769, never compared against cfg.n_layers.
-TEST(GgufFaultInjection, DeclaredLayersWithoutTensorsLoadWithNullWeights) {
+// The check is deliberately weak per layer — attention, GDN and SSM blocks mix
+// freely across the architectures here, so no single tensor is universally
+// required — and rejects only a block that carries none of them and no FFN
+// either, which cannot be executed under any architecture.
+TEST(GgufFaultInjection, DeclaredLayersWithoutTensorsAreRejected) {
     GgufBytes g = build_valid_gguf();
     patch_u32(g.buf, g.off_block_count, 2);
-    auto model = load_buf(g.buf);
+    EXPECT_EQ(load_buf(g.buf), nullptr)
+        << "a GGUF declaring layers it has no tensors for must not load";
+}
 
-    ASSERT_NE(model, nullptr) << "documenting today's behaviour: the load succeeds";
-    EXPECT_EQ(model->config().n_layers, 2);
-    ASSERT_EQ(model->layers_.size(), 2u);
-    for (size_t i = 0; i < model->layers_.size(); ++i) {
-        EXPECT_EQ(model->layers_[i].wq.data, nullptr)
-            << "layer " << i << ": if this is now non-null the loader changed — see #1312";
-        EXPECT_EQ(model->layers_[i].wk.data, nullptr) << "layer " << i;
-        EXPECT_EQ(model->layers_[i].w_down.data, nullptr) << "layer " << i;
-    }
-    // The one thing the file did supply is present, so the null layers above
-    // are a missing-tensor consequence and not a wholesale load failure.
+// The zero-layer baseline must keep loading: block_count=0 has no block to be
+// empty, so the check above must not fire on it. Without this, tightening the
+// rule to "every declared layer needs weights" could silently start rejecting
+// embedding-only models.
+TEST(GgufFaultInjection, ZeroDeclaredLayersStillLoads) {
+    GgufBytes g = build_valid_gguf();  // block_count = 0
+    auto model = load_buf(g.buf);
+    ASSERT_NE(model, nullptr);
+    EXPECT_EQ(model->config().n_layers, 0);
     EXPECT_NE(model->token_embedding().data, nullptr);
 }
 


### PR DESCRIPTION
Closes #1312.

A GGUF whose metadata declared N transformer blocks but shipped no layer tensor **loaded successfully**: `load_gguf` returned a `Model` reporting `n_layers == N` with every layer weight null, and the only log line was an unrelated tokenizer warning. A truncated download or an interrupted conversion was indistinguishable from a complete file at the API boundary.

`n_attn` was already counted (`gguf_loader.cpp:730`) and printed next to `cfg.n_layers` in one format string (`:769`) — never compared. All three config/tensor consistency checks in the file are `WARN` and none covered this case; `engine_weight_upload.cpp:145` then papered over it with `if (n_attn == 0) n_attn = mcfg.n_layers`.

## The check is deliberately weak

Attention, GDN and SSM blocks mix freely across the architectures here, so no single tensor is universally required. It rejects only a block carrying **none** of attention, GDN, SSM or FFN — which cannot be executed under any architecture.

That conservatism is the whole risk of this change, so it was measured rather than assumed: **seven real models still load** — dense (Qwen3-4B, Qwen3-8B, Llama-3.2-3B), GDN hybrid (Qwen3.5-4B-mxfp4), MoE/mxfp4 (gpt-oss-20b), embedding (nomic-embed) and reranker (qwen3-reranker-0.6b).

## Tests

The characterisation test from #1312 is **inverted into the invariant**, and `ZeroDeclaredLayersStillLoads` pins the boundary so a later tightening to "every declared layer needs weights" cannot silently start rejecting embedding-only models.

Full suite identical to the pre-change baseline: `test-core` 963, `test-compute` 209, `test-attention` 201, `test-quant` 199, `test-kv` 61, `test-moe-gdn` 143. `test-e2e`'s 61 failures are the documented single-process VRAM capacity limit and are present in both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Vsh8gvJbp8uVg2gvpkir8
