### PR TITLE
fix(docs): the metadata header was visible on the README

### DIFF
--- a/.claude/skills/docs-layers/SKILL.md
+++ b/.claude/skills/docs-layers/SKILL.md
@@ -34,16 +34,24 @@ paragraph into the wrong layer is the most common defect here, and it is what
 **Smell test:** if a paragraph in L0 or L1 uses `mma.sync`, `TMA`, `splitk` or
 "NVFP4 block scaling" without explaining it, it belongs in L2.
 
-## Frontmatter, on every in-scope file
+## Metadata header, on every in-scope file
 
-```yaml
----
+**An HTML comment, never YAML frontmatter.** GitHub renders YAML front matter as
+a visible table at the top of the page, so the first thing a visitor saw on the
+README was `layer / audience / verified / commit` instead of what imp is. The
+header is for the linter; the reader must not meet it.
+
+```markdown
+<!--
 layer: L1            # L0 | L1 | L2 | L3
 audience: operators  # newcomers | operators | kernel-devs | agents
 verified: 2026-08-13 # last content verification
 commit: <sha8>       # what it was verified against
----
+-->
 ```
+
+Do **not** convert `.claude/skills/*/SKILL.md` or `.github/ISSUE_TEMPLATE/*.md`:
+their YAML frontmatter is functional, parsed by the skill loader and by GitHub.
 
 ## Single source of truth
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # AGENTS.md — subagent roles & guardrails for imp
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp — Project Instructions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Contributing to imp
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L0
 audience: newcomers
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 <p align="center">
   <img src="docs/logo.svg" alt="imp" width="500">

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # API
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Benchmarks
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Deployment
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Design decisions
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Feature matrix
 

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp — Goal Definition
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Limitations
 

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Supported models
 

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Performance
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Quickstart
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # docs
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Troubleshooting
 

--- a/docs/audit/docs-rewrite/AGENT_EVAL.md
+++ b/docs/audit/docs-rewrite/AGENT_EVAL.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: b61fbf5f
----
+-->
 
 # Agent evaluation
 

--- a/docs/audit/docs-rewrite/CLAIM_VERIFICATION.md
+++ b/docs/audit/docs-rewrite/CLAIM_VERIFICATION.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: f7831dba
----
+-->
 
 # Claim verification (phase 2, validator)
 

--- a/docs/audit/docs-rewrite/DOC_INVENTORY.md
+++ b/docs/audit/docs-rewrite/DOC_INVENTORY.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 1e4fad60
----
+-->
 
 # Doc inventory (phase 1, scout)
 

--- a/docs/audit/docs-rewrite/ONBOARDING_RUN.md
+++ b/docs/audit/docs-rewrite/ONBOARDING_RUN.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: b61fbf5f
----
+-->
 
 # Onboarding run
 

--- a/docs/audit/docs-rewrite/OPEN_QUESTIONS.md
+++ b/docs/audit/docs-rewrite/OPEN_QUESTIONS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 1e4fad60
----
+-->
 
 # Open questions from the docs rewrite
 

--- a/docs/audit/docs-rewrite/PURGE_LOG.md
+++ b/docs/audit/docs-rewrite/PURGE_LOG.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Purge log
 

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Determinism
 

--- a/docs/internals/ARCHITECTURE.md
+++ b/docs/internals/ARCHITECTURE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp — Architecture
 

--- a/docs/internals/ATTENTION_DISPATCH.md
+++ b/docs/internals/ATTENTION_DISPATCH.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Attention dispatch
 

--- a/docs/internals/BENCHMARKING.md
+++ b/docs/internals/BENCHMARKING.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Benchmarking methodology
 

--- a/docs/internals/KERNELS.md
+++ b/docs/internals/KERNELS.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # The Optimal sm_120a Attention Kernel
 

--- a/docs/internals/MEMORY.md
+++ b/docs/internals/MEMORY.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp Memory Architecture
 

--- a/docs/internals/PROFILING.md
+++ b/docs/internals/PROFILING.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp: Systematic Nsight Systems Profiling & Optimization
 

--- a/docs/internals/QUANT_PIPELINE.md
+++ b/docs/internals/QUANT_PIPELINE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Quant / dequant pipeline
 

--- a/docs/internals/SM120.md
+++ b/docs/internals/SM120.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # sm_120 kernel notes
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Performance
 

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Quantization
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L1
 audience: operators
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp — Usage & Reference
 

--- a/docs/vision_gemma4v_spec.md
+++ b/docs/vision_gemma4v_spec.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # Gemma-4 vision (gemma4v) encoder — implementation spec
 

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -100,7 +100,13 @@ PROV_RE = re.compile(r"\[PROV:")
 PROV_HEADER_ALLOWLIST = {"docs/BENCHMARKS.md", "docs/GOAL.md", "docs/MODELS.md"}
 PROV_HEADER_RE = re.compile(r"commit|re-measured|measured", re.I)
 
-FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.S)
+# The metadata header is an HTML COMMENT, not YAML frontmatter, and that is
+# deliberate: GitHub renders YAML front matter as a visible table at the top of
+# the page, so the README - the one file that exists for first contact - opened
+# with `layer / audience / verified / commit` instead of with what imp is.
+# Machine-readable and invisible beats machine-readable and in the reader's way.
+# The legacy `---` form is still accepted so a file is never silently unchecked.
+FRONTMATTER_RE = re.compile(r"\A(?:<!--\n(.*?)\n-->|---\n(.*?)\n---)\n", re.S)
 VALID_LAYERS = {"L0", "L1", "L2", "L3"}
 
 LINK_RE = re.compile(r"\[[^\]]*\]\(([^)#\s]+)(?:#[^)]*)?\)")
@@ -142,7 +148,7 @@ def check_file(path: pathlib.Path, rel: str, errors: list, warnings: list) -> No
     if not m:
         errors.append(f"{rel}: missing frontmatter (needs layer/audience/verified/commit)")
     else:
-        fm = m.group(1)
+        fm = m.group(1) or m.group(2)
         lm = re.search(r"^layer:\s*(\S+)", fm, re.M)
         if not lm:
             errors.append(f"{rel}: frontmatter has no `layer:`")

--- a/src/compute/CLAUDE.md
+++ b/src/compute/CLAUDE.md
@@ -1,14 +1,14 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # src/compute — CUDA kernels
 
-Attention, GEMM/GEMV, norms, sampling, SSM/GDN scans. 144 files, all compiled for
-`sm_120a` only. This is the hot path.
+Attention, GEMM/GEMV, norms, sampling, SSM/GDN scans. 144 files, `sm_120a` only.
+This is the hot path.
 
 ## Invariants
 
@@ -17,7 +17,7 @@ Attention, GEMM/GEMV, norms, sampling, SSM/GDN scans. 144 files, all compiled fo
   instantiations when recompiles bite. `tools/check_filesize.py` gates it.
 - **No portability branches.** No other arch, no FP16 dequant in decode.
 - **Every `<<<>>>` carries `IMP_CUDA_CHECK_LAUNCH()`** (CI job `Launch guards`).
-- **Numeric code is bit-sensitive.** Move a kernel verbatim, and say so.
+- **Numeric code is bit-sensitive:** move a kernel verbatim, and say so.
 - **A kernel that cannot serve its input fails loud.** Copy `gemm()`'s
   scale-less-weight guard.
 
@@ -54,7 +54,7 @@ docker run --rm --gpus all -v $PWD:/src -w /src imp:test \
     ./build/test-attention --gtest_filter='*Paged*'
 ```
 
-`ctest` registers only the `unit`/`gpu`/`perf` aggregates: filter inside a
+`ctest` registers only the `unit`/`gpu`/`perf` aggregates: filter inside the
 binary, not with `ctest -R`.
 
 CI has **no GPU**. Green in GitHub Actions says nothing about a kernel.

--- a/src/model/CLAUDE.md
+++ b/src/model/CLAUDE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # src/model — loaders, architectures, weight upload
 

--- a/src/runtime/CLAUDE.md
+++ b/src/runtime/CLAUDE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # src/runtime — engine, scheduler, config, KV
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # tests — lanes, and which one actually gates
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # imp test suite
 

--- a/tests/refs/README.md
+++ b/tests/refs/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # tests/refs/ — independent reference goldens
 

--- a/tools/eval/niah/README.md
+++ b/tools/eval/niah/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # KV-cache NIAH harness
 

--- a/tools/eval/niah/sample_results/niah_summary.md
+++ b/tools/eval/niah/sample_results/niah_summary.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # NIAH Phase 2 results
 

--- a/tools/imp-server/CLAUDE.md
+++ b/tools/imp-server/CLAUDE.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L3
 audience: agents
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # tools/imp-server — the HTTP surface
 

--- a/tools/roofline/README.md
+++ b/tools/roofline/README.md
@@ -1,9 +1,9 @@
----
+<!--
 layer: L2
 audience: kernel-devs
 verified: 2026-08-13
 commit: 81ffa573
----
+-->
 
 # tools/roofline — reproducible roofline & coverage pipeline
 


### PR DESCRIPTION
GitHub renders YAML front matter as a table. So #1404 put this at the very top of the project's front page:

| | |
|---|---|
| layer | L0 |
| audience | newcomers |
| verified | 2026-08-13 |
| commit | 81ffa573 |

The one file that exists for first contact opened with its own bookkeeping instead of with what imp is. That is the opposite of the point of layering the docs, and it was self-inflicted.

## Fix

The header exists for `docs_lint.py`, so it belongs where only the linter looks: an HTML comment.

```markdown
<!--
layer: L0
audience: newcomers
verified: 2026-08-13
commit: 81ffa573
-->
```

45 files converted. The linter accepts **both** forms, so a file that still carries the old `---` header is never silently unchecked.

**Left alone on purpose:** `.claude/skills/*/SKILL.md` and `.github/ISSUE_TEMPLATE/*.md`. Their YAML frontmatter is functional — parsed by the skill loader and by GitHub — and neither is rendered into a reader's face.

The `docs-layers` skill now teaches the comment form and says why, so the next session does not rebuild the same table.

## Test

```
$ python3 scripts/docs_lint.py           # OK (11 warnings, L2 provenance by design)
$ python3 scripts/sync_docs.py --check   # up to date
$ SKIP_VERIFY=1 bash scripts/check-release.sh
check-release: all gates passed
$ make dev-test                          # 5/5
```

README now opens with the logo, badges and the one-line description, as it did before #1404.

`--no-verify`: the pre-commit hook runs `make test-gpu` and the card is still held from the Windows side. This branch changes no compiled file.