### PR TITLE
refactor(attention): one source of truth for "does this KV dtype apply sinks"

### DIFF
--- a/src/compute/attention_paged.cu
+++ b/src/compute/attention_paged.cu
@@ -1141,6 +1141,10 @@ void paged_attention_get_splitk_scratch(void** out_ptr, size_t* out_size) {
         *out_size = s_splitk_scratch_size;
 }
 
+bool paged_attention_applies_sinks(QType kv_dtype) {
+    return kv_dtype == QType::F16 || kv_dtype == QType::FP8_E4M3;
+}
+
 void paged_attention_launch_reduce(float* partial, half* O, int batch_size, int n_heads, int head_dim,
                                    int num_splits, cudaStream_t stream, const half* attn_sinks) {
     dim3 grid(batch_size, n_heads);

--- a/src/compute/attention_paged.h
+++ b/src/compute/attention_paged.h
@@ -179,6 +179,22 @@ void paged_attention_decode_nvfp4_tc(const Tensor& Q, const Tensor& K_cache, con
 // Returns pointer + size. Either can be nullptr/0 if unset.
 void paged_attention_get_splitk_scratch(void** out_ptr, size_t* out_size);
 
+// Does the paged DECODE path for this KV dtype apply learned attention sinks
+// (gpt-oss, #547)? This is the single source of truth for the question, and it
+// lives here because the answer is a property of the kernels, not of the model.
+//
+// It exists because the resolver used to answer it with a hand-maintained dtype
+// list (#1339, #1345): the sink term reaches the output only if the decode
+// kernel takes an `attn_sinks` pointer and hands it to
+// crosswarp_reduce_and_write, and every dtype wired up since had to be
+// remembered in a second place. Wire a dtype, add it here, and the fallback
+// stops firing for it — one edit, not two.
+//
+// FP16 has applied sinks since #547; FP8 since #1346. The rest route their
+// NON-split decode through crosswarp_reduce_and_write with no sink pointer, so
+// the shared split-K reduce being wired is not enough to make them correct.
+bool paged_attention_applies_sinks(QType kv_dtype);
+
 // Launch the split-K reduce kernel (shared across FP16/FP8/INT8).
 void paged_attention_launch_reduce(float* partial, half* O, int batch_size, int n_heads, int head_dim,
                                    int num_splits, cudaStream_t stream,

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -10,6 +10,7 @@
 #include "runtime/config.h"
 #include "runtime/vram_budget.h"
 #include "model/model_arch.h"
+#include "compute/attention_paged.h"
 #include "runtime/process_diag.h"
 #include "core/logging.h"
 #include "core/tensor.h"
@@ -219,11 +220,10 @@ void Engine::init_resolve_kv_dtype_policy_() {
     // ("Paris", the prime list, both finish_reason=stop) while FP8 KV emits no
     // content at all on either prompt (finish_reason=length, empty). Decide it
     // here, where the choice can still be changed.
-    if (config_.kv_cache_dtype != QType::F16 && config_.kv_cache_dtype != QType::FP8_E4M3 &&
-        mcfg.arch == ModelArch::GPT_OSS) {
+    if (!paged_attention_applies_sinks(config_.kv_cache_dtype) && mcfg.arch == ModelArch::GPT_OSS) {
         IMP_LOG_WARN("KV cache dtype: %s requested, but this architecture carries learned attention "
-                     "sinks and only the FP16 paged decode kernels apply them (#1339) — falling back "
-                     "to FP16 KV rather than serving a wrong softmax denominator.",
+                     "sinks, and the decode kernels for this dtype do not apply them (#1345) — "
+                     "falling back to FP16 KV rather than serving a wrong softmax denominator.",
                      qtype_name(config_.kv_cache_dtype));
         config_.kv_cache_dtype = QType::F16;
     }


### PR DESCRIPTION
The fallback that keeps a sink model off a KV dtype whose kernels drop the sink term was a hand-maintained list in the resolver:

```cpp
if (dtype != QType::F16 && dtype != QType::FP8_E4M3 && arch == GPT_OSS) { … }
```

The kernels decide that answer; the resolver repeated it. Wiring the next dtype would need both files changed — and the second one stays silently wrong if forgotten.

That is not a hypothetical failure mode. Three instances turned up in this codebase this week alone:

- the OR in `Engine::init`, justified by *"RuntimeConfig defaults for these match the EngineConfig defaults (off)"* — true when written, false after #758 flipped one of them, and a C-API embedder could no longer turn prefix caching off (#1337);
- the comment promising GGUF-MoE *"stays on the async conditional-graph loop"*, while the scheduler chopped it into bursts anyway because it asked the config flag instead of the gates (#1341);
- the first version of this very guard, keyed on `head_dim == 64`, which would have let `int8`, `int4` and `nvfp4` through — the same silent defect, minus the crash that made it visible.

`paged_attention_applies_sinks(QType)` now lives next to the kernels that answer it, with the reasoning in the comment. Wire a dtype, add it there, and the fallback stops firing for it: one edit instead of two, and the resolver stops encoding kernel knowledge.

## No behaviour change — verified, not assumed

| case | result |
|---|---|
| gpt-oss + `fp8` | `FP8_E4M3` — wired since #1346, still allowed |
| gpt-oss + `int8` / `int4` / `nvfp4` | `F16` — still guarded |
| dense Qwen3-4B (no sinks) + `int8` | `INT8` — untouched |
| `ctest -L unit` | 4/4 |

Refs #1345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx