### PR TITLE
fix(tools): stop hardcoding the maintainer's model path in the offload harness

### DIFF
--- a/tools/analysis/expert_cache_offload_sweep.sh
+++ b/tools/analysis/expert_cache_offload_sweep.sh
@@ -23,6 +23,7 @@
 set -u
 
 MODEL=${MODEL:-/models/Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf}
+MODELS_DIR="${MODELS_DIR:-$HOME/models}"
 IMG=${IMG:-imp:test}
 OUT=${OUT:-/tmp/expert_cache_sweep}
 MODE=${MODE:-sweep}
@@ -41,7 +42,7 @@ fi
 # Run one arm; echo "<pp tok/s> <tg tok/s> <hit rate>".
 run_arm() {
     local log=$1; shift
-    docker run --rm --gpus all -v /home/kekz/models:/models "$IMG" \
+    docker run --rm --gpus all -v "$MODELS_DIR":/models "$IMG" \
         imp-cli --model "$MODEL" "$@" \
         --bench --bench-pp "$PP" --bench-reps "$REPS" \
         --max-tokens "$TOKENS" --temperature 0 \


### PR DESCRIPTION
`Release hygiene` went red on #1365 (non-required, so the PR merged anyway). The cause is real and mine: `tools/analysis/expert_cache_offload_sweep.sh` mounted `/home/kekz/models` directly, which the personal-path gate in `scripts/check-release.sh` flags.

Switched to the `MODELS_DIR="${MODELS_DIR:-$HOME/models}"` convention that `moe_routing_skew.sh` and the other harnesses in `tools/analysis/` already use.

Verified: the gate's own leak query returns nothing, `bash -n` clean, and the harness still runs end to end (`MODE=sweep ARMS=48 PP=8 TOKENS=8 REPS=1` → 73 slots/layer, 81.0 % hit rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx