### PR TITLE
fix(kv-cache): stop INT8 KV and the prefix cache from silently colliding

### DIFF
--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -228,6 +228,25 @@ void Engine::init_resolve_kv_dtype_policy_() {
         config_.kv_cache_dtype = QType::F16;
     }
 
+    // INT8 KV and the prefix cache do not compose. A cache hit prefills only the
+    // uncached tail, and that partial prefill routes its attention through the
+    // chunk path, whose KV dtypes are F16/FP8/NVFP4/MXFP4/INT4 — INT8 has no
+    // paged_kv_gather kernel. The failure is not a clean refusal: the second
+    // request for any prompt dies with
+    //   "chunked_prefill: unsupported KV dtype 67 — engine should have prevented this"
+    // and the client gets no HTTP response at all. Measured on Qwen3-4B-Q8_0,
+    // three identical requests: prefix_cache=true -> HTTP 200/000/000,
+    // prefix_cache=false -> 200/200/200.
+    //
+    // Prefix caching is the one that yields: it is a latency optimisation, while
+    // dropping INT8 would cost the memory the operator explicitly asked for.
+    if (config_.kv_cache_dtype == QType::INT8 && config_.use_prefix_caching) {
+        IMP_LOG_WARN("prefix cache: disabled because kv_cache.dtype=int8 — a cache hit prefills only "
+                     "the tail, and the partial-prefill attention path has no INT8 KV gather kernel "
+                     "(#1348). Use fp8/nvfp4/int4 KV to keep prefix caching.");
+        config_.use_prefix_caching = false;
+    }
+
     if (fp8_auto_legacy && config_.kv_cache_dtype == QType::F16 && !debug_raw_ && !force_kv_fp16 &&
         true) {
         config_.kv_cache_dtype = QType::FP8_E4M3;


### PR DESCRIPTION
Closes #1348.

With `kv_cache.dtype=int8` on the server, the **first** request for a prompt answers and every one after it dies with **no HTTP response at all** — `curl` reports `000`. The server stays up and reports healthy; only the requests stop coming back.

```
$ for i in 1 2 3; do curl -s -o /dev/null -w '%{http_code} ' -X POST … ; done
200 000 000
```

## Cause

A prefix-cache hit prefills only the uncached **tail**, and that partial prefill routes its attention through the chunk path, whose supported KV dtypes are `F16 / FP8_E4M3 / NVFP4 / MXFP4_KV / INT4`. INT8 is the one quantised dtype missing — `supports_chunked_prefill_()` carries the same list with the comment *"INT8 and TurboQuant variants would need their own gather kernels"*.

So request one (full prefill) is fine and request two (partial, after the hit) hits:

```
executor_attention_prefill.cu:32: chunked_prefill: unsupported KV dtype 67 at L0
                                  — engine should have prevented this
```

The message was right. Nothing prevented it.

| | request 1 / 2 / 3 |
|---|---|
| `server.prefix_cache=true` (default) | **200 / 000 / 000** |
| `server.prefix_cache=false` | 200 / 200 / 200 |

INT8 is alone in this: `int4`, `nvfp4`, `fp8` and `mxfp4` all answer 200/200/200 under identical conditions.

## The fix, and which side yields

INT8 KV disables prefix caching at init, with a WARN naming the reason and the dtypes that keep both. Prefix caching is the side that gives way: it is a latency optimisation, while dropping INT8 would cost the memory the operator explicitly asked for by setting the flag.

The real fix is the piece the code comment already names — an INT8 `paged_kv_gather` kernel so the partial-prefill path can serve it. Until that exists, the combination is refused rather than half-served.

## Verified

| check | result |
|---|---|
| int8, three identical requests | 200/000/000 → **200/200/200** |
| fp8 control (keeps prefix caching) | 200/200/200, unchanged |
| `ctest -L unit` | 4/4 |

## One dead end, recorded so it is not retried

My first attempt made the dtype check in `supports_chunked_prefill_()` unconditional instead of skipped when `kv_cache_raw_` is null. It reads like the bug — a guard that exists and is not always asked — and it changed **nothing measurable**, because the partial-prefill path after a cache hit is a different mechanism from configured chunked prefill. That change is not in this PR.

## How it surfaced

While wiring attention sinks into the INT8 decode path (#1345). The first symptom looked like "INT8 serves one request per process", which was wrong twice: it is per *prompt*, not per process, and it has nothing to do with sinks — a dense model with none reproduces it. The #1345 comment carrying that wrong description has been corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx