### PR TITLE
feat(moe): serve NVFP4 experts from host instead of refusing the load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,20 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **NVFP4 MoE experts can now live on host**, so a checkpoint whose experts
+  exceed VRAM runs instead of being refused. Qwen3-30B-A3B-NVFP4 with all 48 MoE
+  layers off-GPU answers correctly at 23.0 tok/s, against 384.0 fully resident.
+  ([`docs/roadmap.md`](docs/roadmap.md))
+
 ### Fixed
 
 - **An NVFP4 MoE checkpoint whose experts do not fit is refused at load**
   instead of skipping their GEMMs and answering from the rest at exit code 0.
-  GGUF experts keep their host path. ([`docs/roadmap.md`](docs/roadmap.md))
+  The refusal now fires only when the expert cache cannot hold a layer's working
+  set; otherwise the host path above serves it. GGUF experts are unaffected.
+  ([`docs/roadmap.md`](docs/roadmap.md))
 
 ## [0.25.0] - 2026-08-13
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ set(IMP_EXEC_SOURCES
     src/exec/executor_forward_moe.cu
     src/exec/executor_forward_moe_cutlass.cu
     src/exec/executor_forward_moe_batch.cu
+    src/exec/executor_forward_moe_nvfp4_host.cu
     src/exec/executor_forward_moe_legacy.cu
     src/exec/expert_cache.cu
     src/exec/weight_handle.cu
@@ -650,6 +651,7 @@ if(IMP_BUILD_TESTS)
         # model/expert_placement.h takes the placement as data, so no GPU and no
         # checkpoint are needed to pin the refusal.
         tests/test_expert_placement.cpp
+        tests/test_nvfp4_expert_offload.cpp
         # Memory subsystem L1 (docs/internals/MEMORY.md). FakeBackend is the
         # substitution seam that keeps the whole allocator stack testable in the
         # CPU lane; it is test scaffolding, so it is compiled here rather than

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -98,6 +98,6 @@ Source: `src/core/qtype.h`.
 | speculative decoding: n-gram, suffix, MTP | ✅ | economics differ per model, see limitations |
 | Gated DeltaNet / Mamba2 hybrids | ✅ | |
 | MoE host offload for GGUF experts | ✅ | see the figure in [`PERF.md`](PERF.md#moe-host-offload) |
-| MoE host offload for NVFP4 experts | ⚪ | refused at load rather than served wrong (#1403) |
+| MoE host offload for NVFP4 experts | 🟡 | served from the expert cache; no automatic gate, see [`LIMITATIONS.md`](LIMITATIONS.md) |
 | multi-GPU, tensor parallelism | ⚪ | |
 | non-Blackwell GPUs, CPU inference | ⚪ | |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -44,9 +44,20 @@ These have a code path and no gate. They may work; nothing proves it.
 - **INT4 KV cache produces empty output on gpt-oss.** Its sink term is correct
   and is unit-tested against a sink-aware reference; 4 bits per value on a
   64-wide head is simply not enough. It falls back to FP16 rather than pretending.
-- **NVFP4 MoE experts cannot be host-offloaded.** A checkpoint whose experts do
-  not fit is refused at load instead of served with those experts silently
-  skipped (#1403). GGUF experts do have a working host path.
+- **Host-offloaded NVFP4 MoE experts are slow, and nothing gates them.** They run
+  correctly (Qwen3-30B-A3B-NVFP4, all 48 MoE layers on host: 23.0 tok/s against
+  384.0 resident), but the price is steep and the only checks that exercise the
+  path are manual. The CPU lane covers the slot arithmetic, not the kernels.
+  Two known costs: prefill goes through the serial per-expert fallback, and
+  prefill evicts the decode working set from the expert cache (74.6 % hit rate
+  measured, against 88.7 % on the equivalent GGUF path). A placement the cache
+  cannot hold at all is still refused at load rather than served wrong (#1403).
+
+  [PROV: commit=67d2c44 date=2026-08-13 hw=RTX5090 model=Qwen3-30B-A3B-NVFP4-Modelopt
+         quant=NVFP4 cuda=13.3 path=nvfp4-moe-host-offload
+         cmd=`imp-cli --max-tokens 220 --temperature 0 --set moe.force_host_experts=48`
+         n=1 note=single greedy run per arm; resident arm is the same command
+         without the --set. Cold cache, short prompt — not a benchmark figure]
 - **Batched and solo decode are not bit-identical.** Joining a batch costs
   rounding, measured at 0.22 % of the logit range, with identical greedy argmax.
   A neighbour's *content* provably cannot reach another row. No flag makes the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -306,6 +306,22 @@ What did **not** materialise is the rest of the 19x. Establishing residency need
 
 So the entry above stands, with one correction: the symptom is not only "repeated-token garbage + IMA". At a *partial* offload the model stays fluent and is simply wrong, which is the harder failure to notice. Building the path itself is still open, and the shape is the same one #1370 used: a cache slot would hold one expert's packed bytes and its micro-scales concatenated, so `gemv_nvfp4_moe_*` can be fed slot indices with `expert_stride_packed = expert_stride_ms = slot_size_`, needing no kernel change. The one piece that does not fall out for free is `tensor_scales`, which those kernels index with the same id as the weight, so it needs a per-slot mirror rather than the per-expert array that exists today.
 
+**Built 2026-08-13, and the decode half was exactly that. The estimate still missed roughly half the work, in a way worth recording.** Measured on Qwen3-30B-A3B-NVFP4-Modelopt, greedy, same prompt as the refusal above:
+
+| arm | before (#1403) | after |
+|---|---|---|
+| experts resident | 361.97 tok/s, coherent | **384.03**, coherent |
+| 8 of 48 layers on host | 88.77 tok/s, **wrong answer** | **44.54**, correct |
+| all 48 layers on host | repeats `ftp` forever | **23.03**, correct |
+
+Note the middle row got *slower*, which is the point: those eight layers were fast because they were skipping their GEMMs. Both host arms now emit the same answer as the resident one, and the 8-layer arm stops at the identical token count (119). GGUF offload is unchanged (39.77 tok/s at full offload, 65.7 % hit rate), and `make verify-fast` is flat (decode −1.05 %, prefill +0.95 %, peak VRAM +0.01 %).
+
+**What the estimate missed: the prefill.** #1370 could ignore `n > 1` — its own entry says "prefill unchanged, n>1 still takes the legacy path" — because GGUF experts reach `dequant_expert`'s staging buffer there. Per-expert NVFP4 tensors do not: the M>1 fallback handed the 593 MiB expert matrix to `gemm_nvfp4`, which dequantises on the device, so the first working decode still died on an IMA. The fix is small once located (stage one expert per `expert_gemm` call through the same slot pool, three slots regardless of how many experts the prompt activates), but it is a second path, not a detail of the first.
+
+**And the promotion had a blast radius nobody costed.** Letting Phase 0 label host-resident experts NVFP4 makes them visible to every consumer that keys off `qtype == NVFP4` and then does device work. Four had to learn the difference, each found by a separate crash or wrong answer: Phase 0b registered them for the CUTLASS grouped prefill (host pointer into a kernel); Phase 3 tried to copy them into a contiguous device buffer with `cudaMemcpyDeviceToDevice` (fails on a host source, leaving the buffer uninitialised — and it would have pulled back into VRAM exactly what was moved out); the micro-scales were still uploaded to VRAM, so the promotion's own both-on-host guard never fired; and `can_decode_fast` keys off `expert_up_packed`, which is only stamped for device-resident experts, so the decode sat in the serial legacy path at 35 tok/s while the new one went unused. **The generalisable rule: `qtype` says how to decode bytes, never where they live. A predicate that reads one and means the other is the #1384 / #1403 shape, and it appeared four more times here.**
+
+Two costs remain, both measured rather than assumed. Prefill runs the serial per-expert fallback, and it evicts the decode working set — 74.6 % hit rate against the 88.7 % the GGUF path reaches, which is the same thrashing #1365's working-set gate fixed there and which nothing yet fixes here. Neither is a correctness issue and both are ordinary follow-on work.
+
 *Where the path stands after all of it, re-profiled 2026-08-11 on the shipped build.* The entry opened by calling this path issue-bound; after #1370 and #1376 **it is not any more, and that retires the framing rather than confirming it.** Same config (256 cold decode tokens, all experts host-resident), tg phase 7.06 s:
 
 | term | per token | share |

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -800,6 +800,25 @@ private:
                              const Tensor& no, Tensor& h, const Tensor& r,
                              bool moe_use_fp32_residual, bool moe_fused_norm_q8,
                              bool will_skip_residual_copy, bool& residual_fused);
+    // Decode step for a layer whose NVFP4 experts live on host: stages the
+    // routed experts into the LRU cache's slot pool and runs the ordinary
+    // fused NVFP4 GEMVs against it. Only called when the dispatch predicate in
+    // run_moe_decode_fast says every precondition holds — see
+    // nvfp4_expert_offload.h. Defined in executor_forward_moe_nvfp4_host.cu.
+    void run_moe_decode_nvfp4_host(int layer, cudaStream_t stream, int d, int eff, int top_k,
+                                   const MoeRoutingResult& routing, const Tensor& no, Tensor& h,
+                                   const Tensor& r, bool moe_use_fp32_residual,
+                                   bool will_skip_residual_copy, bool& residual_fused,
+                                   bool non_gated_experts);
+
+public:
+    // Throws when a MoE layer's NVFP4 experts are host-resident and nothing
+    // can serve them from there. Call after pre_dequant_weights(): it needs
+    // Phase 0's promotion and the initialised expert cache, which is why it
+    // cannot live at weight-upload time. See the definition for the history.
+    void verify_host_expert_placement() const;
+
+private:
     // Compute MoE routing: gate logits (FP32 router fast-path for Gemma-4
     // already done by caller — signaled via `fp32_gate_logits_ready`) + topk
     // gating + per-expert weight scaling (Nemotron, Gemma-4). Caller passes

--- a/src/exec/executor_forward_moe.cu
+++ b/src/exec/executor_forward_moe.cu
@@ -95,9 +95,16 @@ namespace {
 // which measured ~48 kernel launches per layer against this path's ~3
 // (docs/roadmap.md).
 static bool can_decode_fast(int n, const Tensor& expert_up_packed, QType up_qtype, void* dequant_buf,
-                            QType compute_dtype, bool host_pool_ok) {
-    return (n == 1 && expert_up_packed.data != nullptr && dequant_buf != nullptr &&
-            compute_dtype == QType::F16 && (expert_up_packed.on_device || host_pool_ok) &&
+                            QType compute_dtype, bool host_pool_ok, bool nvfp4_host_ok) {
+    if (n != 1 || compute_dtype != QType::F16)
+        return false;
+    // Host-resident NVFP4 experts have no packed 3-D tensor to test — the slot
+    // path addresses the per-expert tensors directly. Its own predicate has
+    // already checked everything this one would.
+    if (nvfp4_host_ok)
+        return true;
+    return (expert_up_packed.data != nullptr && dequant_buf != nullptr &&
+            (expert_up_packed.on_device || host_pool_ok) &&
             (up_qtype == QType::Q6_K || up_qtype == QType::Q8_0 || up_qtype == QType::Q4_0 ||
              up_qtype == QType::Q4_K || up_qtype == QType::Q5_K || up_qtype == QType::Q2_K ||
              up_qtype == QType::Q3_K || up_qtype == QType::Q5_1 || up_qtype == QType::NVFP4));
@@ -189,7 +196,9 @@ void GraphExecutor::moe_ffn_phase2_state_and_norm_(int layer, cudaStream_t strea
         can_decode_fast(ctx.n, ly.expert_up_packed, ly.expert_up_packed.qtype, moe_.dequant_buf,
                         compute_dtype_,
                         host_expert_pool_ready(ly.expert_up_packed, expert_cache_, moe_,
-                                               model_->config().n_experts_active)) &&
+                                               model_->config().n_experts_active),
+                        nvfp4_host_decode_ready(ly, expert_cache_, moe_,
+                                                model_->config().n_experts_active)) &&
         ly.w_up_shared.data == nullptr;  // must not have shared expert for full residual fusion
 
     if (!ctx.will_skip_residual_copy) {
@@ -316,7 +325,9 @@ void GraphExecutor::moe_ffn_phase3_route_(int layer, cudaStream_t stream, MoeFfn
     ctx.will_decode_fast = can_decode_fast(ctx.n, ly.expert_up_packed, ctx.up_qtype, moe_.dequant_buf,
                                            compute_dtype_,
                                            host_expert_pool_ready(ly.expert_up_packed, expert_cache_, moe_,
-                                                                  cfg.n_experts_active));
+                                                                  cfg.n_experts_active),
+                                           nvfp4_host_decode_ready(ly, expert_cache_, moe_,
+                                                                   cfg.n_experts_active));
     // Gemma 4: dp4a decode fast path ENABLED by default. dp4a matches llama's
     // Q4_K×Q8_1 accumulation for MoE experts, preventing the routing drift that
     // occurs with FP16 dequant+cuBLAS. Set IMP_G4_NO_DECODE_FAST=1 to disable.

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -6,6 +6,7 @@
 #include "compute/mmq_q8_imma.h"
 #include "core/cuda_static_reset.h"
 #include "exec/executor_forward_moe_internal.h"
+#include "exec/nvfp4_expert_offload.h"
 #include "exec/executor_helpers.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
@@ -948,6 +949,27 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
     bool use_nvfp4_moe = (ly.nvfp4_moe_up_ptr != nullptr && ly.nvfp4_moe_down_ptr != nullptr);
     if (use_nvfp4_moe && !non_gated_experts)
         use_nvfp4_moe = (ly.nvfp4_moe_gate_ptr != nullptr);
+
+    // ---- Host-resident NVFP4 experts: address the LRU cache's slot pool ----
+    // Phase 3 builds nvfp4_moe_*_ptr only for device-resident experts, so a
+    // host-resident NVFP4 layer arrives here with none of them — which is how
+    // #1403's placement reached a generic GEMM as raw bytes and answered from
+    // the experts that happened to be resident.
+    //
+    // The fix is the #1370 trick with one addition. An NVFP4 expert is TWO
+    // ranges, so a slot holds `packed || micro_scales` and the kernels get
+    // both bases pointing into the same pool with the same stride. The one
+    // piece that does not fall out is the tensor scale, which the kernels
+    // index by the SAME id as the weight: it comes from the cache's per-slot
+    // mirror instead of the checkpoint's per-expert array. Details and the
+    // layout arithmetic are in nvfp4_expert_offload.h.
+    if (!use_nvfp4_moe && !model_->profile().is_gpt_oss &&
+        nvfp4_host_decode_ready(ly, expert_cache_, moe_, top_k)) {
+        run_moe_decode_nvfp4_host(layer, stream, d, eff, top_k, routing, no, h, r,
+                                  moe_use_fp32_residual, will_skip_residual_copy, residual_fused,
+                                  non_gated_experts);
+        return;
+    }
 
     if (use_nvfp4_moe) {
         if (model_->profile().is_gpt_oss) {

--- a/src/exec/executor_forward_moe_internal.h
+++ b/src/exec/executor_forward_moe_internal.h
@@ -6,6 +6,8 @@
 #include "quant/dequant_gpu.h"
 #include "exec/expert_cache.h"
 #include "exec/moe_workspace.h"
+#include "exec/nvfp4_expert_offload.h"
+#include "model/model_config.h"
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
@@ -81,6 +83,49 @@ inline bool host_expert_pool_ready(const Tensor& up_packed, const ExpertLRUCache
     return (!up_packed.on_device && cache.n_slots_ > 0 && cache.pool_ != nullptr && cache.slot_size_ > 0 &&
             moe.d_slot_idx != nullptr && moe.d_slot_idx_count >= kExpertProjCount * top_k &&
             cache.slots_per_layer_ >= kExpertProjCount * top_k);
+}
+
+// The weaker form the LEGACY (prefill) path needs. It stages one expert at a
+// time and consumes the result before touching the next, so it needs neither
+// the slot-index buffer nor `3 * top_k` slots — stream ordering already keeps
+// a refill behind the kernel that read the previous occupant. What it does
+// need is a pool that carries NVFP4 slots at all.
+inline bool nvfp4_host_pool_ready_for_staging(const ExpertLRUCache& cache) {
+    return (cache.nvfp4_slots_ && cache.d_slot_scales_ != nullptr && cache.pool_ != nullptr &&
+            cache.slot_size_ > 0 && cache.slots_per_layer_ >= kExpertProjCount);
+}
+
+// Same question for NVFP4 experts. Two extra requirements over the GGUF case:
+// the pool must have been initialised with NVFP4 slots (they are wider — one
+// slot holds packed weights AND micro-scales), and the per-slot tensor-scale
+// mirror must exist, because the fused kernels index it with the slot number.
+inline bool nvfp4_host_pool_ready(const ExpertLRUCache& cache, const MoEWorkspace& moe, int top_k) {
+    return (cache.nvfp4_slots_ && cache.d_slot_scales_ != nullptr && cache.n_slots_ > 0 &&
+            cache.pool_ != nullptr && cache.slot_size_ > 0 && moe.d_slot_idx != nullptr &&
+            moe.d_slot_idx_count >= kExpertProjCount * top_k &&
+            cache.slots_per_layer_ >= kExpertProjCount * top_k);
+}
+
+// Does this layer's n==1 decode go to the host-resident NVFP4 slot path?
+//
+// ONE definition, three readers: `can_decode_fast` (may I take the decode fast
+// path at all), the residual-fusion pre-check, and run_moe_decode_fast's own
+// branch. They must agree exactly — if the first says yes and the last
+// declines, the layer falls through to a path that cannot serve it.
+//
+// This deliberately does NOT look at `expert_up_packed`: that tensor is only
+// stamped for device-resident experts, so a host-resident NVFP4 layer arrives
+// with it empty. Reading it there is what kept this decode in the serial
+// legacy path at 35 tok/s while the slot path sat unused.
+inline bool nvfp4_host_decode_ready(const TransformerLayer& ly, const ExpertLRUCache& cache,
+                                    const MoEWorkspace& moe, int top_k) {
+    if (!nvfp4_host_pool_ready(cache, moe, top_k))
+        return false;
+    const bool non_gated = (ly.expert_gate_packed.data == nullptr &&
+                            (ly.expert_w_gate.empty() || ly.expert_w_gate[0].data == nullptr));
+    return nvfp4_host_experts_servable(ly.expert_w_up) &&
+           nvfp4_host_experts_servable(ly.expert_w_down) &&
+           (non_gated || nvfp4_host_experts_servable(ly.expert_w_gate));
 }
 
 }  // namespace imp

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -4,6 +4,7 @@
 #include "core/dispatch_policy.h"
 #include "exec/executor.h"
 #include "exec/executor_forward_moe_internal.h"
+#include "exec/nvfp4_expert_offload.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
 #include "exec/executor_debug.h"
@@ -237,6 +238,74 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                         gemm_nvfp4(nw, a_t, c_t, stream);
                     }
                     return;
+                }
+            }
+
+            // Host-resident NVFP4 expert: stage it into the LRU cache's slot
+            // pool first, then run the ordinary NVFP4 GEMM against the slot.
+            //
+            // Without this the branch below hands `wh.payload.nvfp4.data` —
+            // a HOST pointer for these experts — straight to gemm_nvfp4, which
+            // dequantises it on the device: an illegal access, and the reason
+            // the M>1 fallback died on the 593 MiB expert matrix. #1370 never
+            // hit this because its GGUF experts reach dequant_expert's staging
+            // buffer instead; per-expert NVFP4 tensors do not.
+            //
+            // One expert at a time is exactly what this loop already does, so
+            // three slots suffice regardless of how many experts the prompt
+            // activates — the pool is not thrashed the way a batched path
+            // would thrash it.
+            //
+            // Note the condition is on the EXPERT tensor, not on the `qtype`
+            // parameter: that one comes from `ly.expert_*_packed`, which stays
+            // empty for host-resident NVFP4 layers (Phase 3 only stamps it for
+            // device-resident ones). Reading the parameter here would test a
+            // tensor this branch never touches — the same mismatch that made
+            // #1384 and #1403 miss what they were meant to catch.
+            if (static_cast<size_t>(eidx) < fallback.size() &&
+                fallback[eidx].qtype == QType::NVFP4) {
+                const Tensor& w = fallback[eidx];
+                if (w.data && !w.on_device && w.scales && w.ndim == 2 &&
+                    nvfp4_host_pool_ready_for_staging(expert_cache_)) {
+                    const auto layout = nvfp4_slot_layout(w.shape[0], w.shape[1] * 2);
+                    if (layout.slot_bytes() > 0 && layout.slot_bytes() <= expert_cache_.slot_size_) {
+                        ExpertCacheKey ck{fallback[0].data, eidx};
+                        void* slot = expert_cache_.get_or_load_nvfp4(
+                            layer, proj, ck, w.data, layout.packed_bytes, w.scales, layout.ms_bytes,
+                            layout.packed_off(), w.tensor_scale, stream);
+                        if (slot) {
+                            NvFP4QuantResult nw;
+                            nw.packed_data = slot;
+                            nw.micro_scales = static_cast<char*>(slot) + layout.packed_off();
+                            nw.tensor_scale = w.tensor_scale;
+                            nw.N = static_cast<int>(w.shape[0]);
+                            nw.K = static_cast<int>(w.shape[1] * 2);
+                            const int M = static_cast<int>(a.shape[0]);
+                            if (M == 1) {
+                                gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
+                                                static_cast<half*>(c.data), nw.N, nw.K, stream);
+                            } else {
+                                // M>1 goes through gemm_nvfp4 for the same
+                                // reason the resident path does: the per-row
+                                // gemv loop is wrong on multi-token expert
+                                // prefill (bisected 2026-04-27, see below).
+                                int64_t a_shape[2] = {static_cast<int64_t>(M),
+                                                      static_cast<int64_t>(nw.K)};
+                                int64_t c_shape[2] = {static_cast<int64_t>(M),
+                                                      static_cast<int64_t>(nw.N)};
+                                Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
+                                           QType::F16, 2, a_shape, true);
+                                Tensor c_t(c.data, QType::F16, 2, c_shape, true);
+                                gemm_nvfp4(nw, a_t, c_t, stream);
+                            }
+                            return;
+                        }
+                    }
+                    IMP_LOG_FATAL(
+                        "MoE legacy fallback: host-resident NVFP4 expert %d on layer %d cannot be "
+                        "staged (slot %zu B, pool slot %zu B). Continuing would hand a host "
+                        "pointer to a device kernel.",
+                        eidx, layer, layout.slot_bytes(), expert_cache_.slot_size_);
                 }
             }
 

--- a/src/exec/executor_forward_moe_nvfp4_host.cu
+++ b/src/exec/executor_forward_moe_nvfp4_host.cu
@@ -1,0 +1,257 @@
+// Decode path for MoE layers whose NVFP4 experts live on host.
+//
+// The GGUF host-offload path (#1370) works by handing the fused decode kernels
+// the LRU cache's per-layer slot pool instead of the model's expert array: the
+// kernels read `base + idx * stride`, and the pool is exactly that shape, so
+// `idx` becomes a slot index and no kernel changes.
+//
+// NVFP4 experts did not have that path at all. A host-resident placement was
+// loaded and served WRONG — Phase 0 skipped promoting scales onto host weights,
+// the generic GEMM then recognised the scale-less packed weight and returned
+// without multiplying, and the model answered from whichever experts happened
+// to be resident, at exit code 0 (#1403 refused the placement rather than
+// serve it). This file is the path that refusal was standing in for.
+//
+// What is different from the GGUF case, and why it is only different by this
+// much: an NVFP4 expert is TWO byte ranges (packed FP4 weights + FP8 E4M3
+// micro-scales) rather than one. Both are addressed by the same slot index,
+// because the kernels take separate bases and separate strides for them — so a
+// slot holding `packed || micro_scales` resolves both at once. The layout
+// arithmetic is in nvfp4_expert_offload.h.
+//
+// The one piece that genuinely does not fall out is the per-tensor scale: the
+// kernels read `tensor_scales[idx]` with the SAME index as the weight, so the
+// checkpoint's per-EXPERT array cannot be handed to a slot-indexed kernel. The
+// cache keeps a per-SLOT mirror, written whenever a slot's occupant changes.
+
+#include "exec/executor.h"
+#include "exec/executor_forward_moe_internal.h"
+#include "exec/executor_helpers.h"
+#include "exec/executor_kernels.h"
+#include "exec/nvfp4_expert_offload.h"
+#include "compute/activation.h"
+#include "compute/moe_routing.h"
+#include "quant/nvfp4_gemm.h"
+#include "core/logging.h"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace imp {
+
+// Refuse a placement nothing can serve — the gate #1403 installed, moved to
+// where the answer is actually known.
+//
+// At weight-upload time it was not: whether a host-resident NVFP4 layer can be
+// served depends on the expert cache, which is sized later (init_weights runs
+// before init_kv_cache). The old gate resolved that by refusing every
+// host-resident NVFP4 placement outright, which was correct while no path
+// existed. Now that one does, re-deriving the cache's sizing at placement time
+// would mean a second copy of that arithmetic — and a copy that drifts is
+// exactly the failure #1384 and #1403 both were.
+//
+// So the check runs here instead, after pre-dequant, against the real tensors
+// and the real cache. It uses the SAME predicates the dispatch uses, so a
+// placement that passes here is one run_moe_decode_fast will route to the slot
+// path rather than quietly fall through to a GEMM that cannot multiply it.
+void GraphExecutor::verify_host_expert_placement() const {
+    const auto& cfg = model_->config();
+    if (!cfg.is_nvfp4_prequant)
+        return;  // GGUF-class experts have a staging fallback that is slow, not wrong.
+
+    const int top_k = std::max(1, cfg.n_experts_active);
+    int host_layers = 0, unservable = 0, first_bad = -1;
+    for (int i = 0; i < cfg.n_layers; ++i) {
+        const auto& L = model_->layer(i);
+        if (L.expert_w_up.empty() || !L.expert_w_up[0].data || L.expert_w_up[0].on_device)
+            continue;
+        ++host_layers;
+        const bool has_gate = (!L.expert_w_gate.empty() && L.expert_w_gate[0].data != nullptr);
+        const bool ok = nvfp4_host_experts_servable(L.expert_w_up) &&
+                        nvfp4_host_experts_servable(L.expert_w_down) &&
+                        (!has_gate || nvfp4_host_experts_servable(L.expert_w_gate)) &&
+                        nvfp4_host_pool_ready(expert_cache_, moe_, top_k);
+        if (!ok) {
+            ++unservable;
+            if (first_bad < 0)
+                first_bad = i;
+        }
+    }
+
+    if (unservable > 0) {
+        const int need = kExpertProjCount * top_k;
+        std::string msg = "NVFP4 experts are host-resident on ";
+        msg += std::to_string(unservable);
+        msg += " MoE layer(s) (first: layer ";
+        msg += std::to_string(first_bad);
+        msg += ") that the expert cache cannot serve. Serving them anyway would skip those "
+               "experts' GEMMs and answer from the rest, at exit code 0. The slot path needs at "
+               "least ";
+        msg += std::to_string(need);
+        msg += " slots per layer (3 projections x top_k) and has ";
+        msg += std::to_string(expert_cache_.slots_per_layer_);
+        msg += ". Raise moe.expert_cache_budget_pct, reduce runtime.max_seq_len, pick a smaller "
+               "KV dtype, or use a GGUF quantisation of this model.";
+        throw std::runtime_error(msg);
+    }
+
+    if (host_layers > 0) {
+        IMP_LOG_INFO("NVFP4 experts: %d MoE layer(s) host-resident, served from the expert cache "
+                     "(%d slots/layer, %.2f MiB per slot)",
+                     host_layers, expert_cache_.slots_per_layer_,
+                     expert_cache_.slot_size_ / (1024.0 * 1024.0));
+    }
+}
+
+namespace {
+
+// Point an NvFP4MoEQuantResult at one layer's slot pool. `ms_off` is where a
+// slot's micro-scale block starts; the cache filled the slot with the same
+// value, and disagreeing about it is fatal there rather than silent here.
+NvFP4MoEQuantResult pool_view(char* layer_pool, size_t slot_size, size_t ms_off, float* slot_scales,
+                              int slots_per_layer, int64_t N, int64_t K) {
+    NvFP4MoEQuantResult r;
+    r.packed_data = layer_pool;
+    r.micro_scales = layer_pool + ms_off;
+    r.tensor_scales = slot_scales;
+    r.n_experts = slots_per_layer;
+    r.N = N;
+    r.K = K;
+    r.expert_stride_packed = slot_size;
+    r.expert_stride_ms = slot_size;
+    r.borrowed = true;  // every pointer belongs to the cache
+    return r;
+}
+
+}  // namespace
+
+void GraphExecutor::run_moe_decode_nvfp4_host(int layer, cudaStream_t stream, int d, int eff,
+                                              int top_k, const MoeRoutingResult& routing,
+                                              const Tensor& no, Tensor& h, const Tensor& r,
+                                              bool moe_use_fp32_residual,
+                                              bool will_skip_residual_copy, bool& residual_fused,
+                                              bool non_gated_experts) {
+    const auto& cfg = model_->config();
+    const auto& ly = model_->layer(layer);
+
+    const int32_t* expert_indices = static_cast<const int32_t*>(routing.expert_indices.data);
+    const float* expert_weights = static_cast<const float*>(routing.expert_weights.data);
+
+    half* norm_ptr = static_cast<half*>(no.data);
+    half* gate_buf = static_cast<half*>(moe_.expert_gate.data);   // [top_k, eff]
+    half* up_buf = static_cast<half*>(moe_.expert_up.data);       // [top_k, eff]
+    half* act_buf = static_cast<half*>(moe_.expert_swiglu.data);  // [top_k, eff]
+    half* down_buf = static_cast<half*>(moe_.expert_down.data);   // [top_k, d]
+
+    // Establishing residency needs the routing on the host, so this path pays
+    // one D2H + sync per layer — the same one the GGUF slot path pays, and the
+    // reason CUDA graphs stay disabled under host-resident experts.
+    moe_host_args_capture_guard(stream);
+    std::vector<int32_t> h_experts(top_k);
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_experts.data(), expert_indices,
+                                       static_cast<size_t>(top_k) * sizeof(int32_t),
+                                       cudaMemcpyDeviceToHost, stream));
+    cudaStreamSynchronize(stream);
+
+    std::vector<int32_t> h_slots(static_cast<size_t>(kExpertProjCount) * top_k, -1);
+    size_t ms_off[kExpertProjCount] = {0, 0, 0};
+
+    auto stage = [&](const std::vector<Tensor>& experts, ExpertProj proj) -> bool {
+        const int proj_idx = std::to_underlying(proj);
+        if (experts.empty() || !experts[0].data)
+            return true;  // non-gated model has no gate projection
+        const auto layout = nvfp4_slot_layout(experts[0].shape[0], experts[0].shape[1] * 2);
+        ms_off[proj_idx] = layout.packed_off();
+        const int off = proj_idx * top_k;
+        for (int k = 0; k < top_k; ++k) {
+            const int e = h_experts[k];
+            if (e < 0 || e >= static_cast<int>(experts.size()))
+                return false;
+            const Tensor& w = experts[e];
+            // packed_ptr identifies the projection; expert 0's address is
+            // stable and unique per (layer, projection).
+            ExpertCacheKey ck{experts[0].data, e};
+            void* p = expert_cache_.get_or_load_nvfp4(layer, proj, ck, w.data, layout.packed_bytes,
+                                                      w.scales, layout.ms_bytes, layout.packed_off(),
+                                                      w.tensor_scale, stream);
+            if (!p)
+                return false;
+            const size_t flat =
+                static_cast<size_t>(static_cast<char*>(p) - static_cast<char*>(expert_cache_.pool_)) /
+                expert_cache_.slot_size_;
+            h_slots[off + k] = static_cast<int32_t>(flat) - layer * expert_cache_.slots_per_layer_;
+        }
+        return true;
+    };
+
+    if (!stage(ly.expert_w_gate, ExpertProj::Gate) || !stage(ly.expert_w_up, ExpertProj::Up) ||
+        !stage(ly.expert_w_down, ExpertProj::Down)) {
+        // Unreachable by construction: the dispatch predicate checked every
+        // precondition, and staging can only fail on an out-of-range expert
+        // id. Falling through would hand a HOST pointer to a kernel, so say so
+        // instead.
+        IMP_LOG_FATAL(
+            "MoE NVFP4 host decode: experts could not be staged into the LRU pool (layer %d, "
+            "top_k %d, slots/layer %d). The dispatch predicate and this path have diverged.",
+            layer, top_k, expert_cache_.slots_per_layer_);
+    }
+
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.d_slot_idx, h_slots.data(),
+                                       h_slots.size() * sizeof(int32_t), cudaMemcpyHostToDevice,
+                                       stream));
+
+    char* layer_pool = static_cast<char*>(expert_cache_.pool_) +
+                       static_cast<size_t>(layer) * expert_cache_.slots_per_layer_ *
+                           expert_cache_.slot_size_;
+    float* slot_scales = expert_cache_.layer_slot_scales(layer);
+    const size_t slot_size = expert_cache_.slot_size_;
+    const int slots_per_layer = expert_cache_.slots_per_layer_;
+
+    const int32_t* gate_idx = moe_.d_slot_idx;
+    const int32_t* up_idx = moe_.d_slot_idx + top_k;
+    const int32_t* down_idx = moe_.d_slot_idx + 2 * top_k;
+
+    const NvFP4MoEQuantResult up_view =
+        pool_view(layer_pool, slot_size, ms_off[std::to_underlying(ExpertProj::Up)], slot_scales,
+                  slots_per_layer, eff, d);
+    const NvFP4MoEQuantResult down_view =
+        pool_view(layer_pool, slot_size, ms_off[std::to_underlying(ExpertProj::Down)], slot_scales,
+                  slots_per_layer, d, eff);
+
+    if (!non_gated_experts) {
+        const NvFP4MoEQuantResult gate_view =
+            pool_view(layer_pool, slot_size, ms_off[std::to_underlying(ExpertProj::Gate)], slot_scales,
+                      slots_per_layer, eff, d);
+        // gate and up sit in DIFFERENT slots, so the one-index fused gate+up
+        // kernel cannot express both. Two decodes still collapse 2*top_k
+        // weight launches into 2 — the same trade the GGUF slot path makes.
+        gemv_nvfp4_moe_decode(gate_view, gate_idx, norm_ptr, gate_buf, eff, d, /*x_stride=*/0, top_k,
+                              stream);
+        gemv_nvfp4_moe_decode(up_view, up_idx, norm_ptr, up_buf, eff, d, /*x_stride=*/0, top_k, stream);
+        apply_expert_activation(gate_buf, up_buf, act_buf, /*non_gated=*/false, top_k, eff,
+                                compute_dtype_, cfg.ffn_activation, stream);
+        gemv_nvfp4_moe_decode(down_view, down_idx, act_buf, down_buf, d, eff, /*x_stride=*/eff, top_k,
+                              stream);
+    } else {
+        gemv_nvfp4_moe_decode(up_view, up_idx, norm_ptr, up_buf, eff, d, /*x_stride=*/0, top_k, stream);
+        int64_t act_shape[2] = {static_cast<int64_t>(top_k), static_cast<int64_t>(eff)};
+        Tensor up_t(up_buf, compute_dtype_, 2, act_shape, true);
+        relu_sqr_inplace(up_t, stream);
+        gemv_nvfp4_moe_decode(down_view, down_idx, up_buf, down_buf, d, eff, /*x_stride=*/eff, top_k,
+                              stream);
+    }
+
+    const bool has_shared_expert = (ly.w_up_shared.data != nullptr);
+    const void* res_ptr = (has_shared_expert || moe_use_fp32_residual)
+                              ? nullptr
+                              : (will_skip_residual_copy ? h.data : r.data);
+    moe_weighted_sum_residual(down_buf, expert_weights, res_ptr, h.data, d, top_k, stream);
+    if (!has_shared_expert && !moe_use_fp32_residual)
+        residual_fused = true;
+}
+
+}  // namespace imp

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -8,6 +8,7 @@
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "exec/gemm_scratch.h"  // prewarm_mmvq_scratch
+#include "exec/nvfp4_expert_offload.h"
 #include "compute/gemm.h"       // kGemmCublasWorkspaceBytes, block_q8_1
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
@@ -522,6 +523,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         // device-resident (the common all-on-device load).
         size_t max_expert_raw = 0;
         bool any_host_packed_experts = false;
+        bool nvfp4_host_experts = false;
         {
             for (int li = 0; li < model_->n_layers(); li++) {
                 const auto& L = model_->layer(li);
@@ -537,6 +539,37 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 check(L.expert_up_packed, L.expert_up_packed.qtype);
                 check(L.expert_down_packed, L.expert_down_packed.qtype);
                 check(L.expert_gate_packed, L.expert_gate_packed.qtype);
+            }
+            // NVFP4-prequant checkpoints have no 3-D packed tensor at this
+            // point — their experts are per-expert 2-D tensors and Phase 3
+            // stamps the packed slot later, well after this runs. So size the
+            // pool off those instead, and off the FULL slot (packed weights +
+            // micro-scales), which is what an NVFP4 slot has to hold.
+            //
+            // The qtype is still INT8 here: Phase 0's promotion to NVFP4 runs
+            // in pre_dequant_weights(), which is init_kv_cache() — after this.
+            // is_nvfp4_prequant comes from config.json and is known already.
+            if (model_->config().is_nvfp4_prequant) {
+                for (int li = 0; li < model_->n_layers(); li++) {
+                    const auto& L = model_->layer(li);
+                    auto check_nv = [&](const std::vector<Tensor>& experts) {
+                        if (experts.empty() || !experts[0].data || experts[0].ndim != 2)
+                            return;
+                        // Per-expert 2-D NVFP4 weights are stored [N, K/2].
+                        const auto layout =
+                            nvfp4_slot_layout(experts[0].shape[0], experts[0].shape[1] * 2);
+                        if (layout.slot_bytes() == 0)
+                            return;
+                        max_expert_raw = std::max(max_expert_raw, layout.slot_bytes());
+                        if (!experts[0].on_device) {
+                            any_host_packed_experts = true;
+                            nvfp4_host_experts = true;
+                        }
+                    };
+                    check_nv(L.expert_w_gate);
+                    check_nv(L.expert_w_up);
+                    check_nv(L.expert_w_down);
+                }
             }
             if (max_expert_raw > 0 && any_host_packed_experts) {
                 moe_.raw_staging_buf = vram_alloc(vram_alloc_, max_expert_raw, "moe_staging");
@@ -572,6 +605,9 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                         break;
                     }
                 }
+                // NVFP4-prequant experts are per-expert 2-D at this point, so
+                // the loop above cannot see them.
+                has_host_experts = has_host_experts || nvfp4_host_experts;
             }
             if (has_host_experts && !runtime_config().moe.no_expert_cache) {
                 // Budget: proportional to free VRAM (15%) instead of flat cap.
@@ -587,7 +623,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                 const auto& mcfg = model_->config();
                 bool debug_parity = runtime_config().moe.expert_cache_debug_parity;
                 if (expert_cache_.init(max_expert_raw, budget, vram_alloc_, mcfg.n_layers,
-                                       mcfg.n_experts, debug_parity)) {
+                                       mcfg.n_experts, debug_parity, nvfp4_host_experts)) {
                     IMP_LOG_INFO("Expert LRU cache: %d slots (%.2f MiB / %.2f MiB budget)",
                                  expert_cache_.n_slots_,
                                  expert_cache_.n_slots_ * max_expert_raw / (1024.0 * 1024.0),

--- a/src/exec/expert_cache.cu
+++ b/src/exec/expert_cache.cu
@@ -11,12 +11,13 @@
 namespace imp {
 
 bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc,
-                          int n_layers, int n_experts, bool debug_parity) {
+                          int n_layers, int n_experts, bool debug_parity, bool nvfp4_slots) {
     if (max_expert_raw == 0 || budget_bytes == 0)
         return false;
 
     alloc_ = alloc;
     slot_size_ = max_expert_raw;
+    nvfp4_slots_ = nvfp4_slots;
 
     // Phase 3: partition the pool per-layer. When n_layers == 0 (tests that
     // don't care about the per-layer split or callers that haven't migrated
@@ -132,6 +133,36 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         }
     }
 
+    // Per-slot tensor-scale mirror. Unlike d_lookup_ above this one IS read on
+    // the device — the fused NVFP4 kernels index it with the slot number the
+    // dispatch feeds them as `expert_indices`. Zero-init so a slot that is
+    // read before it is filled contributes 0 rather than a stale scale; the
+    // dispatch cannot produce that ordering, but a zero is a recognisable
+    // wrong answer where garbage is not.
+    if (nvfp4_slots_) {
+        const size_t bytes = static_cast<size_t>(n_slots_) * sizeof(float);
+        d_slot_scales_ = static_cast<float*>(
+            alloc_ ? alloc_->allocate(bytes, "expert_cache_slot_scales") : nullptr);
+        if (!alloc_) {
+            if (cudaMalloc(reinterpret_cast<void**>(&d_slot_scales_), bytes) != cudaSuccess)
+                d_slot_scales_ = nullptr;
+        }
+        if (!d_slot_scales_) {
+            IMP_LOG_WARN("Expert LRU cache: per-slot NVFP4 scale mirror alloc failed (%zu bytes) — "
+                         "cache disabled, experts fall back to the staging path.",
+                         bytes);
+            if (alloc_)
+                alloc_->free(pool_);
+            else
+                cudaFree(pool_);
+            pool_ = nullptr;
+            n_slots_ = 0;
+            slots_per_layer_ = 0;
+            return false;
+        }
+        IMP_CUDA_CHECK_LOG(cudaMemset(d_slot_scales_, 0, bytes));
+    }
+
     // Host-side tables — used in production regardless of the mirror above.
     if (n_experts_ > 0) {
         // Host source-pointer table: [layer][proj * n_experts + expert].
@@ -196,12 +227,12 @@ void* ExpertLRUCache::find(int layer, ExpertCacheKey key) {
     return slots_[flat_slot(layer, slot_in_layer, slots_per_layer_)].gpu_ptr;
 }
 
-void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
-                                  const void* src_host, size_t expert_bytes,
-                                  cudaStream_t stream) {
-    const int proj_idx = std::to_underlying(proj);
+ExpertLRUCache::Slot* ExpertLRUCache::acquire_slot_(int layer, int proj_idx, ExpertCacheKey key,
+                                                    const void* src_host, size_t stamp_bytes,
+                                                    cudaStream_t stream, bool* hit) {
+    *hit = false;
     if (layer < 0 || layer >= n_layers_) {
-        IMP_LOG_ERROR("ExpertLRUCache::get_or_load: layer %d out of range [0, %d)", layer,
+        IMP_LOG_ERROR("ExpertLRUCache::acquire_slot_: layer %d out of range [0, %d)", layer,
                       n_layers_);
         return nullptr;
     }
@@ -227,8 +258,8 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
     // (not slot_size_) to avoid reading past the pinned host region.
     if (!host_expert_bytes_.empty()) {
         size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj_idx;
-        if (pp_off < host_expert_bytes_.size() && expert_bytes > 0)
-            host_expert_bytes_[pp_off] = expert_bytes;
+        if (pp_off < host_expert_bytes_.size() && stamp_bytes > 0)
+            host_expert_bytes_[pp_off] = stamp_bytes;
     }
 
     // Phase 4: record the access into the per-layer history ring (regardless
@@ -248,7 +279,9 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
     if (cached) {
         if (debug_parity_)
             check_parity(stream);
-        return cached;
+        *hit = true;
+        auto it = plru.lookup.find(key);
+        return &slots_[flat_slot(layer, it->second.first, slots_per_layer_)];
     }
 
     misses_++;
@@ -279,8 +312,6 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
 
     const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
     Slot& slot = slots_[flat];
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot.gpu_ptr, src_host, expert_bytes, cudaMemcpyHostToDevice,
-                                       stream));
 
     slot.key = key;
     slot.occupied = true;
@@ -295,7 +326,85 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
     if (debug_parity_)
         check_parity(stream);
 
-    return slot.gpu_ptr;
+    return &slot;
+}
+
+void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
+                                  const void* src_host, size_t expert_bytes,
+                                  cudaStream_t stream) {
+    if (nvfp4_slots_) {
+        // A slot in this mode holds packed weights AND micro-scales; filling
+        // it from a single range would leave the scales as whatever the
+        // previous occupant left behind, which decodes to fluent nonsense
+        // rather than failing. Refuse where the two paths disagree.
+        IMP_LOG_FATAL(
+            "ExpertLRUCache::get_or_load called on an NVFP4 slot pool (layer %d) — "
+            "this pool's slots carry packed weights + micro-scales and must be filled "
+            "via get_or_load_nvfp4().",
+            layer);
+    }
+    bool hit = false;
+    Slot* slot = acquire_slot_(layer, std::to_underlying(proj), key, src_host, expert_bytes, stream, &hit);
+    if (!slot)
+        return nullptr;
+    if (!hit)
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(slot->gpu_ptr, src_host, expert_bytes,
+                                           cudaMemcpyHostToDevice, stream));
+    return slot->gpu_ptr;
+}
+
+void* ExpertLRUCache::get_or_load_nvfp4(int layer, ExpertProj proj, ExpertCacheKey key,
+                                        const void* src_packed, size_t packed_bytes,
+                                        const void* src_ms, size_t ms_bytes, size_t ms_off,
+                                        float tensor_scale, cudaStream_t stream) {
+    if (!nvfp4_slots_ || !d_slot_scales_) {
+        IMP_LOG_FATAL(
+            "ExpertLRUCache::get_or_load_nvfp4 called on a pool that was not initialised for "
+            "NVFP4 slots (layer %d) — there is no per-slot scale mirror to write.",
+            layer);
+    }
+    if (ms_off + ms_bytes > slot_size_ || packed_bytes > ms_off) {
+        IMP_LOG_FATAL(
+            "ExpertLRUCache::get_or_load_nvfp4: layout does not fit the slot (layer %d, "
+            "packed %zu B, ms_off %zu, ms %zu B, slot %zu B).",
+            layer, packed_bytes, ms_off, ms_bytes, slot_size_);
+    }
+    bool hit = false;
+    Slot* slot = acquire_slot_(layer, std::to_underlying(proj), key, src_packed, packed_bytes, stream,
+                               &hit);
+    if (!slot)
+        return nullptr;
+
+    if (hit) {
+        // The dispatch derives the kernel's micro_scales base from its own copy
+        // of the layout. If that ever stops matching what this slot was filled
+        // with, the kernel reads scales from the wrong offset — coherent-looking
+        // and wrong. Assert the agreement instead of assuming it.
+        if (slot->ms_off != ms_off) {
+            IMP_LOG_FATAL(
+                "ExpertLRUCache: slot layout disagreement on layer %d expert %d — slot was "
+                "filled with ms_off %zu, dispatch now says %zu.",
+                layer, key.expert_idx, slot->ms_off, ms_off);
+        }
+        return slot->gpu_ptr;
+    }
+
+    char* dst = static_cast<char*>(slot->gpu_ptr);
+    IMP_CUDA_CHECK_LOG(
+        cudaMemcpyAsync(dst, src_packed, packed_bytes, cudaMemcpyHostToDevice, stream));
+    IMP_CUDA_CHECK_LOG(
+        cudaMemcpyAsync(dst + ms_off, src_ms, ms_bytes, cudaMemcpyHostToDevice, stream));
+    slot->ms_off = ms_off;
+
+    // The scale mirror is indexed by the layer-relative slot index — the same
+    // number the dispatch hands the kernels as `expert_indices`.
+    const int slot_in_layer = static_cast<int>(
+        (static_cast<char*>(slot->gpu_ptr) - static_cast<char*>(pool_)) / slot_size_) -
+        layer * slots_per_layer_;
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_slot_scales_ + static_cast<size_t>(layer) * slots_per_layer_ +
+                                           slot_in_layer,
+                                       &tensor_scale, sizeof(float), cudaMemcpyHostToDevice, stream));
+    return slot->gpu_ptr;
 }
 
 int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes_fallback) {
@@ -505,6 +614,14 @@ void ExpertLRUCache::destroy() {
         cudaFree(d_lookup_);
         d_lookup_ = nullptr;
     }
+    if (d_slot_scales_) {
+        if (alloc_)
+            alloc_->free(d_slot_scales_);
+        else
+            cudaFree(d_slot_scales_);
+        d_slot_scales_ = nullptr;
+    }
+    nvfp4_slots_ = false;
     if (!prefetch_done_.empty()) {
         if (prefetch_h2ds_ > 0 || prefetch_skipped_cached_ > 0) {
             IMP_LOG_INFO("Expert LRU prefetch stats: %ld H2Ds issued, %ld skipped (already cached)",

--- a/src/exec/expert_cache.h
+++ b/src/exec/expert_cache.h
@@ -81,6 +81,12 @@ struct ExpertLRUCache {
         int layer = -1;
         int proj = -1;   // ExpertProj
         int expert = -1;
+        // NVFP4 slots only: where this slot's micro-scale block starts. The
+        // dispatch derives the kernel's `micro_scales` base from the SAME
+        // layout, so a disagreement would silently point the kernel at the
+        // wrong bytes. Recorded here so a hit can assert the two agree
+        // instead of trusting them to (the #1384 / #1403 shape).
+        size_t ms_off = 0;
     };
 
     void* pool_ = nullptr;     // contiguous GPU allocation for all slots
@@ -147,14 +153,35 @@ struct ExpertLRUCache {
     int* d_lookup_ = nullptr;
     int n_layers_ = 0;
     int n_experts_ = 0;
+
+    // ---- NVFP4 slots ------------------------------------------------------
+    // An NVFP4 expert is two byte ranges (packed FP4 weights + FP8 E4M3
+    // micro-scales), so a slot holds both concatenated — see
+    // nvfp4_expert_offload.h for why that makes the existing fused kernels
+    // work unchanged.
+    //
+    // What does NOT come for free is the tensor scale: the kernels read
+    // `tensor_scales[idx]` with the SAME index they use for the weight, so a
+    // per-EXPERT array cannot be handed to a slot-indexed kernel. This is the
+    // per-SLOT mirror they read instead, rewritten whenever a slot's occupant
+    // changes.
+    //
+    // Non-null marks the cache as serving NVFP4 experts. In that mode the
+    // plain get_or_load() is a programming error (it would fill a slot with
+    // weights and no scales, which decodes to garbage) and says so loudly.
+    float* d_slot_scales_ = nullptr;  // [n_slots_], device
+    bool nvfp4_slots_ = false;
     bool debug_parity_ = false;
     mutable int64_t parity_checks_ok_ = 0;  // exposed for tests; bumped by const check_parity()
 
     // Initialize: allocate the slot pool (partitioned per-layer) + the
     // device mirror + the host source-pointer table. Returns false if GPU
     // allocation fails (cache disabled).
+    // `nvfp4_slots` sizes the per-slot tensor-scale mirror and puts the cache
+    // in NVFP4 mode; `max_expert_raw` is then the full slot size (packed +
+    // micro-scales, aligned), not a single range.
     [[nodiscard]] bool init(size_t max_expert_raw, size_t budget_bytes, VRAMAllocator* alloc, int n_layers,
-                            int n_experts, bool debug_parity = false);
+                            int n_experts, bool debug_parity = false, bool nvfp4_slots = false);
 
     // Lookup or insert an expert. Returns GPU pointer to cached expert data.
     // If cache miss: copies from host, evicts LRU entry within the layer's
@@ -165,9 +192,38 @@ struct ExpertLRUCache {
     void* get_or_load(int layer, ExpertProj proj, ExpertCacheKey key,
                       const void* src_host, size_t expert_bytes, cudaStream_t stream);
 
+    // NVFP4 variant: stages one expert's packed weights AND its micro-scales
+    // into a single slot, and mirrors its tensor scale into d_slot_scales_ so
+    // a slot-indexed kernel reads the right one.
+    //
+    // `ms_off` is the slot-relative offset of the micro-scale block. The
+    // dispatch computes the kernel's `micro_scales` base from the same value;
+    // passing a different one on a later call for the same slot is a
+    // disagreement between the two, and is fatal rather than silent.
+    void* get_or_load_nvfp4(int layer, ExpertProj proj, ExpertCacheKey key, const void* src_packed,
+                            size_t packed_bytes, const void* src_ms, size_t ms_bytes, size_t ms_off,
+                            float tensor_scale, cudaStream_t stream);
+
+    // Device pointer to layer L's per-slot tensor-scale block, or nullptr
+    // outside NVFP4 mode. Indexed by the same layer-relative slot index the
+    // dispatch feeds the kernels as `expert_indices`.
+    float* layer_slot_scales(int layer) const {
+        if (!d_slot_scales_ || layer < 0 || layer >= n_layers_)
+            return nullptr;
+        return d_slot_scales_ + static_cast<size_t>(layer) * slots_per_layer_;
+    }
+
     // Check if (layer, expert) is cached (no insertion). Updates LRU recency
     // within the layer.
     void* find(int layer, ExpertCacheKey key);
+
+    // Shared LRU body behind both get_or_load variants: returns the slot that
+    // holds (layer, proj, key) — an existing one on a hit, a free or evicted
+    // one on a miss — with the bookkeeping (host pointer table, access ring,
+    // recency, device mirror) already done. `*hit` says whether the caller
+    // still has to copy anything in. Returns nullptr on a bad layer index.
+    Slot* acquire_slot_(int layer, int proj_idx, ExpertCacheKey key, const void* src_host,
+                        size_t stamp_bytes, cudaStream_t stream, bool* hit);
 
     void destroy();
 

--- a/src/exec/nvfp4_expert_offload.h
+++ b/src/exec/nvfp4_expert_offload.h
@@ -1,0 +1,175 @@
+#pragma once
+
+#include "core/tensor.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Host-resident NVFP4 MoE experts: the slot layout and the predicates that
+// decide whether the path applies.
+//
+// The GGUF host-offload path (#1370) works because one expert is one
+// contiguous byte range, so the LRU cache's fixed-stride slot pool IS the
+// array the fused decode kernels want: feed them slot indices with
+// `stride = slot_size` and they need no change.
+//
+// An NVFP4 expert is TWO ranges — packed FP4 weights and FP8 E4M3
+// micro-scales — which is why the same trick does not fall out for free. It
+// still works, because the kernels address the two with separate bases and
+// separate strides:
+//
+//     W  = packed_data  + idx * expert_stride_packed
+//     MS = micro_scales + idx * expert_stride_ms
+//
+// Concatenating both halves into one slot and passing
+//
+//     packed_data          = pool
+//     micro_scales         = pool + packed_off()
+//     expert_stride_packed = expert_stride_ms = slot_bytes()
+//
+// resolves both to the same slot. No kernel changes.
+//
+// `tensor_scales` is the one piece that does NOT fall out: the kernels read
+// it as `tensor_scales[idx]`, i.e. with the same index as the weight, so a
+// per-EXPERT array cannot be handed to a slot-indexed kernel. It needs a
+// per-slot device mirror, written whenever a slot's occupant changes.
+// ---------------------------------------------------------------------------
+
+// The kernels load packed weights through `uint2` (nvfp4_gemm_internal.cuh,
+// gemv_nvfp4_row), so both the slot base and the packed stride must be
+// 8-byte aligned. Micro-scales are read byte-wise and need no alignment of
+// their own — but they sit behind the packed block, so the padding is what
+// keeps the NEXT slot's packed block aligned. 16 covers both with room.
+inline constexpr size_t kNvFP4SlotAlign = 16;
+
+inline constexpr size_t nvfp4_align_up(size_t v, size_t a) { return (v + a - 1) / a * a; }
+
+// Byte layout of one cache slot holding a single NVFP4 expert.
+struct NvFP4SlotLayout {
+    size_t packed_bytes = 0;  // N * K/2, the FP4 weights
+    size_t ms_bytes = 0;      // N * K/16, the FP8 E4M3 micro-scales
+
+    // Offset of the micro-scale block within the slot.
+    constexpr size_t packed_off() const { return nvfp4_align_up(packed_bytes, kNvFP4SlotAlign); }
+    // Total slot size, itself aligned so slot i+1 starts aligned too.
+    constexpr size_t slot_bytes() const {
+        return nvfp4_align_up(packed_off() + ms_bytes, kNvFP4SlotAlign);
+    }
+};
+
+// Layout for an [N, K] expert. K must be a multiple of 16 (the micro-block
+// size the kernels hard-code); returns an empty layout otherwise, which every
+// caller treats as "this path does not apply".
+inline NvFP4SlotLayout nvfp4_slot_layout(int64_t N, int64_t K) {
+    NvFP4SlotLayout l;
+    if (N <= 0 || K <= 0 || K % 16 != 0)
+        return l;
+    l.packed_bytes = static_cast<size_t>(N) * static_cast<size_t>(K / 2);
+    l.ms_bytes = static_cast<size_t>(N) * static_cast<size_t>(K / 16);
+    return l;
+}
+
+// Can this projection's experts be served from the slot pool?
+//
+// This is the single definition of the condition. The dispatch calls it to
+// decide whether to stage, the load-time gate calls it to decide whether the
+// placement is servable at all, and the staging loop below relies on exactly
+// these facts holding — a weight that is NVFP4-promoted (so Phase 0 ran and
+// found its scales), host-resident (so it is the cache's business), carrying
+// micro-scales, and shaped like every other expert in the projection.
+//
+// Keeping one definition is the point: #1384 and #1403 were both a predicate
+// standing in front of the check that was supposed to catch the problem.
+inline bool nvfp4_host_experts_servable(const std::vector<Tensor>& experts) {
+    if (experts.empty() || !experts[0].data)
+        return false;
+    const Tensor& e0 = experts[0];
+    if (e0.on_device || e0.qtype != QType::NVFP4 || !e0.scales || e0.ndim != 2)
+        return false;
+    if (nvfp4_slot_layout(e0.shape[0], e0.shape[1] * 2).slot_bytes() == 0)
+        return false;
+    for (const Tensor& e : experts) {
+        if (!e.data || !e.scales || e.on_device || e.qtype != QType::NVFP4)
+            return false;
+        if (e.ndim != 2 || e.shape[0] != e0.shape[0] || e.shape[1] != e0.shape[1])
+            return false;
+    }
+    return true;
+}
+
+// An nvfp4_scratch_ key naming one per-expert MoE weight.
+// Key form: "L{layer}.expert_w_{gate,up,down}.{expert}". Dense weights
+// ("L5.wq", "out_proj") deliberately do not parse — they have no host path,
+// so promoting a host-resident one would label bytes NVFP4 that nothing can
+// serve from where they sit.
+//
+// One definition because three places ask the same question: Phase 0 (may I
+// promote this host-resident weight?) and both scale-upload paths (does this
+// scale belong to a weight that stayed on host, and must therefore stay there
+// too?). Parsing it twice is how the two halves drift apart.
+struct NvFP4ExpertKey {
+    enum class Kind { Gate, Up, Down };
+    bool valid = false;
+    int layer = -1;
+    int expert = -1;
+    Kind kind = Kind::Gate;
+};
+
+inline NvFP4ExpertKey parse_expert_key(std::string_view key) {
+    NvFP4ExpertKey out;
+    if (key.size() < 2 || key[0] != 'L')
+        return out;
+    const size_t dot = key.find('.', 1);
+    if (dot == std::string_view::npos || dot == 1)
+        return out;
+
+    int layer = 0;
+    for (size_t i = 1; i < dot; ++i) {
+        if (key[i] < '0' || key[i] > '9')
+            return out;
+        layer = layer * 10 + (key[i] - '0');
+    }
+
+    std::string_view rest = key.substr(dot + 1);
+    if (rest.rfind("expert_w_", 0) != 0)
+        return out;
+    rest.remove_prefix(9);  // "expert_w_"
+
+    NvFP4ExpertKey::Kind kind;
+    if (rest.rfind("gate.", 0) == 0) {
+        kind = NvFP4ExpertKey::Kind::Gate;
+        rest.remove_prefix(5);
+    } else if (rest.rfind("up.", 0) == 0) {
+        kind = NvFP4ExpertKey::Kind::Up;
+        rest.remove_prefix(3);
+    } else if (rest.rfind("down.", 0) == 0) {
+        kind = NvFP4ExpertKey::Kind::Down;
+        rest.remove_prefix(5);
+    } else {
+        return out;
+    }
+
+    if (rest.empty())
+        return out;
+    int expert = 0;
+    for (char c : rest) {
+        if (c < '0' || c > '9')
+            return out;
+        expert = expert * 10 + (c - '0');
+    }
+
+    out.valid = true;
+    out.layer = layer;
+    out.expert = expert;
+    out.kind = kind;
+    return out;
+}
+
+inline bool is_expert_key(std::string_view key) { return parse_expert_key(key).valid; }
+
+}  // namespace imp

--- a/src/exec/pre_dequant_phase0_nvfp4_loader.cu
+++ b/src/exec/pre_dequant_phase0_nvfp4_loader.cu
@@ -13,6 +13,7 @@
 #include "exec/executor.h"
 #include "exec/quant_pipeline.h"
 #include "exec/pre_dequant_internal.h"
+#include "exec/nvfp4_expert_offload.h"
 #include "compute/gemm_cutlass_sm120.h"
 #include "core/logging.h"
 #include "quant/nvfp4_quant.h"
@@ -91,7 +92,20 @@ void QuantPipeline::pre_dequant_phase0_promote_nvfp4_sidecars_(
             return false;  // not an NVFP4 promotion — nothing else to do here
         }
 
-        if (!w.on_device || !sc.weight_scale.on_device) {
+        // Promotion itself is host bookkeeping — it labels the weight NVFP4 and
+        // records where its micro-scales and tensor scale live. What it must
+        // never do is mix address spaces: `w.scales` is read with the same
+        // pointer discipline as `w.data`, so a device weight carrying a host
+        // scale (or the reverse) would hand one of them to the wrong consumer.
+        //
+        // Both-on-host is a legitimate combination for MoE experts, which the
+        // expert cache stages into VRAM per (layer, projection) at decode time.
+        // Skipping them is what made #1403's placement unservable: the weight
+        // stayed QType::INT8 and reached the generic GEMM as raw bytes. Dense
+        // weights have no host path, so they keep the device requirement.
+        const bool both_device = (w.on_device && sc.weight_scale.on_device);
+        const bool both_host = (!w.on_device && !sc.weight_scale.on_device);
+        if (!both_device && !(both_host && is_expert_key(key))) {
             IMP_LOG_DEBUG("NVFP4 prequant: skipping %s (data_dev=%d, scale_dev=%d)", key, w.on_device,
                           sc.weight_scale.on_device);
             return false;
@@ -458,6 +472,15 @@ void QuantPipeline::pre_dequant_phase0b_register_cutlass_nvfp4_(
         // instead (phase 2b). Always register.
         auto register_prequant = [&](const Tensor& w) {
             if (w.qtype != QType::NVFP4 || !w.data || !w.scales)
+                return;
+            // These caches feed device kernels: every pointer registered here
+            // is dereferenced on the GPU. A host-resident weight put in one is
+            // an illegal access, not a slow path — which is exactly what
+            // happened once Phase 0 started promoting host-resident experts
+            // (they reached the CUTLASS grouped prefill as host pointers).
+            // Host-resident MoE experts are served by the expert cache
+            // instead; see exec/nvfp4_expert_offload.h.
+            if (!w.on_device)
                 return;
             if (wcache_->nvfp4.count(w.data))
                 return;

--- a/src/exec/pre_dequant_phase3_moe.cu
+++ b/src/exec/pre_dequant_phase3_moe.cu
@@ -463,6 +463,16 @@ bool QuantPipeline::cache_moe_native_nvfp4_(Tensor& packed, std::vector<Tensor>&
             return false;
         if (packed.data && wcache_->nvfp4_moe.count(packed.data))
             return false;
+        // Host-resident experts are the expert cache's business, not this one.
+        // Both branches below build a DEVICE decode cache: the borrow branch
+        // points at resident bytes, and the fallback copies the experts into a
+        // contiguous device buffer with cudaMemcpyDeviceToDevice — which fails
+        // with "invalid argument" on a host source, leaving the buffer
+        // uninitialised and the layer decoding from garbage. It is also the
+        // opposite of what the placement asked for: it would pull back into
+        // VRAM exactly the experts that were moved out of it.
+        if (!experts[0].on_device)
+            return false;
         // ZERO-COPY decode cache (LEAD-2): NVFP4-prequant SafeTensors upload the
         // per-expert weights AND scales into contiguous VRAM (one buffer per
         // projection, sliced per expert). When that holds we point an

--- a/src/model/expert_placement.h
+++ b/src/model/expert_placement.h
@@ -5,48 +5,55 @@
 
 namespace imp {
 
-// Can this MoE expert placement actually be served?
+// Does this MoE expert placement depend on the NVFP4 host-offload path?
 //
-// For NVFP4-prequant checkpoints the answer is no as soon as one expert layer
-// stays on host, and the failure is silent rather than loud. Three places
-// disagree about it today, which is why it reached a released build:
+// History, because it explains where the real gate now lives. NVFP4-prequant
+// experts used to have no host path at all, and the failure was silent rather
+// than loud — three places disagreed about it, which is why it reached a
+// released build:
 //
-//   1. Phase 0 (`pre_dequant_phase0_nvfp4_loader.cu`) promotes the
+//   1. Phase 0 (`pre_dequant_phase0_nvfp4_loader.cu`) promoted the
 //      `weight_scale` / `weight_scale_2` sidecars onto a weight only when that
-//      weight is already `on_device`. A host-resident expert therefore keeps
-//      `scales == nullptr`, and Phase 0 says so at IMP_LOG_DEBUG, i.e. not at
+//      weight was already `on_device`. A host-resident expert therefore kept
+//      `scales == nullptr`, and Phase 0 said so at IMP_LOG_DEBUG, i.e. not at
 //      all under the default log level.
-//   2. `gemm()` recognises the scale-less packed weight, logs an ERROR and
-//      RETURNS without multiplying (bounded to 20 lines). The output buffer is
-//      pre-zeroed, so the forward continues with those experts contributing
+//   2. `gemm()` recognised the scale-less packed weight, logged an ERROR and
+//      RETURNED without multiplying (bounded to 20 lines). The output buffer is
+//      pre-zeroed, so the forward continued with those experts contributing
 //      nothing.
-//   3. `decide_expert_layer_placement_` warns about this, but only on the
+//   3. `decide_expert_layer_placement_` warned about this, but only on the
 //      budget route (`budget < total_expert_bytes`). `moe.force_host_experts`
-//      reaches the same placement without passing that branch at all.
+//      reached the same placement without passing that branch at all.
 //
 // Measured on Qwen3-30B-A3B-NVFP4-Modelopt, 2026-08-13, greedy, same prompt:
-// resident is coherent at 361.97 tok/s; 8 of 48 layers on host answers "the
+// resident was coherent at 361.97 tok/s; 8 of 48 layers on host answered "the
 // capital of France is the city of the same name, France itself" at 88.77
-// tok/s; all 48 on host repeats "ftp" forever. Every one of the three exits 0.
+// tok/s; all 48 on host repeated "ftp" forever. Every one of the three exited 0.
 //
-// So the placement has to be rejected where it is decided, and by a predicate
-// that does not care which route produced it. This is that predicate, kept
-// pure so it can be tested without a GPU or a checkpoint.
+// #1403 refused the placement outright. The path itself now exists — Phase 0
+// promotes host-resident experts too, and the expert cache stages them into a
+// slot pool the fused NVFP4 kernels can address (see
+// `exec/nvfp4_expert_offload.h`). What is still undecidable HERE is whether the
+// cache will be large enough, because it is sized after weight upload. So this
+// predicate answers only "does this placement rely on that path", and the
+// refusal moved to `GraphExecutor::verify_host_expert_placement()`, which runs
+// once the promotion and the real cache both exist. Kept pure so it can be
+// tested without a GPU or a checkpoint.
 //
 // `layer_expert_bytes[i] > 0` marks layer i as an MoE layer;
 // `experts_upload_layer[i]` is true when its experts go to the device.
-inline bool expert_placement_is_serveable(bool is_nvfp4_prequant,
-                                          const std::vector<size_t>& layer_expert_bytes,
-                                          const std::vector<bool>& experts_upload_layer) {
+inline bool expert_placement_needs_host_path(bool is_nvfp4_prequant,
+                                             const std::vector<size_t>& layer_expert_bytes,
+                                             const std::vector<bool>& experts_upload_layer) {
     if (!is_nvfp4_prequant)
-        return true;  // GGUF-class experts have a working host path (#1370).
+        return false;  // GGUF-class experts have their own host path (#1370).
     const size_t n = layer_expert_bytes.size() < experts_upload_layer.size() ? layer_expert_bytes.size()
                                                                              : experts_upload_layer.size();
     for (size_t i = 0; i < n; ++i) {
         if (layer_expert_bytes[i] > 0 && !experts_upload_layer[i])
-            return false;
+            return true;
     }
-    return true;
+    return false;
 }
 
 // How many MoE layers the placement leaves on host, for the error message.

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -3,6 +3,7 @@
 #include "memory/weight_snapshot.h"
 #include "memory/weight_cache_file.h"
 #include "model/expert_placement.h"
+#include "exec/nvfp4_expert_offload.h"
 #include "model/gguf_loader.h"
 #include "memory/mem_account.h"
 #include "quant/dequant_gpu.h"
@@ -1830,25 +1831,26 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
     decide_expert_layer_placement_(layer_expert_bytes, total_expert_bytes, expert_reserve_bytes, n_layers,
                                    experts_upload_layer, ctx.is_nvfp4_prequant);
 
-    // Refuse a placement this build cannot serve, rather than answering from
-    // the experts that happen to be resident. See expert_placement.h for why
-    // the three existing guards all miss this, and for the measurements.
-    if (!expert_placement_is_serveable(ctx.is_nvfp4_prequant, layer_expert_bytes, experts_upload_layer)) {
+    // A host-resident NVFP4 placement is servable now — the expert cache
+    // stages those experts per layer and the fused kernels address its slot
+    // pool. What CANNOT be decided here is whether the cache will be big
+    // enough: it is sized in init_weights()' workspace pass, which runs after
+    // this. Re-deriving that sizing here would be a second copy of the
+    // arithmetic, and a copy that drifts is exactly the failure #1403 was.
+    //
+    // So this only reports; the refusal lives in
+    // GraphExecutor::verify_host_expert_placement(), which runs once both the
+    // promotion and the real cache exist.
+    if (expert_placement_needs_host_path(ctx.is_nvfp4_prequant, layer_expert_bytes,
+                                         experts_upload_layer)) {
         const int host_layers = expert_placement_host_layers(layer_expert_bytes, experts_upload_layer);
         size_t free_mem = 0, total_mem = 0;
         vram_budget_mem_get_info(&free_mem, &total_mem);
-        std::string msg = "NVFP4-prequant experts do not fit on the device: ";
-        msg += std::to_string(host_layers);
-        msg += " MoE layer(s) would be host-resident, and there is no host-offload path for this ";
-        msg += "weight format. Serving it would silently skip those experts' GEMMs and answer from ";
-        msg += "the rest (";
-        msg += std::to_string(total_expert_bytes / (1024 * 1024));
-        msg += " MiB of experts, ";
-        msg += std::to_string(free_mem / (1024 * 1024));
-        msg += " MiB free). Reduce runtime.max_seq_len, pick a smaller KV dtype ";
-        msg += "(kv_cache.dtype=nvfp4), or use a GGUF quantisation of this model, whose experts ";
-        msg += "do have a host path.";
-        throw std::runtime_error(msg);
+        IMP_LOG_INFO(
+            "NVFP4 experts: %d MoE layer(s) stay host-resident (%zu MiB of experts, %zu MiB free) — "
+            "they will be served from the expert cache. Decode on those layers is materially "
+            "slower than resident; the load is refused later if the cache cannot hold them.",
+            host_layers, total_expert_bytes / (1024 * 1024), free_mem / (1024 * 1024));
     }
 
     // Upload expert weights for each layer
@@ -2425,6 +2427,13 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                 const int N = static_cast<int>(experts.size());
                 if (N == 0)
                     return;
+                // Experts that stayed on host keep their micro-scales there.
+                // The expert cache stages BOTH halves of an NVFP4 expert into
+                // one slot, so a scale already in VRAM would be the wrong
+                // address space for that copy — and VRAM spent on a layer that
+                // was moved out of VRAM precisely because it did not fit.
+                if (!experts[0].on_device)
+                    return;
                 std::vector<NvFP4PreQuantWeight*> grp(N, nullptr);
                 size_t e_ms = 0;
                 for (int e = 0; e < N; ++e) {
@@ -2519,7 +2528,23 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                     is_samples.push_back(std::move(s));
                 }
             }
-            upload_scale(sc.weight_scale);
+            // Same rule as the slab path above, for the experts it declined
+            // (ragged shapes, or a projection it bailed out of): a scale whose
+            // weight is host-resident stays on host. Asking the weight itself
+            // rather than tracking a parallel flag is what keeps the two in
+            // agreement — the failure mode of #1384 and #1403 both.
+            bool weight_is_host_expert = false;
+            if (const auto ek = parse_expert_key(name); ek.valid && ek.layer < n_layers()) {
+                const auto& L = layers_[ek.layer];
+                const std::vector<Tensor>& vec = (ek.kind == NvFP4ExpertKey::Kind::Gate) ? L.expert_w_gate
+                                                 : (ek.kind == NvFP4ExpertKey::Kind::Up) ? L.expert_w_up
+                                                                                         : L.expert_w_down;
+                if (ek.expert < static_cast<int>(vec.size()))
+                    weight_is_host_expert = (vec[ek.expert].data != nullptr && !vec[ek.expert].on_device);
+            }
+            if (!weight_is_host_expert) {
+                upload_scale(sc.weight_scale);
+            }
             upload_scale(sc.weight_scale_2);
             // input_scale is loaded for diagnostics but never read by any
             // GEMM kernel (see executor_pre_dequant.cu Phase 0 comment + the

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -356,6 +356,12 @@ bool Engine::init_kv_cache() {
     executor_->pre_dequant_weights(stream_, vram_budget);
     dequant_done_ = true;
 
+    // Both facts this needs exist only now: Phase 0 (inside pre_dequant) has
+    // labelled host-resident NVFP4 experts, and the expert cache was sized in
+    // init_weights(). Refusing here rather than at weight-upload time is the
+    // point — see verify_host_expert_placement().
+    executor_->verify_host_expert_placement();
+
     // KV now takes the MEASURED residual, not a predicted one. This can only
     // shrink the pool relative to the budget's projection, never grow it, so
     // it cannot overcommit; and it keeps the allocator's headroom free, which

--- a/tests/test_expert_placement.cpp
+++ b/tests/test_expert_placement.cpp
@@ -1,15 +1,20 @@
-// Which MoE expert placements can actually be served (2026-08-13).
+// Which MoE expert placements depend on the NVFP4 host-offload path (2026-08-13).
 //
-// An NVFP4-prequant expert that stays on host reaches the generic cuBLAS path
-// with scales == nullptr, where gemm() logs an ERROR and returns WITHOUT
-// multiplying. The forward continues, the missing experts contribute zero, and
-// the process exits 0 with a wrong answer. Reproduced on
-// Qwen3-30B-A3B-NVFP4-Modelopt: 8 of 48 layers on host answers "the capital of
-// France is the city of the same name, France itself"; all 48 repeats "ftp".
+// History: an NVFP4-prequant expert that stayed on host used to reach the
+// generic cuBLAS path with scales == nullptr, where gemm() logged an ERROR and
+// returned WITHOUT multiplying. The forward continued, the missing experts
+// contributed zero, and the process exited 0 with a wrong answer. Reproduced on
+// Qwen3-30B-A3B-NVFP4-Modelopt: 8 of 48 layers on host answered "the capital of
+// France is the city of the same name, France itself"; all 48 repeated "ftp".
+// #1403 refused that placement outright.
 //
-// The load must therefore be refused where the placement is decided. These
-// tests pin the predicate that decides it. CPU-only by construction: it is
-// pure, and takes the placement as data rather than reading a checkpoint.
+// The path exists now (see exec/nvfp4_expert_offload.h), so this predicate no
+// longer decides servability — it decides whether the placement DEPENDS on that
+// path. The refusal moved to verify_host_expert_placement(), which runs once
+// the expert cache is sized, because that is the fact this cannot see.
+//
+// These tests pin the predicate. CPU-only by construction: it is pure, and
+// takes the placement as data rather than reading a checkpoint.
 
 #include <gtest/gtest.h>
 
@@ -22,48 +27,49 @@ namespace {
 // A 4-layer model whose layers 1 and 3 carry experts (0 and 2 are dense).
 // Interleaving matters: a predicate that scans `experts_upload_layer` alone,
 // without gating on "is this an MoE layer at all", reads the dense layers'
-// false and refuses every model. That mutant passes a uniform-layer fixture.
+// false and claims every model needs the path. That mutant passes a
+// uniform-layer fixture.
 constexpr size_t kExpertBytes = 512ull * 1024 * 1024;
 
 std::vector<size_t> interleaved_costs() { return {0, kExpertBytes, 0, kExpertBytes}; }
 
 }  // namespace
 
-TEST(ExpertPlacement, Nvfp4WithEveryExpertLayerResidentIsServeable) {
+TEST(ExpertPlacement, Nvfp4WithEveryExpertLayerResidentNeedsNoHostPath) {
     // Dense layers are false here and must not be read as "host-resident".
     const std::vector<bool> upload = {false, true, false, true};
-    EXPECT_TRUE(expert_placement_is_serveable(true, interleaved_costs(), upload));
+    EXPECT_FALSE(expert_placement_needs_host_path(true, interleaved_costs(), upload));
     EXPECT_EQ(expert_placement_host_layers(interleaved_costs(), upload), 0);
 }
 
-TEST(ExpertPlacement, Nvfp4WithOneExpertLayerOnHostIsRefused) {
-    // The 8-of-48 arm above, reduced: one layer short is already wrong output,
-    // so the threshold is one, not "most of them".
+TEST(ExpertPlacement, Nvfp4WithOneExpertLayerOnHostNeedsTheHostPath) {
+    // The 8-of-48 arm above, reduced: one layer short already changed the
+    // output, so the threshold is one, not "most of them".
     const std::vector<bool> upload = {false, true, false, false};
-    EXPECT_FALSE(expert_placement_is_serveable(true, interleaved_costs(), upload));
+    EXPECT_TRUE(expert_placement_needs_host_path(true, interleaved_costs(), upload));
     EXPECT_EQ(expert_placement_host_layers(interleaved_costs(), upload), 1);
 }
 
-TEST(ExpertPlacement, Nvfp4WithEveryExpertLayerOnHostIsRefused) {
+TEST(ExpertPlacement, Nvfp4WithEveryExpertLayerOnHostNeedsTheHostPath) {
     const std::vector<bool> upload = {false, false, false, false};
-    EXPECT_FALSE(expert_placement_is_serveable(true, interleaved_costs(), upload));
+    EXPECT_TRUE(expert_placement_needs_host_path(true, interleaved_costs(), upload));
     EXPECT_EQ(expert_placement_host_layers(interleaved_costs(), upload), 2);
 }
 
-// The refusal must be scoped to the weight format that lacks a host path.
-// GGUF-class experts got one in #1370 and are measured at 48.3 tok/s with all
-// 48 layers host-resident, so refusing them would delete a working feature.
-TEST(ExpertPlacement, GgufClassExpertsOnHostStayServeable) {
+// GGUF-class experts have their own host path (#1370), measured at 48.3 tok/s
+// with all 48 layers host-resident. They must not be routed through the NVFP4
+// one, which addresses a different slot layout.
+TEST(ExpertPlacement, GgufClassExpertsDoNotUseTheNvfp4HostPath) {
     const std::vector<bool> upload = {false, false, false, false};
-    EXPECT_TRUE(expert_placement_is_serveable(false, interleaved_costs(), upload));
+    EXPECT_FALSE(expert_placement_needs_host_path(false, interleaved_costs(), upload));
 }
 
 // A dense model has no expert layers at all: every cost is zero, so nothing
-// can be host-resident and the NVFP4 flag must not refuse it.
-TEST(ExpertPlacement, DenseNvfp4ModelIsServeable) {
+// can be host-resident and the NVFP4 flag must not claim it needs the path.
+TEST(ExpertPlacement, DenseNvfp4ModelNeedsNoHostPath) {
     const std::vector<size_t> costs = {0, 0, 0, 0};
     const std::vector<bool> upload = {false, false, false, false};
-    EXPECT_TRUE(expert_placement_is_serveable(true, costs, upload));
+    EXPECT_FALSE(expert_placement_needs_host_path(true, costs, upload));
     EXPECT_EQ(expert_placement_host_layers(costs, upload), 0);
 }
 
@@ -74,6 +80,6 @@ TEST(ExpertPlacement, DenseNvfp4ModelIsServeable) {
 TEST(ExpertPlacement, MismatchedLengthsStopAtTheShorter) {
     const std::vector<size_t> costs = {0, kExpertBytes, kExpertBytes};
     const std::vector<bool> upload = {false, true};
-    EXPECT_TRUE(expert_placement_is_serveable(true, costs, upload));
+    EXPECT_FALSE(expert_placement_needs_host_path(true, costs, upload));
     EXPECT_EQ(expert_placement_host_layers(costs, upload), 0);
 }

--- a/tests/test_nvfp4_expert_offload.cpp
+++ b/tests/test_nvfp4_expert_offload.cpp
@@ -1,0 +1,193 @@
+// The slot layout that lets host-resident NVFP4 experts reach the fused decode
+// kernels unchanged (2026-08-13).
+//
+// The GGUF host path (#1370) works because one expert is one contiguous byte
+// range, so the LRU cache's fixed-stride pool IS the array the kernels index.
+// An NVFP4 expert is TWO ranges — packed FP4 weights and FP8 micro-scales — and
+// the trick still works only because the kernels take separate bases and
+// separate strides for them.
+//
+// That makes the arithmetic load-bearing in a way a comment cannot pin: the
+// cache WRITES a slot at one address and the kernel READS it at another,
+// computed independently. If those two ever disagree the kernel reads a
+// neighbouring expert's scales, which is coherent-looking and wrong — the
+// failure mode #1403 measured ("the capital of France is the city of the same
+// name"), not a crash. So the central test here is that the two agree.
+//
+// CPU-only: the layout is pure arithmetic and takes its inputs as data.
+
+#include <gtest/gtest.h>
+
+#include "exec/nvfp4_expert_offload.h"
+
+#include <vector>
+
+using namespace imp;
+
+namespace {
+
+// Qwen3-30B-A3B-NVFP4: d_model 2048, moe_intermediate 768.
+constexpr int64_t kGateN = 768, kGateK = 2048;   // gate/up: [768, 2048]
+constexpr int64_t kDownN = 2048, kDownK = 768;   // down:    [2048, 768]
+
+}  // namespace
+
+TEST(NvFP4SlotLayout, HoldsBothRangesOfOneExpert) {
+    const auto l = nvfp4_slot_layout(kGateN, kGateK);
+    EXPECT_EQ(l.packed_bytes, static_cast<size_t>(kGateN) * (kGateK / 2));   // 768 KiB
+    EXPECT_EQ(l.ms_bytes, static_cast<size_t>(kGateN) * (kGateK / 16));      //  96 KiB
+    EXPECT_GE(l.slot_bytes(), l.packed_bytes + l.ms_bytes);
+}
+
+// The kernels load packed weights through uint2 (gemv_nvfp4_row), so every
+// slot's packed block must start 8-byte aligned. Both the stride and the
+// micro-scale offset feed that address, so both have to hold.
+//
+// The 8 is written out rather than taken from kNvFP4SlotAlign on purpose: it
+// is the KERNEL's requirement, and a test that reads the layout's own constant
+// passes unchanged if that constant is set to 1.
+TEST(NvFP4SlotLayout, EverySlotStartsWhereAUint2LoadCanReadIt) {
+    constexpr size_t kUint2Align = 8;  // sizeof(uint2), from gemv_nvfp4_row
+    for (const auto [N, K] : std::vector<std::pair<int64_t, int64_t>>{
+             {kGateN, kGateK}, {kDownN, kDownK}, {1, 16}, {17, 48}, {3, 80}, {129, 176}}) {
+        const auto l = nvfp4_slot_layout(N, K);
+        ASSERT_GT(l.slot_bytes(), 0u) << "N=" << N << " K=" << K;
+        EXPECT_EQ(l.slot_bytes() % kUint2Align, 0u) << "stride, N=" << N << " K=" << K;
+        EXPECT_EQ(l.packed_off() % kUint2Align, 0u) << "scale offset, N=" << N << " K=" << K;
+        EXPECT_GE(l.packed_off(), l.packed_bytes);
+        EXPECT_LE(l.packed_off() + l.ms_bytes, l.slot_bytes());
+    }
+}
+
+// THE property the whole path rests on: the kernel reads a slot's micro-scales
+// from `micro_scales + idx * expert_stride_ms`, and that has to land INSIDE
+// slot idx — the same slot whose packed weights it is decoding.
+//
+// This is not automatic. The natural stride for a scale array is its own size
+// (`ms_bytes`), which is what a contiguous per-expert scale buffer uses and
+// what the resident path passes. Using it here would walk the scale base
+// forward far slower than the slot stride, so slot 1's weights would be decoded
+// with scales from inside slot 0 — coherent-looking, wrong output. Passing the
+// SLOT stride for both is what makes the two halves stay together.
+//
+// The assertion below fails for `expert_stride_ms = ms_bytes` and for any other
+// stride that is not the slot stride.
+TEST(NvFP4SlotLayout, ScaleAddressStaysInsideItsOwnSlot) {
+    for (const auto [N, K] : std::vector<std::pair<int64_t, int64_t>>{{kGateN, kGateK},
+                                                                     {kDownN, kDownK}}) {
+        const auto l = nvfp4_slot_layout(N, K);
+        constexpr size_t kPoolBase = 0x10000000;  // stand-in for the layer pool base
+        const size_t stride = l.slot_bytes();
+
+        // The two bases the dispatch hands the kernel.
+        const size_t packed_base = kPoolBase;
+        const size_t ms_base = kPoolBase + l.packed_off();
+
+        for (int idx = 0; idx < 24; ++idx) {  // 3 projections x top_k 8
+            const size_t slot_begin = kPoolBase + static_cast<size_t>(idx) * stride;
+            const size_t slot_end = slot_begin + stride;
+
+            const size_t w = packed_base + static_cast<size_t>(idx) * stride;
+            const size_t ms = ms_base + static_cast<size_t>(idx) * stride;
+
+            EXPECT_EQ(w, slot_begin) << "weights, slot " << idx;
+            EXPECT_GE(ms, slot_begin + l.packed_bytes) << "scales overlap weights, slot " << idx;
+            EXPECT_LE(ms + l.ms_bytes, slot_end) << "scales spill into slot " << (idx + 1);
+        }
+    }
+}
+
+// Neighbouring slots must not overlap — an expert's scales spilling into the
+// next slot's packed block is the silent-wrong-answer case.
+TEST(NvFP4SlotLayout, SlotsDoNotOverlap) {
+    const auto l = nvfp4_slot_layout(kDownN, kDownK);
+    EXPECT_LE(l.packed_off() + l.ms_bytes, l.slot_bytes());
+    EXPECT_LE(l.packed_bytes, l.packed_off());
+}
+
+// K must be a multiple of the 16-value micro-block the kernels hard-code. A
+// checkpoint that violates it has no valid scale mapping, so the layout reports
+// "path does not apply" rather than rounding it into something plausible.
+TEST(NvFP4SlotLayout, RejectsShapesTheKernelsCannotAddress) {
+    EXPECT_EQ(nvfp4_slot_layout(768, 2044).slot_bytes(), 0u);  // K % 16 != 0
+    EXPECT_EQ(nvfp4_slot_layout(0, 2048).slot_bytes(), 0u);
+    EXPECT_EQ(nvfp4_slot_layout(768, 0).slot_bytes(), 0u);
+    EXPECT_EQ(nvfp4_slot_layout(-1, 2048).slot_bytes(), 0u);
+}
+
+// Phase 0 promotes host-resident weights only for MoE experts: dense weights
+// have no host path, so labelling one NVFP4 where it sits would produce bytes
+// nothing can serve.
+TEST(NvFP4ExpertKey, MatchesPerExpertMoeWeightsOnly) {
+    EXPECT_TRUE(is_expert_key("L0.expert_w_gate.0"));
+    EXPECT_TRUE(is_expert_key("L47.expert_w_down.127"));
+    EXPECT_TRUE(is_expert_key("L5.expert_w_up.7"));
+
+    EXPECT_FALSE(is_expert_key("L5.wq"));
+    EXPECT_FALSE(is_expert_key("L5.w_gate"));  // the DENSE gate, not an expert
+    EXPECT_FALSE(is_expert_key("out_proj"));
+    EXPECT_FALSE(is_expert_key(""));
+    EXPECT_FALSE(is_expert_key("L5"));
+    EXPECT_FALSE(is_expert_key("expert_w_gate.0"));  // no layer prefix
+}
+
+namespace {
+
+// One projection's experts as the loader leaves them: host-resident, NVFP4,
+// 2-D [N, K/2], each carrying its own micro-scale block.
+std::vector<Tensor> make_host_experts(int n, int64_t N, int64_t K_packed) {
+    static std::vector<char> backing(1 << 20);
+    std::vector<Tensor> v(n);
+    for (int i = 0; i < n; ++i) {
+        v[i].data = backing.data() + i * 16;
+        v[i].scales = backing.data() + 4096 + i * 16;
+        v[i].qtype = QType::NVFP4;
+        v[i].on_device = false;
+        v[i].ndim = 2;
+        v[i].shape[0] = N;
+        v[i].shape[1] = K_packed;
+        v[i].tensor_scale = 1.0f;
+    }
+    return v;
+}
+
+}  // namespace
+
+TEST(NvFP4HostExpertsServable, AcceptsAPromotedHostResidentProjection) {
+    EXPECT_TRUE(nvfp4_host_experts_servable(make_host_experts(8, kGateN, kGateK / 2)));
+}
+
+// Each rejection below is a way the dispatch would otherwise hand the staging
+// loop something it cannot use.
+TEST(NvFP4HostExpertsServable, RejectsWhatTheStagingLoopCannotUse) {
+    EXPECT_FALSE(nvfp4_host_experts_servable({}));  // non-gated model: no gate projection
+
+    auto device_resident = make_host_experts(8, kGateN, kGateK / 2);
+    for (auto& e : device_resident)
+        e.on_device = true;
+    EXPECT_FALSE(nvfp4_host_experts_servable(device_resident))
+        << "device-resident experts belong to the resident path, not the cache";
+
+    // Phase 0 did not promote — the #1403 state. Serving it is what produced a
+    // fluent wrong answer, so it must not look servable.
+    auto unpromoted = make_host_experts(8, kGateN, kGateK / 2);
+    for (auto& e : unpromoted)
+        e.qtype = QType::INT8;
+    EXPECT_FALSE(nvfp4_host_experts_servable(unpromoted));
+
+    auto no_scales = make_host_experts(8, kGateN, kGateK / 2);
+    for (auto& e : no_scales)
+        e.scales = nullptr;
+    EXPECT_FALSE(nvfp4_host_experts_servable(no_scales));
+
+    // A ragged projection would give one launch two different strides.
+    auto ragged = make_host_experts(8, kGateN, kGateK / 2);
+    ragged[5].shape[0] = kGateN / 2;
+    EXPECT_FALSE(nvfp4_host_experts_servable(ragged));
+
+    // A defect in a LATER expert must be caught too — checking experts[0] only
+    // is the cheap mistake here, and every routed expert reaches a kernel.
+    auto late_host_miss = make_host_experts(8, kGateN, kGateK / 2);
+    late_host_miss[7].scales = nullptr;
+    EXPECT_FALSE(nvfp4_host_experts_servable(late_host_miss));
+}


### PR DESCRIPTION
## What

PR #1403 refused a load whose NVFP4 MoE experts did not fit VRAM, because
serving it answered from whichever experts happened to be resident, at exit
code 0. That refusal was correct while no host path existed. This builds the
path, so those checkpoints run.

## How

Decode reuses the mechanism from #1370. The expert cache partitions its pool
per layer at a fixed stride, which is exactly the `base + idx * stride` array
the fused NVFP4 GEMVs index, so feeding them slot indices instead of expert ids
needs no kernel change.

Two things are different from the GGUF case:

- **An NVFP4 expert is two byte ranges**, packed FP4 weights and FP8 E4M3
  micro-scales. A slot holds `packed || micro_scales`, and since the kernels
  take separate bases and separate strides for the two, pointing both at the
  pool with `stride = slot_size` resolves them to the same slot.
- **The tensor scale does not fall out.** The kernels read `tensor_scales[idx]`
  with the same index as the weight, so a per-expert array cannot be handed to a
  slot-indexed kernel. The cache keeps a per-slot mirror, rewritten whenever a
  slot changes occupant.

The layout arithmetic and the predicates live in `src/exec/nvfp4_expert_offload.h`.

## Measured

`Qwen3-30B-A3B-NVFP4-Modelopt` on one RTX 5090, greedy, same prompt as #1403:

| experts | before (#1403) | after |
|---|---|---|
| resident | 361.97 tok/s, coherent | **384.03 tok/s**, correct |
| 8 of 48 layers on host | 88.77 tok/s, **wrong answer** | **44.54 tok/s**, correct |
| all 48 layers on host | repeats `ftp` forever | **23.03 tok/s**, correct |

The middle row got slower, which is the point: those eight layers were fast
because they were skipping their GEMMs. Both host arms now produce the same
answer as the resident one, and the 8-layer arm stops at the identical token
count (119).

No perf-baseline refresh: this changes nothing on the resident paths.
`make verify-fast` is flat (decode -1.05%, prefill +0.95%, peak VRAM +0.01%),
and GGUF host offload is unchanged (`Qwen3-30B-A3B-Q4_K_M`, all 48 layers on
host: 39.77 tok/s, correct, 65.7% cache hit rate).

## Two things the plan did not cost

Both are written up in `docs/roadmap.md`, because they generalise.

**The prefill was a second path.** #1370 could ignore `n > 1`, its own entry
says so, because GGUF experts reach the staging buffer in `dequant_expert`
there. Per-expert NVFP4 tensors never do, so the M>1 fallback handed the
593 MiB expert matrix to `gemm_nvfp4`, which dequantises on the device. The
first working decode still died on an illegal access. The fix is small once
located, one expert per `expert_gemm` call through the same slot pool, but it
is a second path rather than a detail of the first.

**Promoting host-resident weights had a blast radius.** Letting Phase 0 label
them NVFP4 makes them visible to every consumer that keys off `qtype == NVFP4`
and then does device work. Four had to learn the difference, each found by its
own crash or wrong answer: Phase 0b registered them for the CUTLASS grouped
prefill; Phase 3 tried to copy them into a contiguous device buffer with
`cudaMemcpyDeviceToDevice`; the micro-scales were still being uploaded to VRAM,
so the promotion's own guard never fired; and `can_decode_fast` keys off
`expert_up_packed`, which is only stamped for device-resident experts, so the
decode sat in the serial legacy path at 35 tok/s while the new one went unused.

The rule that falls out: **`qtype` says how to decode bytes, never where they
live.** A predicate that reads one and means the other is the same shape as
#1384 and #1403, and it appeared four more times here.

## Where the refusal went

It could not stay at placement time. Whether a host-resident layer is servable
depends on the expert cache, which is sized in the workspace pass that runs
after weight upload, so re-deriving that arithmetic there would have been a
second copy of it. It now runs in `verify_host_expert_placement()` after
pre-dequant, where both the promotion and the real cache exist, and it uses the
same predicates the dispatch uses.

## Tests

14 CPU cases in `tests/test_nvfp4_expert_offload.cpp` and the rewritten
`tests/test_expert_placement.cpp`, in the CI lane. The central one asserts that
a slot's scale address lands inside its own slot, which fails for the natural
but wrong `expert_stride_ms = ms_bytes`. Mutation-validated: forcing
`packed_off()` to 0 fails four cases, dropping the per-expert validation loop
fails one.

## Known costs

Both measured, both in `docs/LIMITATIONS.md`: prefill runs the serial
per-expert fallback, and it evicts the decode working set from the cache
(74.6% hit rate against 88.7% on the GGUF path, the same thrashing #1365's
working-set gate fixed there). Neither is a correctness issue.
