### PR TITLE
docs(changelog): fold the check-release fix into [0.25.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,6 @@ there instead of retelling it.
 
 ## [Unreleased]
 
-### Fixed
-
-- **`check-release.sh` aborted silently right after a release cut.** Its
-  changelog-hygiene step greps `[Unreleased]` for duplicate `###` headings, and
-  an empty `[Unreleased]` — exactly what cutting a release leaves behind — makes
-  grep exit 1, which under the script's `set -euo pipefail` killed the run with
-  no FAIL line and before `make verify-fast` had a chance to execute. v0.25.0
-  was cut with the check dying at that point. The grep is now `|| true`.
-
-
 ## [0.25.0] - 2026-08-13
 
 ### Added
@@ -125,6 +115,13 @@ there instead of retelling it.
   [`docs/roadmap.md`](docs/roadmap.md).
 
 ### Fixed
+
+- **`check-release.sh` aborted silently right after a release cut.** Its
+  changelog-hygiene step greps `[Unreleased]` for duplicate `###` headings, and
+  an empty `[Unreleased]` — exactly what cutting a release leaves behind — makes
+  grep exit 1, which under the script's `set -euo pipefail` killed the run with
+  no FAIL line and before `make verify-fast` had a chance to execute. v0.25.0
+  was cut with the check dying at that point. The grep is now `|| true`.
 
 - **The entire Nemotron-H family decodes ~3x faster: CUDA graphs were demoted
   for pure-SSM layers on an assumption that does not hold.** `has_pure_ssm`


### PR DESCRIPTION
#1394 landed after the release commit (#1393) but before the tag, so it ships **inside** v0.25.0. Leaving its entry under `[Unreleased]` would make the tagged changelog disagree with the tagged tree about what the release contains.

Moves the one entry into the `[0.25.0]` Fixed block and leaves `[Unreleased]` empty. No code change.

`check-release.sh` passes end to end (exit 0, including `make verify-fast`) — which it can now do at all, thanks to #1394.

Tag `v0.25.0` goes on the squash of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2gif2RwLC3F7mGm8DhXvA