### PR TITLE
feat(diagnostics): per-token expert trace — and the locality that redirects the entry

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -190,7 +190,24 @@ Three caveats on the band, none of them small: it is measured on an **idle** GPU
 
 **The first prompt buys almost all of it, and then the curve goes flat.** Calibration is worth 38 → 63 tok/s; eight times the calibration data adds 8 more. What it does *not* buy is the last ~20 points: the gap to the oracle is genuine per-prompt variation in which experts run hot, and no static set closes it. So the 103 tok/s "matched workload" row above is not an operating point — 63-71 is, and 142 is what an oracle would get.
 
-That leaves the remaining 2x reachable only by an **adaptive** resident set, whose eviction traffic none of these budgets include — and that is now the question, rather than whether calibration is worth doing. It is measurable with the histogram already in the tree, needs no AVX kernel, and no amendment to the [`GOAL.md`](GOAL.md) non-goal, which stands unamended.
+*Is an adaptive resident set worth its eviction traffic?* Measured with a per-token expert trace (`diagnostics.moe_expert_trace`), and the answer redirects this entry away from its own premise.
+
+**Expert selection has strong temporal locality.** Median reuse distance is **2 tokens** — 45 % of selections repeat at the very next token, 80 % within eight. An LRU at the same 40 % residency therefore needs almost no traffic once warm: over three prompts on Qwen3-30B-A3B, steady-state hit rates are **94.7 % / 90.0 % / 95.3 %**, i.e. only **0.38-0.80 experts per layer per token** are new. The cache warms in ~64 tokens (13.8 % miss over the first 64, 5.3 % thereafter).
+
+That is 4-5x fewer misses than the corpus-calibrated static set achieves, and it needs no calibration at all — the cache converges on the prompt it is actually serving.
+
+**Which makes host-side compute the weaker design.** Two ways to serve a miss, priced for a 120B-A5B shape (~5.9 MB per expert, 48 layers):
+
+| design | per token | cost |
+|---|---|---|
+| static calibrated split, host computes the cold half | 105 experts, 620 MB from host RAM @ 62.5 GB/s | 9.9 ms + 4.1 ms round trips = **14.0 ms** |
+| LRU, stream the missing expert into VRAM, GPU computes | 20-39 experts, 120-228 MB over PCIe @ 25.6 GB/s | **4.7-8.9 ms** |
+
+Streaming also deletes the per-layer host round trip entirely, because the GPU never stops being the thing that computes. Measured PCIe H2D is 25.6 GB/s at a single expert's 6 MiB but 50.6 GB/s at 64 MiB, so batching several promotions is worth more than any host-side kernel would be.
+
+**And imp already has that mechanism**: `ExpertCache::get_or_load()` (`executor_forward_moe_legacy.cu`), with `moe.no_expert_cache` to switch it off. So the work this entry was reaching for is not an AVX kernel and not a `GOAL.md` amendment — it is whether that cache holds this hit rate for a model whose experts do not fit, and whether a promotion can be issued early enough. The latter is the same structural constraint entry 6 records for KV spill: routing for layer N is known only at layer N, so the fetch sits in front of the kernels rather than behind them.
+
+Caveats: one model as proxy, three prompts, 512 tokens each; expert size and layer count assumed for the 120B shape rather than measured; promotions priced as if serialised on the critical path, and the existing cache's behaviour under a genuinely non-fitting model is untested here.
 
 Sample caveats: one model, 512 tokens per prompt, and the k=8 row has a single held-out prompt per split (spread +-8.8 points against +-1.7 at k=3), so the flat middle of the curve is the trustworthy part, not its ends.
 

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -735,6 +735,12 @@ struct Diagnostics {
     // token's top-k as a DEBUG line, this counts EVERY routing decision of the
     // run — the dataset the resident/host expert-split question needs.
     std::string moe_expert_hist;
+    // Path for a per-token MoE expert TRACE (JSON), written at executor
+    // teardown. Empty = off. The histogram above is an aggregate and cannot see
+    // temporal locality, which is the whole question for a cache: an LRU pays
+    // only if an expert selected now is selected again soon. Decode only (n==1),
+    // so each record is one (token, layer).
+    std::string moe_expert_trace;
     bool dump_tokens = false;
     // Teacher-forced perplexity: restrict the NLL sum to logit rows
     // i in [ppl_first, ppl_last] (row i predicts token i+1); ppl_last=-1

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -812,6 +812,7 @@ private:
     // Write + release the expert-activation histogram (diagnostics.moe_expert_hist).
     // Destructor-time, so it covers the whole process rather than one request.
     void dump_moe_expert_hist_();
+    void dump_moe_expert_trace_();
     // Fused Q6_K prefill MoE path: reads Q6_K weights directly (no FP16
     // dequant scratch), TC variant uses gather-free sorted_token_ids
     // indirection, scalar variant materializes the gathered buffer.

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -708,6 +708,24 @@ __global__ void moe_expert_hist_kernel(const int32_t* __restrict__ expert_indice
     atomicAdd(&hist[static_cast<size_t>(layer) * n_experts + e], 1u);
 }
 
+// Per-token expert trace. One record per (token, layer): [layer, e0..e_{k-1}],
+// appended at an atomically claimed offset so records stay whole even though the
+// claim is concurrent. Capacity is checked before the claim is committed —
+// overrunning would corrupt the tail of a trace that is read as evidence.
+__global__ void moe_expert_trace_kernel(const int32_t* __restrict__ expert_indices, int* __restrict__ trace,
+                                        unsigned int* __restrict__ cursor, unsigned long long capacity,
+                                        int top_k, int layer) {
+    if (threadIdx.x != 0 || blockIdx.x != 0)
+        return;
+    unsigned int rec = 1u + static_cast<unsigned int>(top_k);
+    unsigned int off = atomicAdd(cursor, rec);
+    if (static_cast<unsigned long long>(off) + rec > capacity)
+        return;  // full: stop appending, the reader sees a short trace
+    trace[off] = layer;
+    for (int j = 0; j < top_k; j++)
+        trace[off + 1 + j] = expert_indices[j];
+}
+
 void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, int d, int ne,
                                         int top_k, const Tensor& router_in,
                                         bool fp32_gate_logits_ready, bool will_decode_fast,
@@ -842,6 +860,40 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
             moe_expert_hist_kernel<<<blocks, threads, 0, stream>>>(static_cast<const int32_t*>(
                                                                        routing.expert_indices.data),
                                                                    moe_.expert_hist, n_dec, ne, layer);
+            IMP_CUDA_CHECK_LAUNCH();
+        }
+    }
+
+    // Per-token expert trace. Decode only: a prefill call routes n tokens at once
+    // and would append n*top_k behind a single record header, which the reader
+    // cannot split back apart. Prefill decisions are not what a cache is judged
+    // on anyway — the per-token stream is.
+    if (n == 1 && !runtime_config().diagnostics.moe_expert_trace.empty()) {
+        if (moe_.expert_trace == nullptr) {
+            // 8M ints ~= 32 MiB: 512 tokens x 48 layers x (1+8) is 221k, so this
+            // holds a very long run before the capacity guard bites.
+            moe_.trace_capacity = 8u << 20;
+            moe_.expert_trace = static_cast<int*>(
+                vram_alloc(vram_alloc_, moe_.trace_capacity * sizeof(int), "moe_expert_trace"));
+            moe_.trace_cursor = static_cast<unsigned int*>(
+                vram_alloc(vram_alloc_, sizeof(unsigned int), "moe_trace_cursor"));
+            if (moe_.expert_trace != nullptr && moe_.trace_cursor != nullptr) {
+                IMP_CUDA_CHECK_LOG(cudaMemsetAsync(moe_.trace_cursor, 0, sizeof(unsigned int), stream));
+                moe_.trace_top_k = top_k;
+                IMP_LOG_INFO("moe expert trace: recording -> %s",
+                             runtime_config().diagnostics.moe_expert_trace.c_str());
+            } else {
+                vram_free(vram_alloc_, moe_.expert_trace);
+                vram_free(vram_alloc_, moe_.trace_cursor);
+                moe_.expert_trace = nullptr;
+                moe_.trace_cursor = nullptr;
+                IMP_LOG_WARN("moe expert trace: allocation failed — not recording");
+            }
+        }
+        if (moe_.expert_trace != nullptr && top_k == moe_.trace_top_k) {
+            moe_expert_trace_kernel<<<1, 32, 0, stream>>>(
+                static_cast<const int32_t*>(routing.expert_indices.data), moe_.expert_trace,
+                moe_.trace_cursor, static_cast<unsigned long long>(moe_.trace_capacity), top_k, layer);
             IMP_CUDA_CHECK_LAUNCH();
         }
     }

--- a/src/exec/executor_workspace.cu
+++ b/src/exec/executor_workspace.cu
@@ -88,8 +88,52 @@ void GraphExecutor::dump_moe_expert_hist_() {
     moe_.expert_hist = nullptr;
 }
 
+// Write the per-token expert trace (diagnostics.moe_expert_trace) and release
+// it. Same destructor-ordering argument as the histogram above.
+void GraphExecutor::dump_moe_expert_trace_() {
+    if (moe_.expert_trace == nullptr)
+        return;
+    const std::string& path = runtime_config().diagnostics.moe_expert_trace;
+    unsigned int used = 0;
+    cudaError_t rc = cudaMemcpy(&used, moe_.trace_cursor, sizeof(unsigned int), cudaMemcpyDeviceToHost);
+    if (rc == cudaSuccess) {
+        bool truncated = used > moe_.trace_capacity;
+        size_t n = std::min(static_cast<size_t>(used), moe_.trace_capacity);
+        std::vector<int> t(n, 0);
+        if (n > 0)
+            rc = cudaMemcpy(t.data(), moe_.expert_trace, n * sizeof(int), cudaMemcpyDeviceToHost);
+        const int rec = 1 + moe_.trace_top_k;
+        size_t records = (rc == cudaSuccess) ? n / rec : 0;
+        FILE* f = path.empty() ? nullptr : fopen(path.c_str(), "w");
+        if (!f) {
+            IMP_LOG_WARN("moe expert trace: cannot open %s for writing", path.c_str());
+        } else {
+            fprintf(f, "{\n  \"top_k\": %d,\n  \"records\": %zu,\n  \"truncated\": %s,\n", moe_.trace_top_k,
+                    records, truncated ? "true" : "false");
+            fprintf(f, "  \"trace\": [\n");
+            for (size_t r = 0; r < records; r++) {
+                fprintf(f, "    [");
+                for (int j = 0; j < rec; j++)
+                    fprintf(f, "%s%d", j ? "," : "", t[r * rec + j]);
+                fprintf(f, "]%s\n", r + 1 < records ? "," : "");
+            }
+            fprintf(f, "  ]\n}\n");
+            fclose(f);
+            IMP_LOG_INFO("moe expert trace: %zu records (top_k=%d)%s -> %s", records, moe_.trace_top_k,
+                         truncated ? " TRUNCATED" : "", path.c_str());
+        }
+    } else {
+        IMP_LOG_WARN("moe expert trace: cursor readback failed (%s)", cudaGetErrorString(rc));
+    }
+    vram_free(vram_alloc_, moe_.expert_trace);
+    vram_free(vram_alloc_, moe_.trace_cursor);
+    moe_.expert_trace = nullptr;
+    moe_.trace_cursor = nullptr;
+}
+
 GraphExecutor::~GraphExecutor() {
     dump_moe_expert_hist_();
+    dump_moe_expert_trace_();
     free_buffers();
 }
 

--- a/src/exec/moe_workspace.h
+++ b/src/exec/moe_workspace.h
@@ -52,6 +52,15 @@ struct MoEWorkspace {
     int hist_experts = 0;
     int hist_top_k = 0;
 
+    // Per-token expert trace (diagnostics.moe_expert_trace). Flat append of
+    // records [layer, e0..e_{top_k-1}], one per (token, layer), in stream order.
+    // Decode only — a prefill call would append n*top_k at once and break the
+    // fixed record stride the reader relies on.
+    int* expert_trace = nullptr;
+    unsigned int* trace_cursor = nullptr;  // device counter, in ints
+    size_t trace_capacity = 0;             // ints
+    int trace_top_k = 0;
+
     // Pre-allocated device pointer array for batched MoE GEMM.
     // Layout: [A_ptrs..., B_ptrs..., C_ptrs...] = 3 * n_experts void pointers.
     void** d_work_ptrs = nullptr;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -277,6 +277,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("diagnostics.dump_logits_dir", cfg.diagnostics.dump_logits_dir);
     S("diagnostics.dump_routing_dir", cfg.diagnostics.dump_routing_dir);
     S("diagnostics.moe_expert_hist", cfg.diagnostics.moe_expert_hist);
+    S("diagnostics.moe_expert_trace", cfg.diagnostics.moe_expert_trace);
     B("diagnostics.dump_tokens", cfg.diagnostics.dump_tokens);
     I("diagnostics.ppl_first", cfg.diagnostics.ppl_first);
     I("diagnostics.ppl_last", cfg.diagnostics.ppl_last);


### PR DESCRIPTION
Follow-up to #1358, which ended on: *is an adaptive resident set worth its
eviction traffic?* Measured — and the answer redirects the entry away from its
own premise.

## Expert selection has strong temporal locality

`diagnostics.moe_expert_trace` writes one record per (token, layer) with the
selected expert ids, decode only. The #1356 histogram is an aggregate and
structurally cannot see this.

Qwen3-30B-A3B, three prompts x 512 tokens:

- **median reuse distance: 2 tokens** — 45 % of selections repeat at the very
  next token, 80 % within eight
- LRU at the same 40 % residency: steady-state hit **94.7 % / 90.0 % / 95.3 %**
- i.e. **0.38-0.80 new experts per layer per token**, warming in ~64 tokens
  (13.8 % miss over the first 64, 5.3 % after)

That is 4-5x fewer misses than #1358's corpus-calibrated static set — with no
calibration at all, because the cache converges on the prompt it is serving.

## Which makes host-side compute the weaker design

Priced for a 120B-A5B shape (~5.9 MB/expert, 48 layers):

| design | per token | cost |
|---|---|---|
| static calibrated split, host computes the cold half | 105 experts, 620 MB from host RAM @ 62.5 GB/s | 9.9 ms + 4.1 ms round trips = **14.0 ms** |
| LRU, stream the missing expert into VRAM, GPU computes | 20-39 experts, 120-228 MB over PCIe @ 25.6 GB/s | **4.7-8.9 ms** |

Streaming also deletes the per-layer host round trip entirely — the GPU never
stops being the thing that computes. Measured PCIe H2D: 25.6 GB/s at one
expert's 6 MiB, 50.6 GB/s at 64 MiB, so **batching promotions is worth more than
any host-side kernel would be.**

## And imp already has the mechanism

`ExpertCache::get_or_load()` (`executor_forward_moe_legacy.cu`), with
`moe.no_expert_cache` to switch it off.

So the work this entry was reaching for is **not an AVX kernel and not a
`GOAL.md` amendment**. It is whether that cache holds this hit rate for a model
whose experts genuinely do not fit, and whether a promotion can be issued early
enough — routing for layer N is known only at layer N, the same structural
constraint entry 6 already records for KV spill.

## Caveats, in the text rather than buried

One model as proxy, three prompts, 512 tokens each; expert size and layer count
assumed for the 120B shape rather than measured; promotions priced as if
serialised on the critical path; the existing cache's behaviour under a genuinely
non-fitting model is untested here.

`ctest -L unit` green, `Alloc sites` clean (the trace allocates through
`vram_alloc` like everything else), `check-release.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx