### PR TITLE
docs(shipping): the release recipe stopped at the tag

### DIFF
--- a/.claude/skills/shipping-prs/SKILL.md
+++ b/.claude/skills/shipping-prs/SKILL.md
@@ -72,6 +72,9 @@ Single source of truth for the version is **`CMakeLists.txt`** `project(imp … 
 2. `CHANGELOG.md`: rename the `## [Unreleased]` section to `## [X.Y.Z] - YYYY-MM-DD` (Keep-a-Changelog format; Added / Changed / Fixed). Leave a fresh empty `[Unreleased]`.
 3. `docs/BENCHMARKS.md`: update the "current: **vX.Y.Z**" line — tagged releases snapshot a SHA, so published numbers must name the release they were taken on.
 4. Merge that PR (squash) as usual, then tag the merged commit on `main`: `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`. Tags are `vX.Y.Z` (e.g. `v0.18.0`). `scripts/check-release.sh` gates release-touching PRs in CI.
+5. **Publish a GitHub Release on that tag — the tag alone is not the release.** Every version back to v0.20.x has one, and it is what a reader actually sees: `gh release create vX.Y.Z --title "vX.Y.Z — <what changed, in words>" --notes-file <file> --verify-tag`. House style, from the existing ones: PR count since the last tag, then `## Highlights` with the measured numbers inline, `## Also in here`, and a `## Gate` paragraph quoting the verify-fast figures **from a run on the tagged tree**. `check-release.sh` prints only `PASS make verify-fast` and swallows those figures, so run `make verify-fast` separately if you need to quote them. Publish negative results too — a lever that measured worse is a finding.
+
+**Run the release check before tagging, and read its exit code.** `bash scripts/check-release.sh; echo $?` — grepping its output for `FAIL` is not enough, because a gate that aborts prints no FAIL line at all (that is #1394: an empty `[Unreleased]` made a `grep` exit 1 and `set -euo pipefail` killed the script silently, before `make verify-fast` ran).
 
 ## Common mistakes → fix
 


### PR DESCRIPTION
## What

Step 4 of "Cutting a tagged release" ended at `git push origin vX.Y.Z`. But every version back to v0.20.x also carries a **GitHub Release** with hand-written notes, and that is what a reader sees — the tag is just a ref. The step existed only as folklore.

v0.25.0 demonstrated the gap: it was tagged, correctly and with a green gate, and had no release. That surfaced by accident, from a `gh release list` run for an unrelated reason.

## What this adds

- **Step 5**: `gh release create … --verify-tag`, plus the house style read off the existing releases (PR count since the last tag → `## Highlights` with measured numbers inline → `## Also in here` → `## Gate`).
- **Where the Gate figures come from.** `check-release.sh` prints `PASS make verify-fast` and swallows the numbers, so quoting them needs a separate `make verify-fast` on the tagged tree. Without this note the next author either omits the paragraph or copies stale figures.
- **Read check-release's exit code, do not grep for `FAIL`** — the #1394 lesson, stated in the place someone cutting a release will actually be reading. A gate that aborts prints no FAIL line, which is exactly how that defect shipped.

Documentation only — no code, no config, no CHANGELOG entry (this is an agent skill, not user-visible behaviour).