### PR TITLE
fix(attention): size the FP8 KV staging copy by ELEMS, and refuse quantised KV on sink models

### DIFF
--- a/src/compute/attention_paged_fp8.cu
+++ b/src/compute/attention_paged_fp8.cu
@@ -22,6 +22,43 @@ __device__ __forceinline__ float fp8_e4m3_to_float(uint8_t bits) {
 // Pipelined Split-K: FP8 E4M3 variant
 // ---------------------------------------------------------------------------
 
+// Copy exactly ELEMS bytes per lane from global KV into the per-warp smem
+// staging buffer. The valid cp.async transfer sizes are 4, 8 and 16 bytes, and
+// each lane's address is `lane_id * ELEMS`, so the instruction size has to
+// match ELEMS *and* the resulting alignment:
+//
+//   ELEMS 16 (hd=512) -> 16 B, lane_id*16 is 16 B aligned
+//   ELEMS  8 (hd=256) ->  8 B, lane_id*8  is  8 B aligned
+//   ELEMS  4 (hd=128) ->  4 B, lane_id*4  is  4 B aligned
+//   ELEMS  2 (hd=64), 3 (hd=96) -> no cp.async size fits
+//
+// The old code had one branch for `ELEMS >= 8` (always 8 B — so hd=512 copied
+// half its bytes and left the rest of K/V unwritten) and a hard-coded 4 B
+// otherwise, which at hd=64 both over-copied (4 B for a 2 B slice, running past
+// k_buf0 into k_buf1) and misaligned (odd lanes land on offset 2 mod 4). That
+// misalignment is #1339: the kernel faulted and took the CUDA context with it.
+//
+// For the two head dims no cp.async size fits, the copy is synchronous. The
+// pipeline loses its overlap there and nothing else changes — correct and
+// slower beats fast and faulting, and hd=64/96 are not the shapes this kernel
+// was tuned for.
+template <int ELEMS>
+__device__ __forceinline__ void fp8_kv_stage_lane(uint8_t* smem_dst, const uint8_t* glob_src) {
+    if constexpr (ELEMS == 16) {
+        cp_async_ca_16(smem_dst, glob_src);
+    } else if constexpr (ELEMS == 8) {
+        cp_async_ca_8(smem_dst, glob_src);
+    } else if constexpr (ELEMS == 4) {
+        asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(
+                         static_cast<uint32_t>(__cvta_generic_to_shared(smem_dst))),
+                     "l"(glob_src));
+    } else {
+#pragma unroll
+        for (int i = 0; i < ELEMS; i++)
+            smem_dst[i] = glob_src[i];
+    }
+}
+
 template <int HEAD_DIM>
 __global__ void paged_attention_splitk_fp8_pipeline_kernel(
     const half* __restrict__ Q, const uint8_t* __restrict__ K_cache, const uint8_t* __restrict__ V_cache,
@@ -120,13 +157,7 @@ __global__ void paged_attention_splitk_fp8_pipeline_kernel(
         // FP8: ELEMS bytes per thread (4 for HD=128, 8 for HD=256)
         {
             const uint8_t* K_tok = K_block + first_tok * kv_slot_stride + kv_head * HEAD_DIM;
-            if constexpr (ELEMS >= 8) {
-                cp_async_ca_8(&k_buf0[lane_offset], &K_tok[lane_offset]);
-            } else {
-                asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(
-                                 static_cast<uint32_t>(__cvta_generic_to_shared(&k_buf0[lane_offset]))),
-                             "l"(&K_tok[lane_offset]));
-            }
+            fp8_kv_stage_lane<ELEMS>(&k_buf0[lane_offset], &K_tok[lane_offset]);
             cp_async_commit();
         }
 
@@ -140,17 +171,8 @@ __global__ void paged_attention_splitk_fp8_pipeline_kernel(
             // Start async V[t] + K[t+1] loads (branchless: clamp to last valid token)
             int t_next = min(t + 1, first_tok + n_toks - 1);
             const uint8_t* K_next = K_block + t_next * kv_slot_stride + kv_head * HEAD_DIM;
-            if constexpr (ELEMS >= 8) {
-                cp_async_ca_8(&v_buf[lane_offset], &V_tok[lane_offset]);
-                cp_async_ca_8(&k_bufs[1 - cur][lane_offset], &K_next[lane_offset]);
-            } else {
-                asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(
-                                 static_cast<uint32_t>(__cvta_generic_to_shared(&v_buf[lane_offset]))),
-                             "l"(&V_tok[lane_offset]));
-                asm volatile("cp.async.ca.shared.global [%0], [%1], 4;\n" ::"r"(static_cast<uint32_t>(
-                                 __cvta_generic_to_shared(&k_bufs[1 - cur][lane_offset]))),
-                             "l"(&K_next[lane_offset]));
-            }
+            fp8_kv_stage_lane<ELEMS>(&v_buf[lane_offset], &V_tok[lane_offset]);
+            fp8_kv_stage_lane<ELEMS>(&k_bufs[1 - cur][lane_offset], &K_next[lane_offset]);
             cp_async_commit();
             cp_async_wait_group<1>();
 

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -207,28 +207,28 @@ void Engine::init_resolve_kv_dtype_policy_() {
         }
     }
 
-    // FP8 KV decode is broken at head_dim=64 (#1339): the paged split-K FP8
-    // pipeline kernel faults with `misaligned address` at its HD=64
-    // instantiation (attention_paged_fp8.cu, the `case 64:` launch), and the
-    // fault takes the CUDA context with it — every later launch and even
-    // cudaFree fails, so a server wedges with 0-token completions instead of
-    // erroring out. `ELEMS = HEAD_DIM / WARP_SIZE` is 2 there against 4 at
-    // hd=128, so the vectorised load path (FP8_VEC4 = ELEMS / 4) degenerates.
+    // Learned attention sinks are applied by the FP16 paged decode kernels and
+    // by nothing else: paged_attention_decode() takes an `attn_sinks` pointer,
+    // paged_attention_decode_fp8() has only `n_sinks` and no pointer at all. So
+    // a quantised KV cache on a sink model silently drops the sink term from
+    // the softmax denominator. executor_attention_decode.cu already WARNs about
+    // exactly this — but at decode time, long after the dtype was chosen, so
+    // the user got a line in the log and wrong output anyway.
     //
-    // Fall back rather than refuse: FP8 KV is a memory optimisation, and losing
-    // it is strictly better than losing the process. The kernel bug itself is
-    // still open — this only stops it being reachable by configuration.
-    if (config_.kv_cache_dtype == QType::FP8_E4M3 && mcfg.head_dim == 64) {
-        IMP_LOG_WARN("KV cache dtype: FP8_E4M3 requested but head_dim=64 — falling back to FP16. "
-                     "The FP8 paged decode kernel faults at this head dim (#1339); FP8 KV is "
-                     "available on head_dim 96/128/256/512.");
+    // Measured on gpt-oss-20b-mxfp4 (#1339), greedy, 300 tokens: FP16 KV answers
+    // ("Paris", the prime list, both finish_reason=stop) while FP8 KV emits no
+    // content at all on either prompt (finish_reason=length, empty). Decide it
+    // here, where the choice can still be changed.
+    if (config_.kv_cache_dtype != QType::F16 && mcfg.arch == ModelArch::GPT_OSS) {
+        IMP_LOG_WARN("KV cache dtype: %s requested, but this architecture carries learned attention "
+                     "sinks and only the FP16 paged decode kernels apply them (#1339) — falling back "
+                     "to FP16 KV rather than serving a wrong softmax denominator.",
+                     qtype_name(config_.kv_cache_dtype));
         config_.kv_cache_dtype = QType::F16;
     }
 
-    // head_dim != 64: the legacy auto-upgrade must not undo the #1339 fallback
-    // above — it runs on exactly the F16 state that fallback produces.
     if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16 &&
-        mcfg.head_dim != 64) {
+        mcfg.arch != ModelArch::GPT_OSS) {
         config_.kv_cache_dtype = QType::FP8_E4M3;
         IMP_LOG_INFO("KV cache dtype: kv_cache.fp8_auto_legacy → FP8_E4M3 (legacy auto-upgrade)");
     } else if (config_.kv_cache_dtype == QType::F16) {


### PR DESCRIPTION
Two defects behind #1339 — one loud, one silent. #1342 made the loud one unreachable; this fixes both.

## Loud: the copy size never matched the head dim

The FP8 pipeline kernel staged KV into smem with one branch for `ELEMS >= 8` (always an 8-byte `cp.async`) and a hard-coded 4-byte copy otherwise — while each lane owns exactly `ELEMS` bytes at offset `lane_id * ELEMS`:

| head_dim | ELEMS | what it did |
|---|---|---|
| 512 | 16 | copied **8 of 16** bytes — half of K/V left unwritten |
| 256 | 8 | correct |
| 128 | 4 | correct |
| 96 | 3 | 4 bytes for a 3-byte slice, offset 3 mod 4 |
| **64** | **2** | **4 bytes for a 2-byte slice, offset 2 mod 4** |

The last row is the fault: `cp.async` size 4 needs 4-byte alignment, odd lanes do not have it, and the misaligned access took the CUDA context with it — 4931 errors, 387/387 weight frees failing, servers wedged reporting `unhealthy`.

**hd=512 never faulted.** It read uninitialised smem instead, which is the failure mode nobody notices — and which a guard would have preserved forever.

`fp8_kv_stage_lane<ELEMS>` now selects 16/8/4-byte `cp.async` by ELEMS and copies synchronously for ELEMS 2 and 3, where no `cp.async` size fits. The pipeline loses its overlap on those two head dims only.

## Silent: that fix alone would have replaced a crash with wrong output

Learned attention sinks are applied by the FP16 paged decode kernels and nothing else — `paged_attention_decode()` takes an `attn_sinks` pointer, `paged_attention_decode_fp8()` has `n_sinks` and **no pointer at all**. `executor_attention_decode.cu` already WARNs about this, but at decode time, long after the dtype was chosen.

Measured on `gpt-oss-20b-mxfp4`, greedy, 300 tokens, after the kernel fix:

| KV dtype | finish_reason | content |
|---|---|---|
| FP16 | `stop` | `Paris` / `The first five prime numbers are: 1. **2** …` |
| FP8 | `length` | **empty**, both prompts |

So the resolver falls back to FP16 for any non-F16 KV dtype on an architecture carrying sinks. **Keyed on the arch, not on head_dim** — the version of this guard in #1342 used `head_dim == 64`, which would have let `int8`, `int4`, `nvfp4` and `mxfp4` through: the same silent defect, minus the crash that made it visible.

## Verified

| check | result |
|---|---|
| gpt-oss + `fp8` / `int8` / `nvfp4` | 0 errors, `dtype=F16`, WARN shown |
| dense Qwen3-4B (no sinks) + forced `fp8` | still `FP8_E4M3` — guard not over-broad |
| `test-attention` | 203/203 |
| `test-kv` | 61/61 |
| `make verify-fast` | OK — decode `tg128` +0.56 %, pp512 +1.30 %, pp4096 +1.95 %, peak VRAM +0.01 % |

The gate exercises the changed path directly: it loads the repo `imp.conf` (`dtype = "fp8"`) on a head_dim=128 model, i.e. the `ELEMS == 4` branch. Caveat on the number: that run had an **8.63 % spread**, so it bounds a regression only loosely — the point estimate is above baseline, and an earlier gate run on this host at 0.12 % spread put a comparable change at +0.47 %.

Closes #1339. The remaining gap — sinks are not wired into the quantised-KV decode kernels at all — is a feature, not this bug, and gets its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx