### PR TITLE
docs(roadmap): measure the host round trip — and withdraw the claim it dominates

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -153,19 +153,34 @@ So the router is genuinely skewed, and **more so at the higher expert count** �
 
 *The catch, and it is the reason this is not a green light.* That coverage is **in-sample**: it assumes the resident set is chosen for the workload being served. Cross-validated — resident set picked on prompt 0, applied to the others — the 30B loses 15.2 and 29.5 points against those prompts' own oracles (78.8 % and 58.7 % against 94.0 % and 88.1 %). **The hot expert set is prompt-dependent**, so a static split calibrated once does not transfer, and an adaptive one pays PCIe traffic this budget does not model. Three prompts is a small sample and two of them are topically far apart, so treat the 29.5-point figure as a magnitude, not a constant.
 
+*The transfer term, measured rather than assumed.* The 165 µs figure quoted above for a blocking transfer is what a *host call* costs, not what a completed round trip costs, and using it twice per layer overstates the real thing by ~3.8x. Measured directly on this box at 8 KiB (one token's activations at d_model 4096), medians over 300 reps, idle GPU:
+
+| | µs |
+|---|---|
+| single D2H + synchronize | 45.4 |
+| **D2H + H2D, no kernel between — the cold-expert shape** | **86.2** |
+| D2H + kernel + H2D | 126.5 |
+| bare kernel launch + synchronize | 34.6 |
+
+The three add up, so the split is clean: a GPU kernel between the transfers costs its own launch, and the cold-expert path has none there — the host is what computes. The cost is also **size-independent** (8 KiB, 64 KiB and 1 MiB all land within noise of each other), which is what makes it latency and not bandwidth. So one MoE layer's round trip is 86 µs and 48 of them are **4.1 ms/token**, not 15.8.
+
+A trap worth recording, because it is what made the old figure look plausible: a small **pageable** H2D returns before the transfer has completed — CUDA stages it — so timing `cudaMemcpy` on pageable memory measures the staging, not the arrival. Pinned memory times *slower* here (45 vs 22 µs) for exactly that reason, not because pinning is worse. Only synchronized numbers are comparable.
+
 *The resulting band*, for a 120B-A5B shape (4.3B active routed params, 0.53 B/param, 48 MoE layers):
 
 | assumption | cold/token | bandwidth | transfer | total | ceiling |
 |---|---|---|---|---|---|
-| pooled / matched workload | 0.35 GB | 5.6 ms | 15.8 ms | 21.4 ms | **47 tok/s** |
-| held-out prompt | 0.94 GB | 15.1 ms | 15.8 ms | 30.9 ms | **32 tok/s** |
-| flat, i.e. this entry's own prior | 1.37 GB | 21.9 ms | 15.8 ms | 37.7 ms | 27 tok/s |
+| pooled / matched workload | 0.35 GB | 5.6 ms | 4.1 ms | 9.7 ms | **103 tok/s** |
+| held-out prompt | 0.94 GB | 15.1 ms | 4.1 ms | 19.2 ms | **52 tok/s** |
+| flat, i.e. this entry's own prior | 1.37 GB | 21.9 ms | 4.1 ms | 26.0 ms | 38 tok/s |
 
-**The finding that matters is the middle column, not the last one.** Skew cuts the bandwidth term by up to 4x, and the moment it does, **the per-layer blocking round trip becomes the dominant cost — 74 % of the best case, and it is workload-independent.** Faster memory buys nothing here. What decides this idea is whether the two transfers per MoE layer can be batched, overlapped or made non-blocking; at 165 µs each, 48 layers cost 15.8 ms/token before a single weight is read.
+**So the binding constraint is the cold-weight stream after all, and it is set by how well the resident set matches the workload** — not by the round trip, which is a fifth of the budget at the pessimistic end. An intermediate revision of this entry claimed the opposite ("the round trip is 74 % of the best case, faster memory buys nothing"); that rested on the 165 µs estimate and is withdrawn by the measurement above.
 
-So the next question is no longer "can DDR5 keep up" — it can — but **"can the round trip be hidden"**, and that is answerable in the existing engine without writing one AVX kernel. Until it is answered, the non-goal in [`GOAL.md`](GOAL.md) stands unamended.
+Three caveats on the band, none of them small: it is measured on an **idle** GPU, so queueing under real decode load can only make the transfer term worse; it assumes the host compute is fully overlapped, which the sequential layer dependency makes non-trivial; and the residency figure is in-sample. Treat 52 tok/s as the honest end and 103 as the ceiling nobody should plan against.
 
-Reproduce: `bash tools/analysis/moe_routing_skew.sh`.
+The open question is therefore back to being a *quality* one: can a resident set be chosen that survives workload drift — an LRU over experts, with its eviction traffic priced in. That is measurable with the histogram already in the tree, and it needs no AVX kernel and no amendment to the [`GOAL.md`](GOAL.md) non-goal, which stands unamended.
+
+Reproduce: `bash tools/analysis/moe_routing_skew.sh` for the skew, `tools/analysis/host_transfer_latency.cu` for the transfer term.
 
 Closed competitive records (kept for the record, not active work):
 

--- a/tools/analysis/host_transfer_latency.cu
+++ b/tools/analysis/host_transfer_latency.cu
@@ -1,0 +1,64 @@
+// tools/analysis/host_transfer_latency.cu — what one MoE-layer host round trip
+// actually costs on this box (docs/roadmap.md, "CPU-resident cold experts").
+//
+// Build + run (needs a free GPU):
+//   docker run --rm --gpus all -v $PWD/tools/analysis:/w -w /w imp:toolchain \
+//     bash -c "nvcc -O3 -arch=sm_120 host_transfer_latency.cu -o hxl && ./hxl 300"
+//
+// Split the round trip: how much of it is the two transfers, and how much is
+// the kernel launch sitting between them? The cold-expert path has NO GPU
+// kernel there — the CPU is what computes — so launch overhead must not be
+// billed to the transfer.
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <cuda_runtime.h>
+using clk = std::chrono::steady_clock;
+static double us_since(clk::time_point t) {
+    return std::chrono::duration<double, std::micro>(clk::now() - t).count();
+}
+#define CK(x) do { cudaError_t e=(x); if(e!=cudaSuccess){printf("err %s L%d\n",cudaGetErrorString(e),__LINE__);exit(1);} } while(0)
+__global__ void touch(float* p, int n){int i=blockIdx.x*blockDim.x+threadIdx.x; if(i<n) p[i]+=1.0f;}
+static double med(std::vector<double> v){std::sort(v.begin(),v.end());return v[v.size()/2];}
+
+int main(int argc,char**argv){
+    int reps = argc>1?atoi(argv[1]):300;
+    size_t bytes = 8*1024;                       // one token's activations
+    void* d; CK(cudaMalloc(&d,bytes));
+    void* h; CK(cudaHostAlloc(&h,bytes,cudaHostAllocDefault));
+    cudaStream_t st; CK(cudaStreamCreate(&st));
+    for(int i=0;i<50;i++){CK(cudaMemcpyAsync(d,h,bytes,cudaMemcpyHostToDevice,st));CK(cudaStreamSynchronize(st));}
+
+    std::vector<double> d2h, rt_nokernel, rt_kernel, launch;
+    for(int i=0;i<reps;i++){
+        auto t=clk::now();
+        CK(cudaMemcpyAsync(h,d,bytes,cudaMemcpyDeviceToHost,st)); CK(cudaStreamSynchronize(st));
+        d2h.push_back(us_since(t));
+
+        // the cold-expert shape: pull activations out, push the result back.
+        // No GPU kernel in between — the host is what computes.
+        t=clk::now();
+        CK(cudaMemcpyAsync(h,d,bytes,cudaMemcpyDeviceToHost,st)); CK(cudaStreamSynchronize(st));
+        CK(cudaMemcpyAsync(d,h,bytes,cudaMemcpyHostToDevice,st)); CK(cudaStreamSynchronize(st));
+        rt_nokernel.push_back(us_since(t));
+
+        // same, with a kernel between — separates launch cost out
+        t=clk::now();
+        CK(cudaMemcpyAsync(h,d,bytes,cudaMemcpyDeviceToHost,st)); CK(cudaStreamSynchronize(st));
+        touch<<<8,256,0,st>>>((float*)d,(int)(bytes/4));
+        CK(cudaMemcpyAsync(d,h,bytes,cudaMemcpyHostToDevice,st)); CK(cudaStreamSynchronize(st));
+        rt_kernel.push_back(us_since(t));
+
+        t=clk::now(); touch<<<8,256,0,st>>>((float*)d,(int)(bytes/4)); CK(cudaStreamSynchronize(st));
+        launch.push_back(us_since(t));
+    }
+    printf("8 KiB, medians over %d reps:\n", reps);
+    printf("  single D2H + sync                      %7.1f us\n", med(d2h));
+    printf("  D2H + H2D, no kernel (cold-expert)     %7.1f us   <- one MoE layer\n", med(rt_nokernel));
+    printf("  D2H + kernel + H2D                     %7.1f us\n", med(rt_kernel));
+    printf("  bare kernel launch + sync              %7.1f us\n", med(launch));
+    printf("  => 48 layers, cold-expert shape:       %7.2f ms/token\n", med(rt_nokernel)*48/1000.0);
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #1356, which is on `main`. It left a number in the entry that I had
taken on trust rather than measured, and the number was wrong in the direction
that changes the conclusion.

## What was wrong

The entry priced a blocking transfer at 165 µs and billed two per MoE layer —
15.8 ms/token. That figure is what a *host call* costs, not what a completed
round trip costs.

Measured at 8 KiB (one token's activations at d_model 4096), medians over 300
reps, idle GPU:

| | µs |
|---|---|
| single D2H + synchronize | 45.4 |
| **D2H + H2D, no kernel between — the cold-expert shape** | **86.2** |
| D2H + kernel + H2D | 126.5 |
| bare kernel launch + synchronize | 34.6 |

The three add up, so the split is clean: a kernel between the transfers costs its
own launch, and the cold-expert path has none there — the host is what computes.
The cost is size-independent from 8 KiB to 1 MiB, i.e. latency and not bandwidth.

**48 layers cost 4.1 ms/token, not 15.8.**

## What that reverses

#1356 concluded: *"the per-layer blocking round trip becomes the dominant cost —
74 % of the best case, and it is workload-independent. Faster memory buys nothing
here."* With the measured figure that is **false**, and it is withdrawn in the
text rather than quietly edited, because it was published as a finding.

| assumption | bandwidth | transfer | total | ceiling |
|---|---|---|---|---|
| pooled / matched workload | 5.6 ms | 4.1 ms | 9.7 ms | **103 tok/s** |
| held-out prompt | 15.1 ms | 4.1 ms | 19.2 ms | **52 tok/s** |
| flat, the entry's own prior | 21.9 ms | 4.1 ms | 26.0 ms | 38 tok/s |

The cold-weight stream binds again, and what sets it is how well the resident set
matches the workload — the in-sample/held-out gap #1356 measured. So the open
question is back to being a quality one: can a resident set survive workload
drift, with its eviction traffic priced in. Measurable with the histogram already
in the tree; still no AVX kernel and no amendment to the `GOAL.md` non-goal.

## The trap that made the old number plausible

A small **pageable** H2D returns before the transfer has completed — CUDA stages
it — so timing `cudaMemcpy` on pageable memory measures the staging, not the
arrival. That is why pinned memory times *slower* here (45 vs 22 µs), which reads
as absurd until you notice the pageable call was never waiting for anything. Only
synchronized numbers are comparable, and the table above uses only those.

## Caveats stated in the entry, not buried

Idle GPU, so queueing under real decode can only make the transfer term worse;
host compute assumed fully overlapped, which the sequential layer dependency
makes non-trivial; residency in-sample. 52 tok/s is the honest end, 103 is the
ceiling nobody should plan against.

Harness: `tools/analysis/host_transfer_latency.cu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx