### PR TITLE
fix(spec): stop chopping the decode loop for models that can never speculate

### DIFF
--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -838,6 +838,10 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     MemAccount::instance().sampler_start(2000);
     MemAccount::instance().report("init_complete");
 
+    // Model + profile + ssm_state_ are final here, and none of the inputs can
+    // change afterwards — so the answer is taken once, off the per-step path.
+    spec_ngram_model_capable_flag_ = spec_ngram_model_capable_uncached_();
+
     return true;
 }
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -917,8 +917,18 @@ private:
                                             : runtime_config_.speculative.ngram;
     }
     // The model-level half of spec_ngram_gates_ok_: facts that cannot change
-    // between requests or between steps.
-    bool spec_ngram_model_capable_() const;
+    // between requests or between steps — so it is computed once and cached.
+    // spec_ngram_enabled_ sits on the per-step decode path; recomputing this
+    // there (it reaches into supports_chunked_prefill_) would put avoidable
+    // work on the hot path of every model, including the ones this change does
+    // not affect at all.
+    bool spec_ngram_model_capable_() const { return spec_ngram_model_capable_flag_; }
+    // Computed ONCE at the end of Engine::init, never lazily: a lazy cache
+    // filled on the first call locks in whatever the answer was before
+    // `ssm_state_` and the model profile were final, which measured as the MoE
+    // determinism cases going from 0 failing back to 7.
+    bool spec_ngram_model_capable_uncached_() const;
+    bool spec_ngram_model_capable_flag_ = false;
     bool spec_ngram_gates_ok_(const Request& req, bool ignore_think = false) const;
     bool spec_burst_launch_ok_(const Request& req) const;
     int spec_effective_miss_burst_(const Request& req) const;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -903,9 +903,22 @@ private:
     // Effective n-gram speculation state for a request: honors the per-request
     // tri-state override (Request::spec_ngram_override), else the global default.
     bool spec_ngram_enabled_(const Request& req) const {
+        // A model that can never speculate must not look "enabled" to anyone:
+        // the decode loop chops itself into miss_burst bursts whenever this
+        // says yes (engine_scheduler.cpp), so a model whose gates always fail
+        // paid the chopping for drafts that could not happen — and the burst
+        // boundaries, not the drafts, are what made greedy output depend on
+        // request history (#1299). The comment in spec_ngram_gates_ok_ already
+        // says GGUF-MoE "stays on the async conditional-graph loop"; this is
+        // what makes that true.
+        if (!spec_ngram_model_capable_())
+            return false;
         return req.spec_ngram_override >= 0 ? req.spec_ngram_override == 1
                                             : runtime_config_.speculative.ngram;
     }
+    // The model-level half of spec_ngram_gates_ok_: facts that cannot change
+    // between requests or between steps.
+    bool spec_ngram_model_capable_() const;
     bool spec_ngram_gates_ok_(const Request& req, bool ignore_think = false) const;
     bool spec_burst_launch_ok_(const Request& req) const;
     int spec_effective_miss_burst_(const Request& req) const;

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -304,10 +304,26 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     // draft-poor floor (miss_burst hybrid). GGUF-MoE verify re-dequants every
     // activated expert per step and measured -22% — those stay on the async
     // conditional-graph loop (as does everything when speculative.moe=false).
+    if (!spec_ngram_model_capable_())
+        return false;
+    return true;
+}
+
+// Model-level gates, split out of spec_ngram_gates_ok_ so spec_ngram_enabled_
+// can ask the same question without the per-request checks. Nothing here
+// depends on a request, so a false answer means "this model never speculates,
+// whatever the flag says".
+bool Engine::spec_ngram_model_capable_() const {
+    if (ssm_state_ && !runtime_config_.speculative.hybrid)
+        return false;
+    // GGUF-MoE verify re-dequants every activated expert per step (-22%), so
+    // these stay on the async conditional-graph loop — as does everything when
+    // speculative.moe=false.
     if (model_->profile().is_moe &&
         !(runtime_config_.speculative.moe && model_->profile().moe_experts_nvfp4))
         return false;
-    if (!supports_chunked_prefill_()) return false;
+    if (!supports_chunked_prefill_())
+        return false;
     return true;
 }
 

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -313,7 +313,7 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
 // can ask the same question without the per-request checks. Nothing here
 // depends on a request, so a false answer means "this model never speculates,
 // whatever the flag says".
-bool Engine::spec_ngram_model_capable_() const {
+bool Engine::spec_ngram_model_capable_uncached_() const {
     if (ssm_state_ && !runtime_config_.speculative.hybrid)
         return false;
     // GGUF-MoE verify re-dequants every activated expert per step (-22%), so


### PR DESCRIPTION
Closes the same-context half of #1299 on MoE.

`spec_ngram_gates_ok_` carries a **model-level** gate — a MoE model without native-NVFP4 experts can never speculate, whatever the request looks like — and its own comment says those models *"stay on the async conditional-graph loop"*. They did not.

The decode loop asks `spec_ngram_enabled_()`, which only consulted the config flag and the per-request override:

```cpp
// engine_scheduler.cpp:2290 — loop runs unbounded only if speculation is off
(!spec_ngram_enabled_(*dreq) || dreq->spec_ngram_given_up || miss_burst > 0)
// :2312 — otherwise it is chopped into spec_limit-step bursts
```

So on `gpt-oss-20b-mxfp4` the engine chopped the decode loop into `miss_burst` bursts to probe for drafts its own gates had already ruled out. **The burst boundaries — not the drafts — are what made greedy output depend on how many requests came before.** The engine says so itself:

```
spec-ngram: gates failed (... moe=1 moe_nvfp4=0 spec_moe=1 ...)
```

`spec_ngram_enabled_()` now asks `spec_ngram_model_capable_()` first. A model that can never speculate no longer looks enabled to anyone, and the loop runs to completion as the comment always claimed. The answer is taken **once at the end of `Engine::init`** — not lazily; a lazy cache locks in whatever the answer was before `ssm_state_` and the profile were final.

## Measured — isolated, one case per process

`gpt-oss-20b-mxfp4`, `deterministic=1`:

| case | before | after |
|---|---|---|
| `GreedyReproducibleSameContext` | FAIL 3/3 | **OK 2/2** |
| `GreedyReproducibleSameContextGraphsOff` | FAIL 3/3 | **OK 2/2** |
| `DISABLED_GreedyReproducibleAcrossFreshContexts` | FAIL | **still FAILS** |

Dense `Qwen3-4B-Q8_0`: all cases green, unchanged.

**Scope, stated plainly:** two cells are fixed, the disabled fresh-context case is a separate fault and stays open. An earlier measurement of mine claimed it was fixed too — that came from a five-case single-process run counted with a grep that collapses failures, and the same run produced two 115 ms "failures" that are the documented WSL2 peak-VRAM cascade. One case per process, or the numbers lie in both directions.

## Perf

`make verify-fast`, median of 3 independent runs, **spread 0.12 %**:

| | measured | baseline | delta |
|---|---|---|---|
| decode `tg128` | 288.54 tok/s | 287.19 | **+0.47 %** |
| prefill `pp512` | 12599.13 | 12406.87 | +1.55 % |
| prefill `pp4096` | 15613.14 | 15324.70 | +1.88 % |
| own peak VRAM | 20718 MiB | 20716 | +0.01 % |

Graphs ON/OFF 2.18×, smoke degeneration green.

An earlier build of this change measured decode at −2.95 % with a **4.69 %** spread — green against the 3 % threshold, but the spread was larger than the delta, so it said nothing. That version recomputed the capability per decode step; this one does not, and at 0.12 % spread the answer is unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx