### PR TITLE
docs(changelog): repair the [Unreleased] block, and gate the defect that caused it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- **MoE host-offload decode ~2x faster again: the expert cache stopped
-  maintaining a device mirror nothing reads.** `d_lookup_` was built for
-  dispatch kernels to resolve slots from; #1370 instead derives the slot from
-  `get_or_load`'s returned pointer, leaving the mirror write-only — two extra
-  4-byte `cudaMemcpyAsync` per cache miss with no consumer. Now built and
-  maintained only under `moe.expert_cache_debug_parity`, its sole reader.
-  Qwen3-30B-A3B-Q4_K_M, all experts host-resident, 256 cold decode tokens:
-  `cudaMemcpyAsync` 519638 -> 212454 (-59%), decode ~20 -> ~41 tok/s. Cache hit
-  rate is identical to three digits (74.1%) and generated output is
-  byte-identical, as a write-only structure implies.
+- **`moe.expert_cache_budget_pct`** — the share of free VRAM the MoE expert LRU
+  cache may claim, previously hardcoded at 15. On the host-offload path this is
+  the dominant lever, because the pool depth decides how many tokens of routing
+  history the cache holds: Qwen3-30B-A3B-Q4_K_M with all experts host-resident,
+  256 cold decode tokens, 5 % → 50 % moves decode 10.51 → 51.86 tok/s (hit rate
+  36.6 % → 96.2 %). **Default unchanged at 15** — on a model that genuinely does
+  not fit, the same VRAM is what the KV pool and weight caches want. Sweep and
+  the floor below which the cache is bypassed entirely: [`docs/roadmap.md`](docs/roadmap.md).
 
 ### Changed
 
@@ -36,9 +34,6 @@ there instead of retelling it.
   families; the perplexity figure first cited here measured prefill, which the
   change does not touch — see [`docs/roadmap.md`](docs/roadmap.md) for what the
   decode evidence actually is.
-
-### Changed
-
 - **MoE host-offload: the expert LRU cache is skipped for a dispatch it cannot
   hold.** One dispatch touches three cells per *active* expert, so prefill asks
   for 384 against the 73 slots a Qwen3-30B-A3B gets and the cache retains
@@ -48,6 +43,26 @@ there instead of retelling it.
   byte-identical. Measurement and the rest of the offload picture:
   [`docs/roadmap.md`](docs/roadmap.md); harness
   `tools/analysis/expert_cache_offload_sweep.sh`.
+- **A Qwen3.6 checkpoint's vision tower is now recognised instead of dismissed.**
+  Its `vision_config.model_type` is `qwen3_5_moe`, which failed a literal string
+  compare even though the tower layout is Qwen3-VL's — 333 `model.visual.*`
+  tensors, the same nine geometry fields. **This does not yet enable vision on
+  Qwen3.6**: the weights are still dropped a layer lower, and the log now names
+  the missing tensor and count rather than shrugging. Second gate scoped in
+  [`docs/roadmap.md`](docs/roadmap.md).
+
+### Fixed
+
+- **MoE host-offload decode ~2x faster again: the expert cache stopped
+  maintaining a device mirror nothing reads.** `d_lookup_` was built for
+  dispatch kernels to resolve slots from; the change above instead derives the
+  slot from `get_or_load`'s returned pointer, leaving the mirror write-only —
+  two extra 4-byte `cudaMemcpyAsync` per cache miss with no consumer. Now built
+  and maintained only under `moe.expert_cache_debug_parity`, its sole reader.
+  Qwen3-30B-A3B-Q4_K_M, all experts host-resident, 256 cold decode tokens:
+  `cudaMemcpyAsync` 519638 -> 212454 (-59%), decode ~20 -> ~41 tok/s. Cache hit
+  rate is identical to three digits (74.1%) and generated output is
+  byte-identical, as a write-only structure implies.
 
 ## [0.24.0] - 2026-08-10
 

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -273,6 +273,22 @@ else
     fail "version drift — CMakeLists '$CM_VER', CHANGELOG '${CL_VER:-none}', BENCHMARKS '${BM_VER:-none}'"
 fi
 
+# ------------------------------------------- 5b. changelog section hygiene
+# Entries get prepended to [Unreleased] one PR at a time, and prepending a
+# "### Changed" block in front of an existing one produces a section with the
+# same heading twice. Keep-a-Changelog readers (and the release cut, which
+# renames the whole block) then silently carry the duplicate into a tag.
+# Mechanical, so gate it rather than rely on noticing.
+section "changelog section hygiene"
+UNREL=$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
+DUP=$(printf '%s\n' "$UNREL" | grep -E '^### ' | sort | uniq -d)
+if [ -n "$DUP" ]; then
+    printf '%s\n' "$DUP" | sed 's/^/  duplicate heading: /'
+    fail "[Unreleased] repeats a '###' heading — merge the blocks"
+else
+    pass "[Unreleased] has no repeated '###' heading"
+fi
+
 # ----------------------------------------------- 6. defer to make verify-fast
 section "make verify-fast"
 if [ "${SKIP_VERIFY:-0}" = "1" ]; then


### PR DESCRIPTION
Found while assessing whether to cut a release. Three defects, one of them mechanical enough to gate.

| defect | |
|---|---|
| **`### Changed` appeared twice** | Entries get prepended one PR at a time; prepending a `Changed` block in front of an existing one duplicates the heading. A release cut renames the whole block, so this would have shipped into a tag. |
| **`moe.expert_cache_budget_pct` (#1374) had no entry** | A new config key — exactly what a reader goes to a changelog for. |
| **The Qwen3.6 vision tower recognition (#1379) had none** | |

`[Unreleased]` is rewritten as one **Added / Changed / Fixed** each, in Keep-a-Changelog order, with both missing entries added. The vision entry states plainly that it does **not** yet enable vision on Qwen3.6 — a changelog that oversells a half-landed feature is worse than one that omits it.

## The gate

`check-release.sh` was green through all three. It cannot reasonably judge completeness, but the duplicate heading is deterministic, so that one is now a failure rather than something you have to notice.

**Mutation-validated** — a gate that cannot fail is worthless:

```
--- with the defect reintroduced ---
  duplicate heading: ### Changed
FAIL  [Unreleased] repeats a '###' heading — merge the blocks
--- restored ---
PASS  [Unreleased] has no repeated '###' heading
```

## No release is cut here

v0.24.0 is a day old; today's work moves **one narrow path** (host-offload MoE, unreachable on a model that fits, so the pinned benchmark numbers move by zero); the vision change is step 1 of 2; and the host is measuring ~5 % low today, which is the wrong day to pin `BENCHMARKS.md` figures to a release SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx