### PR TITLE
test(attention): reach the sink term the two earlier sink tests could not

### DIFF
--- a/docs/audit/ESCAPE_ANALYSIS.md
+++ b/docs/audit/ESCAPE_ANALYSIS.md
@@ -169,6 +169,20 @@ same lesson one iteration earlier: *"The split-K branch only activates when
 scratch is set — none of the older tests set it, so the hd=64 split-K path was
 never covered."*
 
+**Closed in iteration 13.** The recipe above (an FP8-KV decode with sinks) would
+not have worked either: `paged_attention_decode_fp8` has no sink parameter at
+all, and neither do the int4/int8/nvfp4 launchers — all six quantised callers
+leave `attn_sinks` at its `nullptr` default. The branch is reachable through
+exactly one launch configuration, the cluster kernel's: no split-K scratch
+(`num_splits` stays 1), `n_q_per_kv` in {2,4,8}, head_dim in {64,96,128,256} and
+**at least 8 context blocks**. `GQA_Cluster_HD64_Sinks` (256 tokens, scratch
+withheld) hits it; with M31 injected it is the only one of the 16
+`PagedAttentionTest` cases that fails.
+
+A second defect had to be fixed for that test to be able to fail at all: the
+sink values were numerically invisible. See `TEST_HARDENING_LOG.md`,
+iteration 13.
+
 ## E1 — no test exists
 
 ### M29 / M30 — nothing in the suite can observe performance

--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -1137,8 +1137,9 @@ fails on `'2 + 2 = 4'` vs `'2 + 2 = 4.'` — the greedy-divergence class of #129
 
 ## Iteration 13 — 2026-08-09 — focus: the mutant that two tests failed to kill — commit: `583923bc`
 
-**Mutation score: M31 killed in the unit lane — the campaign's only remaining
-survivors are the two perf-only `controlflow` mutants (M29/M30)** · **Bugs found:** none in production. **Test defects: 2
+**Mutation score: 48/52 = 92.3 %** (prev 47/52 = 90.4 %) — M31 killed, so
+`masking` closes at 6/6. `controlflow` is still 0/2, so the campaign's stopping
+rule is unchanged: substance met, letter not, for the reasons iteration 10 gave · **Bugs found:** none in production. **Test defects: 2
 (both in tests written to close this exact gap) · coverage gaps filed: 1 (#1329).**
 
 ### #1303, third attempt

--- a/docs/audit/TEST_HARDENING_LOG.md
+++ b/docs/audit/TEST_HARDENING_LOG.md
@@ -1132,3 +1132,134 @@ fails on `'2 + 2 = 4'` vs `'2 + 2 = 4.'` — the greedy-divergence class of #129
    JSON error envelope for bodyless errors.
 6. **Are all new tests wired into CI?** Yes — that is the iteration. What is
    *not* wired is generation; it needs a GPU runner, which remains a WON'T FIX.
+
+---
+
+## Iteration 13 — 2026-08-09 — focus: the mutant that two tests failed to kill — commit: `583923bc`
+
+**Mutation score: M31 killed in the unit lane — the campaign's only remaining
+survivors are the two perf-only `controlflow` mutants (M29/M30)** · **Bugs found:** none in production. **Test defects: 2
+(both in tests written to close this exact gap) · coverage gaps filed: 1 (#1329).**
+
+### #1303, third attempt
+
+M31 deletes the attention-sink term from `crosswarp_reduce_and_write`. Iteration 1
+filed it, iteration 2 added `GQA_NoSplitK_HD64_Sinks` from the diagnosis "the
+mutated function is the non-split reduction", iteration 3 corrected that
+diagnosis in `ESCAPE_ANALYSIS.md` — and the issue stayed open because nobody
+re-ran the mutant. Re-run:
+
+```
+[1/1] M31 masking: Attention sink logit is dropped from the softmax denominator.
+    -> SURVIVED (565.4s)
+```
+
+Two independent defects were keeping it alive.
+
+**1. The sink was numerically invisible.** The sink logit competes against the
+*sum* of `seq_len` score exponentials, so a value inside the score range
+contributes almost nothing. Computed independently of the kernel:
+
+| sinks | share of softmax mass | max &#124;Δ output&#124; when the term is dropped |
+|---|---|---|
+| `-1.0 + 0.05h` (as written) | 0 – 12.6 % | **0.00167** |
+| `+4.0 + 0.05h` | 0.5 – 95.6 % | 0.0566 |
+
+and the comparison was `EXPECT_NEAR(..., 0.05f)`. **The signal was 30x smaller
+than the tolerance.** The tolerance was itself unmoored: measured max error
+against the fp32 host reference on the clean build is 1.7e-4 (seq_len 48) and
+7.1e-5 (256), so `0.05` was ~300x looser than the kernel needs — loose enough to
+swallow most faults this test nominally covers, not only the sink.
+
+**2. Neither test could reach the mutated line even in principle.** There are
+three sink implementations, and `crosswarp_reduce_and_write` is the shared one.
+Six of its seven call sites — int4, int8, nvfp4, nvfp4_tc, fp8 and the tc
+variant — leave `attn_sinks` at its `nullptr` default. Exactly one passes a sink
+pointer: the SM120 thread-block-**cluster** kernel (`attention_paged.cu:1342`).
+So the branch is reachable through one launch configuration:
+
+- no split-K scratch, so `num_splits` stays 1
+- `n_q_per_kv` ∈ {2,4,8}, `head_dim` ∈ {64,96,128,256}
+- **≥ 8 context blocks**
+
+The two existing cases miss it from both sides: 48 tokens is 3 blocks (< 8 → the
+plain GQA kernel, which handles sinks inline), and 256 tokens *with* scratch goes
+split-K (its own reduction, also inline). Green either way.
+
+**Fixed:** sinks that carry real mass, tolerance `2e-3` (12x over the measured
+kernel error, 4.7x–28x under the sink signal), and two new cases —
+`GQA_Cluster_HD64_Sinks` / `GQA_Cluster_HD64` — at 256 tokens with the split-K
+scratch withheld, which is the only shape that enters the cluster kernel.
+
+### The harness's second verdict was a false KILL
+
+The re-run after the tolerance fix reported `-> KILLED (658.7s)`, on
+`test-e2e`: `LongContext8k`, `MultiDecodeOutputIsolation`,
+`GenerateCoherentOutput`, `MultiTurnConversation`, **`TokenizeRoundtrip`**. A
+tokenizer round-trip cannot observe a softmax denominator. That lane's own
+baseline is red for environmental reasons (11 failures from the documented
+WSL2/WDDM peak-VRAM behaviour when three large models load in one process), and
+iteration 1 already recorded that it *"cost this audit two false 'survivor'
+verdicts"*. This time it produced the opposite error.
+
+So the verdict used here is not the harness's. It is the isolated injection:
+with M31 in the tree, exactly **one** of the 16 `PagedAttentionTest` cases fails
+— `GQA_Cluster_HD64_Sinks` — and the other 15 pass, including both older sink
+tests. That is a deterministic unit-lane kill, and it doubles as proof of the
+reachability claim.
+
+**The lesson is one level up from E6.** This campaign has filed E6 five times as
+"the inputs cannot reach the fault". Here the *fix* for an E6 was itself an E6,
+twice over: wrong reachability, and an assertion that could not see the
+difference even where the code was reached. A test aimed at a mutant is not
+evidence until the mutant has been run against it — the campaign's own rule,
+applied to its own output.
+
+### /v1/messages: the Anthropic surface is pinned by nothing (#1329)
+
+With the real-binary lane from iteration 12 in place, the next question is what
+else it can reach. `tests/api/mock_server.py` implements four POST endpoints; the
+server ships eleven. `/v1/messages` — the headline Anthropic-compatibility
+feature, native per-token SSE since #754 — **has no test file at all**, and the
+mock cannot answer it, so nothing in CI has ever sent it a request.
+`tests/test_anthropic_transform.cpp` covers the transform as a unit; status
+codes, error envelope, SSE order and `usage` are all downstream of it.
+
+Probed model-less: the endpoint is correct today. Every error arrives in the
+Anthropic envelope (top-level `type: error` plus `error.type`), including the
+parse-error path — the one most likely to fall back to the OpenAI shape used two
+files away.
+
+**A truncated dump nearly turned that into a false bug report.** The probe
+printed `json.dumps(j)[:80]`, and nlohmann orders object keys alphabetically, so
+`"error"` came first and `"type": "error"` sat past the cutoff. "The envelope
+leaks the OpenAI shape" survived until it was checked with `curl`. Same class as
+this campaign's other measurement traps: the tool's output format, not the
+system, produced the signal.
+
+Two deliberate leniencies are now pinned as decisions rather than left implicit:
+`max_tokens` may be omitted (the Anthropic API requires it) and `temperature` is
+validated against `[0,2]` rather than `[0,1]`, both because the OpenAI validator
+is shared.
+
+**Tests added:** `tests/api/test_messages.py`, 20 cases. The validation half is
+`nomodel` and runs in CI against the shipping binary; generation and SSE order
+need weights and stay in the local lane.
+
+### Self-check
+
+1. **Did I modify, skip or loosen any existing test?** One was *tightened*
+   (sink tolerance 5e-2 → 2e-3, stronger sink values). Nothing loosened or
+   skipped.
+2. **Did every mutant get reverted?** Yes — `git status --porcelain` after each
+   run showed only untracked files.
+3. **Did I watch every new test fail before it passed?** Yes: M31 survived
+   before, and the new cluster cases were run against the injected mutant.
+4. **Is every bug claim backed by a script I ran twice?** The sink arithmetic was
+   computed independently of the kernel and then confirmed on the GPU by the
+   measured `max_err`; the reachability claim was read out of all seven call
+   sites and then confirmed by the mutant run.
+5. **Did I fix any production code?** No — both defects were in tests.
+6. **Are all new tests wired into CI?** The `/v1/messages` validation half, yes.
+   The sink tests are GPU-only, like every kernel test in this repo — which is
+   the standing consequence of the no-GPU-runner decision, not a new gap.

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -1,0 +1,220 @@
+"""
+Tests for the /v1/messages endpoint (Anthropic Messages API).
+
+What it tests:   The Anthropic dialect on the wire — status codes, the error
+                 envelope (top-level `type: error`, not the OpenAI shape), the
+                 response shape and the SSE event order.
+What it does NOT test: transform internals (tests/test_anthropic_transform.cpp
+                 covers `anthropic_to_openai_body()` as a unit) or model quality.
+External state:  Running imp-server. The validation half is marked `nomodel`
+                 and runs in CI against the shipping binary started without a
+                 model (#1302); it never reaches generation, because the server
+                 validates before it looks for weights. Skipped against the
+                 Python mock, which does not implement this endpoint at all —
+                 that gap is #1329.
+"""
+
+import json
+
+import httpx
+import pytest
+
+import conftest
+
+
+@pytest.fixture(autouse=True)
+def _skip_on_mock(is_mock):
+    if is_mock:
+        pytest.skip("mock server does not implement /v1/messages (#1329)")
+
+
+def _msg(**kw):
+    body = {"max_tokens": 4, "messages": [{"role": "user", "content": "Hi"}]}
+    body.update(kw)
+    return body
+
+
+def _assert_anthropic_error(r, status, err_type="invalid_request_error"):
+    """Every error on this endpoint must arrive in the Anthropic envelope.
+
+    An Anthropic SDK reads the top-level `type` first; the OpenAI shape used two
+    files away in handlers.cpp has no such key, so a client would see an
+    unrecognised body instead of a reason.
+    """
+    assert r.status_code == status, r.text
+    body = r.json()
+    assert body.get("type") == "error", body
+    assert body["error"]["type"] == err_type, body
+    assert body["error"]["message"], body
+
+
+@pytest.mark.nomodel
+class TestMessagesValidation:
+    """Rejections. Reached before the server resolves a model, hence `nomodel`."""
+
+    @pytest.mark.parametrize("max_tokens", [0, -1])
+    def test_max_tokens_below_one(self, client, model, max_tokens):
+        r = client.post("/v1/messages", json=_msg(model=model, max_tokens=max_tokens))
+        _assert_anthropic_error(r, 400)
+        assert "max_tokens" in r.json()["error"]["message"]
+
+    def test_missing_messages(self, client, model):
+        r = client.post("/v1/messages", json={"model": model, "max_tokens": 4})
+        _assert_anthropic_error(r, 400)
+
+    def test_empty_messages(self, client, model):
+        r = client.post("/v1/messages", json=_msg(model=model, messages=[]))
+        _assert_anthropic_error(r, 400)
+
+    def test_messages_not_an_array(self, client, model):
+        r = client.post("/v1/messages", json=_msg(model=model, messages="nope"))
+        _assert_anthropic_error(r, 400)
+
+    def test_missing_model(self, client):
+        r = client.post("/v1/messages", json=_msg())
+        _assert_anthropic_error(r, 400)
+        assert "model" in r.json()["error"]["message"]
+
+    @pytest.mark.parametrize("temperature", [-0.1, 2.5])
+    def test_temperature_out_of_range(self, client, model, temperature):
+        """imp validates [0,2] here, not Anthropic's [0,1] — the OpenAI bound is
+        shared by both endpoints. Pinned so the leniency is a decision, not an
+        accident (#1329)."""
+        r = client.post("/v1/messages", json=_msg(model=model, temperature=temperature))
+        _assert_anthropic_error(r, 400)
+        assert "temperature" in r.json()["error"]["message"]
+
+    def test_top_p_out_of_range(self, client, model):
+        r = client.post("/v1/messages", json=_msg(model=model, top_p=1.5))
+        _assert_anthropic_error(r, 400)
+        assert "top_p" in r.json()["error"]["message"]
+
+    @pytest.mark.parametrize("raw", ["not json{{{", "", "[1,2,3]", "42"])
+    def test_unparseable_body_keeps_the_anthropic_envelope(self, client, raw):
+        """The parse-error path is the one most likely to fall back to the
+        OpenAI shape: it runs before any Anthropic-specific code."""
+        r = client.post(
+            "/v1/messages",
+            content=raw,
+            headers={"content-type": "application/json"},
+        )
+        _assert_anthropic_error(r, 400)
+
+    def test_unknown_subpath_is_a_not_found_error(self, client):
+        r = client.post("/v1/messages/nope", json={})
+        _assert_anthropic_error(r, 404, err_type="not_found_error")
+
+
+@pytest.mark.nomodel
+class TestMessagesLeniency:
+    """Places imp deliberately accepts what the upstream API rejects.
+
+    These are not 400s, so they are pinned by what they are NOT: a client that
+    omits `max_tokens` must not be rejected — imp supplies the server default
+    (handlers_messages.cpp). Written as "not a 400" so the assertion holds both
+    model-less (503) and with weights (200).
+    """
+
+    def test_max_tokens_may_be_omitted(self, client, model):
+        r = client.post("/v1/messages", json={
+            "model": model,
+            "messages": [{"role": "user", "content": "Hi"}],
+        })
+        assert r.status_code != 400, r.text
+
+    def test_max_tokens_null_is_treated_as_absent(self, client, model):
+        r = client.post("/v1/messages", json=_msg(model=model, max_tokens=None))
+        assert r.status_code != 400, r.text
+
+
+class TestMessagesGeneration:
+    """Needs weights: not `nomodel`, so it stays out of the CPU-only CI lane."""
+
+    def test_non_stream_response_shape(self, model):
+        with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+            r = c.post("/v1/messages", json={
+                "model": model,
+                "max_tokens": 24,
+                "temperature": 0,
+                "messages": [{"role": "user", "content": "Say hello. /no_think"}],
+            })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["type"] == "message"
+        assert body["role"] == "assistant"
+        assert body["model"]
+        assert body["id"]
+        assert isinstance(body["content"], list) and body["content"]
+        assert body["content"][0]["type"] == "text"
+        assert body["content"][0]["text"]
+        assert body["stop_reason"] in ("end_turn", "max_tokens", "stop_sequence")
+        assert body["usage"]["input_tokens"] > 0
+        assert body["usage"]["output_tokens"] > 0
+
+    def test_max_tokens_is_honoured_and_reported(self, model):
+        with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+            r = c.post("/v1/messages", json={
+                "model": model,
+                "max_tokens": 3,
+                "temperature": 0,
+                "messages": [{"role": "user", "content": "Count from one to fifty."}],
+            })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["stop_reason"] == "max_tokens"
+        assert body["usage"]["output_tokens"] <= 3
+
+    def test_stream_event_order(self, model):
+        """The documented Anthropic SSE sequence, in order, with a real
+        per-token stream (#754) — not a replay of a finished completion."""
+        events = []
+        with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+            with c.stream("POST", "/v1/messages", json={
+                "model": model,
+                "max_tokens": 24,
+                "temperature": 0,
+                "stream": True,
+                "messages": [{"role": "user", "content": "Say hello. /no_think"}],
+            }) as r:
+                assert r.status_code == 200
+                for line in r.iter_lines():
+                    if line.startswith("data: "):
+                        events.append(json.loads(line[6:]))
+
+        types = [e["type"] for e in events]
+        assert types[0] == "message_start", types[:5]
+        assert types[-1] == "message_stop", types[-5:]
+        for expected in ("content_block_start", "content_block_delta",
+                         "content_block_stop", "message_delta"):
+            assert expected in types, (expected, types)
+        assert types.index("content_block_start") < types.index("content_block_delta")
+        assert types.index("content_block_delta") < types.index("content_block_stop")
+        assert types.index("content_block_stop") < types.index("message_delta")
+
+        start = events[0]["message"]
+        assert start["type"] == "message"
+        assert start["role"] == "assistant"
+        text = "".join(e["delta"]["text"] for e in events
+                       if e["type"] == "content_block_delta" and "text" in e.get("delta", {}))
+        assert text.strip()
+
+    def test_count_tokens(self, model):
+        with httpx.Client(base_url=conftest.BASE_URL, timeout=120.0) as c:
+            short = c.post("/v1/messages/count_tokens", json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hi"}],
+            })
+            long = c.post("/v1/messages/count_tokens", json={
+                "model": model,
+                "messages": [{"role": "user", "content": "Hi " * 200}],
+            })
+        assert short.status_code == 200, short.text
+        assert long.status_code == 200, long.text
+        n_short = short.json()["input_tokens"]
+        n_long = long.json()["input_tokens"]
+        assert n_short > 0
+        # Compared against each other, not a magic number: the absolute count is
+        # tokenizer- and template-specific, but 200 repetitions of a word have to
+        # add at least ~150 tokens on any tokenizer. A ratio would break on a
+        # model whose chat template inflates the short baseline.
+        assert n_long > n_short + 150, (n_short, n_long)

--- a/tests/test_paged_attention.cu
+++ b/tests/test_paged_attention.cu
@@ -676,7 +676,7 @@ TEST(PagedAttentionTest, GQALongContext) {
 // first hd=64 model; the rest of the zoo is hd>=128).
 // =========================================================================
 
-void run_gptoss_shape_splitk_case(bool with_sinks, int seq_len = 256) {
+void run_gptoss_shape_splitk_case(bool with_sinks, int seq_len = 256, bool with_scratch = true) {
     constexpr int batch = 1, n_heads = 64, n_kv_heads = 8, head_dim = 64;
     // seq_len 256 = 16 blocks >= 4 → split-K heuristics fire (compute_splitk_splits).
     // seq_len  48 =  3 blocks  < 4 → they do not, which is the ONLY way to reach
@@ -696,8 +696,16 @@ void run_gptoss_shape_splitk_case(bool with_sinks, int seq_len = 256) {
         h_V[i] = sinf(static_cast<float>(i) * 0.011f + 0.5f);
     }
     std::vector<float> h_sinks(n_heads);
-    for (int h = 0; h < n_heads; h++)
-        h_sinks[h] = -1.0f + 0.05f * static_cast<float>(h);  // mix of weak/strong sinks
+    for (int h = 0; h < n_heads; h++) {
+        // The sink logit has to compete with the SUM of seq_len score
+        // exponentials, so a value near the score range contributes almost
+        // nothing. At the original -1.0 + 0.05h the sink carried 0-13% of the
+        // mass and deleting it moved the output by at most 0.0017 — under the
+        // tolerance this test compared with, which is why mutant M31 (#1303)
+        // survived a test written to catch it. At 4.0 + 0.05h it carries
+        // 0.5-96% and deleting it moves the output by up to 0.057.
+        h_sinks[h] = 4.0f + 0.05f * static_cast<float>(h);
+    }
 
     // CPU reference: softmax over [scores, sink]; sink column dropped.
     std::vector<float> h_O(n_heads * head_dim, 0.0f);
@@ -753,12 +761,19 @@ void run_gptoss_shape_splitk_case(bool with_sinks, int seq_len = 256) {
     int ctx = seq_len;
     cudaMemcpy(d_ctx, &ctx, sizeof(int), cudaMemcpyHostToDevice);
 
-    // Force split-K: provide scratch (64 blocks < 2*SMs on any modern GPU).
+    // Split-K needs scratch: with it and >=4 blocks the split path takes over,
+    // without it num_splits stays 1 and the dispatch falls through to the GQA
+    // branch — which is how the cluster kernel becomes reachable (see the test
+    // list at the bottom of this block).
     constexpr int kMaxSplits = 64;
     size_t scratch_size = static_cast<size_t>(batch) * n_heads * kMaxSplits * (2 + head_dim) * sizeof(float);
     void* d_scratch = nullptr;
-    cudaMalloc(&d_scratch, scratch_size);
-    paged_attention_set_splitk_scratch(d_scratch, scratch_size);
+    if (with_scratch) {
+        cudaMalloc(&d_scratch, scratch_size);
+        paged_attention_set_splitk_scratch(d_scratch, scratch_size);
+    } else {
+        paged_attention_set_splitk_scratch(nullptr, 0);
+    }
 
     half* d_sinks = nullptr;
     if (with_sinks) {
@@ -781,14 +796,21 @@ void run_gptoss_shape_splitk_case(bool with_sinks, int seq_len = 256) {
         for (int d = 0; d < head_dim; d++) {
             int idx = qh * head_dim + d;
             max_err = std::max(max_err, static_cast<double>(std::abs(result[idx] - h_O[idx])));
-            EXPECT_NEAR(result[idx], h_O[idx], 0.05f)
-                << "split-K hd64 mismatch at Q-head " << qh << " dim " << d
-                << " (with_sinks=" << with_sinks << ")";
+            // 2e-3, not the 0.05 this used to allow: measured max error against
+            // the fp32 host reference is 1.7e-4 (seq_len 48) / 7.1e-5 (256), so
+            // 0.05 was ~300x looser than the kernel needs and swallowed the
+            // whole sink term. 2e-3 keeps a 12x margin over the kernel and still
+            // catches a dropped sink by 4.7x (seq_len 256) to 28x (seq_len 48).
+            EXPECT_NEAR(result[idx], h_O[idx], 2e-3f)
+                << "hd64 decode mismatch at Q-head " << qh << " dim " << d << " (with_sinks=" << with_sinks
+                << ", seq_len=" << seq_len << ", splitk_scratch=" << with_scratch << ", max_err=" << max_err
+                << ")";
         }
     }
 
     paged_attention_set_splitk_scratch(nullptr, 0);
-    cudaFree(d_scratch);
+    if (d_scratch)
+        cudaFree(d_scratch);
     if (d_sinks)
         cudaFree(d_sinks);
     free_gpu(d_Q);
@@ -811,6 +833,25 @@ TEST(PagedAttentionTest, GQA_NoSplitK_HD64_Sinks) {
 }
 TEST(PagedAttentionTest, GQA_NoSplitK_HD64) {
     run_gptoss_shape_splitk_case(/*with_sinks=*/false, /*seq_len=*/48);
+}
+
+// Third sink implementation, third test. `crosswarp_reduce_and_write` in
+// attention_paged_common.cuh is shared by the cluster kernel and every
+// quantised-KV decode (int4/int8/nvfp4/nvfp4_tc/fp8) — but only the cluster
+// kernel passes it a sink pointer; the others leave the argument at its nullptr
+// default. So the sink branch in that helper is reachable through exactly one
+// launch configuration: no split-K scratch (num_splits stays 1), n_q_per_kv in
+// {2,4,8}, >=8 context blocks and head_dim in {64,96,128,256}.
+//
+// That is what mutant M31 (#1303) deletes. The two cases above cannot reach it:
+// 48 tokens is 3 blocks (< 8, so the plain GQA kernel runs, which handles sinks
+// inline) and 256 tokens with scratch goes split-K (its own reduction, also
+// inline). Both stayed green with the term removed.
+TEST(PagedAttentionTest, GQA_Cluster_HD64_Sinks) {
+    run_gptoss_shape_splitk_case(/*with_sinks=*/true, /*seq_len=*/256, /*with_scratch=*/false);
+}
+TEST(PagedAttentionTest, GQA_Cluster_HD64) {
+    run_gptoss_shape_splitk_case(/*with_sinks=*/false, /*seq_len=*/256, /*with_scratch=*/false);
 }
 
 // =========================================================================


### PR DESCRIPTION
Closes #1303, closes #1329.

M31 — delete the attention-sink term from `crosswarp_reduce_and_write` — has survived since iteration 1 through two attempts to close it. Re-running it was the point of this iteration, and it was still alive. **Two independent defects** were keeping it there.

## 1. Neither existing test could reach the mutated line

There are three sink implementations; `crosswarp_reduce_and_write` is the shared one. Six of its seven call sites — int4, int8, nvfp4, nvfp4_tc, fp8 and the tc variant — leave `attn_sinks` at its `nullptr` default. Exactly one passes a sink pointer: the SM120 thread-block-**cluster** kernel (`attention_paged.cu:1342`), which runs only when

- there is no split-K scratch, so `num_splits` stays 1, **and**
- `n_q_per_kv` ∈ {2,4,8}, `head_dim` ∈ {64,96,128,256}, **and**
- there are ≥ 8 context blocks.

The two existing cases miss it from both sides: 48 tokens is 3 blocks (< 8 → the plain GQA kernel, which handles sinks inline), and 256 tokens *with* scratch goes split-K (its own reduction, also inline).

This also retires the recipe #1303 carried — "extend the FP8-KV decode harness with a sink variant". `paged_attention_decode_fp8` has no sink parameter at all.

## 2. The sink was numerically invisible

The sink logit competes against the *sum* of `seq_len` score exponentials, so a value inside the score range contributes almost nothing:

| sinks | share of softmax mass | max ∣Δ output∣ when the term is dropped |
|---|---|---|
| `-1.0 + 0.05h` (as written) | 0 – 12.6 % | **0.00167** |
| `+4.0 + 0.05h` (this PR) | 0.5 – 95.6 % | 0.0566 |

and the comparison was `EXPECT_NEAR(..., 0.05f)` — **the signal was 30× smaller than the tolerance**. The tolerance was itself unmoored: measured max error against the fp32 host reference is 1.7e-4 (seq_len 48) and 7.1e-5 (256), so `0.05` was ~300× looser than the kernel needs — loose enough to swallow most faults this test nominally covers. Now `2e-3`: 12× over the kernel error, 4.7×–28× under the sink signal.

## The kill

```
$ ./build-dev/test-attention --gtest_filter='PagedAttentionTest.*'    # M31 injected
[  FAILED  ] PagedAttentionTest.GQA_Cluster_HD64_Sinks
[  PASSED  ] 15 tests.
```

Exactly one failure, and it is the new case — which is simultaneously the proof of the reachability claim, since both older sink tests stay green. Clean tree: `test-attention` 203/203.

**Not** the harness's own verdict. Its re-run reported `KILLED` via `test-e2e` — including `TokenizeRoundtrip`, which cannot observe a softmax denominator. That lane's baseline is red for environmental reasons (11 failures, the documented WSL2/WDDM peak-VRAM behaviour), and iteration 1 recorded that it had already cost this audit two false *survivor* verdicts. This time it produced the opposite error, so the evidence used here is the isolated injection above.

## Also: /v1/messages had no HTTP-level test (#1329)

`tests/api/mock_server.py` implements four POST endpoints; the server ships eleven. The Anthropic surface — native per-token SSE since #754 — has never been sent a request by any CI job. `tests/test_anthropic_transform.cpp` covers the transform as a unit; status codes, error envelope, SSE order and `usage` are all downstream of it.

`tests/api/test_messages.py`, 20 cases: the validation half is `nomodel` and runs against the shipping binary in CI (the lane from #1302), generation and SSE order need weights and stay local. Two deliberate leniencies are pinned as decisions rather than left implicit — `max_tokens` may be omitted (the Anthropic API requires it) and `temperature` is validated against `[0,2]` rather than `[0,1]`, both because the OpenAI validator is shared.

## Verification

| lane | result |
|---|---|
| `test-attention` (clean) | 203 passed |
| `test-attention` (M31 injected) | 1 failed — the new case — 15 passed |
| `nomodel` lane vs the shipping binary | 58 passed |
| full API suite vs Qwen3-4B-IQ4_NL | 116 passed, 1 skipped |
| `ctest -L unit` | 4/4 |

Write-up: `docs/audit/TEST_HARDENING_LOG.md`, iteration 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx