### PR TITLE
fix(release): check-release.sh aborted silently on an empty [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`check-release.sh` aborted silently right after a release cut.** Its
+  changelog-hygiene step greps `[Unreleased]` for duplicate `###` headings, and
+  an empty `[Unreleased]` — exactly what cutting a release leaves behind — makes
+  grep exit 1, which under the script's `set -euo pipefail` killed the run with
+  no FAIL line and before `make verify-fast` had a chance to execute. v0.25.0
+  was cut with the check dying at that point. The grep is now `|| true`.
+
+
 ## [0.25.0] - 2026-08-13
 
 ### Added

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -281,7 +281,11 @@ fi
 # Mechanical, so gate it rather than rely on noticing.
 section "changelog section hygiene"
 UNREL=$(awk '/^## \[Unreleased\]/{f=1;next} /^## \[/{f=0} f' CHANGELOG.md)
-DUP=$(printf '%s\n' "$UNREL" | grep -E '^### ' | sort | uniq -d)
+# `|| true`: right after a release cut [Unreleased] is empty by design, grep
+# then exits 1, and under `set -euo pipefail` that aborted the whole script —
+# silently, with no FAIL line, before `make verify-fast` ever ran. v0.25.0 was
+# cut with this check dying at exactly this point.
+DUP=$(printf '%s\n' "$UNREL" | grep -E '^### ' | sort | uniq -d || true)
 if [ -n "$DUP" ]; then
     printf '%s\n' "$DUP" | sed 's/^/  duplicate heading: /'
     fail "[Unreleased] repeats a '###' heading — merge the blocks"


### PR DESCRIPTION
The changelog-hygiene step greps `[Unreleased]` for duplicate `###` headings. **Right after a release cut that section is empty by design** — so grep finds nothing, exits 1, and under the script's own `set -euo pipefail` the run ends there: no FAIL line, no summary, and `make verify-fast` (the very next step) never executes.

```
+ UNREL=
++ grep -E '^### '      ← no match → exit 1 → set -e kills the script
+ DUP=
```

## How it presented

On #1393 the **Release hygiene** job went red in 6 seconds while every gate it had printed said PASS. Running it locally *looked* clean — because grepping the output for `FAIL` finds nothing when the script dies without printing one. The exit code was the only signal, and I had not checked it. Worth stating plainly: I reported that PR as "all gates green" on the strength of that grep, and it was not.

## The fix

One `|| true` on the grep, with a comment naming the condition so it does not get "tidied" away. Verified on current `main`: the script now exits 0 and reaches `PASS make verify-fast` instead of stopping three steps earlier.

## The shape of it

This gate was added in #1380 to catch a real changelog problem — and then made **every release cut** abort before the heaviest check it guards. A gate that cannot fail loudly is worse than no gate: #1393 merged with its release check having never run `verify-fast` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2gif2RwLC3F7mGm8DhXvA