### PR TITLE
perf(moe): reach the fused decode kernels with host-resident experts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ there instead of retelling it.
 
 ### Changed
 
+- **MoE host-offload decode is ~2.1x faster: the fused decode kernels now reach
+  host-resident experts.** They address an expert as `base + idx * stride`, and
+  the LRU cache's per-layer slot pool is already exactly that shape — feeding
+  them slot indices instead of expert ids makes the whole family reachable with
+  no new kernel and no staging copy. Qwen3-30B-A3B-Q4_K_M with all 48 MoE layers
+  on host: decode 22.9 -> 48.3 tok/s (median), CUDA launches 197809 -> 61585
+  (-69%, against 52024 for the same model fully resident). Perplexity matches the
+  resident path to 0.019% (10.9616 vs 10.9637). Detail:
+  [`docs/roadmap.md`](docs/roadmap.md).
+
+### Changed
+
 - **MoE host-offload: the expert LRU cache is skipped for a dispatch it cannot
   hold.** One dispatch touches three cells per *active* expert, so prefill asks
   for 384 against the 73 slots a Qwen3-30B-A3B gets and the cache retains

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -88,10 +88,16 @@ __global__ void sanitize_fp16_kernel(__half* __restrict__ data, int64_t n) {
 
 namespace {
 
+// `host_pool_ok` lets host-resident experts through: the fused decode kernels
+// address `base + idx * stride`, and the expert cache's per-layer slot pool is
+// exactly that shape, so run_moe_decode_fast can feed them slot indices instead
+// of expert ids. Without it a host-resident layer drops to the serial fallback,
+// which measured ~48 kernel launches per layer against this path's ~3
+// (docs/roadmap.md).
 static bool can_decode_fast(int n, const Tensor& expert_up_packed, QType up_qtype, void* dequant_buf,
-                            QType compute_dtype) {
+                            QType compute_dtype, bool host_pool_ok) {
     return (n == 1 && expert_up_packed.data != nullptr && dequant_buf != nullptr &&
-            compute_dtype == QType::F16 && expert_up_packed.on_device &&
+            compute_dtype == QType::F16 && (expert_up_packed.on_device || host_pool_ok) &&
             (up_qtype == QType::Q6_K || up_qtype == QType::Q8_0 || up_qtype == QType::Q4_0 ||
              up_qtype == QType::Q4_K || up_qtype == QType::Q5_K || up_qtype == QType::Q2_K ||
              up_qtype == QType::Q3_K || up_qtype == QType::Q5_1 || up_qtype == QType::NVFP4));
@@ -179,10 +185,12 @@ void GraphExecutor::moe_ffn_phase2_state_and_norm_(int layer, cudaStream_t strea
     }
 
     // Pre-check decode fast path (same logic as will_decode_fast below)
-    ctx.will_skip_residual_copy = can_decode_fast(ctx.n, ly.expert_up_packed, ly.expert_up_packed.qtype,
-                                                  moe_.dequant_buf, compute_dtype_) &&
-                                  ly.w_up_shared.data ==
-                                      nullptr;  // must not have shared expert for full residual fusion
+    ctx.will_skip_residual_copy =
+        can_decode_fast(ctx.n, ly.expert_up_packed, ly.expert_up_packed.qtype, moe_.dequant_buf,
+                        compute_dtype_,
+                        host_expert_pool_ready(ly.expert_up_packed, expert_cache_, moe_,
+                                               model_->config().n_experts_active)) &&
+        ly.w_up_shared.data == nullptr;  // must not have shared expert for full residual fusion
 
     if (!ctx.will_skip_residual_copy) {
         // Kernel copy, not cudaMemcpyAsync: the D2D DMA submission blocked
@@ -306,7 +314,9 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
 
     ctx.up_qtype         = ly.expert_up_packed.qtype;
     ctx.will_decode_fast = can_decode_fast(ctx.n, ly.expert_up_packed, ctx.up_qtype, moe_.dequant_buf,
-                                           compute_dtype_);
+                                           compute_dtype_,
+                                           host_expert_pool_ready(ly.expert_up_packed, expert_cache_, moe_,
+                                                                  cfg.n_experts_active));
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
     // Q4_K×Q8_1 accumulation for MoE experts, preventing the routing drift that
     // occurs with FP16 dequant+cuBLAS. Set IMP_G4_NO_DECODE_FAST=1 to disable.

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -998,6 +998,87 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         return;
     }
 
+    // ---- Host-resident experts: address the LRU cache's slot pool ----------
+    // The fused MoE decode kernels read an expert as `base + idx * stride`.
+    // With experts on host the contiguous array is the cache's per-layer slot
+    // pool (fixed stride slot_size_), so `idx` is a SLOT index rather than an
+    // expert id — no new kernel, no staging copy. Establishing residency needs
+    // the routing on the host, hence one D2H per layer; that is what the
+    // serial fallback this replaces already paid, and CUDA graphs are disabled
+    // on this path anyway. Requires the whole working set to fit the layer's
+    // pool, or one projection's loads would evict another's.
+    const bool host_experts = (ly.expert_up_packed.data != nullptr &&
+                               host_expert_pool_ready(ly.expert_up_packed, expert_cache_, moe_, top_k));
+
+    const void* gate_base = ly.expert_gate_packed.data;
+    const void* up_base = ly.expert_up_packed.data;
+    const void* down_base = ly.expert_down_packed.data;
+    const int32_t* gate_idx = expert_indices;
+    const int32_t* up_idx = expert_indices;
+    const int32_t* down_idx = expert_indices;
+    size_t slot_stride = 0;  // non-zero once the pool is the array
+    bool pool_addressed = false;
+
+    if (host_experts) {
+        moe_host_args_capture_guard(stream);
+        std::vector<int32_t> h_experts(top_k);
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_experts.data(), expert_indices,
+                                           static_cast<size_t>(top_k) * sizeof(int32_t),
+                                           cudaMemcpyDeviceToHost, stream));
+        cudaStreamSynchronize(stream);
+
+        std::vector<int32_t> h_slots(static_cast<size_t>(kExpertProjCount) * top_k, -1);
+        auto stage = [&](const Tensor& packed, ExpertProj proj, int off) -> bool {
+            if (!packed.data)
+                return true;  // non-gated model has no gate tensor
+            size_t rb = qtype_row_bytes(packed.qtype, packed.shape[2]);
+            size_t expert_raw = static_cast<size_t>(packed.shape[1]) * rb;
+            for (int k = 0; k < top_k; ++k) {
+                int e = h_experts[k];
+                if (e < 0 || e >= packed.shape[0])
+                    return false;
+                const char* host_ptr = static_cast<const char*>(packed.data) +
+                                       static_cast<size_t>(e) * expert_raw;
+                ExpertCacheKey ck{packed.data, e};
+                void* p = expert_cache_.get_or_load(layer, proj, ck, host_ptr, expert_raw, stream);
+                if (!p)
+                    return false;
+                size_t flat = static_cast<size_t>(static_cast<char*>(p) -
+                                                  static_cast<char*>(expert_cache_.pool_)) /
+                              expert_cache_.slot_size_;
+                h_slots[off + k] = static_cast<int32_t>(flat) - layer * expert_cache_.slots_per_layer_;
+            }
+            return true;
+        };
+        if (stage(ly.expert_gate_packed, ExpertProj::Gate, 0) &&
+            stage(ly.expert_up_packed, ExpertProj::Up, top_k) &&
+            stage(ly.expert_down_packed, ExpertProj::Down, 2 * top_k)) {
+            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.d_slot_idx, h_slots.data(),
+                                               h_slots.size() * sizeof(int32_t), cudaMemcpyHostToDevice,
+                                               stream));
+            char* layer_pool = static_cast<char*>(expert_cache_.pool_) + static_cast<size_t>(layer) *
+                                                                             expert_cache_.slots_per_layer_ *
+                                                                             expert_cache_.slot_size_;
+            gate_base = up_base = down_base = layer_pool;
+            gate_idx = moe_.d_slot_idx;
+            up_idx = moe_.d_slot_idx + top_k;
+            down_idx = moe_.d_slot_idx + 2 * top_k;
+            slot_stride = expert_cache_.slot_size_;
+            pool_addressed = true;
+        } else {
+            // Unreachable by construction: host_expert_pool_ready() is the same
+            // predicate the dispatch used to send us here, and staging can only
+            // fail on an out-of-range expert id or layer. Say so loudly rather
+            // than fall through — the fall-through would hand a HOST pointer to
+            // a device kernel.
+            IMP_LOG_FATAL(
+                "MoE decode fast: host-resident experts could not be staged into the LRU pool "
+                "(layer %d, top_k %d, slots/layer %d). The dispatch predicate and this path "
+                "have diverged.",
+                layer, top_k, expert_cache_.slots_per_layer_);
+        }
+    }
+
     // dp4a/FP16 sub-path: gate+up projection (fused if gated)
     bool use_dp4a = (qscratch_.q8_1_buf != nullptr && qscratch_.d8_buf != nullptr);
 
@@ -1006,30 +1087,47 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         if (!moe_fused_norm_q8)
             quantize_fp16_to_q8_1(norm_ptr, q8, qscratch_.d8_buf, d, stream);
 
-        size_t up_stride_bytes = expert_stride(ly.expert_up_packed, up_qtype);
+        size_t up_stride_bytes = pool_addressed ? slot_stride : expert_stride(ly.expert_up_packed, up_qtype);
+
+        auto select_moe_gemv = [](QType qt) {
+            return (qt == QType::Q6_K)   ? gemv_q6k_q8_1_moe_decode
+                   : (qt == QType::Q4_0) ? gemv_q4_0_q8_1_moe_decode
+                   : (qt == QType::Q4_K) ? gemv_q4_k_q8_1_moe_decode
+                   : (qt == QType::Q5_K) ? gemv_q5_k_q8_1_moe_decode
+                   : (qt == QType::Q2_K) ? gemv_q2_k_q8_1_moe_decode
+                   : (qt == QType::Q3_K) ? gemv_q3_k_q8_1_moe_decode
+                                         : gemv_q8_0_q8_1_moe_decode;
+        };
 
         if (!non_gated_experts) {
-            size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);
-            auto gate_up_fused = (up_qtype == QType::Q6_K) ? gemv_q6k_q8_1_moe_gate_up_fused
-                               : (up_qtype == QType::Q4_K) ? gemv_q4_k_q8_1_moe_gate_up_fused
-                               : (up_qtype == QType::Q5_K) ? gemv_q5_k_q8_1_moe_gate_up_fused
-                               : (up_qtype == QType::Q4_0) ? gemv_q4_0_q8_1_moe_gate_up_fused
-                               : (up_qtype == QType::Q2_K) ? gemv_q2_k_q8_1_moe_gate_up_fused
-                               : (up_qtype == QType::Q3_K) ? gemv_q3_k_q8_1_moe_gate_up_fused
-                                                           : gemv_q8_0_q8_1_moe_gate_up_fused;
-            gate_up_fused(ly.expert_gate_packed.data, ly.expert_up_packed.data, expert_indices, q8,
-                          qscratch_.d8_buf, gate_buf, up_buf, eff, d, gate_stride, up_stride_bytes,
-                          /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
+            size_t gate_stride = pool_addressed
+                                     ? slot_stride
+                                     : expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);
+            if (pool_addressed) {
+                // gate and up sit in different slots, so the one-index fused
+                // kernel cannot express both. Two decodes still collapse
+                // 2*top_k weight launches into 2.
+                select_moe_gemv(ly.expert_gate_packed.qtype)(gate_base, gate_idx, q8, qscratch_.d8_buf,
+                                                             gate_buf, eff, d, gate_stride,
+                                                             /*q8_1_stride=*/0, /*d8_stride=*/0, top_k,
+                                                             stream);
+                select_moe_gemv(up_qtype)(up_base, up_idx, q8, qscratch_.d8_buf, up_buf, eff, d,
+                                          up_stride_bytes, /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
+            } else {
+                auto gate_up_fused = (up_qtype == QType::Q6_K)   ? gemv_q6k_q8_1_moe_gate_up_fused
+                                     : (up_qtype == QType::Q4_K) ? gemv_q4_k_q8_1_moe_gate_up_fused
+                                     : (up_qtype == QType::Q5_K) ? gemv_q5_k_q8_1_moe_gate_up_fused
+                                     : (up_qtype == QType::Q4_0) ? gemv_q4_0_q8_1_moe_gate_up_fused
+                                     : (up_qtype == QType::Q2_K) ? gemv_q2_k_q8_1_moe_gate_up_fused
+                                     : (up_qtype == QType::Q3_K) ? gemv_q3_k_q8_1_moe_gate_up_fused
+                                                                 : gemv_q8_0_q8_1_moe_gate_up_fused;
+                gate_up_fused(gate_base, up_base, expert_indices, q8, qscratch_.d8_buf, gate_buf, up_buf, eff,
+                              d, gate_stride, up_stride_bytes,
+                              /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
+            }
         } else {
-            auto up_gemv = (up_qtype == QType::Q6_K) ? gemv_q6k_q8_1_moe_decode
-                         : (up_qtype == QType::Q4_0) ? gemv_q4_0_q8_1_moe_decode
-                         : (up_qtype == QType::Q4_K) ? gemv_q4_k_q8_1_moe_decode
-                         : (up_qtype == QType::Q5_K) ? gemv_q5_k_q8_1_moe_decode
-                         : (up_qtype == QType::Q2_K) ? gemv_q2_k_q8_1_moe_decode
-                         : (up_qtype == QType::Q3_K) ? gemv_q3_k_q8_1_moe_decode
-                                                     : gemv_q8_0_q8_1_moe_decode;
-            up_gemv(ly.expert_up_packed.data, expert_indices, q8, qscratch_.d8_buf, up_buf, eff, d,
-                    up_stride_bytes, /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
+            select_moe_gemv(up_qtype)(up_base, up_idx, q8, qscratch_.d8_buf, up_buf, eff, d, up_stride_bytes,
+                                      /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
         }
     } else {
         // FP16 dequant fallback — only Q6_K / Q8_0 wired.
@@ -1086,9 +1184,9 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
                        : (dqt == QType::Q3_K) ? gemv_q3_k_q8_1_moe_decode
                        : (dqt == QType::Q5_1) ? gemv_q5_1_q8_1_moe_decode
                                               : gemv_q8_0_q8_1_moe_decode;
-        size_t down_stride = expert_stride(ly.expert_down_packed, dqt);
-        down_gemv(ly.expert_down_packed.data, expert_indices, q8, qscratch_.d8_buf, down_buf, d, eff,
-                  down_stride, /*q8_1_stride=*/eff_q8_blocks, /*d8_stride=*/eff_q8_blocks, top_k, stream);
+        size_t down_stride = pool_addressed ? slot_stride : expert_stride(ly.expert_down_packed, dqt);
+        down_gemv(down_base, down_idx, q8, qscratch_.d8_buf, down_buf, d, eff, down_stride,
+                  /*q8_1_stride=*/eff_q8_blocks, /*d8_stride=*/eff_q8_blocks, top_k, stream);
     } else {
         apply_expert_activation(gate_buf, up_buf, act_buf, non_gated_experts, top_k, eff, compute_dtype_,
                                 cfg.ffn_activation, stream);

--- a/src/exec/executor_forward_moe_internal.h
+++ b/src/exec/executor_forward_moe_internal.h
@@ -4,6 +4,8 @@
 #include "compute/activation.h"
 #include "compute/ssm.h"
 #include "quant/dequant_gpu.h"
+#include "exec/expert_cache.h"
+#include "exec/moe_workspace.h"
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
@@ -63,6 +65,22 @@ inline size_t expert_stride(const Tensor& packed, QType qtype) {
     int64_t rows = packed.shape[1];
     int64_t cols = packed.shape[2];
     return static_cast<size_t>(rows) * qtype_row_bytes(qtype, cols);
+}
+
+// Can the fused MoE decode kernels address host-resident experts through the
+// LRU cache's per-layer slot pool? They read `base + idx * stride`, and the
+// pool is exactly that (fixed `slot_size_` stride), so `idx` becomes a slot
+// index. Lives here because the DISPATCH predicate and run_moe_decode_fast
+// must agree exactly: if the dispatch says yes and the function then declines,
+// a host pointer reaches a kernel. One definition, two call sites.
+//
+// The whole working set must fit the layer's pool, or one projection's loads
+// evict another's — the same threshold the cache gate in #1365 enforces.
+inline bool host_expert_pool_ready(const Tensor& up_packed, const ExpertLRUCache& cache,
+                                   const MoEWorkspace& moe, int top_k) {
+    return (!up_packed.on_device && cache.n_slots_ > 0 && cache.pool_ != nullptr && cache.slot_size_ > 0 &&
+            moe.d_slot_idx != nullptr && moe.d_slot_idx_count >= kExpertProjCount * top_k &&
+            cache.slots_per_layer_ >= kExpertProjCount * top_k);
 }
 
 }  // namespace imp

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -590,6 +590,13 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                                  expert_cache_.n_slots_,
                                  expert_cache_.n_slots_ * max_expert_raw / (1024.0 * 1024.0),
                                  budget / (1024.0 * 1024.0));
+                    // Slot-index buffer for the host-offload decode path: one
+                    // block of top_k int32 per projection.
+                    int idx_count = kExpertProjCount * std::max(1, mcfg.n_experts_active);
+                    size_t idx_bytes = static_cast<size_t>(idx_count) * sizeof(int32_t);
+                    moe_.d_slot_idx = static_cast<int32_t*>(
+                        vram_alloc(vram_alloc_, idx_bytes, "moe_slot_idx"));
+                    moe_.d_slot_idx_count = moe_.d_slot_idx ? idx_count : 0;
                 }
             } else if (has_host_experts) {
                 IMP_LOG_INFO("Expert LRU cache disabled via IMP_NO_EXPERT_CACHE (staging fallback)");

--- a/src/exec/moe_workspace.h
+++ b/src/exec/moe_workspace.h
@@ -133,6 +133,14 @@ struct MoEWorkspace {
     void* raw_staging_buf = nullptr;
     size_t raw_staging_size = 0;
 
+    // Slot indices for the host-offload decode path: [3 * top_k] int32, one
+    // block per projection (gate, up, down). The fused MoE decode kernels
+    // address an expert as `base + idx * stride`; with host-resident experts
+    // the contiguous array is the LRU cache's per-layer slot pool, so `idx` is
+    // the expert's slot rather than its id. See docs/roadmap.md.
+    int32_t* d_slot_idx = nullptr;
+    int d_slot_idx_count = 0;
+
     // CUTLASS 3.x NVFP4 grouped GEMM staging:
     //   packed: [max_expanded, max_K/2] — contiguous FP4 activations
     //   sf:     per-expert SfAtom slabs (worst-case padded to 128 rows per expert)


### PR DESCRIPTION
Builds the design note from #1369 and measures it. **Decode on the MoE host-offload path is ~2.1x faster**, and the launch count lands within 18 % of the same model fully resident.

## The idea

The fused MoE decode kernels read an expert as `base + idx * stride`. The LRU cache's per-layer slot pool is *already* that shape — `pool_ + (layer * slots_per_layer + slot) * slot_size_`, a fixed stride. Feeding those kernels **slot** indices instead of expert ids makes the whole family reachable for host-resident experts, with **no new kernel, no staging copy, and no change to the cache's data structures**.

Until now a host-resident layer failed the `on_device` test that selects them and dropped to the serial per-expert fallback: 48 launches per layer against ~3. That is exactly what made this path issue-bound in #1367/#1368.

## Measured — Qwen3-30B-A3B-Q4_K_M, all 48 MoE layers on host

| | before | after |
|---|---|---|
| decode tg256 | **22.9** tok/s (median of 17 runs, 21.0–25.0) | **48.3** tok/s (median of 5, 45.8–50.0) |
| `cudaLaunchKernel` | 197 809 | **61 585** (−69 %; 52 024 for the same model resident) |
| prefill pp512 | ~300–340 | ~305–329 (unchanged — `n>1` still takes the legacy path) |

The two decode distributions do not overlap, so this is not host drift.

## Correctness

The change routes offload decode through the *same* dp4a kernels the resident path uses, which gives a reference the previous fused-kernel attempt (#1367) did not have:

- **Perplexity over `ppl_corpus_45k.txt`, `deterministic_gemm=true`: 10.9616 (host+pool) vs 10.9637 (resident) — 0.019 %.** It reproduces the resident path, which is the arithmetic it now shares.
- Degeneration probes on the offload path: coherent single-turn, multi-turn and long-decode output; `stderr` clean of the fail pattern.
- `make verify-fast`: **PASS** — decode +0.10 %, prefill +1.28 %, peak VRAM +0.01 %. **No baseline refresh**: the pinned model is dense Qwen3-8B and never takes this path.
- CI lane (`make dev-test`): 5/5.

## The one thing worth reviewing carefully

Establishing residency needs the routing on the host, so this costs **one D2H + sync per layer**. That is a cost the serial fallback it replaces already paid, and CUDA graphs are disabled on this path regardless — but it is why the win is 2.1x and not 16x.

`host_expert_pool_ready()` deliberately lives in the shared internal header: the **dispatch predicate and `run_moe_decode_fast` must agree exactly**, because if the dispatch says yes and the function then declines, a host pointer reaches a device kernel. One definition, two call sites, and the single impossible-by-construction failure is `IMP_LOG_FATAL` rather than a fall-through. It also requires the whole `3 · top_k` working set to fit the layer's pool, or one projection's loads would evict another's — the same threshold the cache gate in #1365 enforces.

Prefill and every on-device model are untouched; the new branch is gated on `!on_device`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx