### PR TITLE
fix(kv-cache): fall back to FP16 instead of faulting when FP8 KV meets head_dim=64

### DIFF
--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -207,7 +207,28 @@ void Engine::init_resolve_kv_dtype_policy_() {
         }
     }
 
-    if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16) {
+    // FP8 KV decode is broken at head_dim=64 (#1339): the paged split-K FP8
+    // pipeline kernel faults with `misaligned address` at its HD=64
+    // instantiation (attention_paged_fp8.cu, the `case 64:` launch), and the
+    // fault takes the CUDA context with it — every later launch and even
+    // cudaFree fails, so a server wedges with 0-token completions instead of
+    // erroring out. `ELEMS = HEAD_DIM / WARP_SIZE` is 2 there against 4 at
+    // hd=128, so the vectorised load path (FP8_VEC4 = ELEMS / 4) degenerates.
+    //
+    // Fall back rather than refuse: FP8 KV is a memory optimisation, and losing
+    // it is strictly better than losing the process. The kernel bug itself is
+    // still open — this only stops it being reachable by configuration.
+    if (config_.kv_cache_dtype == QType::FP8_E4M3 && mcfg.head_dim == 64) {
+        IMP_LOG_WARN("KV cache dtype: FP8_E4M3 requested but head_dim=64 — falling back to FP16. "
+                     "The FP8 paged decode kernel faults at this head dim (#1339); FP8 KV is "
+                     "available on head_dim 96/128/256/512.");
+        config_.kv_cache_dtype = QType::F16;
+    }
+
+    // head_dim != 64: the legacy auto-upgrade must not undo the #1339 fallback
+    // above — it runs on exactly the F16 state that fallback produces.
+    if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16 &&
+        mcfg.head_dim != 64) {
         config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: kv_cache.fp8_auto_legacy → FP8_E4M3 (legacy auto-upgrade)");
     } else if (config_.kv_cache_dtype == QType::F16) {


### PR DESCRIPTION
Closes #1339.

Forcing `kv_cache.dtype=fp8` on `gpt-oss-20b-mxfp4` produced **4931 CUDA `misaligned address` errors**, no output, and a CUDA context so broken that even `cudaFree` failed (387/387 weight frees). Over HTTP the server answered 0-token completions and then reported `status: unhealthy` while still accepting requests it could never serve. The repo's own `imp.conf` sets `dtype = "fp8"`, so running `imp-server` from the checkout with that model walked straight into it.

## Localising it took two wrong turns worth recording

1. `CUDA_LAUNCH_BLOCKING=1` reported `CudaGraphCapture: replay failed` first — which is **not** the origin. A graph replay is a single launch, so blocking cannot look inside it.
2. The obvious follow-up, "then it is the graphs", is refuted: with `--no-cuda-graphs` the fault persists (2535 errors). Neither `attention.splitk_pipe=false` nor `attention.fp8_tile=false` avoids it either.

Graphs off **and** blocking together name the site: `attention_paged_fp8.cu`, the `case 64:` launch — the HD=64 instantiation of the paged split-K FP8 pipeline kernel. `ELEMS = HEAD_DIM / WARP_SIZE` is **2** there against 4 at hd=128, so `FP8_VEC4 = ELEMS / 4` degenerates to 0 and the vectorised load path does not hold. gpt-oss is the only hero model at `head_dim=64` (confirmed from its load log), which is why nothing else shows it.

## What this PR does — and does not

It does **not** fix the kernel. It stops the broken path being reachable by configuration: FP8 KV requested at `head_dim=64` falls back to FP16 with a WARN naming the issue and the head dims where FP8 KV does work.

Falling back rather than refusing to start: FP8 KV is a memory optimisation, and losing it beats losing the process. The kernel bug stays open with its exact site named in the code comment.

**Both entry points are covered, which the first version of this guard was not.** `kv_cache.fp8_auto_legacy` runs on exactly the `F16` state the fallback produces, so it would have silently undone it — invisible in testing because it is off by default. Found by re-reading the guard against the surrounding control flow rather than by a test.

## Verified

| case | result |
|---|---|
| gpt-oss + `kv_cache.dtype=fp8` | 0 errors, `dtype=F16`, WARN shown |
| gpt-oss + `kv_cache.fp8_auto_legacy=true` | 0 errors, `dtype=F16` |
| gpt-oss server + repo `imp.conf` | real completion, `status: ok` (was: 0 tokens, `unhealthy`) |
| **dense Qwen3-4B (head_dim=128) + forced fp8** | **still `FP8_E4M3`** — guard is not over-broad |
| `ctest -L unit` | 4/4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx