### PR TITLE
perf(moe): optional pinned staging for host-resident NVFP4 experts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ there instead of retelling it.
   layers off-GPU answers correctly at 23.0 tok/s, against 384.0 fully resident.
   ([`docs/roadmap.md`](docs/roadmap.md))
 
+- **`moe.pin_host_experts`** (default off) copies host-resident NVFP4 experts
+  into pinned host memory at load, which speeds up prefill on that path by
+  **14.8 %** (pp512 276.6 to 317.6 tok/s on Qwen3-30B-A3B-NVFP4 with every MoE
+  layer host-resident, six paired rounds). Decode is unaffected. Off by default
+  because it costs 4.4x model-load time. ([`docs/roadmap.md`](docs/roadmap.md))
+
 ### Fixed
 
 - **MoE prefill no longer evicts the decode working set from the expert cache**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -335,6 +335,26 @@ Two costs remain, both measured rather than assumed. Prefill runs the serial per
 
 Two caveats on the numbers: the arms were not alternated (each switch is a full rebuild), and the first run of any arm is cold — 35.06 tok/s against 57-60 warm on identical code, the same warm/cold gap this entry records for the GGUF path.
 
+*What the remaining serial prefill actually costs, profiled 2026-08-13.* Host-offloaded prefill is **61x** slower than resident on this model (pp512 17508 vs 285 tok/s), against only 6.9x on decode — so prefill, not decode, is where this path loses most. nsys says why, and it is not the GEMMs: `cudaMemcpyAsync` is **53.7 %** of API time at 90 759 calls, and the host sits in those calls for **4.13 s** while the GPU spends **795 ms** actually transferring. The gap is the driver staging an mmap source synchronously, because WSL2 cannot page-lock a mapping in place.
+
+Isolated at one expert's size (768 KiB weights + 96 KiB micro-scales), medians over 300 reps:
+
+| source | host time in the call | GPU time | rate |
+|---|---|---|---|
+| pageable mmap, 2 calls (what it did) | 76.2 µs | 92.3 µs | 9.6 GB/s |
+| pinned, 1 call | 2.8 µs | 27.3 µs | 32.4 GB/s |
+
+**`moe.pin_host_experts` (default off) copies those experts into pinned host memory at load**, which is what the GGUF packed path already does at `weight_upload.cu` Path A1 — the per-expert NVFP4 tensors simply never reached it, the same "one path got the treatment, the other did not" shape as the rest of this entry. Six alternating paired rounds, all 48 MoE layers host-resident:
+
+| | pp512 | tg256 | model load |
+|---|---|---|---|
+| off | 276.6 | no effect | 5.1 s |
+| **on** | **317.6 (+14.8 %, 6/6 pairs)** | 3 up / 3 down | 22.6 s |
+
+Decode does not move because its cache hits 96-98 % and barely transfers; prefill touches every expert. It stays **off by default** because 4.4x model-load time is too visible a cost to impose silently, and break-even is around 32k prompt tokens.
+
+**Two method notes, both of which cost a wrong conclusion first.** A per-expert pinned buffer was the obvious implementation and is the wrong one: nsys measured **36 877 `cudaHostAlloc` calls costing 24.7 s** plus 6.4 s of `cudaFreeHost`, to save 0.5 s of transfer. One slab per (layer, projection) is 144 allocations for the same result. And **three paired rounds read decode as −33 % and that was noise** — this path's decode spread is wider than the effect (the off arm alone spanned 34.7 to 66.1 tok/s), which is exactly the "only paired, alternating rounds decide anything here" rule already recorded above, needing six pairs rather than three.
+
 *Where the path stands after all of it, re-profiled 2026-08-11 on the shipped build.* The entry opened by calling this path issue-bound; after #1370 and #1376 **it is not any more, and that retires the framing rather than confirming it.** Same config (256 cold decode tokens, all experts host-resident), tg phase 7.06 s:
 
 | term | per token | share |

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -245,6 +245,27 @@ struct MoE {
     // the ~45% next-token reuse but not the ~80%-within-8 band. Exposed so that
     // trade is measurable rather than hardcoded; 15 is the long-standing value.
     int expert_cache_budget_pct = 15;
+    // Copy host-resident NVFP4 experts into pinned host memory at load, so the
+    // per-expert H2D transfers become real DMAs instead of driver-staged
+    // copies. On WSL2 an mmap cannot be page-locked in place, which is why this
+    // is a copy rather than a registration (the GGUF packed path does the same
+    // thing at weight_upload.cu's Path A1).
+    //
+    // It is a TRADE, not a win, which is why it is off by default. Measured on
+    // Qwen3-30B-A3B-NVFP4 with all 48 MoE layers host-resident, SIX alternating
+    // paired rounds (the switch exists partly so the arms can alternate without
+    // a rebuild):
+    //   prefill pp512  276.6 -> 317.6 tok/s   +14.8 %, 6/6 pairs positive
+    //   decode  tg256  no effect              3 pairs up, 3 down
+    //   model load     5.1 s -> 22.6 s        4.4x, for ~14 GiB of pinned copies
+    // Decode is unaffected because its cache hits 96-98 % and barely transfers;
+    // prefill touches every expert and is what the transfers cost.
+    //
+    // Three paired rounds read decode as -33 % and that was noise: this path's
+    // own decode spread is wider than the effect (the off arm alone measured
+    // 34.7 to 66.1 tok/s across six runs). Do not re-derive this from fewer
+    // than six pairs.
+    bool pin_host_experts = false;
     // Phase 2 (MoE host-offload Graphs design): assert device-side mirror
     // == host-side LRU state after every cache mutation. Off by default;
     // turn on via `moe.expert_cache_debug_parity = true` in imp.conf for

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -2209,6 +2209,65 @@ static bool upload_expert_weights(std::vector<TransformerLayer>& layers, int n_l
             convert_host_bf16(L.expert_w_gate);
             convert_host_bf16(L.expert_w_up);
             convert_host_bf16(L.expert_w_down);
+
+            // Host-resident NVFP4 experts: copy the mmap'd bytes into pinned
+            // host memory, for exactly the reason Path A1 does it for the
+            // packed GGUF tensor — on WSL2 an mmap cannot be page-locked in
+            // place, so a cudaMemcpyAsync from it is staged synchronously
+            // inside the driver.
+            //
+            // Measured on this box at one expert's size (768 KiB weights +
+            // 96 KiB micro-scales): 76.2 us of HOST time inside the copy calls
+            // from mmap against 2.8 us from pinned, and the DMA itself runs at
+            // 9.6 vs 32.4 GB/s. The offload prefill issues ~89k such transfers,
+            // which nsys measured as 4.13 s of host time against 795 ms of
+            // actual GPU transfer.
+            //
+            // These stay pageable until here because the per-expert path never
+            // ran Path A1's pinning: the BF16 converter above is the only thing
+            // in this branch that produced pinned experts, and it declines
+            // anything that is not BF16.
+            // ONE buffer per projection, not one per expert. Pinning is a
+            // syscall-heavy operation: a first cut took a buffer per expert and
+            // nsys measured 36 877 cudaHostAlloc calls costing 24.7 s, plus
+            // 6.4 s of cudaFreeHost at teardown, to save 0.5 s of transfer
+            // time. Per projection it is 144 allocations for the same result,
+            // and the experts land contiguously as a side benefit.
+            auto pin_host_nvfp4_experts = [&](std::vector<Tensor>& expert_vec) {
+                if (!ctx.is_nvfp4_prequant || expert_vec.empty())
+                    return;
+                if (!process_diag_moe_pin_host_experts())
+                    return;  // off by default — see moe.pin_host_experts
+                size_t total = 0;
+                for (const Tensor& w : expert_vec) {
+                    if (!w.data || w.on_device || w.qtype == QType::BF16)
+                        return;  // mixed placement: leave the whole projection alone
+                    total += w.nbytes();
+                }
+                if (total == 0)
+                    return;
+                PinnedBuffer pin = PinnedBuffer::acquire(cuda_host_pinned_allocator(), total);
+                if (pin.empty()) {
+                    // Correct but slow: the experts stay on the mmap and every
+                    // transfer pays the staging cost above.
+                    IMP_LOG_WARN(
+                        "Host NVFP4 experts: pinned alloc failed (%.2f MiB) — staying on mmap, "
+                        "H2D will be ~3x slower",
+                        total / (1024.0 * 1024.0));
+                    return;
+                }
+                char* dst = static_cast<char*>(pin.data());
+                for (Tensor& w : expert_vec) {
+                    const size_t bytes = w.nbytes();
+                    std::memcpy(dst, w.data, bytes);
+                    w.data = dst;
+                    dst += bytes;
+                }
+                ctx.host_pinned_allocs.push_back(std::move(pin));
+            };
+            pin_host_nvfp4_experts(L.expert_w_gate);
+            pin_host_nvfp4_experts(L.expert_w_up);
+            pin_host_nvfp4_experts(L.expert_w_down);
         }
     }
 
@@ -2432,8 +2491,44 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                 // one slot, so a scale already in VRAM would be the wrong
                 // address space for that copy — and VRAM spent on a layer that
                 // was moved out of VRAM precisely because it did not fit.
-                if (!experts[0].on_device)
+                //
+                // They do get pinned, in ONE slab for the whole projection, for
+                // the same reason and with the same per-allocation discipline
+                // as the weights: the scale is the second of the two transfers
+                // every staged expert pays.
+                if (!experts[0].on_device) {
+                    if (!process_diag_moe_pin_host_experts())
+                        return;  // stays on host, unpinned
+                    size_t total = 0;
+                    std::vector<Tensor*> host_scales;
+                    host_scales.reserve(N);
+                    for (int e = 0; e < N; ++e) {
+                        std::string k = "L" + std::to_string(layer) + "." + kind + "." +
+                                        std::to_string(e);
+                        auto it = nvfp4_scratch_.find(k);
+                        if (it == nvfp4_scratch_.end())
+                            return;
+                        Tensor& ws = it->second.weight_scale;
+                        if (!ws.data || ws.on_device || ws.numel() == 0)
+                            return;
+                        total += ws.nbytes();
+                        host_scales.push_back(&ws);
+                    }
+                    if (total == 0)
+                        return;
+                    PinnedBuffer pin = PinnedBuffer::acquire(cuda_host_pinned_allocator(), total);
+                    if (pin.empty())
+                        return;  // stays on mmap: slower, still correct
+                    char* dst = static_cast<char*>(pin.data());
+                    for (Tensor* ws : host_scales) {
+                        const size_t b = ws->nbytes();
+                        std::memcpy(dst, ws->data, b);
+                        ws->data = dst;
+                        dst += b;
+                    }
+                    host_pinned_allocs_.push_back(std::move(pin));
                     return;
+                }
                 std::vector<NvFP4PreQuantWeight*> grp(N, nullptr);
                 size_t e_ms = 0;
                 for (int e = 0; e < N; ++e) {
@@ -2542,6 +2637,9 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
                 if (ek.expert < static_cast<int>(vec.size()))
                     weight_is_host_expert = (vec[ek.expert].data != nullptr && !vec[ek.expert].on_device);
             }
+            // A host expert's scale stays on host. The slab pass above already
+            // pinned it per projection; if that pass declined (ragged shapes,
+            // missing entry) it stays on the mmap, which is slower but correct.
             if (!weight_is_host_expert) {
                 upload_scale(sc.weight_scale);
             }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -188,6 +188,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("moe.force_fp16_sync", cfg.moe.force_fp16_sync);
     B("moe.no_expert_cache", cfg.moe.no_expert_cache);
     I("moe.expert_cache_budget_pct", cfg.moe.expert_cache_budget_pct);
+    B("moe.pin_host_experts", cfg.moe.pin_host_experts);
     B("moe.expert_cache_debug_parity", cfg.moe.expert_cache_debug_parity);
     I("moe.prefetch_top_k", cfg.moe.prefetch_top_k);
     B("moe.allow_graphs_under_offload", cfg.moe.allow_graphs_under_offload);

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -50,6 +50,7 @@ struct ProcessDiag {
     int moe_mr_nr = 8;
     int moe_expert_overhead_pct = 10;
     int moe_force_host_experts = 0;
+    bool moe_pin_host_experts = false;
 
     // GDN
     std::string gdn_layout_override;
@@ -117,6 +118,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.moe_mr_nr = cfg.moe.mr_nr;
     d.moe_expert_overhead_pct = cfg.moe.expert_overhead_pct;
     d.moe_force_host_experts = cfg.moe.force_host_experts;
+    d.moe_pin_host_experts = cfg.moe.pin_host_experts;
     d.gdn_layout_override = cfg.gdn.layout_override;
 }
 
@@ -166,6 +168,7 @@ bool process_diag_ffn_sparsity_probe() { return slot().ffn_sparsity_probe; }
 int process_diag_moe_mr_nr() { return slot().moe_mr_nr; }
 int process_diag_moe_expert_overhead_pct() { return slot().moe_expert_overhead_pct; }
 int process_diag_moe_force_host_experts() { return slot().moe_force_host_experts; }
+bool process_diag_moe_pin_host_experts() { return slot().moe_pin_host_experts; }
 const std::string& process_diag_gdn_layout_override() { return slot().gdn_layout_override; }
 
 }  // namespace imp

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -96,6 +96,9 @@ int process_diag_moe_mr_nr();  // rows-per-block for NVFP4 MoE decode (4/8/16/32
 // + force-host-experts). No per-Engine context at that point.
 int process_diag_moe_expert_overhead_pct();
 int process_diag_moe_force_host_experts();
+// Copy host-resident NVFP4 experts into pinned host memory at load (a trade:
+// +14.7 % prefill for 4.6x model-load time — see dispatch_policy.h).
+bool process_diag_moe_pin_host_experts();
 
 // GDN: layout override read at model-load time by hf_config_loader (no
 // per-Engine context at that point in the loader pipeline).


### PR DESCRIPTION
## What

On the NVFP4 host-offload path, prefill is where the damage is: **61x** slower
than resident on this model (pp512 17508 vs 285 tok/s), against only 6.9x on
decode. This adds an opt-in that recovers ~15% of it, and measures what the rest
is.

## Why it is slow, measured rather than assumed

nsys says the cost is not the GEMMs. `cudaMemcpyAsync` is **53.7%** of API time
over 90 759 calls, and the host sits inside those calls for **4.13 s** while the
GPU spends **795 ms** actually transferring. WSL2 cannot page-lock an mmap in
place, so the driver stages every copy synchronously.

Isolated at one expert's size (768 KiB weights + 96 KiB micro-scales), medians
over 300 reps:

| source | host time in the call | GPU time | rate |
|---|---|---|---|
| pageable mmap, 2 calls (what it did) | 76.2 µs | 92.3 µs | 9.6 GB/s |
| pinned, 1 call | 2.8 µs | 27.3 µs | 32.4 GB/s |

## How

`weight_upload.cu` Path A1 already copies host-resident experts into pinned
memory for the GGUF packed tensor. The per-expert NVFP4 tensors never reached
it, which is the same "one path got the treatment, the other did not" shape as
the rest of this feature. This applies the same treatment behind a switch.

## Measured

`moe.pin_host_experts`, **default off**. Six alternating paired rounds on
`Qwen3-30B-A3B-NVFP4-Modelopt`, one RTX 5090, all 48 MoE layers host-resident.
The switch is what makes alternating cheap: no rebuild between arms.

| | pp512 | tg256 | model load |
|---|---|---|---|
| off | 276.6 | no effect | 5.1 s |
| **on** | **317.6 tok/s, +14.8% (6/6 pairs positive)** | 3 pairs up / 3 down | 22.6 s |

Decode does not move because its cache hits 96-98% and barely transfers;
prefill touches every expert, which is what the transfers cost.

**Off by default** because 4.4x model-load time is too visible a cost to impose
silently. Break-even is around 32k prompt tokens, so it pays for a long-lived
server and not for a one-shot CLI run.

## Two method notes, each of which produced a wrong answer first

**A pinned buffer per expert is the obvious implementation and the wrong one.**
nsys measured **36 877 `cudaHostAlloc` calls costing 24.7 s**, plus 6.4 s of
`cudaFreeHost` at teardown, to save ~0.5 s of transfer time. One slab per
(layer, projection) is 144 allocations for the same result, and the experts land
contiguously as a side benefit.

**Three paired rounds read decode as −33%, and that was noise.** This path's
decode spread is wider than the effect: the off arm alone spanned 34.7 to
66.1 tok/s across six runs. Six pairs flip it to 3-up/3-down. The repo already
records "only paired, alternating rounds decide anything here" for this path;
the correction is that three of them are not enough either.

## Checks

Correctness unchanged with the switch on (`Qwen3-30B-A3B-NVFP4`, 48 of 48 layers
host-resident, answers correctly, clean stderr). `make verify-fast` flat, CI lane
green. No perf-baseline refresh: default-off, and nothing here touches a resident
path.
