### PR TITLE
feat(vision): recognise the Qwen3.6 vision tower — step 1 of 2, weights still blocked

### DIFF
--- a/src/model/hf_config_loader.cpp
+++ b/src/model/hf_config_loader.cpp
@@ -766,11 +766,17 @@ bool HFConfigLoader::load_config(const std::string& model_dir, ModelConfig& cfg,
     if (vc && vc->type == JType::OBJECT) {
         std::string vision_type;
         jobj_get_string(*vc, "model_type", vision_type);
-        // Qwen3-VL's tower is understood: parse its geometry here and let
-        // weight_map fill the weights. Everything else still degrades to
-        // text-only, loudly.
+        // Which vision_config model_types use the Qwen3-VL tower layout.
+        // Qwen3.6 (`qwen3_5_moe`) ships the same tower under a different name:
+        // 333 `model.visual.*` tensors whose names are a strict subset of
+        // Qwen3-VL's patterns, the same nine geometry fields, and an empty
+        // `deepstack_visual_indexes` (which the loader already handles). It is
+        // an allowlist rather than a shape fingerprint on purpose — anything
+        // unrecognised must keep hitting the loud text-only path below rather
+        // than being parsed on a resemblance.
+        const bool qwen3vl_tower = (vision_type == "qwen3_vl" || vision_type == "qwen3_5_moe");
         bool parsed = false;
-        if (vision_type == "qwen3_vl" && out_vision_tower) {
+        if (qwen3vl_tower && out_vision_tower) {
             auto tower = std::make_unique<VisionModel>();
             std::string verr;
             if (parse_qwen3vl_vision_config(*vc, tower->config, verr)) {


### PR DESCRIPTION
The roadmap says a second VL family needs *"a checkpoint staged plus an encoder forward of roughly the size of the Qwen3-VL port itself"*. **The checkpoint half is wrong** — `Qwen3.6-35B-A3B-NVFP4` has been staged all along (it is already a perf-baseline hero) and carries **333 `model.visual.*` tensors** whose names are a strict subset of Qwen3-VL's patterns.

Its `vision_config.model_type` is `"qwen3_5_moe"`, so it failed a literal string compare at `hf_config_loader.cpp` and fell straight to the loud text-only path. Widening that to an allowlist makes the geometry parse:

```
Qwen3-VL vision tower: depth=27 hidden=1152 heads=16 patch=16 merge=2
                       pos_grid=48x48 out=2048 deepstack=0
```

All nine required fields are present and positive, `num_position_embeddings` 2304 is 48², and the empty `deepstack_visual_indexes` is a case the loader already handles.

## What this does not do

**It does not yet enable vision on Qwen3.6**, and the log now says exactly why instead of shrugging:

```
Skipping shard model_visual.safetensors (333 tensors are MTP/vision-only and unused)
Vision tower incomplete (missing patch_embed.proj.weight; 0 assigned, 0 unknown,
                         333 missing) — continuing text-only
```

The second gate is **independent and wider**: `llm_compressor_loader.cpp`'s `name_is_skipped()` drops `model.visual.` prefixes unconditionally, which also makes the shard-drop discard the whole file before it is opened. Making that conditional touches every llm-compressor (NVFP4 SafeTensors) checkpoint, and then wants a BF16 tower living inside an otherwise-NVFP4 file. That is its own PR.

So the honest status change is: *"a project needing a checkpoint and a new encoder"* → **"two named gates, the first one done and the second one scoped"**. No new encoder forward is needed at all — the tower layout is identical.

An **allowlist rather than a shape fingerprint**, deliberately: anything unrecognised must keep hitting the loud text-only path rather than be parsed on a resemblance.

## Verification

- Qwen3-VL-4B-Instruct still loads and generates unchanged (the allowlist only adds an entry).
- CI lane 5/5; format clean on changed lines.
- **`verify-fast` reads red today (decode −5.0 %) and it is NOT this change.** The diff is a config parser and cannot reach a GGUF dense decode path. A paired, alternating A/B against `main` measures **−3.15 / +1.93 / +1.32 %** (signs mixed, mean −0.03 %), and `main` *by itself* reads 270–276 against a 287.19 baseline — the host is depressed, the #526 class. **No baseline refresh**: refreshing on a depressed-host day bakes in a low bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx