### PR TITLE
perf(moe): skip the expert LRU cache for a dispatch it cannot hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Changed
+
+- **MoE host-offload: the expert LRU cache is skipped for a dispatch it cannot
+  hold.** One dispatch touches three cells per *active* expert, so prefill asks
+  for 384 against the 73 slots a Qwen3-30B-A3B gets and the cache retains
+  nothing — measured 24.3 % hit rate against a 19 % structural ceiling. Gating
+  on working-set fit is worth a median +5.6 % pp512 (5/5 paired rounds) at no
+  decode cost, and lifts decode's own hit rate 88.7 % → 95.7 %. Output is
+  byte-identical. Measurement and the rest of the offload picture:
+  [`docs/roadmap.md`](docs/roadmap.md); harness
+  `tools/analysis/expert_cache_offload_sweep.sh`.
+
 ## [0.24.0] - 2026-08-10
 
 ### Added

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -221,7 +221,25 @@ So copy/compute overlap **does** work on this box: given ≥100 µs of compute p
 
 So promotions land in the first column, at the measured LRU rate rather than one per layer: 0.42 experts/layer/token is **~4.4 ms/token** of unhidden PCIe traffic for a 120B shape. Still ~3x better than the 14.0 ms of the host-compute design, and now the largest single term in it.
 
-Caveats: one model as proxy, three prompts, 512 tokens each; expert size and layer count assumed for the 120B shape rather than measured; the spin kernel is a stand-in for real per-layer compute; and the existing `ExpertCache`'s behaviour under a genuinely non-fitting model is still untested — that measurement, not another model, is the next thing worth doing.
+Caveats: one model as proxy, three prompts, 512 tokens each; expert size and layer count assumed for the 120B shape rather than measured; and the spin kernel is a stand-in for real per-layer compute.
+
+*Does the existing `ExpertCache` hold up when the experts genuinely do not fit? Measured 2026-08-11, and the answer is yes — but it was never the binding constraint.* `moe.force_host_experts=N` pins the last N MoE layers to host regardless of fit, which makes the whole range reachable on a model that otherwise fits. Qwen3-30B-A3B-Q4_K_M (48 layers, 128 experts, top_k 8, 1.23 MiB per expert matrix), all 48 MoE layers host-resident, `--bench-reps 3`:
+
+| arm | pp512 tok/s | tg256 tok/s | hit rate |
+|---|---|---|---|
+| experts fully resident (`N=0`) | 10580 | **311.24** | — |
+| host-resident, LRU cache | 254.20 | **24.98** | 88.7 % |
+| host-resident, staging buffer only | 308.11 | **6.63** | — |
+
+**The cache holds its hit rate and earns its keep: 88.7 % at full offload, ~0.9 new experts/layer/token — the same order as the 0.38-0.80 the traces predicted — and 3.8x the decode of the staging fallback it replaces.** The design this entry reached for is therefore not missing; it is in the tree and it works.
+
+**What the measurement moves is the ceiling.** Full offload still costs 12.5x against resident decode (311.24 → 24.98), and residual PCIe explains only part of it: at 88.7 % the misses move ~4.7 GB/s averaged over the run, well under the 25.6 GB/s this box reaches at a single expert's size. The rest is the dispatch shape — a host-resident layer fails the `on_device` test that selects the grouped GEMM, so it runs the serial per-expert path at 3·top_k = 24 launches per layer per token. **So the next lever is the dispatch, not the cache.**
+
+**Two things worth keeping, because neither was predicted.** *First, the budget runs the wrong way and it does not matter.* The pool is 15 % of **free** VRAM, so moving layers to host makes the cache **bigger** — 32 slots/layer at N=2 up to 73 at N=48, hit rate climbing 37.3 % → 89.4 % with it. The starvation this looked like it would produce never happens. *Second, prefill was thrashing the cache.* One dispatch touches `kExpertProjCount` cells per **active** expert, and at pp512 essentially every expert is active: 3·128 = 384 cells against 73 slots, i.e. a 73/384 = **19 % structural ceiling**, and a prefill-dominated run measures 24.3 % against it. Below that threshold the cache retains nothing and is strictly more work than the single-slot staging buffer for identical H2D bytes. Gating the cache on working-set fit is worth a median **+5.6 % pp512 (5/5 paired rounds positive)** at no decode cost, and lifts decode's own hit rate 88.7 % → 95.7 % once the thrashing accesses stop evicting it. Shipped.
+
+**A measurement trap on this path, recorded because it invalidated a first pass:** prefill throughput under host-resident experts varies ~15 % between two runs of the *same* arm, which is larger than every effect above. Only paired, alternating rounds decide anything here — and the decode number moves with how long the prefill was, because prefill is what warms the cache (pp8 → 72.7 % → 13.82 tok/s; pp512 → 88.7 % → 24.98). Two runs with different prompt histories are not an A/B.
+
+Reproduce: `tools/analysis/expert_cache_offload_sweep.sh` (`MODE=ab ROUNDS=5` for the paired comparison).
 
 Sample caveats: one model, 512 tokens per prompt, and the k=8 row has a single held-out prompt per split (spread +-8.8 points against +-1.7 at k=3), so the flat middle of the curve is the trustworthy part, not its ends.
 

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -73,6 +73,30 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                                            cudaMemcpyDeviceToHost, stream));
         cudaStreamSynchronize(stream);
 
+        // Use the LRU cache only when this dispatch's working set fits the
+        // layer's slot pool. One dispatch touches kExpertProjCount cells per
+        // ACTIVE expert; the pool holds slots_per_layer. Above that the cache
+        // retains nothing across the dispatch — every access misses and
+        // evicts — so it does strictly more work than the single-slot staging
+        // buffer for the same H2D bytes.
+        //
+        // Decode stays on the cache (top_k experts -> 3*top_k cells, well
+        // under the pool). Prefill is what overflows: at pp512 essentially
+        // every expert is active, so Qwen3-30B-A3B asks for 3*128 = 384 cells
+        // against 73 slots and the cache measures a 24.3% hit rate against a
+        // 73/384 = 19% structural ceiling. Skipping it there is worth a
+        // median +5.6% pp512 (5/5 paired rounds positive) at no decode cost;
+        // decode's own hit rate rises 88.7% -> 95.7% once the thrashing
+        // prefill accesses stop polluting the pool. Harness:
+        // tools/analysis/expert_cache_offload_sweep.sh
+        int n_active_experts = 0;
+        for (int e = 0; e < ne; ++e)
+            if (h_offsets[e + 1] > h_offsets[e])
+                ++n_active_experts;
+        const int dispatch_cells = n_active_experts * kExpertProjCount;
+        const bool use_expert_cache = expert_cache_.n_slots_ > 0 &&
+                                      dispatch_cells <= expert_cache_.slots_per_layer_;
+
         // Helper: dequant one expert's weight from packed tensor into dequant scratch slot 0.
         // Returns a Tensor view into the scratch buffer with shape [rows, cols], FP16.
         // Uses slot 0 always -- safe because all ops are on the same stream, so the previous
@@ -111,7 +135,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                 // Expert weights offloaded to host — try LRU cache first, then staging
                 // buffer.
                 const char* host_ptr = static_cast<const char*>(packed.data) + offset;
-                if (expert_cache_.n_slots_ > 0) {
+                if (use_expert_cache) {
                     ExpertCacheKey ck{packed.data, expert_idx};
                     void* cached = expert_cache_.get_or_load(layer, proj, ck, host_ptr,
                                                              expert_raw, stream);
@@ -269,7 +293,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                     size_t expert_raw = (size_t)rows * rb;
                     size_t offset = (size_t)eidx * expert_raw;
                     const char* host_ptr = static_cast<const char*>(packed.data) + offset;
-                    if (expert_cache_.n_slots_ > 0) {
+                    if (use_expert_cache) {
                         ExpertCacheKey ck{packed.data, eidx};
                         w = expert_cache_.get_or_load(layer, proj, ck, host_ptr,
                                                        expert_raw, stream);

--- a/tools/analysis/expert_cache_offload_sweep.sh
+++ b/tools/analysis/expert_cache_offload_sweep.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Measure the MoE expert LRU cache under host-resident experts.
+#
+# The engine only offloads experts to host when they do not fit in VRAM, which
+# makes the path awkward to reach on purpose. `moe.force_host_experts=N` pins
+# the last N MoE layers to host regardless of fit, so the whole range from
+# "barely offloaded" to "nothing on the GPU" is reachable on a model that
+# otherwise fits.
+#
+# Reports, per arm, the cache's own sizing and hit-rate lines plus pp/tg
+# throughput, so the hit rate can be read against what it costs.
+#
+# Two things this harness exists to keep honest:
+#   * Prefill throughput on this path is NOISY — a 15% spread between two runs
+#     of the SAME arm was measured on 2026-08-11. Judge only paired, alternating
+#     rounds (ROUNDS>=5), never two runs 20 minutes apart.
+#   * The cache's hit rate pools prefill and decode. `--bench-pp 8` isolates
+#     decode; a large `--bench-pp` with `--max-tokens 8` isolates prefill.
+#
+# Usage:
+#   tools/analysis/expert_cache_offload_sweep.sh              # host-layer sweep
+#   MODE=ab ROUNDS=5 tools/analysis/expert_cache_offload_sweep.sh   # paired A/B
+set -u
+
+MODEL=${MODEL:-/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf}
+IMG=${IMG:-imp:test}
+OUT=${OUT:-/tmp/expert_cache_sweep}
+MODE=${MODE:-sweep}
+ARMS=${ARMS:-"0 2 8 24 48"}
+ROUNDS=${ROUNDS:-5}
+PP=${PP:-512}
+TOKENS=${TOKENS:-256}
+REPS=${REPS:-3}
+
+mkdir -p "$OUT"
+
+if nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -q .; then
+    echo "WARNING: another process holds the GPU — numbers will not be comparable." >&2
+fi
+
+# Run one arm; echo "<pp tok/s> <tg tok/s> <hit rate>".
+run_arm() {
+    local log=$1; shift
+    docker run --rm --gpus all -v /home/kekz/models:/models "$IMG" \
+        imp-cli --model "$MODEL" "$@" \
+        --bench --bench-pp "$PP" --bench-reps "$REPS" \
+        --max-tokens "$TOKENS" --temperature 0 \
+        >"$log" 2>&1
+    local tp
+    tp=$(grep -E "^(pp|tg) " "$log" | sed -E 's/.*\(\s*([0-9.]+) tok\/s.*/\1/' | tr '\n' ' ')
+    local hr
+    hr=$(grep -oE "[0-9.]+% hit rate" "$log" | head -1)
+    echo "${tp}${hr:-n/a}"
+}
+
+case "$MODE" in
+sweep)
+    # How the cache behaves as more of the model moves off the GPU. Note the
+    # budget is 15% of FREE VRAM, so moving layers to host makes the cache
+    # BIGGER — slots/layer and hit rate both climb with N.
+    printf "%-6s %-10s %-10s %s\n" "hostN" "pp tok/s" "tg tok/s" "hit rate"
+    for n in $ARMS; do
+        log="$OUT/host${n}.log"
+        extra=(--set "moe.force_host_experts=$n")
+        [ "$n" = "0" ] && extra=()
+        read -r pp tg hr <<<"$(run_arm "$log" "${extra[@]}")"
+        printf "%-6s %-10s %-10s %s\n" "$n" "$pp" "$tg" "${hr:-—}"
+        grep -E "Expert LRU cache: [0-9]+ layers" "$log" | sed 's/^/       /'
+    done
+    ;;
+ab)
+    # Paired, alternating A/B of the expert cache against the staging-buffer
+    # fallback with everything host-resident. Alternating within a round is the
+    # only comparison this path's variance supports.
+    printf "%-7s %-24s %-10s %-10s %s\n" "round" "arm" "pp tok/s" "tg tok/s" "hit rate"
+    for r in $(seq 1 "$ROUNDS"); do
+        for arm in cache staging; do
+            log="$OUT/ab_${arm}_r${r}.log"
+            extra=(--set "moe.force_host_experts=48")
+            [ "$arm" = "staging" ] && extra+=(--set "moe.no_expert_cache=true")
+            read -r pp tg hr <<<"$(run_arm "$log" "${extra[@]}")"
+            printf "%-7s %-24s %-10s %-10s %s\n" "$r" "$arm" "$pp" "$tg" "${hr:-—}"
+        done
+    done
+    echo
+    echo "Judge the paired deltas per round, not the means — see the header."
+    ;;
+*)
+    echo "unknown MODE=$MODE (want: sweep | ab)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
`docs/roadmap.md` named this as its next step: *"the existing `ExpertCache`'s behaviour under a genuinely non-fitting model is still untested — that measurement, not another model, is the next thing worth doing."* This is that measurement, plus the one fix it turned up.

## The answer to the open question: the cache works

`moe.force_host_experts=N` pins the last N MoE layers to host regardless of fit, which makes the path reachable on a model that otherwise fits. Qwen3-30B-A3B-Q4_K_M (48 layers, 128 experts, top_k 8), all 48 MoE layers host-resident, `--bench-reps 3`:

| arm | pp512 tok/s | tg256 tok/s | hit rate |
|---|---|---|---|
| experts fully resident (`N=0`) | 10580 | **311.24** | — |
| host-resident, LRU cache | 254.20 | **24.98** | 88.7 % |
| host-resident, staging buffer only | 308.11 | **6.63** | — |

The cache holds its hit rate at full offload (88.7 %, ~0.9 new experts/layer/token — same order as the 0.38–0.80 the traces predicted) and is worth **3.8x** the decode of the staging fallback. The design the roadmap was reaching for is already in the tree and it works.

What moves is the ceiling: full offload still costs 12.5x against resident decode, and residual PCIe explains only part of it (~4.7 GB/s averaged, well under the 25.6 GB/s this box reaches). The rest is dispatch shape — a host-resident layer fails the `on_device` test that selects the grouped GEMM, so it runs the serial per-expert path at 24 launches/layer/token. **The next lever is the dispatch, not the cache.**

## The fix

One dispatch touches `kExpertProjCount` cells per **active** expert; the pool holds `slots_per_layer`. Above that the cache retains nothing across the dispatch, so it is strictly more work than the single-slot staging buffer for identical H2D bytes.

Decode never hits this (3·top_k cells, well under the pool). Prefill always does: at pp512 essentially every expert is active, so this model asks for 3·128 = 384 cells against 73 slots, and a prefill-dominated run measures **24.3 % against a 73/384 = 19 % structural ceiling**.

Gating on working-set fit is worth a **median +5.6 % pp512, 5/5 paired rounds positive**, at no decode cost, and lifts decode's own hit rate 88.7 % → 95.7 % once the thrashing accesses stop evicting it.

| round | pp skip=off | pp skip=on | Δ | tg off | tg on | Δ |
|---|---|---|---|---|---|---|
| 1 | 257.53 | 286.90 | +11.4 % | 23.69 | 24.17 | +2.0 % |
| 2 | 297.95 | 305.47 | +2.5 % | 22.57 | 22.86 | +1.3 % |
| 3 | 276.89 | 292.29 | +5.6 % | 22.26 | 21.03 | −5.5 % |
| 4 | 277.24 | 284.11 | +2.5 % | 23.87 | 24.25 | +1.6 % |
| 5 | 293.18 | 340.54 | +16.2 % | 21.91 | 24.00 | +9.5 % |

Decode is unchanged (sign mixed, inside noise) — which also refutes the worry that prefill warming was load-bearing for decode. Shipped build reproduces: 95.7 % hit rate, pp 310.42.

## Two things worth flagging

- **The budget runs the wrong way, and it does not matter.** The pool is 15 % of *free* VRAM, so moving layers to host makes the cache **bigger** (32 slots/layer at N=2 → 73 at N=48, hit rate 37.3 % → 89.4 %). The starvation this looked like it would cause never happens. My own starting hypothesis, refuted by the measurement.
- **Prefill throughput on this path varies ~15 % between two runs of the same arm** — larger than every effect above. Only paired, alternating rounds decide anything here. Noted in the harness header and the roadmap so the next person does not repeat a first pass I had to throw away.

## Verification

- `make verify-fast`: PASS — decode −0.32 %, prefill +1.14 %, peak VRAM +0.01 %. **No baseline refresh needed**: the pinned model is dense Qwen3-8B, which never takes this path.
- CI lane (`make dev-test`): 5/5 pass.
- Degeneration (host-offload path, via server JSON, not CLI stdout): output coherent, stderr clean, deterministic within a server and across restarts, and **byte-identical to the staging-only path at matched request order**. An earlier apparent divergence was the documented cold-vs-warm prefill arithmetic from unequal request history, not this change.

Harness: `tools/analysis/expert_cache_offload_sweep.sh` (`MODE=ab ROUNDS=5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx