### PR TITLE
test(api): run the shipping server in CI, not only its Python stand-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           name: imp-build
           path: |
             build/imp-cli
+            build/imp-server
             build/imp-tests
             build/test-core
             build/test-text
@@ -299,6 +300,46 @@ jobs:
         env:
           IMP_USE_MOCK: "1"
         run: python -m pytest tests/api -m "not perf and not tools" --tb=short -q
+
+  # Real-server API contract (#1302). `Mock API contract` above validates
+  # mock_server.py; this job runs the SHIPPING binary. imp-server started
+  # without --model answers its whole request-validation surface — parameter
+  # bounds, error envelopes, /health, /v1/models, /metrics, unmatched routes —
+  # before it ever looks for weights, so none of it needs a GPU. Tests that
+  # need generated tokens are the ones NOT marked `nomodel`; they stay in the
+  # local `make test-server` lane.
+  #
+  # Runs in the same CUDA image the Build job compiled in: the binary is linked
+  # against that libstdc++, so a plain ubuntu-24.04 runner cannot load it.
+  real-api:
+    name: Real API contract
+    needs: build
+    if: needs.build.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    container:
+      image: nvidia/cuda:13.3.1-devel-ubuntu26.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: imp-build
+          path: build
+
+      - name: Install python
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends python3 python3-pip
+          pip install --break-system-packages -r tests/api/requirements.txt
+
+      - name: Run the API contract against imp-server
+        run: |
+          chmod +x build/imp-server
+          # conftest.py starts it model-less and shuts it down at session end.
+          IMP_SERVER_BIN="$PWD/build/imp-server" \
+            python3 -m pytest tests/api -m nomodel --tb=short -q
 
   # Format check (CI1). clang-format on CHANGED LINES only (git clang-format).
   # ADVISORY: it surfaces the diff but does not fail the job — the repo is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,28 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **`imp-server` starts without `--model`.** `--help` has always called the flag
+  optional and the auto-load path has always existed; startup refused it anyway.
+  Model-less, the server answers `/health`, `/v1/models`, `/metrics` and the
+  whole parameter-validation surface, and the first request naming a model under
+  `--models-dir` loads it. Requests that resolve to no model get 503.
+- **CI now tests the shipping server, not only its stand-in (#1302).** A new
+  `Real API contract` job starts the built `imp-server` model-less on the
+  GPU-less runner and runs the 42 API tests marked `nomodel` against the binary.
+  Until now every one of the suite's 82 assertions described
+  `tests/api/mock_server.py`.
+
 ### Fixed
+
+- **An unmatched route now answers with a JSON error envelope.** `POST /v1/nope`
+  returned 404 with a zero-length body, so a client reading
+  `error.message` got a parse error instead of a reason; `/v1/messages*` paths
+  get the Anthropic shape. Found by pointing the API suite at the real server.
+- **`n` on `/v1/chat/completions` is documented and tested as `[1,4]`.** The
+  suite asserted that `n=2` is a 400 — true of the mock, never of the server,
+  which runs n independent generations.
 
 - **Raising `max_tokens` now buys answer room on a reasoning model (#1297).**
   The think budget reserved a FLAT 256 tokens for the answer and took the later

--- a/docs/audit/ESCAPE_ANALYSIS.md
+++ b/docs/audit/ESCAPE_ANALYSIS.md
@@ -102,6 +102,15 @@ mutant in the dispatch's "API" category would survive by construction, which is
 why none were written: the experiment's outcome is already known from the job
 definition.
 
+**Closed in iteration 12 (#1302).** `--model` became optional, so the shipping
+binary starts model-less and answers its whole request-validation surface
+without a GPU. The `Real API contract` job runs the 42 tests marked `nomodel`
+against `build/imp-server` itself. Pointing the suite at the real server
+immediately falsified two of its assertions and found one server defect — see
+`TEST_HARDENING_LOG.md`, iteration 12. What remains mock-only is generation:
+anything that needs tokens back still needs a GPU, and the split is now visible
+as a marker rather than implicit in the job definition.
+
 ## E6 — the test exists, the inputs cannot trigger the fault
 
 ### M20 / M21 — `top_p` is never given a value that truncates anything

--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -1029,3 +1029,106 @@ Verified in both lanes: mock 8 passed / 3 skipped (CI unchanged), real server
 6. **Are all new tests wired into CI?** The test runs in CI and skips there, for
    a stated reason. Making it meaningful in CI is #1302; making it
    self-validating anywhere is #1321.
+
+---
+
+## Iteration 12 — 2026-08-09 — focus: `imp-server` under test at all (#1302) — commit: `b83a79dd`
+
+**Mutation score: unchanged at 90.4 %** — this iteration moves a different
+number: the API layer's score was **0 % by construction**, because no gate ever
+executed `tools/imp-server/`. It is now 42 tests against the shipping binary.
+
+**Bugs found:** S3: 1 (unmatched route answered 404 with an empty body) ·
+**assertions falsified: 2** (both green in CI, both wrong about the server).
+
+### The blocker was a flag that documented itself as optional
+
+`imp-server --help` has said `--model <path> … (optional)` since it was written,
+`main.cpp:51` describes "auto-load on first request when started without
+`--model`", and `ensure_model_loaded()` implements exactly that. Startup refused
+it anyway — `if (args.model_path.empty()) return 1`. So the one thing standing
+between CI and the real server was four lines that contradicted the two comments
+above them.
+
+Model-less, the server answers `/health`, `/v1/models`, `/props`, `/info`,
+`/metrics` and — the part that matters — every parameter check, because
+validation runs in `parse_chat_request_params` *before*
+`snapshot_state_and_tokenize_` ever looks for weights. Measured against the
+46-case table from iteration 4: all **15** cases that a model-loaded server
+answers 4xx answer identically model-less; the other 31 turn into 503. No GPU,
+no model, no CUDA call — verified by running the binary in a container started
+without `--gpus`.
+
+### What the real server said when the suite finally asked it
+
+| assertion (green in CI for a year) | the shipping server |
+|---|---|
+| `n=2` on `/v1/chat/completions` → 400 | **200 with two choices** — `n` is validated against `[1,4]` and `handlers_chat_core.cpp` runs that many generations |
+| `POST /v1/nope` → 404 with `error.message` | **404 with a zero-length body** — httplib's default |
+
+The first is a mock invention: `mock_server.py` rejected everything but `n=1`,
+and `test_n_greater_than_1` asserted the mock. The second is a real defect —
+a client doing `r.json()["error"]["message"]` on a typo'd path got a JSON parse
+error instead of a reason. Fixed with a body-aware `set_error_handler` (it fires
+for *every* status ≥ 400, so it must leave handler-produced bodies alone) that
+answers in the dialect of the path: OpenAI shape, Anthropic shape under
+`/v1/messages*`.
+
+Three more divergences from the same table were mock-side crashes: `max_tokens:
+null` (the SDK spelling of "unset") and any non-object JSON body killed the
+connection instead of answering. `RemoteProtocolError` in a probe, invisible to
+the suite because nothing sent those.
+
+### Tests added / changed
+
+- **`nomodel` marker + `IMP_SERVER_BIN` lane** (`conftest.py`): starts the
+  binary model-less and shuts it down at session end. `-m nomodel` selects the
+  42 cases that need no weights.
+- **New CI job `Real API contract`** — same CUDA image the Build job compiled
+  in (the binary is linked against that libstdc++), artifact + `chmod +x`,
+  pytest. Non-required, like `Mock API contract`.
+- `TestParameterValidation` split: rejection stays and is now `nomodel`;
+  acceptance ("temperature=2 must be **accepted**") moved to
+  `TestParameterAcceptance`, which needs weights and says so.
+- New: non-object JSON bodies (4), `max_tokens: null`, unknown-route envelope
+  in both dialects, `n` out of range, `n=2` returns two choices.
+
+Watched failing first, both directions: the 7 mock-lane tests against the
+unpatched `mock_server.py`, and the 4 unknown-route tests against a rebuilt
+server with the error handler removed (`JSONDecodeError: Expecting value` —
+i.e. the empty body).
+
+### Verification
+
+| lane | result |
+|---|---|
+| mock (`IMP_USE_MOCK=1`, = CI job) | 85 passed, 12 skipped |
+| **real binary, model-less** (= new CI job) | **42 passed** |
+| real binary + Qwen3-4B-IQ4_NL, full suite | **96 passed, 1 skipped** |
+| real binary + Llama-3.2-3B-IQ4_XS, full suite | 93 passed, **3 failed** |
+| `ctest -L unit` | 4/4 |
+
+The three Llama failures are model-dependent, not server defects: two tool tests
+need a model that emits tool calls, and `test_temperature_zero_deterministic`
+fails on `'2 + 2 = 4'` vs `'2 + 2 = 4.'` — the greedy-divergence class of #1299 /
+#1314, reproduced here from the HTTP surface for the first time.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** Yes, one, and it is the
+   point of the iteration: `test_n_greater_than_1` asserted a contract the
+   shipping server never had. It is not loosened — it now pins `[1,4]` on both
+   ends *and* gained a positive case (n=2 → two choices) that the old assertion
+   made impossible.
+2. **Did every mutant get reverted?** No mutants this iteration. The two
+   temporary reverts (mock, error handler) were restored from a scratchpad copy
+   and the tree diff was checked afterwards.
+3. **Did I watch every new test fail before it passed?** Yes — see above.
+4. **Is every bug claim backed by a script I ran twice?** The empty-body 404 was
+   seen by `curl -D-` and then by the failing test on a rebuilt binary. The
+   `n=2` claim was measured on a model-less server, on a model-loaded server,
+   and read out of `handlers.cpp`.
+5. **Did I fix any production code?** Yes: `--model` optional (main.cpp) and the
+   JSON error envelope for bodyless errors.
+6. **Are all new tests wired into CI?** Yes — that is the iteration. What is
+   *not* wired is generation; it needs a GPU runner, which remains a WON'T FIX.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -246,11 +246,16 @@ Benchmark / eval:
 
 ## Server — imp-server (OpenAI + Anthropic compatible)
 
-`--model` is required at startup. Both GGUF and SafeTensors are accepted.
+Both GGUF and SafeTensors are accepted. `--model` is optional: without it the
+server starts model-less and the first request naming a model under
+`--models-dir` loads it (requests that resolve to nothing get a 503).
 
 ```bash
 # Start with GGUF
 ./build/imp-server --model model.gguf --port 8080
+
+# No model at startup — pick one per request from a directory
+./build/imp-server --models-dir ~/models --port 8080
 
 # Start with SafeTensors (NVFP4 prequant)
 ./build/imp-server --model ./Qwen3-Coder-30B-A3B-FP4 --port 8080

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import time
 
 import httpx
@@ -10,9 +11,24 @@ from mock_server import MOCK_MODEL_ID, run_server
 BASE_URL = os.environ.get("IMP_TEST_URL", "http://localhost:8080")
 MODEL = os.environ.get("IMP_TEST_MODEL", "")
 
+# IMP_SERVER_BIN=<path to imp-server>: start the SHIPPING binary model-less and
+# test it directly. This is the lane a GPU-less runner can have (#1302) — the
+# server answers its whole request-validation surface before it ever looks for a
+# model, so every 4xx the mock claims can be checked against the real thing.
+# Generation needs a GPU and stays out: those tests are the ones NOT marked
+# `nomodel`, and the lane selects `-m nomodel`.
+SERVER_BIN = os.environ.get("IMP_SERVER_BIN", "")
+SERVER_PORT = int(os.environ.get("IMP_SERVER_PORT", "9098"))
+
 # Auto-start mock server when no real server URL or model is configured
-USE_MOCK = os.environ.get("IMP_USE_MOCK", "0") == "1" or (not MODEL and BASE_URL == "http://localhost:8080")
+USE_MOCK = not SERVER_BIN and (
+    os.environ.get("IMP_USE_MOCK", "0") == "1" or (not MODEL and BASE_URL == "http://localhost:8080")
+)
 MOCK_PORT = int(os.environ.get("IMP_MOCK_PORT", "9099"))
+
+# True when a model is resident, i.e. tests may ask for generated tokens.
+# A model-less real server is deliberately not one.
+HAS_MODEL = not SERVER_BIN
 
 
 def wait_for_server(url: str, timeout: float = 120.0):
@@ -31,15 +47,36 @@ def wait_for_server(url: str, timeout: float = 120.0):
 
 # Session-scoped mock server (started once, shared across all tests)
 _mock_server = None
+_real_server = None
 
 
 def pytest_configure(config):
-    """Start mock server if needed, before any test collection."""
-    global _mock_server, BASE_URL, MODEL
-    if USE_MOCK:
+    """Start the server under test (mock or real binary) before collection."""
+    global _mock_server, _real_server, BASE_URL, MODEL
+    if SERVER_BIN:
+        # No --model: the binary serves the validation surface and answers 503
+        # on anything that would need weights. stdout/stderr are inherited so a
+        # start-up failure is visible in the job log instead of a bare timeout.
+        _real_server = subprocess.Popen(
+            [SERVER_BIN, "--host", "127.0.0.1", "--port", str(SERVER_PORT)]
+        )
+        BASE_URL = f"http://127.0.0.1:{SERVER_PORT}"
+        # Any name: nothing resolves on a model-less server, and the tests that
+        # send one only care about what happens BEFORE model resolution.
+        MODEL = MODEL or "no-model-loaded"
+    elif USE_MOCK:
         _mock_server = run_server(port=MOCK_PORT, latency_ms=5)
         BASE_URL = f"http://127.0.0.1:{MOCK_PORT}"
         MODEL = MOCK_MODEL_ID
+
+
+def pytest_unconfigure(config):
+    if _real_server is not None and _real_server.poll() is None:
+        _real_server.terminate()
+        try:
+            _real_server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            _real_server.kill()
 
 
 @pytest.fixture(scope="session")
@@ -56,7 +93,7 @@ def model():
 
 @pytest.fixture(scope="session")
 def client(base_url):
-    wait_for_server(base_url, timeout=10 if USE_MOCK else 120)
+    wait_for_server(base_url, timeout=120 if HAS_MODEL and not USE_MOCK else 10)
     with httpx.Client(base_url=base_url, timeout=60.0) as c:
         yield c
 
@@ -67,11 +104,17 @@ def is_mock():
     return USE_MOCK
 
 
+@pytest.fixture(scope="session")
+def has_model():
+    """False on the model-less real-binary lane: no request can generate."""
+    return HAS_MODEL
+
+
 @pytest.fixture(scope="session", autouse=True)
-def warmup(client, model, is_mock):
+def warmup(client, model, is_mock, has_model):
     """Send warmup requests to prime cuBLAS autotuning and stabilize output."""
-    if is_mock:
-        return  # Mock doesn't need warmup
+    if is_mock or not has_model:
+        return  # Mock needs no warmup; a model-less server has nothing to warm
     for _ in range(2):
         client.post("/v1/chat/completions", json={
             "model": model,

--- a/tests/api/mock_server.py
+++ b/tests/api/mock_server.py
@@ -101,6 +101,15 @@ class MockHandler(BaseHTTPRequestHandler):
         self.wfile.write(data)
 
     def _send_error(self, status: int, message: str, error_type: str = "invalid_request_error"):
+        # Anthropic clients read `type` at the top level; imp-server switches
+        # envelope by path (main.cpp pre-routing + error handler), so the mock
+        # has to as well or the two disagree on every /v1/messages error.
+        if urlparse(self.path).path.startswith("/v1/messages"):
+            if error_type == "invalid_request_error" and status == 404:
+                error_type = "not_found_error"
+            self._send_json(status, {"type": "error",
+                                     "error": {"type": error_type, "message": message}})
+            return
         self._send_json(status, {"error": {"message": message, "type": error_type}})
 
     def _check_model(self, model: str) -> bool:
@@ -204,10 +213,18 @@ class MockHandler(BaseHTTPRequestHandler):
 
     def _parse_json_body(self, raw: bytes) -> dict | None:
         try:
-            return json.loads(raw)
+            body = json.loads(raw)
         except (json.JSONDecodeError, ValueError) as e:
             self._send_error(400, f"Invalid JSON: {e}")
             return None
+        # A well-formed JSON body that is not an object used to fall through and
+        # raise inside the handler thread, so the client saw a dropped
+        # connection instead of a status. imp-server answers 400 (nlohmann
+        # type_error.306) — match the status, not the wording.
+        if not isinstance(body, dict):
+            self._send_error(400, "request body must be a JSON object")
+            return None
+        return body
 
     def _validate_sampling(self, body: dict) -> bool:
         """Validate sampling parameters. Returns False and sends error if invalid."""
@@ -231,8 +248,14 @@ class MockHandler(BaseHTTPRequestHandler):
                 return False
         if "n" in body:
             n = body["n"]
-            if n != 1:
-                self._send_error(400, '"n" must be 1. n > 1 is not supported.')
+            # imp-server accepts n in [1,4] on /v1/chat/completions and runs that
+            # many independent generations (handlers.cpp validate_sampling_params
+            # + handlers_chat_core.cpp). This used to reject everything but n=1,
+            # and the suite asserted that — a contract the shipping server never
+            # had. /v1/completions still refuses n>1; that check lives in its own
+            # handler, as it does in the server.
+            if not isinstance(n, int) or n < 1 or n > 4:
+                self._send_error(400, '"n" must be between 1 and 4.')
                 return False
         return True
 
@@ -283,7 +306,9 @@ class MockHandler(BaseHTTPRequestHandler):
 
         metrics.inc_request()
 
-        max_tokens = body.get("max_tokens", 16)
+        # `max_tokens: null` is "unset" in every OpenAI SDK. Passing None
+        # through reached min(None, 32) and killed the connection.
+        max_tokens = body.get("max_tokens") or 16
         seed = body.get("seed", 42)
         stream = body.get("stream", False)
         include_usage = False
@@ -307,23 +332,27 @@ class MockHandler(BaseHTTPRequestHandler):
             self._stream_chat_response(req_id, created, model, tokens,
                                        prompt_tokens, include_usage)
         else:
+            # n independent generations, like handlers_chat_core.cpp. The mock
+            # repeats the same text; what the suite checks is the choice count
+            # and the index numbering.
+            n_choices = body.get("n", 1)
             self._send_json(200, {
                 "id": req_id,
                 "object": "chat.completion",
                 "created": created,
                 "model": model,
                 "choices": [{
-                    "index": 0,
+                    "index": i,
                     "message": {
                         "role": "assistant",
                         "content": content,
                     },
                     "finish_reason": "stop" if completion_tokens < max_tokens else "length",
-                }],
+                } for i in range(n_choices)],
                 "usage": {
                     "prompt_tokens": prompt_tokens,
-                    "completion_tokens": completion_tokens,
-                    "total_tokens": prompt_tokens + completion_tokens,
+                    "completion_tokens": completion_tokens * n_choices,
+                    "total_tokens": prompt_tokens + completion_tokens * n_choices,
                 },
             })
 
@@ -408,6 +437,13 @@ class MockHandler(BaseHTTPRequestHandler):
         if not self._validate_sampling(body):
             return
 
+        # Multi-choice generation is chat-only in imp-server; /v1/completions
+        # refuses n>1 rather than silently returning one choice.
+        if body.get("n", 1) > 1:
+            self._send_error(
+                400, "n>1 is not supported on /v1/completions; request one completion per call")
+            return
+
         model = body.get("model", "")
         if not model:
             self._send_error(400, '"model" is required')
@@ -432,7 +468,9 @@ class MockHandler(BaseHTTPRequestHandler):
 
         metrics.inc_request()
 
-        max_tokens = body.get("max_tokens", 16)
+        # `max_tokens: null` is "unset" in every OpenAI SDK. Passing None
+        # through reached min(None, 32) and killed the connection.
+        max_tokens = body.get("max_tokens") or 16
         seed = body.get("seed", 42)
         tokens = self._generate_tokens(seed, max_tokens)
         content = "".join(tokens)

--- a/tests/api/pytest.ini
+++ b/tests/api/pytest.ini
@@ -5,3 +5,4 @@ markers =
     perf: performance benchmarks (require real model)
     tools: tool calling tests (require real model)
     mock: tests designed for mock server
+    nomodel: needs no loaded model — runs against the real binary started model-less (see conftest IMP_SERVER_BIN)

--- a/tests/api/test_contract.py
+++ b/tests/api/test_contract.py
@@ -14,6 +14,7 @@ import json
 import pytest
 
 
+@pytest.mark.nomodel
 class TestHealthEndpoint:
     def test_health_returns_200(self, client):
         r = client.get("/health")
@@ -37,6 +38,7 @@ class TestHealthEndpoint:
         assert isinstance(body["queue_depth"], int)
 
 
+@pytest.mark.nomodel
 class TestModelsEndpoint:
     def test_models_returns_200(self, client):
         r = client.get("/v1/models")
@@ -222,6 +224,7 @@ class TestStreamingSchema:
         assert u["total_tokens"] == u["prompt_tokens"] + u["completion_tokens"]
 
 
+@pytest.mark.nomodel
 class TestMetricsEndpoint:
     def test_metrics_returns_200(self, client):
         r = client.get("/metrics")

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -1,8 +1,16 @@
-"""Tests for error handling and parameter validation."""
+"""Tests for error handling and parameter validation.
+
+Everything here that is marked `nomodel` runs in two lanes: against the Python
+mock (CI, `IMP_USE_MOCK=1`) and against the shipping `imp-server` binary started
+without a model (CI, `IMP_SERVER_BIN=...`). Parameter validation happens before
+the server looks for weights, so the second lane needs no GPU — and it is the
+only one that says anything about `tools/imp-server/` (#1302).
+"""
 
 import pytest
 
 
+@pytest.mark.nomodel
 class TestParameterValidation:
     def test_invalid_json(self, client):
         r = client.post(
@@ -44,17 +52,6 @@ class TestParameterValidation:
         assert r.status_code == 400
         assert "temperature" in r.json()["error"]["message"].lower()
 
-    def test_temperature_boundary_valid(self, client, model):
-        """temperature=0 and temperature=2 should be accepted."""
-        for t in [0, 2.0]:
-            r = client.post("/v1/chat/completions", json={
-                "model": model,
-                "messages": [{"role": "user", "content": "Hi"}],
-                "temperature": t,
-                "max_tokens": 1,
-            })
-            assert r.status_code == 200, f"temperature={t} should be valid"
-
     @pytest.mark.parametrize("top_p", [-0.1, 1.5])
     def test_top_p_out_of_range(self, client, model, top_p):
         r = client.post("/v1/chat/completions", json={
@@ -82,14 +79,66 @@ class TestParameterValidation:
         })
         assert r.status_code == 400
 
-    def test_n_greater_than_1(self, client, model):
+    @pytest.mark.parametrize("n", [0, 5, 100])
+    def test_n_out_of_range(self, client, model, n):
+        """/v1/chat/completions accepts n in [1,4] and rejects the rest.
+
+        This used to assert that n=2 is a 400 — which is what the mock does and
+        the shipping server does NOT: `handlers.cpp` validates n against [1,4]
+        and `handlers_chat_core.cpp` runs n independent generations. The
+        assertion was green for a year because only the mock ever answered it.
+        """
         r = client.post("/v1/chat/completions", json={
             "model": model,
             "messages": [{"role": "user", "content": "Hi"}],
-            "n": 2,
+            "n": n,
         })
         assert r.status_code == 400
         assert "n" in r.json()["error"]["message"].lower()
+
+    def test_max_tokens_null_is_not_a_crash(self, client, model):
+        """`max_tokens: null` is the SDK default for "unset", not an error.
+
+        It must be treated as absent — never as a parse failure and never as a
+        dropped connection.
+        """
+        r = client.post("/v1/chat/completions", json={
+            "model": model,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": None,
+        })
+        # 200 with weights, 503 model-less — never 400, never a disconnect.
+        assert r.status_code in (200, 503), r.text[:200]
+
+    @pytest.mark.parametrize("body", ["[1,2,3]", "42", '"a string"', "null"])
+    def test_non_object_json_body(self, client, body):
+        """A well-formed JSON body that is not an object is a 400, not a hang-up."""
+        r = client.post(
+            "/v1/chat/completions",
+            content=body,
+            headers={"content-type": "application/json"},
+        )
+        assert r.status_code == 400
+        assert "error" in r.json()
+
+
+class TestParameterAcceptance:
+    """The other half of validation: values at the boundary must be ACCEPTED.
+
+    Not `nomodel` — proving acceptance means producing a completion, which needs
+    weights. A model-less server answers 503 here, which is not the contract.
+    """
+
+    def test_temperature_boundary_valid(self, client, model):
+        """temperature=0 and temperature=2 should be accepted."""
+        for t in [0, 2.0]:
+            r = client.post("/v1/chat/completions", json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "temperature": t,
+                "max_tokens": 1,
+            })
+            assert r.status_code == 200, f"temperature={t} should be valid"
 
     def test_n_equals_1_valid(self, client, model):
         r = client.post("/v1/chat/completions", json={
@@ -101,7 +150,20 @@ class TestParameterValidation:
         })
         assert r.status_code == 200
 
+    def test_n_within_range_returns_that_many_choices(self, client, model):
+        """n=2 is accepted and produces two choices (the contract the mock denied)."""
+        r = client.post("/v1/chat/completions", json={
+            "model": model,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "n": 2,
+            "max_tokens": 1,
+            "temperature": 0,
+        })
+        assert r.status_code == 200
+        assert len(r.json()["choices"]) == 2
 
+
+@pytest.mark.nomodel
 class TestModelField:
     def test_missing_model_field(self, client):
         r = client.post("/v1/chat/completions", json={
@@ -116,6 +178,33 @@ class TestModelField:
         })
         assert r.status_code == 400
         assert "model" in r.json()["error"]["message"].lower()
+
+
+@pytest.mark.nomodel
+class TestUnknownEndpoint:
+    """An unmatched route must answer in the dialect of the path it was on.
+
+    httplib's built-in 404 has a zero-length body, so a client doing
+    `r.json()["error"]["message"]` on a typo'd path got a JSON parse error and
+    no reason. The mock has always sent an envelope here; nothing checked that
+    the server did too (#1302).
+    """
+
+    @pytest.mark.parametrize("path", ["/v1/nope", "/v1/chat/completion", "/nonsense"])
+    def test_unknown_path_returns_json_error(self, client, path):
+        r = client.post(path, json={})
+        assert r.status_code == 404
+        body = r.json()
+        assert "error" in body
+        assert body["error"]["message"]
+
+    def test_unknown_messages_path_uses_anthropic_envelope(self, client):
+        """Anthropic clients read `type` at the top level, not `error.message`."""
+        r = client.post("/v1/messages/nope", json={})
+        assert r.status_code == 404
+        body = r.json()
+        assert body.get("type") == "error"
+        assert body["error"]["message"]
 
 
 class TestUnknownModel:
@@ -140,6 +229,7 @@ class TestUnknownModel:
         assert "not found" in body["error"]["message"].lower()
 
 
+@pytest.mark.nomodel
 class TestCompletionsEndpoint:
     def test_missing_prompt(self, client, model):
         r = client.post("/v1/completions", json={

--- a/tests/api/test_lifecycle.py
+++ b/tests/api/test_lifecycle.py
@@ -115,6 +115,7 @@ class TestErrorResilience:
         })
         assert r2.status_code == 200
 
+    @pytest.mark.nomodel
     def test_multiple_errors_no_crash(self, client, model):
         """Rapid-fire invalid requests don't crash the server."""
         for _ in range(20):

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -33,11 +33,6 @@ static bool is_inference_endpoint(const std::string& path) {
 int main(int argc, char** argv) {
     ServerArgs args = parse_server_args(argc, argv);
 
-    if (args.model_path.empty()) {
-        fprintf(stderr, "Error: --model is required\n");
-        return 1;
-    }
-
     printf("IMP Server %s\n", imp_version());
 
     ServerState state;
@@ -64,21 +59,31 @@ int main(int argc, char** argv) {
     imp::process_diag_install(state.runtime_config);
     imp::set_pending_runtime_config(state.runtime_config);
 
+    // --model is optional (it has always been documented that way in --help).
+    // Without it the server starts model-less: the request-validation surface,
+    // /health, /v1/models and /metrics all answer, and the first request that
+    // names a model in --models-dir auto-loads it (ensure_model_loaded). A
+    // request that cannot resolve a model gets 503 — never a silent success.
+    // This is also what lets CI run the shipping binary on a GPU-less runner
+    // instead of a Python stand-in (#1302).
     ImpModelFormat resolved_format = IMP_FORMAT_GGUF;
-    std::string resolved_model = imp::resolve_model_auto(args.model_path, resolved_format, args.revision);
-    if (resolved_model.empty()) {
-        fprintf(stderr, "Failed to resolve model: %s\n", args.model_path.c_str());
-        return 1;
-    }
-    if (resolved_model != args.model_path) {
-        printf("Resolved model: %s -> %s (%s)\n", args.model_path.c_str(), resolved_model.c_str(),
-               resolved_format == IMP_FORMAT_SAFETENSORS ? "SafeTensors" : "GGUF");
+    std::string resolved_model;
+    if (!args.model_path.empty()) {
+        resolved_model = imp::resolve_model_auto(args.model_path, resolved_format, args.revision);
+        if (resolved_model.empty()) {
+            fprintf(stderr, "Failed to resolve model: %s\n", args.model_path.c_str());
+            return 1;
+        }
+        if (resolved_model != args.model_path) {
+            printf("Resolved model: %s -> %s (%s)\n", args.model_path.c_str(), resolved_model.c_str(),
+                   resolved_format == IMP_FORMAT_SAFETENSORS ? "SafeTensors" : "GGUF");
+        }
     }
 
     // Models directory: explicit --models-dir overrides, else the resolved model's parent.
     if (!args.models_dir.empty()) {
         state.models_dir = args.models_dir;
-    } else {
+    } else if (!resolved_model.empty()) {
         auto parent = std::filesystem::path(resolved_model).parent_path().string();
         if (!parent.empty())
             state.models_dir = parent;
@@ -98,8 +103,19 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    printf("Loading model: %s\n", resolved_model.c_str());
-    {
+    if (resolved_model.empty()) {
+        if (state.models_dir.empty()) {
+            printf(
+                "No model: started model-less and no --models-dir to auto-load from — "
+                "inference endpoints answer 503.\n");
+        } else {
+            printf(
+                "No model: started model-less — the first request naming a model in %s "
+                "loads it.\n",
+                state.models_dir.c_str());
+        }
+    } else {
+        printf("Loading model: %s\n", resolved_model.c_str());
         std::string error = load_model_into_state(state, resolved_model);
         if (!error.empty()) {
             fprintf(stderr, "%s\n", error.c_str());
@@ -108,6 +124,12 @@ int main(int argc, char** argv) {
     }
 
     // --lora NAME=PATH: load PEFT adapters once; requests select by name.
+    // An adapter needs its base model resident, so this combination is refused
+    // at startup rather than silently dropping the adapters.
+    if (!args.loras.empty() && !state.model_loaded()) {
+        fprintf(stderr, "Error: --lora requires --model (adapters attach to a loaded base model)\n");
+        return 1;
+    }
     for (const auto& [name, path] : args.loras) {
         int32_t id = 0;
         if (imp_lora_load(state.ctx, path.c_str(), &id) != IMP_SUCCESS) {
@@ -313,6 +335,34 @@ int main(int argc, char** argv) {
                 send_json_error(res, 500, "server_error", "unknown internal error");
             }
         });
+
+    // Any error response that would go out with an empty body gets the same
+    // JSON envelope every handler uses. The reachable case is an unmatched
+    // route: httplib answers 404 with zero bytes, so a client that does
+    // `r.json()["error"]["message"]` on a typo'd path got a parse error instead
+    // of a message. The mock CI tests against has always sent an envelope here
+    // (#1302). Responses that already carry a body — i.e. everything a handler
+    // produced — are left untouched: this callback runs for EVERY status >= 400.
+    svr.set_error_handler([](const httplib::Request& req, httplib::Response& res) {
+        if (!res.body.empty())
+            return httplib::Server::HandlerResponse::Unhandled;
+        const bool not_found = res.status == 404;
+        const std::string msg = not_found ? "Unknown endpoint: " + req.method + " " + req.path
+                                          : "Request failed with status " + std::to_string(res.status);
+        if (req.path.rfind("/v1/messages", 0) == 0) {
+            json err = {{"type", "error"},
+                        {"error",
+                         {{"type", not_found ? "not_found_error" : "invalid_request_error"},
+                          {"message", msg}}}};
+            res.set_content(err.dump(), "application/json");
+        } else {
+            json err = {
+                {"error",
+                 {{"message", msg}, {"type", res.status >= 500 ? "server_error" : "invalid_request_error"}}}};
+            res.set_content(err.dump(), "application/json");
+        }
+        return httplib::Server::HandlerResponse::Handled;
+    });
 
     // Track failed requests via post-routing
     svr.set_post_routing_handler([&state](const httplib::Request&, httplib::Response& res) {


### PR DESCRIPTION
Closes #1302.

`Mock API contract` was the only CI job touching the HTTP API, and it ran against `tests/api/mock_server.py` — so all 82 assertions described the mock, never `tools/imp-server/`.

The blocker turned out to be four lines. `imp-server --help` has always called `--model` optional, `main.cpp` describes "auto-load on first request when started without `--model`", and `ensure_model_loaded()` implements exactly that — but startup did `if (args.model_path.empty()) return 1`.

## What this changes

- **`imp-server` starts model-less.** It answers `/health`, `/v1/models`, `/props`, `/info`, `/metrics` and every parameter check, because validation runs in `parse_chat_request_params` *before* `snapshot_state_and_tokenize_` looks for weights. Requests that resolve to no model get 503. Measured against the 46-case probe table: all 15 cases a model-loaded server answers 4xx answer identically model-less.
- **New `Real API contract` CI job** (non-required, sibling of `Mock API contract`): downloads the Build job's `imp-server`, starts it model-less, runs the 42 tests marked `nomodel`. Same CUDA image the binary was linked in.
- **`nomodel` marker + `IMP_SERVER_BIN` lane** in `conftest.py`, so the split between "needs weights" and "does not" is explicit rather than implicit in a job definition.

## What pointing the suite at the real server found

| | mock | shipping server |
|---|---|---|
| `POST /v1/nope` | 404 + `error.message` | **404 with a zero-length body** |
| `n=2` on `/v1/chat/completions` | 400 | **200 with two choices** |
| `max_tokens: null` | connection dropped | 200 |
| `[1,2,3]` as the body | connection dropped | 400 |

- The empty-body 404 is a real defect: a client doing `r.json()["error"]["message"]` on a typo'd path got a parse error instead of a reason. Fixed with a body-aware `set_error_handler` — it fires for *every* status >= 400, so it must leave handler-produced bodies alone — answering in the dialect of the path (Anthropic shape under `/v1/messages*`).
- `n` is validated against `[1,4]` and `handlers_chat_core.cpp` runs that many generations. `test_n_greater_than_1` asserted a contract only the mock had; it now pins both ends and gained the positive case.
- The two mock crashes were invisible because nothing in the suite sent those bodies.

## Verification

| lane | result |
|---|---|
| mock (`IMP_USE_MOCK=1`, = CI job) | 85 passed, 12 skipped |
| real binary, model-less (= new CI job) | **42 passed** |
| real binary + Qwen3-4B-IQ4_NL, full suite | 96 passed, 1 skipped |
| `ctest -L unit` (= `Build`) | 4/4 |

New tests were watched failing first in both directions: the 7 mock-lane tests against the unpatched `mock_server.py`, and the 4 unknown-route tests against a rebuilt server with the error handler removed.

Full write-up: `docs/audit/TEST_HARDENING_LOG.md`, iteration 12.

Note: the `File size` check is red on `main` already (`src/model/gguf_loader.cpp` went 12 code-LOC over the hard gate in #1324) — unrelated to this PR, fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx