### PR TITLE
docs(determinism): measure what deterministic_gemm costs on decode

### DIFF
--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -87,6 +87,25 @@ FP values are bit-identical.
 rest of deterministic mode. The `[runtime] deterministic` guarantee in the first
 section is unaffected — it already covers this.
 
+Its decode cost, measured the way `bench_gate.sh` measures (discarded warm-up
+run per process, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, `--prefill-chunk-size 0`),
+four alternating pairs on Qwen3-4B-IQ4_NL, `tg128` tok/s:
+
+| pair | off | on |
+|---|---|---|
+| 1 | 295.99 | 285.80 |
+| 2 | 268.77 | 280.03 |
+| 3 | 278.02 | 281.24 |
+| 4 | 266.91 | 271.08 |
+
+Medians 273.4 off / 280.6 on — the arms are separated by less than the off arm's
+own spread (10.9 %), and `on` wins three pairs of four. So on this shape the
+"slower but reproducible" note above overstates it: **the decode cost is below
+this host's noise floor.** Prefill is deliberately not quoted — `docs/BENCHMARKING.md`
+rules it out as an A/B signal, and split-k reduction is exactly where a cost
+would be most plausible, so "no measurable cost" is a statement about decode on
+one model, not a general one.
+
 `PrefixCacheE2ETest.FreshVsPrefixHitTokenEqual` asserts the strong version of
 this property and passes: it uses a long multi-block prompt whose decisions have
 no margin this narrow. The gate is right about what it measures; the promise is


### PR DESCRIPTION
Follow-up to #1332, which named `runtime.deterministic_gemm` as the switch for order-independent greedy output without measuring what it costs. `imp.conf.example` calls it *"Slower but reproducible"*.

Measured the way `scripts/bench_gate.sh` measures — discarded warm-up run per process, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, `--prefill-chunk-size 0`, `--bench-reps 3` — four alternating pairs on `Qwen3-4B-Instruct-2507-IQ4_NL`:

| pair | off | on |
|---|---|---|
| 1 | 295.99 | 285.80 |
| 2 | 268.77 | 280.03 |
| 3 | 278.02 | 281.24 |
| 4 | 266.91 | 271.08 |

Medians **273.4 off / 280.6 on** `tg128` tok/s. The arms are separated by less than the off arm's own spread (10.9 %), and `on` is ahead in three pairs of four. **The decode cost is below this host's noise floor** on this shape.

Two things this does not say:

- Nothing about prefill. `docs/BENCHMARKING.md` rules prefill out as an A/B signal (2.6× variance across restarts), and split-k reduction is precisely where a cost would be most plausible — so quoting a prefill number here would be worse than quoting none.
- Nothing about other models or shapes. One model, decode only, stated as such in the doc.

A first attempt without the warm-up run and without the gate's env produced arms with 14–18 % spread and a rising trend inside each arm; those numbers are discarded, not reported.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx