### PR TITLE
fix(release): move `latest` only when the release really is the newest

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -32,6 +32,39 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Is this release the newest version, or an older one published late?
+      #
+      # The moving tags (`latest`, `{{major}}`) must only ever move FORWARD.
+      # They did not: v0.22.0 was created on 2026-08-05 but published on
+      # 2026-08-13, five hours after v0.25.0 — and since this workflow fires on
+      # `release: published` and set `latest` for every non-prerelease, the
+      # older image took both `latest` and `0`. Anyone pulling
+      # ghcr.io/kekzl/imp:latest got a three-release-old build, with nothing to
+      # indicate it. GitHub's own "Latest" badge kept pointing at v0.25.0,
+      # because it sorts by version rather than publish time.
+      #
+      # Compare against every published tag with sort -V rather than the API's
+      # /releases/latest, which sorts by created_at and would have called this
+      # backfill "latest" too.
+      - name: Is this the newest release
+        id: newest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          this="${{ github.event.release.tag_name }}"
+          if [ -z "$this" ]; then echo "newest=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          highest=$(gh api --paginate /repos/${{ github.repository }}/releases \
+                      --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name' \
+                    | sort -V | tail -1)
+          echo "this=$this highest=$highest"
+          if [ "$this" = "$highest" ]; then
+            echo "newest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "newest=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::$this is not the newest release ($highest) — keeping the moving tags where they are."
+          fi
+
       - name: Extract image metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -40,8 +73,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=semver,pattern={{major}},enable=${{ steps.newest.outputs.newest == 'true' }}
+            type=raw,value=latest,enable=${{ steps.newest.outputs.newest == 'true' && !github.event.release.prerelease }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`ghcr.io/kekzl/imp:latest` pointed at v0.22.0**, three releases behind, because
+  that release was published after v0.25.0 and the image workflow moved `latest`
+  (and `0`) on every publish regardless of version. The moving tags now only
+  advance when the release really is the newest.
 - **MoE prefill no longer evicts the decode working set from the expert cache**
   on the NVFP4 host path: it now honours the same working-set rule the GGUF path
   has had since #1365. Cache misses drop 3.5x (106k to 30k over a pp512+tg256


### PR DESCRIPTION
## The bug

`ghcr.io/kekzl/imp:latest` has been pointing at **v0.22.0** since this morning,
three releases behind.

v0.22.0 was created on 2026-08-05 but *published* on 2026-08-13, five hours
after v0.25.0. This workflow fires on `release: published` and set `latest` for
every non-prerelease, so the older image took both `latest` and the `0` major
tag on its way in.

| tag | resolves to | should be |
|---|---|---|
| `latest` | **0.22.0** | 0.25.0 |
| `0` | **0.22.0** | 0.25.0 |
| `0.25`, `0.25.0`, `0.22`, `0.22.0` | correct | — |

Nothing indicated it. GitHub's own "Latest" badge still points at v0.25.0,
because that sorts by version rather than publish time, and every immutable tag
was right. Only the two moving tags were wrong — which is exactly the pair a
plain `docker pull ghcr.io/kekzl/imp` resolves.

## The fix

The moving tags now advance only when the released version is the highest
published one, compared with `sort -V` across all non-draft, non-prerelease
releases.

Deliberately **not** `/repos/.../releases/latest`: that sorts by `created_at`,
so it would have called this backfill the newest too and changed nothing.

`{{version}}` and `{{major}}.{{minor}}` keep firing unconditionally — they were
always correct, including for a late publish, and pinning to them is unaffected.

A skipped release logs a `::notice::` naming both versions, so a future
late-publish is visible in the run rather than silent.

## Not covered here

Retagging the images that already exist, so `latest` and `0` point at v0.25.0
again, is a manual step against the registry. This PR only stops it recurring.