### PR TITLE
docs(roadmap): a promotion can be hidden — but not by anything we can predict

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,7 +207,21 @@ Streaming also deletes the per-layer host round trip entirely, because the GPU n
 
 **And imp already has that mechanism**: `ExpertCache::get_or_load()` (`executor_forward_moe_legacy.cu`), with `moe.no_expert_cache` to switch it off. So the work this entry was reaching for is not an AVX kernel and not a `GOAL.md` amendment — it is whether that cache holds this hit rate for a model whose experts do not fit, and whether a promotion can be issued early enough. The latter is the same structural constraint entry 6 records for KV spill: routing for layer N is known only at layer N, so the fetch sits in front of the kernels rather than behind them.
 
-Caveats: one model as proxy, three prompts, 512 tokens each; expert size and layer count assumed for the 120B shape rather than measured; promotions priced as if serialised on the critical path, and the existing cache's behaviour under a genuinely non-fitting model is untested here.
+*What a promotion actually costs, and whether it can be hidden.* Measured with `tools/analysis/expert_promotion_overlap.cu`: 48 layers, one 6 MiB expert, a spin kernel standing in for per-layer compute, medians over 20 reps.
+
+| per-layer compute | baseline | promotion on the compute stream | prefetched one layer ahead on a copy stream |
+|---|---|---|---|
+| 100 µs | 4.80 ms | 15.47 ms (**+10.67**) | 5.45 ms (+0.66) |
+| 200 µs | 9.50 ms | 20.02 ms (**+10.53**) | 9.85 ms (+0.36) |
+| 400 µs | 18.86 ms | 29.56 ms (**+10.70**) | 19.19 ms (+0.32) |
+
+So copy/compute overlap **does** work on this box: given ≥100 µs of compute per layer, a prefetched promotion is all but free, while the same transfer issued in front of its consumer costs the full ~10.7 ms and hides nothing.
+
+**But the prefetch column is not reachable, and the reason is not engineering.** Issuing a fetch a layer early means knowing layer N+1's routing at layer N, and routing depends on that layer's own attention output. The obvious substitute — prefetch whatever the previous token used — was evaluated on the traces and does not carry: **42-47 % of a token's selections repeat from the token before** (63-68 % from a four-token window, at the price of holding ~19 experts per layer). Worse, it fails precisely where it would be needed: a miss is by definition an expert that was *not* recently used, which is the one case a recency predictor cannot supply.
+
+So promotions land in the first column, at the measured LRU rate rather than one per layer: 0.42 experts/layer/token is **~4.4 ms/token** of unhidden PCIe traffic for a 120B shape. Still ~3x better than the 14.0 ms of the host-compute design, and now the largest single term in it.
+
+Caveats: one model as proxy, three prompts, 512 tokens each; expert size and layer count assumed for the 120B shape rather than measured; the spin kernel is a stand-in for real per-layer compute; and the existing `ExpertCache`'s behaviour under a genuinely non-fitting model is still untested — that measurement, not another model, is the next thing worth doing.
 
 Sample caveats: one model, 512 tokens per prompt, and the k=8 row has a single held-out prompt per split (spread +-8.8 points against +-1.7 at k=3), so the flat middle of the curve is the trustworthy part, not its ends.
 

--- a/tools/analysis/expert_promotion_overlap.cu
+++ b/tools/analysis/expert_promotion_overlap.cu
@@ -1,0 +1,114 @@
+// Can an expert promotion be hidden behind compute, or does it stall the layer?
+//
+// docs/roadmap.md prices promotions as if serialised on the critical path,
+// because routing for layer N is known only at layer N. That is the pessimistic
+// reading. The optimistic one is a prefetch issued a layer early on a copy
+// stream. Which one holds depends on whether copy/compute overlap actually works
+// on this WSL2/WDDM box — so measure all three arms, don't assume.
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <cuda_runtime.h>
+#define CK(x) do{cudaError_t e=(x);if(e!=cudaSuccess){printf("err %s L%d\n",cudaGetErrorString(e),__LINE__);exit(1);} }while(0)
+using clk=std::chrono::steady_clock;
+static double ms(clk::time_point t){return std::chrono::duration<double,std::milli>(clk::now()-t).count();}
+static double med(std::vector<double> v){std::sort(v.begin(),v.end());return v[v.size()/2];}
+
+// Busy-wait kernel standing in for a layer's compute.
+__global__ void spin(long long cycles, float* sink) {
+    long long t0 = clock64();
+    while (clock64() - t0 < cycles) {}
+    if (threadIdx.x == 1023456) sink[0] = 1.0f;   // never taken; defeats DCE
+}
+__global__ void consume(const float* w, float* out, int n) {
+    int i = blockIdx.x*blockDim.x + threadIdx.x;
+    if (i < n) out[i % 256] += w[i];
+}
+
+int main(int argc, char** argv) {
+    const int LAYERS = 48;
+    const size_t EXPERT = 6u << 20;              // ~one expert of a 120B at 4 bit
+    const int reps = (argc>1)?atoi(argv[1]):20;
+    // clocks for a target per-layer compute time, calibrated below
+    float* d_sink; CK(cudaMalloc(&d_sink, 1024*sizeof(float)));
+    float* d_w;    CK(cudaMalloc(&d_w, EXPERT));
+    float* d_out;  CK(cudaMalloc(&d_out, 256*sizeof(float)));
+    void*  h_w;    CK(cudaHostAlloc(&h_w, EXPERT, cudaHostAllocDefault));
+
+    cudaStream_t comp, copy; CK(cudaStreamCreate(&comp)); CK(cudaStreamCreate(&copy));
+    std::vector<cudaEvent_t> ev(LAYERS);
+    for (auto& evt : ev) CK(cudaEventCreateWithFlags(&evt, cudaEventDisableTiming));
+
+    // calibrate: cycles for ~100 us
+    // Calibrate over MANY launches: one launch is mostly launch overhead, so a
+    // single-shot calibration set the spin an order of magnitude too short and
+    // the baseline came out 5x faster than the target.
+    long long cyc = 100000;
+    for (int i=0;i<4;i++){
+        const int K=200;
+        auto t=clk::now();
+        for(int k=0;k<K;k++) spin<<<1,32,0,comp>>>(cyc,d_sink);
+        CK(cudaStreamSynchronize(comp));
+        double per = ms(t)/K;
+        cyc = (long long)(cyc * (0.100/(per>1e-6?per:0.1)));
+    }
+    printf("calibrated: %lld cycles ~= 100 us/layer of compute\n\n", cyc);
+
+    for (double dur_us : {50.0, 100.0, 200.0, 400.0}) {
+        long long c = (long long)(cyc * dur_us / 100.0);
+        std::vector<double> base, naive, pref;
+        for (int r=0;r<reps;r++){
+            // (C) baseline: compute only, no promotion
+            auto t=clk::now();
+            for(int l=0;l<LAYERS;l++) spin<<<1,32,0,comp>>>(c,d_sink);
+            CK(cudaStreamSynchronize(comp)); base.push_back(ms(t));
+
+            // (A) naive: promotion issued on the compute stream, in front of the
+            //     consumer — the pessimistic reading, fully serialised
+            t=clk::now();
+            for(int l=0;l<LAYERS;l++){
+                spin<<<1,32,0,comp>>>(c,d_sink);
+                CK(cudaMemcpyAsync(d_w,h_w,EXPERT,cudaMemcpyHostToDevice,comp));
+                consume<<<64,256,0,comp>>>(d_w,d_out,64*256);
+            }
+            CK(cudaStreamSynchronize(comp)); naive.push_back(ms(t));
+
+            // (B) prefetch: promotion for layer l+1 issued on a copy stream at
+            //     the start of layer l, consumer waits on the event
+            t=clk::now();
+            CK(cudaMemcpyAsync(d_w,h_w,EXPERT,cudaMemcpyHostToDevice,copy));
+            CK(cudaEventRecord(ev[0],copy));
+            for(int l=0;l<LAYERS;l++){
+                spin<<<1,32,0,comp>>>(c,d_sink);
+                if(l+1<LAYERS){
+                    CK(cudaMemcpyAsync(d_w,h_w,EXPERT,cudaMemcpyHostToDevice,copy));
+                    CK(cudaEventRecord(ev[l+1],copy));
+                }
+                CK(cudaStreamWaitEvent(comp,ev[l],0));
+                consume<<<64,256,0,comp>>>(d_w,d_out,64*256);
+            }
+            CK(cudaStreamSynchronize(comp)); pref.push_back(ms(t));
+        }
+        // realistic: only ~42% of layers promote anything (measured LRU miss rate)
+        std::vector<double> real;
+        for(int r=0;r<reps;r++){
+            auto t=clk::now();
+            int pending=0;
+            for(int l=0;l<LAYERS;l++){
+                bool promote = ((l*42)/100) != (((l+1)*42)/100);
+                if(promote){ CK(cudaMemcpyAsync(d_w,h_w,EXPERT,cudaMemcpyHostToDevice,copy));
+                             CK(cudaEventRecord(ev[l],copy)); pending=l; }
+                spin<<<1,32,0,comp>>>(c,d_sink);
+                if(promote){ CK(cudaStreamWaitEvent(comp,ev[pending],0));
+                             consume<<<64,256,0,comp>>>(d_w,d_out,64*256); }
+            }
+            CK(cudaStreamSynchronize(comp)); real.push_back(ms(t));
+        }
+        double b=med(base), a=med(naive), p=med(pref), rr=med(real);
+        printf("  compute %5.0f us/layer: base %6.2f | naive %6.2f (+%5.2f) | prefetch-all %6.2f (+%5.2f) | prefetch@42%% %6.2f (+%5.2f)\n",
+               dur_us, b, a, a-b, p, p-b, rr, rr-b);
+    }
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #1359. It priced promotions as if serialised on the critical path
and flagged that as modelled, not measured. Measured now.

## Overlap works

`tools/analysis/expert_promotion_overlap.cu`: 48 layers, one 6 MiB expert, a spin
kernel standing in for per-layer compute, medians over 20 reps.

| per-layer compute | baseline | promotion on the compute stream | prefetched one layer ahead |
|---|---|---|---|
| 100 µs | 4.80 ms | 15.47 ms (**+10.67**) | 5.45 ms (+0.66) |
| 200 µs | 9.50 ms | 20.02 ms (**+10.53**) | 9.85 ms (+0.36) |
| 400 µs | 18.86 ms | 29.56 ms (**+10.70**) | 19.19 ms (+0.32) |

Copy/compute overlap is real on this box — above ~100 µs of per-layer compute a
prefetched promotion is all but free, while the same transfer issued in front of
its consumer costs the full ~10.7 ms and hides nothing.

## The prefetch column is not reachable

And not for want of engineering. Issuing the fetch a layer early means knowing
layer N+1's routing at layer N, and routing depends on that layer's own attention
output.

The obvious substitute — prefetch whatever the previous token used — was
evaluated on the traces from #1359 and does not carry:

| predictor | hit | prefetch set held |
|---|---|---|
| previous token | 42-47 % | 8 experts/layer |
| last 4 tokens | 63-68 % | ~19 experts/layer |

And it fails precisely where it would be needed: **a miss is by definition an
expert that was not recently used**, which is the one thing a recency predictor
cannot supply.

## What that leaves

Promotions land in the first column, at the measured LRU rate rather than one per
layer: 0.42 experts/layer/token is **~4.4 ms/token** of unhidden PCIe traffic for
a 120B shape. Still ~3x better than the 14.0 ms of the host-compute design this
entry started from, and now the largest single term in it.

Next thing worth doing is not another model but the real one: measure the
existing `ExpertCache` under a genuinely non-fitting checkpoint, instead of
modelling it.

## Note in the harness

A single-launch calibration set the spin kernel an order of magnitude short and
made the baseline look 5x too fast — the first run of this benchmark reported a
0.94 ms baseline where 4.80 ms was correct. Calibration now averages 200
launches, and the note is in the file so the next person does not repeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx