### PR TITLE
docs(determinism): retract the deterministic_gemm recommendation — it does not hold

### DIFF
--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -65,15 +65,23 @@ not bitwise. Any greedy decision whose margin is smaller than that drift can
 then land either way, and the first request of a process is the one that runs
 fresh, so it is the one that differs.
 
-Measured on `Llama-3.2-3B-Instruct-IQ4_XS`, whole `tests/api/test_chat.py`
-against a freshly started server, five fresh servers per arm:
+Measured with two probes, because the first one is too weak to characterise
+this and said so only after the second was run. **Short probe:** whole
+`tests/api/test_chat.py` (a 16-token answer to "What is 2+2?"),
+`Llama-3.2-3B-Instruct-IQ4_XS`, five fresh servers per arm. **Long probe:** the
+three `DetEvalE2ETest` prompts at 96 tokens, three fresh servers per arm.
 
-| arm | runs with a divergence |
-|---|---|
-| default | **5/5** |
-| `server.prefix_cache = false` | 0/5 |
-| `runtime.deterministic = true` | 0/5 |
-| `runtime.deterministic_gemm = true` | 0/5 |
+| arm | short probe | long probe (Qwen3-4B-Q8_0) | long probe (Llama-3.2-3B) |
+|---|---|---|---|
+| default | **5/5 diverge** | **1 of 3 prompts, 3/3 reps** | **1 of 3 prompts, 3/3 reps** |
+| `runtime.deterministic_gemm = true` | 0/5 | **1 of 3 prompts, 3/3 reps** | **1 of 3 prompts, 3/3 reps** |
+| `runtime.deterministic = true` | 0/5 | **1 of 3 prompts, 3/3 reps** | — |
+| `server.prefix_cache = false` | 0/5 | **0 of 3, 3/3 reps** | — |
+
+The GEMM knobs move the *particular* near-tie the short probe lands on; they do
+not remove the phenomenon. Over 96 tokens the divergence returns with
+`deterministic = true` still set. **Only turning the prefix cache off removes
+it.**
 
 Scale: the two paths agree to ≤ 5e-3 in logprob at every position and produce
 identical top-5 candidate sets; the flip happened on a 0.018-nat margin between
@@ -83,11 +91,17 @@ not covered by known limit 1 either, which is about *exactly tied* logits whose
 FP values are bit-identical.
 
 **If you need order-independent greedy output today**, set
-`runtime.deterministic_gemm = true`; it is sufficient on its own, without the
-rest of deterministic mode. The `[runtime] deterministic` guarantee in the first
-section is unaffected — it already covers this.
+`server.prefix_cache = false`. That is the only switch measured to remove it.
+An earlier revision of this section recommended `runtime.deterministic_gemm`
+instead, on the strength of the short probe alone; that recommendation was
+wrong and is retracted here.
 
-Its decode cost, measured the way `bench_gate.sh` measures (discarded warm-up
+This also means the `[runtime] deterministic` guarantee in the first section
+does **not** hold on the server path with prefix caching on — which is what
+#1314's title says, and what a 5/5 result on a 16-token answer briefly appeared
+to refute.
+
+`deterministic_gemm`'s decode cost, measured the way `bench_gate.sh` measures (discarded warm-up
 run per process, `CUBLAS_WORKSPACE_CONFIG=:4096:8`, `--prefill-chunk-size 0`),
 four alternating pairs on Qwen3-4B-IQ4_NL, `tg128` tok/s:
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -13,10 +13,10 @@
 # Lines starting with '#' are comments; section headers in [brackets].
 
 [runtime]
-# Force deterministic GEMM (cuBLASLt no_reduce_split). Slower but reproducible.
-# Also the switch that makes a prefix-cache hit bit-equal to a fresh prefill —
-# without it, the first request of a process can differ from the identical ones
-# after it on a narrow enough margin (#1314, docs/determinism.md).
+# Force deterministic GEMM (cuBLASLt no_reduce_split). Slower but reproducible
+# (decode cost measured below this host's noise floor; ~2-4 % on large-M FP16).
+# It does NOT make a prefix-cache hit bit-equal to a fresh prefill — for that
+# use server.prefix_cache = false (#1314, docs/determinism.md).
 deterministic_gemm   = false
 # Full reproducibility mode for temp=0 evals: deterministic MoE routing /
 # expert-scatter and top-k sampling kernels, implies deterministic_gemm.


### PR DESCRIPTION
#1332 and #1333 shipped guidance that is wrong, and this retracts it.

Both told readers that `runtime.deterministic_gemm = true` restores order-independent greedy output. That rested on **one probe**: `tests/api/test_chat.py`, whose determinism case is a 16-token answer to *"What is 2+2?"*. The flag cleared 5 of 5 runs there, and I generalised.

Rerun with a probe that generates something: the three `DetEvalE2ETest` prompts at 96 tokens, three fresh servers per arm.

| arm | short probe (16 tok) | long probe, Qwen3-4B-Q8_0 | long probe, Llama-3.2-3B |
|---|---|---|---|
| default | **5/5 diverge** | **1 of 3 prompts, 3/3 reps** | **1 of 3 prompts, 3/3 reps** |
| `runtime.deterministic_gemm = true` | 0/5 | **1 of 3 prompts, 3/3 reps** | **1 of 3 prompts, 3/3 reps** |
| `runtime.deterministic = true` | 0/5 | **1 of 3 prompts, 3/3 reps** | — |
| `server.prefix_cache = false` | 0/5 | **0 of 3, 3/3 reps** | — |

The GEMM knobs move the *particular* near-tie the short probe lands on. They do not remove the phenomenon: over 96 tokens the divergence comes back with full `deterministic = true` still set, on two different models. **Only turning the prefix cache off removes it.**

That also means the `[runtime] deterministic` guarantee in the doc's first section does not hold on the server path with prefix caching on — which is exactly what #1314's title says, and what a 5/5 on a 16-token answer briefly appeared to refute. I posted that refutation in the issue; it is retracted there too.

## Changes

- `docs/determinism.md`: both probes side by side, the recommendation switched to `server.prefix_cache = false`, and an explicit note that the earlier recommendation was wrong.
- `imp.conf.example`: the `deterministic_gemm` comment no longer claims it fixes the prefix-cache case.
- The measured *cost* of `deterministic_gemm` stays — that number is about the flag and is unaffected.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx