### PR TITLE
chore(deps): CUTLASS 4.7.0, googletest 1.18.0, httplib 0.53.0 + correct stale docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,14 @@ there instead of retelling it.
 
 ### Changed
 
+- **Dependencies: CUTLASS v4.6.2 → 4.7.0, googletest v1.17.0 → v1.18.0,
+  cpp-httplib v0.50.1 → v0.53.0** (nlohmann/json already current). CUTLASS is
+  the primary GEMM path on sm_120, so it was A/B'd rather than assumed:
+  decode is neutral to within 0.05% on Qwen3-14B-NVFP4 (171.5 vs 171.6) and
+  Qwen3.6-35B-A3B-NVFP4 (319.1 vs 318.9), prefill within the known cuBLAS
+  restart noise. Note for the next bump: NVIDIA dropped the `v` prefix — the
+  tag is `4.7.0`, and `v4.7.0` does not exist.
+
 - **MoE host-offload decode is ~2.1x faster: the fused decode kernels now reach
   host-resident experts.** They address an expert as `base + idx * stride`, and
   the LRU cache's per-layer slot pool is already exactly that shape — feeding

--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -7,7 +7,7 @@
 #
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
-set(IMP_DEP_GOOGLETEST_TAG    v1.17.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       v4.6.2   CACHE STRING "NVIDIA/cutlass git tag")
-set(IMP_DEP_HTTPLIB_TAG       v0.50.1  CACHE STRING "cpp-httplib git tag")
+set(IMP_DEP_GOOGLETEST_TAG    v1.18.0  CACHE STRING "googletest git tag")
+set(IMP_DEP_CUTLASS_TAG       4.7.0    CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_HTTPLIB_TAG       v0.53.0  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -139,7 +139,7 @@ Decode carries ±5–10 % day-to-day variance (issue #526); clocks logged health
 | Qwen3-Coder-30B-A3B | 30B (3B) | 338 |
 | Qwen3.6-35B-A3B | 35B (3B) | 257 → **320**¹ᵇ |
 | Gemma-4-26B-A4B | 26B (4B) | 266 |
-| Nemotron-3-Nano-30B | 30B (3B) | 128 → **148**¹ᶜ |
+| Nemotron-3-Nano-30B | 30B (3B) | 148 → **386**¹ᶜ |
 | gpt-oss-20b¹ | 21B (3.6B) | 325 → **391**¹ᵈ |
 
 ¹ᵇ 2026-07-10, commit `80864b06` + `gemm.fp8_ssm_proj` (default on since that
@@ -148,11 +148,12 @@ PR): FP8 E4M3 per-row-scale decode sidecar for the BF16 GDN in/out projections
 speculation; PPL flat (8.021 → 8.012 same-session teacher-forced). Same
 command pattern as the table; healthy-host clocks sampled during the run.
 
-¹ᶜ 2026-07-11, commit `6946a6cd` + `gemm.fp8_ssm_proj`: the same FP8
-SSM-projection sidecar (221 MiB on Nemotron's 12 GDN projections) lifts
-Nemotron-3-Nano-30B decode 128 → **148** tok/s (+16%), PPL flat (4.184 →
-4.117). Still the slowest 30B — the Mamba2 scan + attention-projection share is
-arch-limited — but the GDN-projection part of the FP16 tax is gone.
+¹ᶜ 2026-08-12, PR #1389: **148 → 386 tok/s**. The FP8 SSM-projection sidecar
+had taken it 128 → 148 on 2026-07-11 (`6946a6cd`, PPL flat 4.184 → 4.117), and
+this table then called the remainder "arch-limited". That was wrong: CUDA graphs
+were being demoted for pure-SSM layers on an unverified assumption, so the model
+decoded eagerly. Removing the demotion is the 2.6x. Nothing about the Mamba2
+scan was the limit.
 
 ¹ᵈ 2026-07-13, commit `63df2d30` (PR #990) + `gemm.fp8_attn_proj` (default
 auto since that PR): FP8 E4M3 per-row-scale decode sidecar for the BF16
@@ -192,8 +193,8 @@ gap:** MoE pp4096 went 30 300 → 37 639 (**+24%**, now *ahead* of vLLM) and den
 pp4096 19 938 → 24 232 (**+21%**, gap 1.27× → 1.04×). pp2048 moved +3.8–4.7%.
 imp also wins TTFT/pp512 outright (2.1–3.4×, vLLM has a flat-cost small-M regime).
 The lone surviving NVFP4-prefill gap is dense pp4096 at ~1.04×. Decode (tg256
-@ctx2048): 14B 159, 30B-A3B ~317. Nemotron-3-Nano is arch-limited (hybrid
-Mamba2 + attention FP16-projection mix).
+@ctx2048): 14B 159, 30B-A3B ~317. (The claim that once stood here — that
+Nemotron-3-Nano is arch-limited — was disproved on 2026-08-12; see note ¹ᶜ.)
 
 ## Long context (pp8192 / tg512 @ 16k ctx)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -5,7 +5,7 @@
 | | |
 |---|---|
 | Hardware | Single NVIDIA RTX 5090, 32 GB GDDR7, `sm_120a`, custom water loop |
-| Toolchain | CUDA 13.3 (rows dated before 2026-05-30: 13.2.1), CUTLASS v4.5.1, GCC 13.3, Release Docker build |
+| Toolchain | CUDA 13.3 (rows dated before 2026-05-30: 13.2.1), CUTLASS 4.7.0 (rows before 2026-08-13: v4.5.1–v4.6.2), GCC 13.3, Release Docker build |
 | imp config | NVFP4 decode cache + FP16 prefill (FP8 auto-disabled on sm_120), CUDA Graphs on |
 | llama.cpp | `b8445+`, flash attention on, full offload (`-ngl 99`) |
 | Sampling | Greedy (temp = 0) |


### PR DESCRIPTION
All three outdated pins bumped (nlohmann/json was already current), plus two documentation claims that today's work disproved.

## CUTLASS was measured, not assumed

It is the primary GEMM path on sm_120 — there are no FP4 cuBLASLt kernels — so a version bump there is not a formality. Paired and alternating, on a quiet host (2868 MHz SM, gate spread 0.10%):

| Model | 4.7.0 | 4.6.2 (main) |
|---|---:|---:|
| Qwen3-14B-NVFP4 | 171.52 / 171.54 | 171.56 / 171.62 |
| Qwen3.6-35B-A3B-NVFP4 | 319.23 / 318.92 | 318.88 / 318.94 |

**Decode neutral to within 0.05%.** Prefill reads +1.0% and +4.2% — that is inside the known cuBLAS algo-reselection noise across container restarts, so it is explicitly *not* claimed as a win.

- verify-fast green: decode +0.14%, prefill +1.23%, peak VRAM +0.01%, graphs 2.33×
- `degen_suite` 45/45 on Qwen3.6-35B-A3B-NVFP4

## A trap for the next bump

NVIDIA **dropped the `v` prefix** with this release. The tag is `4.7.0`; `v4.7.0` returns HTTP 404 and the fetch fails. Every earlier tag was `v4.6.2`-style, so a mechanical bump breaks the build.

While checking I also verified the single-sourcing claim in CLAUDE.md, because the Dockerfile carries its own `ARG IMP_DEP_*` defaults and looked like a second pin. It is not: `scripts/dep_build_args.sh` reads `cmake/imp-deps.cmake` and forwards the tags as `--build-arg`, so the Dockerfile values are fallbacks only. One file remains correct.

## Docs corrected in the same pass

- **`BENCHMARKS.md`** carried `128 → 148` for Nemotron-3-Nano and explained the remainder as *"the Mamba2 scan + attention-projection share is **arch-limited**"* — twice. #1389 disproved that: graphs were demoted for pure-SSM layers on an unverified assumption, and lifting it reached **386 tok/s**. Table, footnote and the vLLM-comparison paragraph now say what actually happened.
- **`performance.md`** claimed CUTLASS v4.5.1 while v4.6.2 was pinned; it now names the current pin and dates the older rows.

CUDA stays at 13.3.1 — that is the newest `devel-ubuntu26.04` image published. The 13.3.0 / 13.2.1 references elsewhere are historical measurement notes, deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2gif2RwLC3F7mGm8DhXvA