### PR TITLE
fix(quantize): refuse --keep-attn-gate with --calib instead of writing a wrong checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`imp-quantize` refuses `--keep-attn-gate` together with `--calib` instead of
+  writing a silently wrong checkpoint.** A fused Q+gate `q_proj` is copied
+  through without the group's column scale, but the calibration planner has no
+  idea that exclusion exists — it builds group A from `{q,k,v}` unconditionally
+  and folds that group's `1/s` into `input_layernorm`. The result is an input
+  divided by `s` whose columns were never multiplied by it: a checkpoint that
+  loads and generates and is wrong. Latent rather than live (every arch with a
+  fused attention gate currently fails `--calib`'s architecture check), so this
+  is armed for whoever widens that check. Same call as #1188 made for stacked
+  experts: refuse rather than mangle.
+
 - **MoE host-offload decode ~2x faster again: the expert cache stopped
   maintaining a device mirror nothing reads.** `d_lookup_` was built for
   dispatch kernels to resolve slots from; the change above instead derives the

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -423,6 +423,27 @@ int main(int argc, char** argv) {
             gated.insert(gated.end(), found.begin(), found.end());
         }
         if (!gated.empty()) {
+            // --keep-attn-gate + --calib is mathematically unsound and would be
+            // SILENT. A fused Q+gate q_proj is copied through below without the
+            // group's column scale, but the planner has no idea this set exists
+            // — it builds group A from {q,k,v} unconditionally and folds that
+            // group's 1/s into input_layernorm. The result is an input divided
+            // by s whose columns were never multiplied by it: a wrong
+            // checkpoint that loads and generates.
+            //
+            // Unreachable today only because every arch with a fused attention
+            // gate (qwen3_5, qwen3_next) fails arch_uses_plain_rmsnorm() — i.e.
+            // it is armed for whoever widens that allowlist. Refuse rather than
+            // mangle, the same call #1188 made for stacked experts.
+            if (opt.keep_attn_gate && !opt.calib_file.empty()) {
+                fprintf(stderr,
+                        "Error: --keep-attn-gate cannot be combined with --calib. The gate half is\n"
+                        "excluded from the group scale, but the calibration plan still folds that\n"
+                        "group's 1/s into input_layernorm — the checkpoint would be silently wrong.\n"
+                        "Drop one of the two flags (%zu fused Q+gate projection(s) found).\n",
+                        gated.size());
+                return 1;
+            }
             size_t extra_bytes = 0;
             for (const RawTensor* t : gated) {
                 // What keeping it full precision costs over quantizing it.


### PR DESCRIPTION
`imp-quantize` would accept `--keep-attn-gate` together with `--calib` and write a **mathematically wrong checkpoint, silently**.

## The mechanism

A fused Q+gate `q_proj` (Qwen3.5 / Qwen3-Next `attn_output_gate`) is copied through unquantized and, crucially, **without the group's column scale** — that is what `--keep-attn-gate` is for. But the set of excluded tensors lives only in `main.cpp`; the calibration planner has no idea it exists and builds **group A from `{q_proj, k_proj, v_proj}` unconditionally**, then folds that group's compensating `1/s` into `input_layernorm`.

So the input gets divided by `s` while `q_proj`'s columns are never multiplied by it. The checkpoint loads, generates, and is wrong.

## Latent, not live — which is the point

Every architecture with a fused attention gate (`qwen3_5`, `qwen3_next`) currently fails `--calib`'s `arch_uses_plain_rmsnorm()` allowlist, so the combination cannot be reached today. It is **armed for whoever widens that allowlist** — which is itself an open item, since `--calib` is currently dead for every MoE and MLA checkpoint.

Refuse rather than mangle: the same call #1188 made for stacked experts.

## Validated in three arms, on a checkpoint that actually has nine of them

`Qwen3.5-4B-BF16`, which reports `9 fused Q+gate projection(s)`:

| flags | result |
|---|---|
| `--keep-attn-gate --calib` | **`Error: ... would be silently wrong` — exit 1**, naming the 9 projections |
| `--keep-attn-gate` alone | proceeds — `KEEPING 9 fused Q+gate projection(s), 259 MiB larger` |
| `--calib` alone | proceeds — `QUANTIZING 9 fused Q+gate projection(s), 259 MiB saved` |

A guard that cannot be shown to fire is worth nothing, and one that fires too eagerly costs a working configuration — so both directions are checked.

## On the pre-push gate

`make verify-fast` is red on this box today (decode −5.5 % at healthy clocks) and it is **not** this change: `git diff main -- src/ include/` is empty — this touches `tools/imp-quantize/` only. Established by paired alternating A/B earlier: −3.15 / +1.93 / +1.32 % (mean −0.03 %), with `main` alone reading 270–276 against a 287.19 baseline. Host drift, the #526 class. No baseline refresh on a depressed-host day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnRMYK5E1noYxEg6ARWLYx
