### PR TITLE
docs(determinism): record the prefix-cache hole in the default-mode guarantee

### DIFF
--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -55,6 +55,43 @@ algo selection; see `deterministic_gemm` for the hard guarantee).
 `runtime.warmup=false` restores the old init time and with it the
 first-request asymmetry — acceptable for dev/CI, not for evals.
 
+### Known hole: a prefix-cache hit is not bit-equal to a fresh prefill (#1314)
+
+The guarantee above has one measured exception. A request served from the
+prefix cache prefills only the uncached tail, so the same prompt reaches
+cuBLASLt with a different M dimension than on a fresh prefill — different algo
+pick, possibly a different split-k reduction, and results that agree closely but
+not bitwise. Any greedy decision whose margin is smaller than that drift can
+then land either way, and the first request of a process is the one that runs
+fresh, so it is the one that differs.
+
+Measured on `Llama-3.2-3B-Instruct-IQ4_XS`, whole `tests/api/test_chat.py`
+against a freshly started server, five fresh servers per arm:
+
+| arm | runs with a divergence |
+|---|---|
+| default | **5/5** |
+| `server.prefix_cache = false` | 0/5 |
+| `runtime.deterministic = true` | 0/5 |
+| `runtime.deterministic_gemm = true` | 0/5 |
+
+Scale: the two paths agree to ≤ 5e-3 in logprob at every position and produce
+identical top-5 candidate sets; the flip happened on a 0.018-nat margin between
+`.` and `<|eot_id|>`. So this is a numerical difference between two ways of
+computing the same thing, not the cache serving different content — but it is
+not covered by known limit 1 either, which is about *exactly tied* logits whose
+FP values are bit-identical.
+
+**If you need order-independent greedy output today**, set
+`runtime.deterministic_gemm = true`; it is sufficient on its own, without the
+rest of deterministic mode. The `[runtime] deterministic` guarantee in the first
+section is unaffected — it already covers this.
+
+`PrefixCacheE2ETest.FreshVsPrefixHitTokenEqual` asserts the strong version of
+this property and passes: it uses a long multi-block prompt whose decisions have
+no margin this narrow. The gate is right about what it measures; the promise is
+wider than what the gate can see.
+
 ## Known limits
 
 These are the documented boundaries of the guarantee. They are deliberate

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -14,6 +14,9 @@
 
 [runtime]
 # Force deterministic GEMM (cuBLASLt no_reduce_split). Slower but reproducible.
+# Also the switch that makes a prefix-cache hit bit-equal to a fresh prefill —
+# without it, the first request of a process can differ from the identical ones
+# after it on a narrow enough margin (#1314, docs/determinism.md).
 deterministic_gemm   = false
 # Full reproducibility mode for temp=0 evals: deterministic MoE routing /
 # expert-scatter and top-k sampling kernels, implies deterministic_gemm.


### PR DESCRIPTION
`docs/determinism.md` promises, on the **default** path:

> identical greedy requests produce identical output no matter how many requests preceded them

A prefix-cache hit breaks that, and none of the four documented known limits covers it.

## Measured

Whole `tests/api/test_chat.py` against a freshly started server, **five fresh servers per arm**, `Llama-3.2-3B-Instruct-IQ4_XS.gguf`:

| arm | runs with a divergence |
|---|---|
| default | **5/5** |
| `server.prefix_cache = false` | 0/5 |
| `runtime.deterministic = true` | 0/5 |
| **`runtime.deterministic_gemm = true`** | **0/5** |

The last row localises it: `deterministic_gemm` is the narrow half of deterministic mode — cuBLASLt `no_reduce_split`, no timing-based algo selection — and it is sufficient alone. So this is the GEMM, not the KV cache, the attention kernel or the sampler. It fits the shapes: a cached run prefills only the uncached tail, so the same prompt arrives at cuBLASLt with a different M than on a fresh prefill.

Scale, from `logprobs` on both halves of the pair (bit-identical across two fresh servers):

- the two paths agree to **≤ 5e-3** in logprob at every position, with identical top-5 candidate sets
- the flip landed on a **0.018-nat** margin between `.` and `<|eot_id|>`

So: a numerical difference between two ways of computing the same thing, not the cache serving different content. Known limit 1 does not cover it — that one is about *exactly tied* logits whose FP values are bit-identical, and here the FP values themselves differ.

## Why it was invisible

`PrefixCacheE2ETest.FreshVsPrefixHitTokenEqual` asserts exactly this property and passes on the same model and commit. Its prompt is deliberately long and multi-block, and none of its decisions has a margin this narrow. The gate is right about what it measures; the promise is wider than what the gate can see.

## What this PR does and does not do

Documents the state, and names `runtime.deterministic_gemm` as the switch for anyone who needs order-independent greedy output today (`imp.conf.example` too). It does **not** weaken the gate and does **not** decide whether the default path should be made bit-equal across the two prefill shapes — that is #1314, and I have not measured what `deterministic_gemm` costs in throughput.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx