### PR TITLE
fix(engine): stop overriding a C-API embedder's explicit prefix-cache "off"

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -558,9 +558,16 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // later refactor). imp.conf is the user's persistent preference; a CLI
     // flag / C-API value can additionally ENABLE a knob (OR), so a library
     // embedder's explicit choice is never clobbered. --mmproj (explicit
-    // one-shot) overrides imp.conf. RuntimeConfig defaults for these match the
-    // EngineConfig defaults (off), so no-imp.conf embedders are unaffected.
-    config_.use_prefix_caching = config_.use_prefix_caching || runtime_config_.server.prefix_cache;
+    // one-shot) overrides imp.conf.
+    //
+    // `use_prefix_caching` is deliberately NOT in that OR. The reasoning above
+    // holds only while the RuntimeConfig default matches the EngineConfig
+    // default; #758 flipped `server.prefix_cache` to true for the shipped
+    // image, and from then on OR-ing it meant a C-API embedder that set
+    // `use_prefix_caching = 0` — the documented default — got caching anyway,
+    // with no way to refuse it. Both shipped tools already pass their own
+    // value (`handlers.cpp` from imp.conf, `imp-cli/main.cpp` from its flag
+    // OR imp.conf), so nothing that ships loses caching. #1299/#1314.
     config_.use_green_contexts = config_.use_green_contexts || runtime_config_.server.green_contexts;
     if (config_.prefix_pin_budget_pct == 25)  // EngineConfig default untouched → take imp.conf
         config_.prefix_pin_budget_pct = runtime_config_.server.prefix_pin_budget_pct;

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -234,8 +234,10 @@ int main(int argc, char** argv) {
         config.use_mxfp4_prefill = 1;
     if (args.dual_path_quant)
         config.dual_path_quant = 1;
-    if (args.prefix_caching)
-        config.use_prefix_caching = 1;
+    // --prefix-caching, else imp.conf ([server] prefix_cache, default on). The
+    // engine used to OR the imp.conf value in for every embedder; it no longer
+    // does, so the CLI states its own choice (#1299).
+    config.use_prefix_caching = (args.prefix_caching || runtime_cfg.server.prefix_cache) ? 1 : 0;
     if (args.streaming_kv) {
         config.streaming_kv_enabled = 1;
         config.streaming_kv_n_sinks = args.streaming_sinks;


### PR DESCRIPTION
`imp_config_default()` documents `use_prefix_caching = 0` — and `Engine::init` then did:

```cpp
config_.use_prefix_caching = config_.use_prefix_caching || runtime_config_.server.prefix_cache;
```

The comment above that line justifies the OR with *"RuntimeConfig defaults for these match the EngineConfig defaults (off), so no-imp.conf embedders are unaffected."* True when written. #758 flipped `server.prefix_cache` to `true` so the shipped image caches by default — and from that moment the OR meant a C-API embedder **could not turn prefix caching off at all**. The documented default was unreachable.

## How it surfaced

Localising #1299. `DetEvalE2ETest` drives the C API with `imp_config_default()`, and a probe on the prefill scheduler showed the *second* generation of each prompt starting at token 16 instead of 0:

```
prefill seq=2 chunk=1024 pos=0  n_in=24     <- first generation
prefill seq=3 chunk=1024 pos=16 n_in=24     <- second, same prompt
```

A prefix-cache hit, in a test that had asked for no prefix cache. That is the same mechanism as #1314: cached and fresh prefill present a different M to cuBLASLt, so any near-tie decides differently.

## Measured — dense, `deterministic=1`, isolated runs

| | before | after |
|---|---|---|
| `GreedyReproducibleSameContext` | FAIL 2/2 | **OK 2/2** |
| `…SameContextGraphsOff` | FAIL 2/2 | **OK 2/2** |
| `DISABLED_GreedyReproducibleAcrossFreshContexts` | OK | **OK** |
| `PerplexityBitIdenticalSameContext` | OK | **OK** |
| `DISABLED_PerplexityBitIdenticalAcrossFreshContexts` | — | **OK** |

Refuted on the way there, each with its control verified: **spec-ngram** (fails 2/2 with it disabled) and **KV block order** (fails under LIFO, under FIFO, and under a forced-identical block sequence — the probe confirmed both generations then received `7 8 9 10 11 12 13`).

## What it does not fix — gpt-oss

On MoE the two same-context cells **trade places**, 3/3 isolated reps each way:

| | before | after |
|---|---|---|
| `GreedyReproducibleSameContext` (graphs ON) | OK 3/3 | **FAIL 3/3** |
| `…GraphsOff` | FAIL 3/3 | **OK 3/3** |

So prefix caching was masking one MoE fault and exposing another; with it genuinely off, the graph-replay path is the one that diverges. #1299's MoE half stays open, and this PR does not claim otherwise. (The 117 ms "failures" in a five-test single-process run were the documented WSL2 peak-VRAM cascade — isolated, perplexity passes.)

## Blast radius

Both shipped tools already pass their own value, so nothing that ships loses caching:

- `imp-server` — `handlers.cpp:471`, from imp.conf, unchanged.
- `imp-cli` — now sets `--prefix-caching || [server] prefix_cache` itself instead of relying on the engine-side OR, so its behaviour is identical to today's.

`use_green_contexts` keeps its OR: that RuntimeConfig default is still `false`, so the original reasoning still holds there. `PrefixCacheE2ETest` stays 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx