### PR TITLE
fix(bench): imp-bench honors --set/--config instead of dropping them

### DIFF
--- a/tools/imp-bench/main.cpp
+++ b/tools/imp-bench/main.cpp
@@ -1,6 +1,11 @@
+#include "runtime/config.h"
+#include "runtime/process_diag.h"
+
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <string>
+#include <vector>
 
 namespace imp {
 void bench_gemm();
@@ -22,7 +27,9 @@ static void print_usage(const char* prog) {
     printf("\nDefault (no argument) runs gemm, attention, decode-attn and e2e;\n");
     printf("nvfp4 is excluded (isolated ncu target) — run it via 'nvfp4' or 'all'.\n");
     printf("\nOptions:\n");
-    printf("  --help, -h  Show this help message\n");
+    printf("  --config <path>       imp.conf path (default: ./imp.conf, ~/.config/imp/imp.conf)\n");
+    printf("  --set <sec.key=val>   Override one imp.conf key (repeatable)\n");
+    printf("  --help, -h            Show this help message\n");
 }
 
 int main(int argc, char** argv) {
@@ -35,37 +42,77 @@ int main(int argc, char** argv) {
     bool run_decode_attn = false;
     bool run_e2e = false;
 
-    if (argc <= 1) {
+    // Every argument is examined. This used to read argv[1] and nothing else,
+    // so `imp-bench gemm --set runtime.deterministic_gemm=true` measured the
+    // default configuration while looking like it measured the flag — the same
+    // trap imp-cli's main already warns about ("this is how a benchmark ends up
+    // measuring a configuration nobody asked for"). A benchmark that silently
+    // drops its knobs is worse than one that has none.
+    std::string config_path;
+    std::vector<std::string> config_overrides;
+    const char* benchmark = nullptr;
+
+    for (int i = 1; i < argc; i++) {
+        const char* arg = argv[i];
+        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        } else if (strcmp(arg, "--config") == 0 && i + 1 < argc) {
+            config_path = argv[++i];
+        } else if (strcmp(arg, "--set") == 0 && i + 1 < argc) {
+            config_overrides.emplace_back(argv[++i]);
+        } else if (arg[0] == '-') {
+            printf("Unknown option: '%s'\n\n", arg);
+            print_usage(argv[0]);
+            return 1;
+        } else if (benchmark == nullptr) {
+            benchmark = arg;
+        } else {
+            printf("Unexpected argument: '%s' (benchmark already set to '%s')\n\n", arg, benchmark);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    // Install the config BEFORE any benchmark runs: gemm.cu reads
+    // deterministic_gemm through process_diag, which is only populated here.
+    {
+        std::vector<std::string> rejected_overrides;
+        imp::RuntimeConfig cfg = imp::RuntimeConfig::load(config_path, config_overrides, &rejected_overrides);
+        if (!rejected_overrides.empty()) {
+            for (const auto& bad : rejected_overrides)
+                fprintf(stderr, "Error: --set %s\n", bad.c_str());
+            fprintf(stderr, "See imp.conf.example for the key names.\n");
+            return 1;
+        }
+        imp::process_diag_install(cfg);
+    }
+
+    if (benchmark == nullptr) {
         run_gemm = true;
         run_attention = true;
         run_decode_attn = true;
         run_e2e = true;
+    } else if (strcmp(benchmark, "gemm") == 0) {
+        run_gemm = true;
+    } else if (strcmp(benchmark, "nvfp4") == 0) {
+        run_gemm_nvfp4 = true;
+    } else if (strcmp(benchmark, "attention") == 0) {
+        run_attention = true;
+    } else if (strcmp(benchmark, "decode-attn") == 0) {
+        run_decode_attn = true;
+    } else if (strcmp(benchmark, "e2e") == 0) {
+        run_e2e = true;
+    } else if (strcmp(benchmark, "all") == 0) {
+        run_gemm = true;
+        run_gemm_nvfp4 = true;
+        run_attention = true;
+        run_decode_attn = true;
+        run_e2e = true;
     } else {
-        const char* arg = argv[1];
-        if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0) {
-            print_usage(argv[0]);
-            return 0;
-        } else if (strcmp(arg, "gemm") == 0) {
-            run_gemm = true;
-        } else if (strcmp(arg, "nvfp4") == 0) {
-            run_gemm_nvfp4 = true;
-        } else if (strcmp(arg, "attention") == 0) {
-            run_attention = true;
-        } else if (strcmp(arg, "decode-attn") == 0) {
-            run_decode_attn = true;
-        } else if (strcmp(arg, "e2e") == 0) {
-            run_e2e = true;
-        } else if (strcmp(arg, "all") == 0) {
-            run_gemm = true;
-            run_gemm_nvfp4 = true;
-            run_attention = true;
-            run_decode_attn = true;
-            run_e2e = true;
-        } else {
-            printf("Unknown benchmark: '%s'\n\n", arg);
-            print_usage(argv[0]);
-            return 1;
-        }
+        printf("Unknown benchmark: '%s'\n\n", benchmark);
+        print_usage(argv[0]);
+        return 1;
     }
 
     auto wall_start = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
`imp-bench`'s `main()` read `argv[1]` and ignored every other argument. So

```
imp-bench gemm --set runtime.deterministic_gemm=true
```

measured the **default** configuration while looking like it measured the flag — `gemm.cu` reads `deterministic_gemm` through `process_diag`, and `imp-bench` never called `process_diag_install()`. Two smaller symptoms of the same parser: `imp-bench gemm --help` ran the benchmark instead of printing usage, and an unknown `--set` key was accepted in silence, where every other tool in the repo refuses to start.

`tools/imp-cli/main.cpp` already carries the warning this reproduces verbatim:

> Silently ignoring these is how a benchmark ends up measuring a configuration nobody asked for: `--set gemm.deterministic=true` sat in the AWQ reproduction harness doing nothing at all.

Same trap, worse form: imp-bench had no rejection path at all.

## Change

Every argument is examined — `--config <path>`, repeatable `--set <sec.key=val>`, `--help` anywhere, and an unknown option or a second benchmark name is an error with usage. The config is loaded and installed before any benchmark runs, rejecting unknown keys the way the other tools do.

No caller passes extra arguments today (`docs/sm120_optimal_kernel.md` uses `imp-bench nvfp4`; nothing in `Makefile`, `scripts/` or CI invokes it), so the stricter parse breaks nothing.

## Verified

| invocation | before | after |
|---|---|---|
| `gemm --set runtime.definitely_not_a_key=true` | ran, exit 0 | `Error: --set … (no such key)`, exit 1 |
| `gemm --bogus` | ran, exit 0 | `Unknown option: '--bogus'` + usage, exit 1 |
| `gemm --help` | ran the benchmark | prints usage |

And the payoff — with the flag actually applied, `deterministic_gemm` becomes measurable on the shape where it should cost something. M=4096 FP16 GEMM, alternating pairs, discarded warm-up run per process:

| pair | off | on | Δ |
|---|---|---|---|
| 1 | 215.67 | 204.00 | −5.4 % |
| 2 | 214.72 | 206.35 | −3.9 % |
| 3 | 219.10 | 215.02 | −1.9 % |
| 4 | 212.89 | 203.68 | −4.3 % |
| 5 | 207.95 | 206.51 | −0.7 % |
| 6 | 208.01 | 210.04 | +1.0 % |

TFLOPS, lower is worse. 5 of 6 pairs negative, medians 213.8 → 206.4. The off arm drifts downward across the session (215-219 early, ~208 late), which is why the per-pair table is here instead of one number. This is the measurement that was impossible before this change — and the numbers I took before noticing the parser were, of course, two identical arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx