### PR TITLE
deps: bump CUTLASS to v4.6.2, and resync the Dockerfile ARG default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV CUDA_HOME=/usr/local/cuda
 # --build-arg from that file. The defaults below keep a bare `docker build .`
 # working and MUST match cmake/imp-deps.cmake.
 ARG IMP_DEP_GOOGLETEST_TAG=v1.17.0
-ARG IMP_DEP_CUTLASS_TAG=v4.6.0
+ARG IMP_DEP_CUTLASS_TAG=v4.6.2
 ARG IMP_DEP_HTTPLIB_TAG=v0.50.1
 ARG IMP_DEP_NLOHMANN_JSON_TAG=v3.12.0
 RUN git clone --depth=1 --branch ${IMP_DEP_GOOGLETEST_TAG} https://github.com/google/googletest.git /deps/googletest \

--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -8,6 +8,6 @@
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
 set(IMP_DEP_GOOGLETEST_TAG    v1.17.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       v4.6.1   CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_CUTLASS_TAG       v4.6.2   CACHE STRING "NVIDIA/cutlass git tag")
 set(IMP_DEP_HTTPLIB_TAG       v0.50.1  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")


### PR DESCRIPTION
`v4.6.2` is a CuTe DSL patch release: it reverts the 4.6.0 TMA bulk-copy `elect_one` change back to 4.5.x behaviour, fixes a vectorized fp32→f8 conversion and a ptxas `opt-level` setting. None of that touches imp's C++ GEMM paths directly — so the evidence here is the gate, not the changelog.

## `make verify-fast` against a freshly built `imp:test`

Median of 3 independent runs, spread 1.69 %:

| | measured | baseline | delta | |
|---|---|---|---|---|
| decode `tg128` | 285.07 tok/s | 287.19 | −0.74 % | PASS (3 %) |
| prefill `pp512` | 12393.83 tok/s | 12406.87 | −0.11 % | PASS (5 %) |
| prefill `pp4096` (FA2) | 15569.88 tok/s | 15324.70 | +1.60 % | PASS (5 %) |
| own peak VRAM | 20718 MiB | 20716 | +0.01 % | PASS (10 %) |
| graphs ON vs OFF `tg256` | 2.83× | — | — | PASS (≥1.3×) |
| smoke degeneration, Qwen3-4B Q8_0 | distinct=11, contains "Paris" | — | — | PASS |

Every delta sits inside the host's own run-to-run spread, so this is **neutral**, not an improvement. Fast gtest filter green.

## The second half: the Dockerfile ARG had drifted

`cmake/imp-deps.cmake` is the authoritative pin, and the Dockerfile keeps matching `ARG` defaults so a bare `docker build .` builds the same thing. That default still said **v4.6.0** while the pin was at v4.6.1 — #1010 bumped the cmake file only. Both now read `v4.6.2`.

## Confirmed the pin reaches the compiler

Assuming a build-arg took effect is exactly how a dependency bump gets measured against the old dependency. Read out of the image instead:

```
$ docker run --rm imp:toolchain grep 'define CUTLASS_' /deps/cutlass/include/cutlass/version.h
#define CUTLASS_MAJOR 4
#define CUTLASS_MINOR 6
#define CUTLASS_PATCH 2
```

(`imp:toolchain` was still on 4.6.1 until `make dev-image` re-ran — `make build` and `make dev-image` are separate targets, and a bump landing in only one of them means later `make dev` work compiles against the old pin.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx