### PR TITLE
ci: allowlist gguf_loader.cpp so the File size gate is green again

### DIFF
--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -74,6 +74,7 @@ roots = ["src", "tools", "tests"]
 "src/runtime/engine_scheduler.cpp" = "(c) 1074 code LOC — one scheduler: prefill/decode scheduling + chunked exec + perplexity capture"
 "src/model/weight_map.cpp" = "(c) 966 code LOC — one mapping module: weight-name parse + layer-index + arch inference"
 "src/model/hf_config_loader.cpp" = "(tu) 810 code LOC — central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow"
+"src/model/gguf_loader.cpp" = "(a->c) 812 code LOC — the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check."
 "src/runtime/cuda_graph.cu" = "(c) 863 code LOC — one module: graph capture/mode-resolve + PDL edges + barrier insert + replay"
 "src/memory/kv_cache_manager.cpp" = "(c) 852 code LOC — one manager: block alloc + residual pool + prefix cache + eviction"
 "tests/test_quant_integration.cu" = "(c) 1442 code LOC — 24 tests, all exercising the quant_gemm/dequant unit — one test target"


### PR DESCRIPTION
`File size` has been red on `main` since #1324: the declared-layers consistency check took `src/model/gguf_loader.cpp` from 788 to **812** code LOC, 12 over the 800 hard-review gate.

The file is not an un-split god-file — it is the *residue* of a split that already happened. `AUDIT_FILESIZE.md:192` records it:

```
src/model/gguf_loader.cpp 1521  →  gguf_loader.cpp 788 · gguf_parse 425 · gguf_tensor_assign 249
```

What is left is one linear load flow — mmap, header, metadata → `ModelConfig`, shard stitch, tensor wiring — the same shape as `src/model/safetensors_loader.cpp`, which is allowlisted at 1147, and the file carries an explicit maintenance-mode header. So it gets an `[allow]` entry with that reasoning rather than a second split that would scatter one path.

Verified: `python3 tools/check_filesize.py` → `scanned 712 files … violations=0 / OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx