### PR TITLE
fix(moe): stop NVFP4 prefill from evicting the decode expert cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ there instead of retelling it.
 
 ### Fixed
 
+- **MoE prefill no longer evicts the decode working set from the expert cache**
+  on the NVFP4 host path: it now honours the same working-set rule the GGUF path
+  has had since #1365. Cache misses drop 3.5x (106k to 30k over a pp512+tg256
+  run on Qwen3-30B-A3B-NVFP4 with every MoE layer host-resident); throughput
+  moves within noise. ([`docs/roadmap.md`](docs/roadmap.md))
 - **An NVFP4 MoE checkpoint whose experts do not fit is refused at load**
   instead of skipping their GEMMs and answering from the rest at exit code 0.
   The refusal now fires only when the expert cache cannot hold a layer's working

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -45,15 +45,14 @@ These have a code path and no gate. They may work; nothing proves it.
   and is unit-tested against a sink-aware reference; 4 bits per value on a
   64-wide head is simply not enough. It falls back to FP16 rather than pretending.
 - **Host-offloaded NVFP4 MoE experts are slow, and nothing gates them.** They run
-  correctly (Qwen3-30B-A3B-NVFP4, all 48 MoE layers on host: 23.0 tok/s against
+  correctly (Qwen3-30B-A3B-NVFP4, all 48 MoE layers on host: 23.3 tok/s against
   384.0 resident), but the price is steep and the only checks that exercise the
   path are manual. The CPU lane covers the slot arithmetic, not the kernels.
-  Two known costs: prefill goes through the serial per-expert fallback, and
-  prefill evicts the decode working set from the expert cache (74.6 % hit rate
-  measured, against 88.7 % on the equivalent GGUF path). A placement the cache
-  cannot hold at all is still refused at load rather than served wrong (#1403).
+  The remaining cost is that prefill goes through the serial per-expert
+  fallback, one expert per GEMM. A placement the expert cache cannot hold at all
+  is still refused at load rather than served wrong (#1403).
 
-  [PROV: commit=67d2c44 date=2026-08-13 hw=RTX5090 model=Qwen3-30B-A3B-NVFP4-Modelopt
+  [PROV: commit=8a7bd8c date=2026-08-13 hw=RTX5090 model=Qwen3-30B-A3B-NVFP4-Modelopt
          quant=NVFP4 cuda=13.3 path=nvfp4-moe-host-offload
          cmd=`imp-cli --max-tokens 220 --temperature 0 --set moe.force_host_experts=48`
          n=1 note=single greedy run per arm; resident arm is the same command

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -322,6 +322,19 @@ Note the middle row got *slower*, which is the point: those eight layers were fa
 
 Two costs remain, both measured rather than assumed. Prefill runs the serial per-expert fallback, and it evicts the decode working set — 74.6 % hit rate against the 88.7 % the GGUF path reaches, which is the same thrashing #1365's working-set gate fixed there and which nothing yet fixes here. Neither is a correctness issue and both are ordinary follow-on work.
 
+**The second of those is now fixed, and the measurement is worth more than the fix.** #1365's rule already existed in `run_moe_legacy_fallback_` as `use_expert_cache` — a dispatch touching more than `slots_per_layer` cells bypasses the cache for the single staging buffer, same H2D bytes, no eviction. The NVFP4 staging path simply did not read it. Honouring it, on Qwen3-30B-A3B-NVFP4 with all 48 MoE layers host-resident, `--bench-pp 512 --bench-reps 3`, three runs per arm (medians):
+
+| | cache misses | pp512 | tg256 |
+|---|---|---|---|
+| gate off | 106 108 | 285.57 | 54.77 |
+| **gate on** | **30 451** | **285.15** | **57.31** |
+
+**Misses drop 3.5x and throughput barely moves.** That is the informative part. It says the prefill transfers were never the cost — they move the same bytes either way, which is why `pp512` is flat to 0.15 % — and that what the eviction destroyed was only the *decode* cache's contents, worth +4.6 % on `tg256`. That figure sits inside this path's own spread (the arms overlap: 50.8-59.7 against 57.3-60.3), so treat the miss count as the result and the throughput as directionally consistent with it, not as a measured win.
+
+**GGUF's +5.6 % on pp512 does not reproduce here, and the reason is structural rather than a failure to reproduce it.** There the bypass replaces a dequant-into-scratch with a straight copy; here both routes are a copy into a slot and the GEMM reads NVFP4 either way. Same rule, different arithmetic underneath, so only the decode half of the benefit transfers.
+
+Two caveats on the numbers: the arms were not alternated (each switch is a full rebuild), and the first run of any arm is cold — 35.06 tok/s against 57-60 warm on identical code, the same warm/cold gap this entry records for the GGUF path.
+
 *Where the path stands after all of it, re-profiled 2026-08-11 on the shipped build.* The entry opened by calling this path issue-bound; after #1370 and #1376 **it is not any more, and that retires the framing rather than confirming it.** Same config (256 cold decode tokens, all experts host-resident), tg phase 7.06 s:
 
 | term | per token | share |

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -251,10 +251,16 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             // hit this because its GGUF experts reach dequant_expert's staging
             // buffer instead; per-expert NVFP4 tensors do not.
             //
-            // One expert at a time is exactly what this loop already does, so
-            // three slots suffice regardless of how many experts the prompt
-            // activates — the pool is not thrashed the way a batched path
-            // would thrash it.
+            // WHERE it is staged follows the same working-set rule as the GGUF
+            // path above: through the LRU pool when this dispatch fits it,
+            // through the single staging buffer when it does not. The bytes
+            // moved are identical either way — what differs is whether the
+            // copies evict anything. A prefill activating every expert asks for
+            // 3*n_active cells against slots_per_layer, so using the cache
+            // there retains nothing AND throws out the entries decode is about
+            // to want. Correctness does not depend on the choice: each expert
+            // is consumed by a kernel launched immediately after it is staged,
+            // and both destinations are written on this stream.
             //
             // Note the condition is on the EXPERT tensor, not on the `qtype`
             // parameter: that one comes from `ly.expert_*_packed`, which stays
@@ -265,47 +271,63 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             if (static_cast<size_t>(eidx) < fallback.size() &&
                 fallback[eidx].qtype == QType::NVFP4) {
                 const Tensor& w = fallback[eidx];
-                if (w.data && !w.on_device && w.scales && w.ndim == 2 &&
-                    nvfp4_host_pool_ready_for_staging(expert_cache_)) {
+                if (w.data && !w.on_device && w.scales && w.ndim == 2) {
                     const auto layout = nvfp4_slot_layout(w.shape[0], w.shape[1] * 2);
-                    if (layout.slot_bytes() > 0 && layout.slot_bytes() <= expert_cache_.slot_size_) {
-                        ExpertCacheKey ck{fallback[0].data, eidx};
-                        void* slot = expert_cache_.get_or_load_nvfp4(
-                            layer, proj, ck, w.data, layout.packed_bytes, w.scales, layout.ms_bytes,
-                            layout.packed_off(), w.tensor_scale, stream);
-                        if (slot) {
-                            NvFP4QuantResult nw;
-                            nw.packed_data = slot;
-                            nw.micro_scales = static_cast<char*>(slot) + layout.packed_off();
-                            nw.tensor_scale = w.tensor_scale;
-                            nw.N = static_cast<int>(w.shape[0]);
-                            nw.K = static_cast<int>(w.shape[1] * 2);
-                            const int M = static_cast<int>(a.shape[0]);
-                            if (M == 1) {
-                                gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
-                                                static_cast<half*>(c.data), nw.N, nw.K, stream);
-                            } else {
-                                // M>1 goes through gemm_nvfp4 for the same
-                                // reason the resident path does: the per-row
-                                // gemv loop is wrong on multi-token expert
-                                // prefill (bisected 2026-04-27, see below).
-                                int64_t a_shape[2] = {static_cast<int64_t>(M),
-                                                      static_cast<int64_t>(nw.K)};
-                                int64_t c_shape[2] = {static_cast<int64_t>(M),
-                                                      static_cast<int64_t>(nw.N)};
-                                Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
-                                           QType::F16, 2, a_shape, true);
-                                Tensor c_t(c.data, QType::F16, 2, c_shape, true);
-                                gemm_nvfp4(nw, a_t, c_t, stream);
-                            }
-                            return;
+                    void* staged = nullptr;
+                    if (layout.slot_bytes() > 0) {
+                        if (use_expert_cache && nvfp4_host_pool_ready_for_staging(expert_cache_) &&
+                            layout.slot_bytes() <= expert_cache_.slot_size_) {
+                            ExpertCacheKey ck{fallback[0].data, eidx};
+                            staged = expert_cache_.get_or_load_nvfp4(
+                                layer, proj, ck, w.data, layout.packed_bytes, w.scales,
+                                layout.ms_bytes, layout.packed_off(), w.tensor_scale, stream);
+                        } else if (moe_.raw_staging_buf &&
+                                   moe_.raw_staging_size >= layout.slot_bytes()) {
+                            // Same slot layout, one buffer: packed at 0, the
+                            // micro-scales behind it, so the NvFP4QuantResult
+                            // below is built the same way for both routes.
+                            char* st = static_cast<char*>(moe_.raw_staging_buf);
+                            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(st, w.data, layout.packed_bytes,
+                                                               cudaMemcpyHostToDevice, stream));
+                            IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(st + layout.packed_off(), w.scales,
+                                                               layout.ms_bytes,
+                                                               cudaMemcpyHostToDevice, stream));
+                            staged = st;
                         }
+                    }
+                    if (staged) {
+                        NvFP4QuantResult nw;
+                        nw.packed_data = staged;
+                        nw.micro_scales = static_cast<char*>(staged) + layout.packed_off();
+                        nw.tensor_scale = w.tensor_scale;
+                        nw.N = static_cast<int>(w.shape[0]);
+                        nw.K = static_cast<int>(w.shape[1] * 2);
+                        const int M = static_cast<int>(a.shape[0]);
+                        if (M == 1) {
+                            gemv_nvfp4_kpar(nw, static_cast<const half*>(a.data),
+                                            static_cast<half*>(c.data), nw.N, nw.K, stream);
+                        } else {
+                            // M>1 goes through gemm_nvfp4 for the same reason
+                            // the resident path does: the per-row gemv loop is
+                            // wrong on multi-token expert prefill (bisected
+                            // 2026-04-27, see below).
+                            int64_t a_shape[2] = {static_cast<int64_t>(M),
+                                                  static_cast<int64_t>(nw.K)};
+                            int64_t c_shape[2] = {static_cast<int64_t>(M),
+                                                  static_cast<int64_t>(nw.N)};
+                            Tensor a_t(const_cast<void*>(static_cast<const void*>(a.data)),
+                                       QType::F16, 2, a_shape, true);
+                            Tensor c_t(c.data, QType::F16, 2, c_shape, true);
+                            gemm_nvfp4(nw, a_t, c_t, stream);
+                        }
+                        return;
                     }
                     IMP_LOG_FATAL(
                         "MoE legacy fallback: host-resident NVFP4 expert %d on layer %d cannot be "
-                        "staged (slot %zu B, pool slot %zu B). Continuing would hand a host "
-                        "pointer to a device kernel.",
-                        eidx, layer, layout.slot_bytes(), expert_cache_.slot_size_);
+                        "staged by either route (needs %zu B; cache slot %zu B, staging buffer "
+                        "%zu B). Continuing would hand a host pointer to a device kernel.",
+                        eidx, layer, layout.slot_bytes(), expert_cache_.slot_size_,
+                        moe_.raw_staging_size);
                 }
             }
 


### PR DESCRIPTION
## What

On the NVFP4 host-offload path added in #1407, MoE prefill staged every expert
through the LRU cache. A prefill dispatch touches three cells per active expert
and at pp512 essentially every expert is active, so it asks for far more cells
than the pool holds: those accesses retain nothing and evict the entries decode
is about to want.

## How

The rule already existed. #1365 solved exactly this for GGUF, and it lives in
`run_moe_legacy_fallback_` as `use_expert_cache`: a dispatch needing more than
`slots_per_layer` cells goes through the single staging buffer instead, moving
identical H2D bytes without evicting anything. The NVFP4 staging path added in
#1407 simply did not read that flag. It does now, and the staging buffer is
written with the same slot layout, so the `NvFP4QuantResult` is built the same
way for both routes.

## Measured

`Qwen3-30B-A3B-NVFP4-Modelopt` on one RTX 5090, all 48 MoE layers host-resident,
`--bench-pp 512 --bench-reps 3`, three runs per arm, medians:

| | cache misses | pp512 tok/s | tg256 tok/s |
|---|---|---|---|
| gate off | 106 108 | 285.57 | 54.77 |
| **gate on** | **30 451** | **285.15** | **57.31** |

**Misses drop 3.5x and throughput barely moves, and that is the informative
result.** It says the prefill transfers were never the cost: both routes move
the same bytes, which is why pp512 is flat to 0.15%. What the eviction destroyed
was only the decode cache's contents, worth +4.6% on tg256.

That 4.6% sits inside this path's own spread, though. The arms overlap
(50.8-59.7 against 57.3-60.3), so please read the miss count as the result and
the throughput as directionally consistent with it, not as a measured win.

**GGUF's +5.6% on pp512 does not reproduce, for a structural reason rather than
a failure to reproduce it.** There the bypass replaces a dequant-into-scratch
with a straight copy. Here both routes are a copy into a slot and the GEMM reads
NVFP4 either way, so only the decode half of the benefit transfers.

Two caveats on the numbers, both stated in `docs/roadmap.md`: the arms were not
alternated, because each switch is a full rebuild; and the first run of any arm
is cold (35.06 tok/s against 57-60 warm on identical code), the same warm/cold
gap this path already had recorded.

## Correctness

Unchanged, and the bypass route is new code so it was checked directly: both
offload arms still answer correctly (48 of 48 layers on host at 23.3 tok/s, 8 of
48 at 45.7, the 8-layer arm still stopping at the same token count as the
resident run). GGUF host offload is unaffected. `make verify-fast` is flat
(decode within 8%, peak VRAM +0.01%). No perf-baseline refresh: nothing here
touches a resident path.
