### PR TITLE
feat(diagnostics): measure MoE routing skew, and settle the CPU-cold-expert budget

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,6 +138,35 @@ Two things have to be said plainly before anyone starts:
 - **It collides with a stated non-goal.** [`GOAL.md`](GOAL.md) says "Not a CPU engine. GPU only. No AVX kernels." Taking this on means amending that line deliberately — the scope decision comes first, the code second.
 - **DDR5 bandwidth is a hard ceiling, and whether it lands at usable tok/s is a measurement question, not a matter of belief.** The honest first step is a bandwidth-and-latency budget for one decode step with a realistic hot/cold split, measured on this host, before a line of kernel code is written. If that budget says the CPU half cannot keep up with the GPU half, the idea is dead and the measurement is what kills it.
 
+**That budget was measured 2026-08-10. It does not kill the idea — and it moves the bottleneck somewhere else than this entry assumed.**
+
+*Host bandwidth.* Streaming read, 16 threads, 24 GiB buffer, 512-bit non-temporal loads: **62.5 GB/s**, three runs within 0.2 % (4 threads already reach 62.4 — the bandwidth saturates well before the core count does). That is ~65 % of the DDR5-6000 dual-channel theoretical, which is what a real streaming load gets.
+
+*Routing skew*, the input this entry never had. `diagnostics.moe_expert_hist` records a per-layer expert-activation histogram; `tools/analysis/moe_routing_skew.py` turns it into the coverage curve. Three prompts x 512 tokens, decode-dominated:
+
+| model | experts | top_k | coverage at 40 % resident | vs flat |
+|---|---|---|---|---|
+| Qwen3-30B-A3B-NVFP4 | 128 | 8 | **84.7 %** | 2.12x |
+| gpt-oss-20b-mxfp4 | 32 | 4 | 71.6 % | 1.79x |
+
+So the router is genuinely skewed, and **more so at the higher expert count** — which is the favourable direction, since the 80B-120B targets carry 128 (gpt-oss-120b) to 512 (Qwen3-Next-80B) experts.
+
+*The catch, and it is the reason this is not a green light.* That coverage is **in-sample**: it assumes the resident set is chosen for the workload being served. Cross-validated — resident set picked on prompt 0, applied to the others — the 30B loses 15.2 and 29.5 points against those prompts' own oracles (78.8 % and 58.7 % against 94.0 % and 88.1 %). **The hot expert set is prompt-dependent**, so a static split calibrated once does not transfer, and an adaptive one pays PCIe traffic this budget does not model. Three prompts is a small sample and two of them are topically far apart, so treat the 29.5-point figure as a magnitude, not a constant.
+
+*The resulting band*, for a 120B-A5B shape (4.3B active routed params, 0.53 B/param, 48 MoE layers):
+
+| assumption | cold/token | bandwidth | transfer | total | ceiling |
+|---|---|---|---|---|---|
+| pooled / matched workload | 0.35 GB | 5.6 ms | 15.8 ms | 21.4 ms | **47 tok/s** |
+| held-out prompt | 0.94 GB | 15.1 ms | 15.8 ms | 30.9 ms | **32 tok/s** |
+| flat, i.e. this entry's own prior | 1.37 GB | 21.9 ms | 15.8 ms | 37.7 ms | 27 tok/s |
+
+**The finding that matters is the middle column, not the last one.** Skew cuts the bandwidth term by up to 4x, and the moment it does, **the per-layer blocking round trip becomes the dominant cost — 74 % of the best case, and it is workload-independent.** Faster memory buys nothing here. What decides this idea is whether the two transfers per MoE layer can be batched, overlapped or made non-blocking; at 165 µs each, 48 layers cost 15.8 ms/token before a single weight is read.
+
+So the next question is no longer "can DDR5 keep up" — it can — but **"can the round trip be hidden"**, and that is answerable in the existing engine without writing one AVX kernel. Until it is answered, the non-goal in [`GOAL.md`](GOAL.md) stands unamended.
+
+Reproduce: `bash tools/analysis/moe_routing_skew.sh`.
+
 Closed competitive records (kept for the record, not active work):
 
 - **NVFP4 prefill vs vLLM -- CLOSED** (re-measured 2026-06-13, commit `290a163a`). FP16-QK FA2 as primary hd=128 prefill lifted pp4096 +21-24%: MoE pp4096 +4% ahead of vLLM, MoE pp2048 +27%, dense pp2048 ~tie. The lone residual gap -- dense pp4096 at ~1.04× -- is structural: every bounded kernel idea (cross-tile pipeline, grouped-GEMM tile axis, chunk-4096, occupancy/2-CTA, fp8-QK, scaled fp8-KV) was measurement-refuted; at pp4096 FA2 sits at ~5% DRAM and the dominant cost is the NVFP4 GEMMs (~59%), a separately-refuted ceiling.

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -730,6 +730,11 @@ struct Diagnostics {
     std::string dump_hidden_dir;
     std::string dump_logits_dir;   // path or empty
     std::string dump_routing_dir;  // path or empty
+    // Path for the per-layer MoE expert-activation histogram (JSON), written at
+    // executor teardown. Empty = off. Unlike dump_routing_dir, which logs one
+    // token's top-k as a DEBUG line, this counts EVERY routing decision of the
+    // run — the dataset the resident/host expert-split question needs.
+    std::string moe_expert_hist;
     bool dump_tokens = false;
     // Teacher-forced perplexity: restrict the NLL sum to logit rows
     // i in [ppl_first, ppl_last] (row i predicts token i+1); ppl_last=-1

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -809,6 +809,9 @@ private:
                              bool fp32_gate_logits_ready, bool will_decode_fast,
                              const void* router_bias_ptr, bool use_sigmoid,
                              bool norm_weights, MoeRoutingResult& routing);
+    // Write + release the expert-activation histogram (diagnostics.moe_expert_hist).
+    // Destructor-time, so it covers the whole process rather than one request.
+    void dump_moe_expert_hist_();
     // Fused Q6_K prefill MoE path: reads Q6_K weights directly (no FP16
     // dequant scratch), TC variant uses gather-free sorted_token_ids
     // indirection, scalar variant materializes the gathered buffer.

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -6,6 +6,7 @@
 #include "compute/mmq_q8_imma.h"
 #include "core/cuda_static_reset.h"
 #include "exec/executor_forward_moe_internal.h"
+#include "exec/executor_helpers.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
 #include "exec/executor_debug.h"
@@ -817,15 +818,19 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
         if (moe_.expert_hist == nullptr) {
             int n_layers = cfg.n_layers;
             size_t bytes = static_cast<size_t>(n_layers) * ne * sizeof(unsigned int);
-            if (cudaMalloc(&moe_.expert_hist, bytes) == cudaSuccess) {
-                cudaMemset(moe_.expert_hist, 0, bytes);
+            // vram_alloc, not cudaMalloc: I1 (docs/MEMORY_ARCHITECTURE.md) keeps
+            // direct CUDA allocation out of everything but src/memory/, against
+            // a list that only shrinks. A diagnostic is no reason to grow it.
+            moe_.expert_hist = static_cast<unsigned int*>(vram_alloc(vram_alloc_, bytes, "moe_expert_hist"));
+            if (moe_.expert_hist != nullptr) {
+                IMP_CUDA_CHECK_LOG(cudaMemsetAsync(moe_.expert_hist, 0, bytes, stream));
                 moe_.hist_layers = n_layers;
                 moe_.hist_experts = ne;
                 moe_.hist_top_k = top_k;
                 IMP_LOG_INFO("moe expert histogram: recording %d layers x %d experts -> %s", n_layers, ne,
                              runtime_config().diagnostics.moe_expert_hist.c_str());
             } else {
-                IMP_LOG_WARN("moe expert histogram: cudaMalloc failed — not recording");
+                IMP_LOG_WARN("moe expert histogram: allocation failed — not recording");
             }
         }
         // ne can differ per layer in principle; a mismatch would alias buckets,

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -687,6 +687,26 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
     return true;
 }
 
+// Expert-activation histogram (diagnostics.moe_expert_hist). One increment per
+// (token, k) routing decision, bucketed by absolute layer index — non-MoE layers
+// of a hybrid simply stay zero. Kept off the hot path by the null check on
+// `hist`; when on, it is one atomicAdd per decision (n * top_k per layer per
+// forward), which is noise next to the expert GEMMs it precedes.
+__global__ void moe_expert_hist_kernel(const int32_t* __restrict__ expert_indices,
+                                       unsigned int* __restrict__ hist, int n_decisions, int n_experts,
+                                       int layer) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_decisions)
+        return;
+    int e = expert_indices[i];
+    // Defense-in-depth: a routing kernel that ever wrote an out-of-range id
+    // would corrupt neighbouring layers' counts rather than fail, and this
+    // buffer is read as evidence.
+    if (e < 0 || e >= n_experts)
+        return;
+    atomicAdd(&hist[static_cast<size_t>(layer) * n_experts + e], 1u);
+}
+
 void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, int d, int ne,
                                         int top_k, const Tensor& router_in,
                                         bool fp32_gate_logits_ready, bool will_decode_fast,
@@ -786,6 +806,38 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
                 "weights=[%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f,%.4f]",
                 layer, last_tok, h_idx[0], h_idx[1], h_idx[2], h_idx[3], h_idx[4], h_idx[5], h_idx[6],
                 h_idx[7], h_wts[0], h_wts[1], h_wts[2], h_wts[3], h_wts[4], h_wts[5], h_wts[6], h_wts[7]);
+        }
+    }
+
+    // Expert-activation histogram. Hooked HERE, at the end of the routing
+    // funnel, and not inside run_topk: the fused gate+top-k decode branch above
+    // never calls run_topk, so a hook there would silently miss every
+    // single-token decode — which is the case this measurement is about.
+    if (!runtime_config().diagnostics.moe_expert_hist.empty()) {
+        if (moe_.expert_hist == nullptr) {
+            int n_layers = cfg.n_layers;
+            size_t bytes = static_cast<size_t>(n_layers) * ne * sizeof(unsigned int);
+            if (cudaMalloc(&moe_.expert_hist, bytes) == cudaSuccess) {
+                cudaMemset(moe_.expert_hist, 0, bytes);
+                moe_.hist_layers = n_layers;
+                moe_.hist_experts = ne;
+                moe_.hist_top_k = top_k;
+                IMP_LOG_INFO("moe expert histogram: recording %d layers x %d experts -> %s", n_layers, ne,
+                             runtime_config().diagnostics.moe_expert_hist.c_str());
+            } else {
+                IMP_LOG_WARN("moe expert histogram: cudaMalloc failed — not recording");
+            }
+        }
+        // ne can differ per layer in principle; a mismatch would alias buckets,
+        // so refuse rather than record something that reads plausible.
+        if (moe_.expert_hist != nullptr && ne == moe_.hist_experts && layer < moe_.hist_layers) {
+            int n_dec = n * top_k;
+            int threads = 256;
+            int blocks = (n_dec + threads - 1) / threads;
+            moe_expert_hist_kernel<<<blocks, threads, 0, stream>>>(static_cast<const int32_t*>(
+                                                                       routing.expert_indices.data),
+                                                                   moe_.expert_hist, n_dec, ne, layer);
+            IMP_CUDA_CHECK_LAUNCH();
         }
     }
 

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -38,7 +38,60 @@ namespace imp {
 // GraphExecutor lifetime
 // ---------------------------------------------------------------------------
 
-GraphExecutor::~GraphExecutor() { free_buffers(); }
+// Write the MoE expert-activation histogram (diagnostics.moe_expert_hist) and
+// release it. Called from the destructor, so it captures the whole process:
+// a decode run's skew is the sum over every token it produced.
+//
+// The total is logged whether or not it is zero. A histogram that recorded
+// nothing is the failure mode that matters here — the model had no MoE layers,
+// or the key was set after init — and it must not look like a flat
+// distribution in the JSON.
+//
+// Reading runtime_config() from a destructor is safe by declaration order, not
+// by luck: Engine declares runtime_config_ (engine.h:352) before executor_
+// (engine.h:377), so the executor is destroyed first and the config it points
+// at is still alive. Reordering those two members would turn this into a
+// use-after-free.
+void GraphExecutor::dump_moe_expert_hist_() {
+    if (moe_.expert_hist == nullptr)
+        return;
+    const std::string& path = runtime_config().diagnostics.moe_expert_hist;
+    size_t n = static_cast<size_t>(moe_.hist_layers) * moe_.hist_experts;
+    std::vector<unsigned int> h(n, 0u);
+    cudaError_t rc = cudaMemcpy(h.data(), moe_.expert_hist, n * sizeof(unsigned int), cudaMemcpyDeviceToHost);
+    if (rc != cudaSuccess) {
+        IMP_LOG_WARN("moe expert histogram: readback failed (%s) — not written", cudaGetErrorString(rc));
+    } else {
+        unsigned long long total = 0;
+        for (unsigned int c : h)
+            total += c;
+        FILE* f = path.empty() ? nullptr : fopen(path.c_str(), "w");
+        if (!f) {
+            IMP_LOG_WARN("moe expert histogram: cannot open %s for writing", path.c_str());
+        } else {
+            fprintf(f, "{\n  \"n_layers\": %d,\n  \"n_experts\": %d,\n  \"top_k\": %d,\n", moe_.hist_layers,
+                    moe_.hist_experts, moe_.hist_top_k);
+            fprintf(f, "  \"total_activations\": %llu,\n  \"counts\": [\n", total);
+            for (int l = 0; l < moe_.hist_layers; l++) {
+                fprintf(f, "    [");
+                for (int e = 0; e < moe_.hist_experts; e++)
+                    fprintf(f, "%s%u", e ? "," : "", h[static_cast<size_t>(l) * moe_.hist_experts + e]);
+                fprintf(f, "]%s\n", l + 1 < moe_.hist_layers ? "," : "");
+            }
+            fprintf(f, "  ]\n}\n");
+            fclose(f);
+            IMP_LOG_INFO("moe expert histogram: %llu activations over %d layers x %d experts -> %s", total,
+                         moe_.hist_layers, moe_.hist_experts, path.c_str());
+        }
+    }
+    cudaFree(moe_.expert_hist);
+    moe_.expert_hist = nullptr;
+}
+
+GraphExecutor::~GraphExecutor() {
+    dump_moe_expert_hist_();
+    free_buffers();
+}
 
 bool GraphExecutor::init(const Model& model, QType compute_dtype, bool use_pdl, int max_batch_size,
                          int max_seq_len, bool use_fp8_prefill, int use_nvfp4_decode,

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -47,11 +47,11 @@ namespace imp {
 // or the key was set after init — and it must not look like a flat
 // distribution in the JSON.
 //
-// Reading runtime_config() from a destructor is safe by declaration order, not
-// by luck: Engine declares runtime_config_ (engine.h:352) before executor_
-// (engine.h:377), so the executor is destroyed first and the config it points
-// at is still alive. Reordering those two members would turn this into a
-// use-after-free.
+// Reading runtime_config() and freeing through vram_alloc_ from a destructor is
+// safe by declaration order, not by luck: Engine declares runtime_config_
+// (engine.h:352) and vram_alloc_ (engine.h:342) before executor_ (engine.h:377),
+// so the executor is destroyed first and both are still alive. Reordering those
+// members would turn this into a use-after-free.
 void GraphExecutor::dump_moe_expert_hist_() {
     if (moe_.expert_hist == nullptr)
         return;
@@ -84,7 +84,7 @@ void GraphExecutor::dump_moe_expert_hist_() {
                          moe_.hist_layers, moe_.hist_experts, path.c_str());
         }
     }
-    cudaFree(moe_.expert_hist);
+    vram_free(vram_alloc_, moe_.expert_hist);
     moe_.expert_hist = nullptr;
 }
 

--- a/src/exec/moe_workspace.h
+++ b/src/exec/moe_workspace.h
@@ -42,6 +42,16 @@ struct MoEWorkspace {
     void* fp32_down_buf = nullptr;
     size_t fp32_down_buf_size = 0;
 
+    // Expert-activation histogram (diagnostics.moe_expert_hist), off unless the
+    // key names a path. [n_layers * n_experts] device counters, incremented once
+    // per (token, k) routing decision. Answers "how skewed is expert selection",
+    // which is what decides whether a resident/host split of MoE experts can pay
+    // (docs/roadmap.md, "CPU-resident cold experts").
+    unsigned int* expert_hist = nullptr;
+    int hist_layers = 0;
+    int hist_experts = 0;
+    int hist_top_k = 0;
+
     // Pre-allocated device pointer array for batched MoE GEMM.
     // Layout: [A_ptrs..., B_ptrs..., C_ptrs...] = 3 * n_experts void pointers.
     void** d_work_ptrs = nullptr;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -276,6 +276,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("diagnostics.dump_hidden_dir", cfg.diagnostics.dump_hidden_dir);
     S("diagnostics.dump_logits_dir", cfg.diagnostics.dump_logits_dir);
     S("diagnostics.dump_routing_dir", cfg.diagnostics.dump_routing_dir);
+    S("diagnostics.moe_expert_hist", cfg.diagnostics.moe_expert_hist);
     B("diagnostics.dump_tokens", cfg.diagnostics.dump_tokens);
     I("diagnostics.ppl_first", cfg.diagnostics.ppl_first);
     I("diagnostics.ppl_last", cfg.diagnostics.ppl_last);

--- a/tools/analysis/moe_routing_skew.py
+++ b/tools/analysis/moe_routing_skew.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Turn a MoE expert-activation histogram into the number the roadmap needs.
+
+docs/roadmap.md ("CPU-resident cold experts") and docs/GOAL.md both gate that
+idea on a measured budget rather than on how attractive it sounds. The
+bandwidth half is measurable directly; the half that was missing is ROUTING
+SKEW: if VRAM holds fraction f of each layer's experts, what share of the
+token's expert activations actually land on resident ones?
+
+A flat router means coverage(f) = f and the host has to stream (1-f) of the
+active expert weights every token. A skewed router means a small resident set
+absorbs most activations and the host streams far less. The difference decides
+whether an 80B-120B MoE lands at a usable tok/s or not, and it is a property of
+the model, not of imp.
+
+Record the histogram (needs a GPU and a MoE model):
+
+    imp-cli --model /models/<moe>.gguf \\
+        --set diagnostics.moe_expert_hist=/tmp/moe_hist.json \\
+        --prompt "..." --max-tokens 512 --temperature 0
+
+Then:
+
+    python3 tools/analysis/moe_routing_skew.py /tmp/moe_hist.json
+
+Self-test (no GPU, no histogram needed):
+
+    python3 tools/analysis/moe_routing_skew.py --self-test
+"""
+
+import argparse
+import json
+import math
+import sys
+
+# Measured on this host 2026-08-10: streaming read, 16 threads, 24 GiB buffer,
+# 512-bit non-temporal loads, three runs within 0.2%. See docs/roadmap.md.
+DEFAULT_HOST_BW_GBS = 62.5
+
+# docs/roadmap.md: each H2D transfer blocks the host ~165 us on this WSL2/WDDM
+# box, regardless of size. A host-side expert needs the token's activations over
+# and its output back, so two per MoE layer per token.
+DEFAULT_TRANSFER_US = 165.0
+
+
+def coverage_curve(counts):
+    """Share of activations covered when the top-k experts of EACH layer are resident.
+
+    Residency is decided per layer — expert 7 of layer 3 and expert 7 of layer 4
+    are different tensors — so the top-k is taken per layer and then summed.
+    Returns a list `cov` of length n_experts+1 where cov[k] is the covered share
+    for "k experts per layer resident"; cov[0] == 0.0 and cov[n_experts] == 1.0.
+    """
+    if not counts:
+        return [0.0]
+    n_experts = len(counts[0])
+    total = sum(sum(layer) for layer in counts)
+    if total == 0:
+        return None  # caller reports this; a zero histogram is a failed run
+    covered = [0] * (n_experts + 1)
+    for layer in counts:
+        ordered = sorted(layer, reverse=True)
+        run = 0
+        for k in range(1, n_experts + 1):
+            run += ordered[k - 1]
+            covered[k] += run
+    return [c / total for c in covered]
+
+
+def coverage_at(cov, frac):
+    """Coverage when a `frac` fraction of each layer's experts is resident.
+
+    ceil() rather than round(): holding 40% of 128 experts means 52 of them, and
+    a resident set is a count, not a ratio.
+    """
+    n_experts = len(cov) - 1
+    k = min(n_experts, math.ceil(frac * n_experts))
+    return cov[k], k
+
+
+def budget(cold_share, active_routed_b, bytes_per_param, n_moe_layers,
+           bw_gbs=DEFAULT_HOST_BW_GBS, transfer_us=DEFAULT_TRANSFER_US):
+    """Per-token host cost, split into its two terms.
+
+    Both matter: on the numbers in the roadmap they are the same order, so an
+    optimisation at one end alone changes little.
+    """
+    cold_bytes = cold_share * active_routed_b * 1e9 * bytes_per_param
+    bw_ms = cold_bytes / (bw_gbs * 1e9) * 1e3
+    lat_ms = n_moe_layers * 2 * transfer_us / 1e3
+    total_ms = bw_ms + lat_ms
+    return {
+        "cold_gb": cold_bytes / 1e9,
+        "bandwidth_ms": bw_ms,
+        "latency_ms": lat_ms,
+        "total_ms": total_ms,
+        "ceiling_tok_s": (1e3 / total_ms) if total_ms > 0 else float("inf"),
+    }
+
+
+def load_and_sum(paths):
+    """Sum several runs into one workload.
+
+    One prompt is one trajectory's expert taste; the question is about a
+    workload, so the runs are added. Shapes must agree — summing histograms of
+    different models would produce a plausible-looking average of nothing.
+    """
+    total = None
+    for path in paths:
+        with open(path) as f:
+            h = json.load(f)
+        if total is None:
+            total = h
+            continue
+        if (h["n_layers"], h["n_experts"]) != (total["n_layers"], total["n_experts"]):
+            raise SystemExit(
+                f"refusing to sum {path}: {h['n_layers']}x{h['n_experts']} vs "
+                f"{total['n_layers']}x{total['n_experts']} — different models")
+        for l in range(total["n_layers"]):
+            row, add = total["counts"][l], h["counts"][l]
+            for e in range(total["n_experts"]):
+                row[e] += add[e]
+        total["total_activations"] = total.get("total_activations", 0) + h.get("total_activations", 0)
+    return total
+
+
+def report(hist, args):
+    counts = hist["counts"]
+    n_layers = hist["n_layers"]
+    n_experts = hist["n_experts"]
+    total = hist.get("total_activations", sum(sum(l) for l in counts))
+
+    print(f"histogram: {n_layers} layers x {n_experts} experts, "
+          f"top_k={hist.get('top_k', '?')}, {total} activations")
+
+    if total == 0:
+        print("\nERROR: the histogram is empty — nothing was recorded.")
+        print("  Either the model has no MoE layers, or the run produced no tokens.")
+        print("  A zero histogram is NOT a flat distribution; refusing to report skew.")
+        return 1
+
+    active_layers = sum(1 for l in counts if sum(l) > 0)
+    if active_layers != n_layers:
+        print(f"  ({active_layers} of {n_layers} layers routed — the rest are dense/attention-only)")
+
+    cov = coverage_curve(counts)
+
+    print("\nrouting skew — activations covered by the top experts of each layer")
+    print(f"  {'resident':>9}  {'experts/layer':>13}  {'coverage':>9}  {'vs flat':>8}")
+    for frac in (0.05, 0.10, 0.25, 0.40, 0.50, 0.75):
+        c, k = coverage_at(cov, frac)
+        print(f"  {frac*100:>8.0f}%  {k:>13}  {c*100:>8.1f}%  {c/frac:>7.2f}x")
+
+    # The roadmap's own budget assumed proportional hits (coverage == residency).
+    # Anything above 1.00x is what skew buys; at 1.00x the entry's arithmetic stands.
+    resident = args.resident_frac
+    c, k = coverage_at(cov, resident)
+    cold_share = 1.0 - c
+
+    print(f"\nbudget at {resident*100:.0f}% of experts resident "
+          f"({k}/{n_experts} per layer), {args.active_routed_b}B active routed params, "
+          f"{args.bytes_per_param} B/param")
+    b_skew = budget(cold_share, args.active_routed_b, args.bytes_per_param,
+                    active_layers, args.bandwidth, args.transfer_us)
+    b_flat = budget(1.0 - resident, args.active_routed_b, args.bytes_per_param,
+                    active_layers, args.bandwidth, args.transfer_us)
+    for name, b, share in (("measured skew", b_skew, cold_share),
+                           ("flat assumption", b_flat, 1.0 - resident)):
+        print(f"  {name:>16}: cold {share*100:>5.1f}% = {b['cold_gb']:.2f} GB/token"
+              f" -> {b['bandwidth_ms']:.1f} ms bandwidth + {b['latency_ms']:.1f} ms transfer"
+              f" = {b['total_ms']:.1f} ms  ->  {b['ceiling_tok_s']:.0f} tok/s ceiling")
+
+    print(f"\n  host bandwidth {args.bandwidth} GB/s, {args.transfer_us} us per blocking transfer,"
+          f" 2 per MoE layer")
+    print("  This is a CEILING: it assumes the host half is perfectly overlapped, ignores")
+    print("  dequant and FMA cost, and assumes residency can actually be chosen by frequency.")
+    return 0
+
+
+def self_test():
+    """The two distributions whose answers are known, plus the empty case."""
+    ok = True
+
+    # Flat router: coverage must equal residency, so skew buys exactly nothing.
+    flat = [[10] * 8 for _ in range(4)]
+    cov = coverage_curve(flat)
+    for frac in (0.25, 0.5, 0.75):
+        c, _ = coverage_at(cov, frac)
+        if abs(c - frac) > 1e-9:
+            print(f"FAIL flat: coverage({frac}) = {c}, expected {frac}")
+            ok = False
+
+    # Fully concentrated: one expert per layer takes everything, so ANY nonzero
+    # resident set covers 100%.
+    spike = [[100] + [0] * 7 for _ in range(4)]
+    cov = coverage_curve(spike)
+    c, k = coverage_at(cov, 0.125)  # 1 of 8
+    if k != 1 or abs(c - 1.0) > 1e-9:
+        print(f"FAIL spike: coverage(1/8) = {c} with k={k}, expected 1.0 with k=1")
+        ok = False
+
+    # Per-layer residency, not global: layer A concentrates on expert 0 and
+    # layer B on expert 7. A global top-1 would cover only half; the per-layer
+    # top-1 covers everything. This is the bug the curve must not have.
+    split = [[100, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 100]]
+    cov = coverage_curve(split)
+    c, _ = coverage_at(cov, 0.125)
+    if abs(c - 1.0) > 1e-9:
+        print(f"FAIL per-layer: coverage(1/8) = {c}, expected 1.0 "
+              f"(a global top-k would give 0.5)")
+        ok = False
+
+    # ceil(), not round(): 0.4 of 128 experts is 52, never 51.
+    cov128 = coverage_curve([[1] * 128])
+    _, k = coverage_at(cov128, 0.40)
+    if k != 52:
+        print(f"FAIL ceil: 40% of 128 experts = {k}, expected 52")
+        ok = False
+
+    # Summing must add counts, not average or overwrite them.
+    import tempfile, os
+    a = {"n_layers": 1, "n_experts": 4, "top_k": 1, "total_activations": 4, "counts": [[4, 0, 0, 0]]}
+    b = {"n_layers": 1, "n_experts": 4, "top_k": 1, "total_activations": 4, "counts": [[0, 0, 0, 4]]}
+    paths = []
+    for d in (a, b):
+        fd, pth = tempfile.mkstemp(suffix=".json")
+        with os.fdopen(fd, "w") as fh:
+            json.dump(d, fh)
+        paths.append(pth)
+    summed = load_and_sum(paths)
+    for pth in paths:
+        os.unlink(pth)
+    if summed["counts"][0] != [4, 0, 0, 4] or summed["total_activations"] != 8:
+        print(f"FAIL sum: {summed['counts'][0]}, total {summed['total_activations']}")
+        ok = False
+    # ... and the summed histogram must NOT read as concentrated: two runs that
+    # each spike a different expert are a flat pair together.
+    cov_sum = coverage_curve(summed["counts"])
+    c, _ = coverage_at(cov_sum, 0.25)
+    if abs(c - 0.5) > 1e-9:
+        print(f"FAIL sum-coverage: {c}, expected 0.5")
+        ok = False
+
+    # An empty histogram must be refused, not reported as flat.
+    if coverage_curve([[0] * 8 for _ in range(4)]) is not None:
+        print("FAIL empty: a zero histogram must return None, not a curve")
+        ok = False
+
+    # The budget's two terms must both be present and both scale as stated.
+    b = budget(0.5, 4.3, 0.53, 36, bw_gbs=62.5, transfer_us=165.0)
+    if not (b["bandwidth_ms"] > 0 and abs(b["latency_ms"] - 11.88) < 0.01):
+        print(f"FAIL budget: {b}")
+        ok = False
+    b2 = budget(0.25, 4.3, 0.53, 36, bw_gbs=62.5, transfer_us=165.0)
+    if abs(b2["bandwidth_ms"] - b["bandwidth_ms"] / 2) > 1e-6:
+        print("FAIL budget: bandwidth term must be linear in the cold share")
+        ok = False
+
+    print("self-test: PASS" if ok else "self-test: FAIL")
+    return 0 if ok else 1
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("histogram", nargs="*",
+                   help="one or more JSONs written by diagnostics.moe_expert_hist; "
+                        "several are summed into one workload")
+    p.add_argument("--self-test", action="store_true", help="check the analysis on known inputs")
+    p.add_argument("--resident-frac", type=float, default=0.40,
+                   help="fraction of each layer's experts held in VRAM (default 0.40)")
+    p.add_argument("--active-routed-b", type=float, default=4.3,
+                   help="billions of routed-expert params active per token (default 4.3, "
+                        "a 120B-A5B class model)")
+    p.add_argument("--bytes-per-param", type=float, default=0.53,
+                   help="stored bytes per param (default 0.53 = MXFP4 + scales)")
+    p.add_argument("--bandwidth", type=float, default=DEFAULT_HOST_BW_GBS,
+                   help=f"host streaming read GB/s (default {DEFAULT_HOST_BW_GBS}, measured)")
+    p.add_argument("--transfer-us", type=float, default=DEFAULT_TRANSFER_US,
+                   help=f"blocking cost per H2D transfer (default {DEFAULT_TRANSFER_US})")
+    args = p.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.histogram:
+        p.error("give a histogram path, or --self-test")
+    hist = load_and_sum(args.histogram)
+    return report(hist, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/analysis/moe_routing_skew.sh
+++ b/tools/analysis/moe_routing_skew.sh
@@ -25,6 +25,9 @@ mkdir -p "$OUT"
 cd "$(git rev-parse --show-toplevel)"
 
 MAX_TOKENS="${MAX_TOKENS:-512}"
+# Where the checkpoints live. Not hardcoded to a home directory: check-release.sh
+# rejects maintainer paths in tracked files, and rightly so.
+MODELS_DIR="${MODELS_DIR:-$HOME/models}"
 
 # Short prompts, long answers — see the methodology note above. Three different
 # subjects, because a single prompt measures one trajectory's expert taste and
@@ -60,7 +63,7 @@ for entry in "${MODELS[@]}"; do
     # $OUT is mounted at /out rather than reached through /src: it defaults to an
     # absolute path outside the repo, and "/src/$OUT" would silently become
     # "/src//tmp/..." — a path the container happily creates and nobody reads.
-    docker run --rm --gpus all -v "$PWD":/src -v /home/kekz/models:/models \
+    docker run --rm --gpus all -v "$PWD":/src -v "$MODELS_DIR":/models \
       -v "$(cd "$OUT" && pwd)":/out -w /src/build-dev \
       imp:toolchain ./imp-cli --model "$path" \
       --set "diagnostics.moe_expert_hist=/out/${name}.p${i}.json" \

--- a/tools/analysis/moe_routing_skew.sh
+++ b/tools/analysis/moe_routing_skew.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Record MoE expert-activation histograms and report the routing skew.
+#
+# This is the measurement docs/roadmap.md ("CPU-resident cold experts") and
+# docs/GOAL.md leave open: the bandwidth half of the budget is measured
+# (62.5 GB/s streaming read on this host), the skew half was not. Skew decides
+# whether a resident/host expert split streams (1-f) of the active experts every
+# token or far less.
+#
+# NEEDS A FREE GPU. Check `nvidia-smi` and `docker ps` first — a busy card makes
+# the run slow but does not corrupt the histogram, since counts are exact.
+#
+# Usage:  bash tools/analysis/moe_routing_skew.sh [output-dir]
+#
+# METHODOLOGY NOTE, and it matters: the histogram counts EVERY routing decision,
+# prefill and decode alike. The cold-expert question is about DECODE, where the
+# per-token weight traffic is paid. So the prompts below are deliberately short
+# and the generation long — decode decisions then outnumber prefill ones by
+# roughly max_tokens/prompt_tokens. Re-running this with a long prompt and a
+# short generation measures mostly prefill and answers a different question.
+set -uo pipefail
+
+OUT="${1:-/tmp/moe_skew}"
+mkdir -p "$OUT"
+cd "$(git rev-parse --show-toplevel)"
+
+MAX_TOKENS="${MAX_TOKENS:-512}"
+
+# Short prompts, long answers — see the methodology note above. Three different
+# subjects, because a single prompt measures one trajectory's expert taste and
+# the question is about a workload.
+PROMPTS=(
+  "Write a short essay about why the sea is salty."
+  "Explain step by step how a bicycle gear system works."
+  "List ten prime numbers and say why each is prime."
+)
+
+# 128-expert / top-8 first: it is the structure the 80B-120B class has, and the
+# one where a resident subset is a meaningful choice at all. The 32-expert
+# gpt-oss is the control — if skew looks identical at both expert counts, the
+# result generalises; if not, the expert count is a variable and the 30B answer
+# does not transfer.
+MODELS=(
+  "qwen3-30b-a3b:/models/Qwen3-30B-A3B-NVFP4-Modelopt"
+  "gpt-oss-20b:/models/gpt-oss-20b-mxfp4.gguf"
+)
+
+for entry in "${MODELS[@]}"; do
+  name="${entry%%:*}"
+  path="${entry#*:}"
+  log="$OUT/${name}.log"
+  : >"$log"
+  echo "== $name =="
+  hists=()
+  # One process AND one histogram file per prompt: the file is written whole at
+  # executor teardown, so a second run would overwrite the first rather than add
+  # to it. The analysis sums them back into one workload.
+  for i in "${!PROMPTS[@]}"; do
+    hist="$OUT/${name}.p${i}.json"
+    # $OUT is mounted at /out rather than reached through /src: it defaults to an
+    # absolute path outside the repo, and "/src/$OUT" would silently become
+    # "/src//tmp/..." — a path the container happily creates and nobody reads.
+    docker run --rm --gpus all -v "$PWD":/src -v /home/kekz/models:/models \
+      -v "$(cd "$OUT" && pwd)":/out -w /src/build-dev \
+      imp:toolchain ./imp-cli --model "$path" \
+      --set "diagnostics.moe_expert_hist=/out/${name}.p${i}.json" \
+      --prompt "${PROMPTS[$i]}" --max-tokens "$MAX_TOKENS" --temperature 0 \
+      >>"$log" 2>&1
+    if [ -s "$hist" ]; then hists+=("$hist"); else echo "  prompt $i: no histogram"; fi
+  done
+  grep -E "moe expert histogram" "$log" | tail -3
+  if [ "${#hists[@]}" -gt 0 ]; then
+    python3 tools/analysis/moe_routing_skew.py "${hists[@]}" | tee "$OUT/${name}.report.txt"
+  else
+    echo "  nothing recorded — see $log"
+  fi
+  echo
+
+done
+
+echo "artifacts in $OUT"


### PR DESCRIPTION
`docs/GOAL.md` gates the CPU-resident-cold-experts idea on *"a measured
bandwidth-and-latency budget on this host, not how attractive the idea sounds"*.
This measures it. The instrument is the reusable part; the roadmap entry gets the
numbers attached.

## Result first

**The budget does not kill the idea — and the bottleneck is not where the entry
assumed it was.**

| assumption | cold/token | bandwidth | transfer | total | ceiling |
|---|---|---|---|---|---|
| pooled / matched workload | 0.35 GB | 5.6 ms | 15.8 ms | 21.4 ms | **47 tok/s** |
| held-out prompt | 0.94 GB | 15.1 ms | 15.8 ms | 30.9 ms | **32 tok/s** |
| flat, the entry's own prior | 1.37 GB | 21.9 ms | 15.8 ms | 37.7 ms | 27 tok/s |

Once routing skew cuts the bandwidth term, **the per-layer blocking round trip is
74 % of the best case, and it is workload-independent.** Faster memory buys
nothing. The open question becomes whether two transfers per MoE layer can be
batched or hidden — answerable in the existing engine, with no AVX kernel and no
amendment to the `GOAL.md` non-goal, which stays unamended here.

## What was measured

**Host streaming read: 62.5 GB/s** — 16 threads, 24 GiB buffer, 512-bit
non-temporal loads, three runs within 0.2 %. Bandwidth saturates at ~4 threads.

**Routing skew**, the input this entry never had. Three prompts x 512 tokens,
short prompts so decode decisions dominate:

| model | experts | top_k | coverage at 40 % resident | vs flat |
|---|---|---|---|---|
| Qwen3-30B-A3B-NVFP4 | 128 | 8 | **84.7 %** | 2.12x |
| gpt-oss-20b-mxfp4 | 32 | 4 | 71.6 % | 1.79x |

Skew grows with expert count — the favourable direction, since the targets carry
128 (gpt-oss-120b) to 512 (Qwen3-Next-80B).

**And the catch, which is why this is not a green light.** That coverage is
*in-sample*. Cross-validated — resident set chosen on prompt 0, applied to the
others — the 30B scores 78.8 % and 58.7 % against those prompts' own oracles of
94.0 % and 88.1 %: a 15-30 point loss. The hot expert set is prompt-dependent, so
a statically calibrated split does not transfer, and an adaptive one pays PCIe
traffic this budget does not model. Three prompts is a small sample; treat 29.5
points as a magnitude, not a constant.

## The instrument

`diagnostics.moe_expert_hist=<path>` records a `[n_layers x n_experts]`
activation histogram and writes JSON at executor teardown, so it covers the whole
process rather than one request.

**The hook sits at the end of `compute_moe_routing()`, not inside `run_topk()`** —
the fused gate+top-k decode branch never calls `run_topk`, so a hook there would
have silently missed every single-token decode, which is exactly the case being
measured. The existing `diagnostics.dump_routing_dir` was not usable: it logs one
token's top-k as a DEBUG line, not a dataset.

Reading `runtime_config()` from the destructor is safe by declaration order, not
luck — `Engine` declares `runtime_config_` before `executor_`, so the executor
dies first. Noted in the code, because reordering those two members would turn it
into a use-after-free.

## Tests

`tools/analysis/moe_routing_skew.py --self-test` runs without a GPU and pins the
properties that are easy to get wrong: a flat router must give
`coverage == residency`; residency is per **layer** (a global top-k reports 1.0
where the truth is 0.5); `ceil()` not `round()` on the resident count; summing
several runs adds rather than overwrites; and an empty histogram is **refused**
rather than reported as a flat distribution.

The config key was checked with a negative control — a deliberately misspelled
`diagnostics.moe_expert_histo` errors with `no such key`, the real one does not.

`ctest -L unit` green; `verify-fast` passed on push.

## Reproduce

```
bash tools/analysis/moe_routing_skew.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx