### PR TITLE
perf(moe): dispatch staged host layers through the CUTLASS grouped prefill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ there instead of retelling it.
   only work together. Decode is unaffected. Off by default because it costs
   4.4x model-load time. ([`docs/roadmap.md`](docs/roadmap.md))
 
+- **`moe.staged_cutlass_prefill`** (default off) runs host-resident NVFP4 experts
+  through the CUTLASS grouped prefill instead of a per-expert dequant, lifting
+  pp512 from 663 to **1564 tok/s** on Qwen3-30B-A3B-NVFP4 with every MoE layer
+  host-resident. Needs `moe.pin_host_experts`. Opt-in: decode measures 36 % lower
+  after a long prefill in the same test, which is reproducible but unexplained
+  and reverses on a short one. ([`docs/roadmap.md`](docs/roadmap.md))
+
 ### Fixed
 
 - **MoE prefill no longer evicts the decode working set from the expert cache**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -382,6 +382,19 @@ That also re-prices `moe.pin_host_experts` itself, and it is now a much better t
 
 **One correction to the scoping above, found by running it rather than reading it: the smallM branch is unreachable, so it is not the cheap option.** Resident prefill logs `CUTLASS 3.x device-args full path`, which is selected at `executor_forward_moe_cutlass.cu:159` — *before* the smallM branch at :405 is ever consulted. So "smallM already accepts the native layout" is true and irrelevant: nothing reaches it on this model. Closing the dequant means the device-args path, which needs SfAtom scale factors and `wcache_->cutlass_nvfp4` entries built per staged layer. The converter exists (`convert_nvfp4_moe_scales_to_sfatom`) and the staged buffer is the right shape to feed it; the work is the per-layer weight-entry bookkeeping, not the conversion.
 
+**Built 2026-08-13 behind `moe.staged_cutlass_prefill` (default off), and it is the largest single step on this path — with a decode question attached that is the reason it is opt-in.** Converting a staged layer's scales to SfAtom and building the per-expert pointer arrays lets a host-resident layer enter the same CUTLASS grouped prefill a resident one uses. Six alternating paired rounds, all 48 MoE layers host-resident, `moe.pin_host_experts` on in both arms:
+
+| | pp512 | tg256 |
+|---|---|---|
+| off (staged + dequant to cuBLAS) | 663.2 | 59.4 |
+| **on (staged + CUTLASS grouped)** | **1563.9 (+136 %, 6/6)** | **37.7 (-36 %, 6/6)** |
+
+The prefill arm is remarkably tight (1558-1568 across six runs, under 1 % spread), which is what a path that stopped waiting on transfers and dequants looks like. Cumulatively this path's prefill has gone **285 to 1564 tok/s** across this campaign, and the gap to resident from 61x to **11x**.
+
+**The decode figure is real and NOT understood, which is why this is opt-in rather than default.** All six pairs are negative, so it is not the spread this entry keeps warning about. But it reverses with context: with `--bench-pp 8` instead of 512, the same two arms measure **25.5 to 30.6 tok/s, i.e. the staged path is FASTER**. This code only runs at `n > 1` and cannot touch the decode kernels, so what differs is the state decode inherits: the expert cache's hit rate is 91 % against 92.9-98.4 % after a long prefill, and 84.8 % against 80.6 % after a short one. A 2.4x prefill win does not get to impose an unexplained decode cost by default; explaining it is the next task here, ahead of further GEMM work.
+
+Not a regression risk elsewhere: the resident NVFP4 path measures unchanged (pp512 17612 against 17508, tg 380 against 395), the default arm still takes the legacy fallback, and `verify-fast` is green.
+
 *Where the path stands after all of it, re-profiled 2026-08-11 on the shipped build.* The entry opened by calling this path issue-bound; after #1370 and #1376 **it is not any more, and that retires the framing rather than confirming it.** Same config (256 cold decode tokens, all experts host-resident), tg phase 7.06 s:
 
 | term | per token | share |

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -272,6 +272,24 @@ struct MoE {
     // 34.7 to 66.1 tok/s across six runs). Do not re-derive this from fewer
     // than six pairs.
     bool pin_host_experts = false;
+    // Dispatch a STAGED host-resident layer through the CUTLASS grouped NVFP4
+    // prefill instead of the per-expert dequant fallback. Requires
+    // pin_host_experts (which is what makes staging possible at all).
+    //
+    // Measured on Qwen3-30B-A3B-NVFP4, all 48 MoE layers host-resident, six
+    // alternating paired rounds:
+    //   prefill pp512  663.2 -> 1563.9 tok/s   +136 %, 6/6 pairs, spread <1 %
+    //   decode  tg256   59.4 ->   37.7 tok/s   -36 %,  6/6 pairs
+    //
+    // Opt-in because that decode figure is real but NOT understood, and it
+    // reverses with context: at pp8 instead of pp512 the same arms measure
+    // 25.5 -> 30.6 tok/s, i.e. the staged path is FASTER. This code only runs
+    // at n > 1, so it cannot slow the decode kernels directly; what differs is
+    // the expert cache's state when decode inherits it (hit rate 91 % vs
+    // 92.9-98.4 % after a long prefill, 84.8 % vs 80.6 % after a short one).
+    // Until that is explained, a 2.4x prefill win does not get to impose an
+    // unexplained decode cost by default.
+    bool staged_cutlass_prefill = false;
     // Phase 2 (MoE host-offload Graphs design): assert device-side mirror
     // == host-side LRU state after every cache mutation. Off by default;
     // turn on via `moe.expert_cache_debug_parity = true` in imp.conf for

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -819,6 +819,17 @@ private:
     // Defined in executor_forward_moe_nvfp4_host.cu.
     bool stage_nvfp4_layer_(int layer, cudaStream_t stream, StagedProj out[kExpertProjCount]);
 
+    // Build a CUTLASS device-args view over a layer staged by the call above,
+    // so a host-resident layer dispatches like a device-resident one. Returns
+    // false when the layer was not staged, a projection could not build its
+    // SfAtom view, or the opt-in is off. Defined alongside the stager.
+    bool build_staged_device_args_(const MoeFfnContext& ctx, bool non_gated,
+                                   MoEWorkspace::PerLayerNvfp4DeviceArgsCache& out) const;
+
+    // Stage a host-resident layer (once per MoE call, carried on ctx) and say
+    // whether the staged copy can carry the CUTLASS prefill.
+    bool stage_layer_for_prefill_(int layer, cudaStream_t stream, MoeFfnContext& ctx);
+
 public:
     // Throws when a MoE layer's NVFP4 experts are host-resident and nothing
     // can serve them from there. Call after pre_dequant_weights(): it needs

--- a/src/exec/executor_forward_moe_cutlass.cu
+++ b/src/exec/executor_forward_moe_cutlass.cu
@@ -104,12 +104,18 @@ bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t
     // walked. A tier the chain never reaches keeps its `false` — see the KNOWN
     // LIMIT above. Same short-circuit order as the six early returns this
     // conjunction replaces, so the cheap checks still gate the expensive ones.
+    // Host-resident NVFP4 experts: stage the layer and report whether the
+    // staged copy can carry this path (see the definition; it is why
+    // `covers_ids` cannot see these weights).
+    const bool staged_covers = stage_layer_for_prefill_(layer, stream, ctx);
+
     MoePrefillWorkspace obs{};
     static const bool force_off = runtime_config().moe.no_cutlass3x;
-    obs.grouped_available = !force_off && cutlass_grouped_3x_nvfp4_available() && moe_.cutlass3x_packed &&
-                            moe_.cutlass3x_sf && covers_ids(ly.expert_up_ids) &&
-                            covers_ids(ly.expert_down_ids) &&
-                            (ctx.non_gated_experts || covers_ids(ly.expert_gate_ids));
+    const bool ids_cover = covers_ids(ly.expert_up_ids) && covers_ids(ly.expert_down_ids) &&
+                           (ctx.non_gated_experts || covers_ids(ly.expert_gate_ids));
+    obs.grouped_available = !force_off && cutlass_grouped_3x_nvfp4_available() &&
+                            moe_.cutlass3x_packed && moe_.cutlass3x_sf &&
+                            (staged_covers || ids_cover);
     if (!obs.grouped_available) {
         verify_against_moe_routing_model(cfg.arch, runtime_config(), obs, MoePrefillPath::LEGACY);
         return false;
@@ -130,6 +136,7 @@ bool GraphExecutor::try_run_moe_cutlass3x_nvfp4_prefill_(int layer, cudaStream_t
 // h_offsets, no D2H+sync — prerequisite for graph capture of
 // the MoE prefill path. Falls back to the legacy path on any
 // dispatch failure or unpopulated workspace.
+//
 bool device_args_done = false;
 {
     // Default ON since 2026-05-14: 4-model A/B showed +11–39%
@@ -229,10 +236,13 @@ bool device_args_done = false;
         const bool da_cache_ready =
             layer < static_cast<int>(moe_.per_layer_da_cache.size()) &&
             moe_.per_layer_da_cache[layer].ready;
-        const auto& da_cache =
-            da_cache_ready
-                ? moe_.per_layer_da_cache[layer]
-                : MoEWorkspace::PerLayerNvfp4DeviceArgsCache{};
+
+        // Host-resident experts: the staged copy stands in for the resident
+        // one, so from here this layer is dispatched like any other. See
+        // build_staged_device_args_().
+        MoEWorkspace::PerLayerNvfp4DeviceArgsCache da_cache{};
+        if (!build_staged_device_args_(ctx, non_gated_experts, da_cache) && da_cache_ready)
+            da_cache = moe_.per_layer_da_cache[layer];
 
         auto dispatch_device =
             [&](const std::vector<TensorID>& weight_ids,

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -118,8 +118,12 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
         // path was losing to. Decode is excluded deliberately: it wants
         // top_k experts, and staging all of them to get 8 would be strictly
         // more traffic than the slot cache it already uses.
-        StagedProj staged[kExpertProjCount];
-        const bool layer_staged = (n > 1) && stage_nvfp4_layer_(layer, stream, staged);
+        // The CUTLASS attempt ahead of us may already have staged this layer;
+        // reuse it rather than transferring the same bytes twice.
+        if (!ctx.staged_done && n > 1)
+            ctx.staged_done = stage_nvfp4_layer_(layer, stream, ctx.staged);
+        const StagedProj* staged = ctx.staged;
+        const bool layer_staged = ctx.staged_done;
 
         // Helper: dequant one expert's weight from packed tensor into dequant scratch slot 0.
         // Returns a Tensor view into the scratch buffer with shape [rows, cols], FP16.

--- a/src/exec/executor_forward_moe_nvfp4_host.cu
+++ b/src/exec/executor_forward_moe_nvfp4_host.cu
@@ -30,6 +30,7 @@
 #include "exec/executor_kernels.h"
 #include "exec/nvfp4_expert_offload.h"
 #include "compute/activation.h"
+#include "compute/gemm_cutlass_sm120.h"
 #include "compute/moe_routing.h"
 #include "quant/nvfp4_gemm.h"
 #include "core/logging.h"
@@ -190,8 +191,97 @@ bool GraphExecutor::stage_nvfp4_layer_(int layer, cudaStream_t stream,
         out[p].ms_stride = mb;
         out[p].n_experts = ne;
         any = true;
+
+        // CUTLASS device-args view: the grouped GEMM reads SfAtom-ordered
+        // scale factors and per-expert pointer arrays, neither of which the
+        // staged bytes carry. Building them here is what lets a host-resident
+        // layer take the same prefill path as a resident one instead of the
+        // per-expert dequant fallback.
+        if (!moe_.layer_stage_sf || moe_.layer_stage_sf_proj_bytes == 0)
+            continue;
+        const int64_t N = experts[0].shape[0];
+        const int64_t K = experts[0].shape[1] * 2;
+        const size_t sf_expert = cutlass_nvfp4_sf_size(static_cast<int>(N), static_cast<int>(K));
+        if (static_cast<size_t>(ne) * sf_expert > moe_.layer_stage_sf_proj_bytes)
+            continue;
+        char* sf_base = static_cast<char*>(moe_.layer_stage_sf) +
+                        static_cast<size_t>(p) * moe_.layer_stage_sf_proj_bytes;
+        convert_nvfp4_moe_scales_to_sfatom(ms_dst, sf_base, ne, static_cast<int>(N),
+                                           static_cast<int>(K), stream);
+
+        std::vector<const void*> hb(ne), hsfb(ne);
+        std::vector<float> halpha(ne);
+        for (int e = 0; e < ne; ++e) {
+            hb[e] = packed_dst + static_cast<size_t>(e) * pb;
+            hsfb[e] = sf_base + static_cast<size_t>(e) * sf_expert;
+            halpha[e] = experts[e].tensor_scale;
+        }
+        const size_t off = static_cast<size_t>(p) * moe_.layer_stage_experts;
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.layer_stage_b_ptrs + off, hb.data(),
+                                           static_cast<size_t>(ne) * sizeof(const void*),
+                                           cudaMemcpyHostToDevice, stream));
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.layer_stage_sfb_ptrs + off, hsfb.data(),
+                                           static_cast<size_t>(ne) * sizeof(const void*),
+                                           cudaMemcpyHostToDevice, stream));
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.layer_stage_alpha + off, halpha.data(),
+                                           static_cast<size_t>(ne) * sizeof(float),
+                                           cudaMemcpyHostToDevice, stream));
+        // The pointer arrays are filled from stack vectors, so this call is
+        // not graph-capturable — which is fine, graphs are already off under
+        // host-resident experts.
+        out[p].cutlass_ready = true;
     }
     return any;
+}
+
+// Stage a host-resident layer for prefill and report whether the staged copy
+// can carry the CUTLASS path.
+//
+// Staged once per MoE call and carried on ctx, so a fallback to the legacy
+// path does not transfer the same bytes again. The weights then live in the
+// staging buffer rather than the registry, which is why the CUTLASS entry
+// predicate (`covers_ids`) cannot see them: those handles exist only for
+// device-resident experts.
+bool GraphExecutor::stage_layer_for_prefill_(int layer, cudaStream_t stream, MoeFfnContext& ctx) {
+    if (!ctx.staged_done && ctx.n > 1 && moe_.layer_stage_buf)
+        ctx.staged_done = stage_nvfp4_layer_(layer, stream, ctx.staged);
+    if (!runtime_config().moe.staged_cutlass_prefill || !ctx.staged_done)
+        return false;
+    const auto ready = [&](ExpertProj p) { return ctx.staged[std::to_underlying(p)].cutlass_ready; };
+    return ready(ExpertProj::Up) && ready(ExpertProj::Down) &&
+           (ctx.non_gated_experts || ready(ExpertProj::Gate));
+}
+
+// Present a staged layer to the CUTLASS grouped prefill as if it were
+// device-resident. The staging pass already wrote the per-expert pointer and
+// alpha arrays; this only slices them per projection.
+//
+// Opt-in (moe.staged_cutlass_prefill): the prefill win is large and the decode
+// effect that comes with it is real but unexplained — see dispatch_policy.h.
+bool GraphExecutor::build_staged_device_args_(
+    const MoeFfnContext& ctx, bool non_gated,
+    MoEWorkspace::PerLayerNvfp4DeviceArgsCache& out) const {
+    if (!runtime_config().moe.staged_cutlass_prefill || !ctx.staged_done ||
+        !moe_.layer_stage_b_ptrs || moe_.layer_stage_experts <= 0)
+        return false;
+    const auto ready = [&](ExpertProj p) { return ctx.staged[std::to_underlying(p)].cutlass_ready; };
+    if (!ready(ExpertProj::Up) || !ready(ExpertProj::Down) ||
+        (!non_gated && !ready(ExpertProj::Gate)))
+        return false;
+
+    const size_t stride = static_cast<size_t>(moe_.layer_stage_experts);
+    const auto at = [&](ExpertProj p) { return static_cast<size_t>(std::to_underlying(p)) * stride; };
+    out.d_gate_B_ptrs = moe_.layer_stage_b_ptrs + at(ExpertProj::Gate);
+    out.d_gate_SFB_ptrs = moe_.layer_stage_sfb_ptrs + at(ExpertProj::Gate);
+    out.d_gate_alpha = moe_.layer_stage_alpha + at(ExpertProj::Gate);
+    out.d_up_B_ptrs = moe_.layer_stage_b_ptrs + at(ExpertProj::Up);
+    out.d_up_SFB_ptrs = moe_.layer_stage_sfb_ptrs + at(ExpertProj::Up);
+    out.d_up_alpha = moe_.layer_stage_alpha + at(ExpertProj::Up);
+    out.d_down_B_ptrs = moe_.layer_stage_b_ptrs + at(ExpertProj::Down);
+    out.d_down_SFB_ptrs = moe_.layer_stage_sfb_ptrs + at(ExpertProj::Down);
+    out.d_down_alpha = moe_.layer_stage_alpha + at(ExpertProj::Down);
+    out.ready = true;
+    return true;
 }
 
 namespace {

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -676,6 +676,48 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                             "MoE layer staging buffer: %.2f MiB (%d experts x 3 projections, "
                             "one layer at a time)",
                             total / (1024.0 * 1024.0), stage_cfg.n_experts);
+
+                        // SfAtom scales + per-expert pointer arrays, so the
+                        // staged layer can take the CUTLASS device-args path
+                        // instead of the per-expert dequant fallback. Sized
+                        // from the largest projection; gate/up and down differ.
+                        const int64_t d_model = stage_cfg.d_model;
+                        const int64_t eff_ff =
+                            stage_cfg.expert_d_ff > 0 ? stage_cfg.expert_d_ff : stage_cfg.d_ff;
+                        const size_t sf_gate = cutlass_nvfp4_sf_size(
+                            static_cast<int>(eff_ff), static_cast<int>(d_model));
+                        const size_t sf_down = cutlass_nvfp4_sf_size(
+                            static_cast<int>(d_model), static_cast<int>(eff_ff));
+                        const size_t sf_proj =
+                            static_cast<size_t>(stage_cfg.n_experts) * std::max(sf_gate, sf_down);
+                        const size_t sf_total =
+                            static_cast<size_t>(kExpertProjCount) * sf_proj;
+                        const size_t ptr_count =
+                            static_cast<size_t>(kExpertProjCount) * stage_cfg.n_experts;
+                        moe_.layer_stage_sf = vram_alloc(vram_alloc_, sf_total, "moe_layer_stage_sf");
+                        moe_.layer_stage_b_ptrs = static_cast<const void**>(
+                            vram_alloc(vram_alloc_, ptr_count * sizeof(void*), "moe_stage_bptr"));
+                        moe_.layer_stage_sfb_ptrs = static_cast<const void**>(
+                            vram_alloc(vram_alloc_, ptr_count * sizeof(void*), "moe_stage_sfbptr"));
+                        moe_.layer_stage_alpha = static_cast<float*>(
+                            vram_alloc(vram_alloc_, ptr_count * sizeof(float), "moe_stage_alpha"));
+                        if (moe_.layer_stage_sf && moe_.layer_stage_b_ptrs &&
+                            moe_.layer_stage_sfb_ptrs && moe_.layer_stage_alpha) {
+                            moe_.layer_stage_sf_proj_bytes = sf_proj;
+                            moe_.layer_stage_sf_size = sf_total;
+                            IMP_LOG_INFO(
+                                "MoE layer staging: CUTLASS device-args view enabled "
+                                "(+%.2f MiB SfAtom)",
+                                sf_total / (1024.0 * 1024.0));
+                        } else {
+                            // Staging still works, it just falls back to the
+                            // per-expert dequant path for the GEMM.
+                            moe_.layer_stage_sf_proj_bytes = 0;
+                            IMP_LOG_WARN(
+                                "MoE layer staging: SfAtom view alloc failed (%.2f MiB) — "
+                                "prefill keeps the per-expert dequant path",
+                                sf_total / (1024.0 * 1024.0));
+                        }
                     }
                 } else {
                     IMP_LOG_INFO(

--- a/src/exec/moe_ffn_context.h
+++ b/src/exec/moe_ffn_context.h
@@ -3,6 +3,8 @@
 #include "core/tensor.h"
 #include "core/qtype.h"          // QType
 #include "compute/moe_routing.h"  // MoeRoutingResult
+#include "exec/expert_cache.h"           // kExpertProjCount
+#include "exec/nvfp4_expert_offload.h"  // StagedProj
 #include <cstddef>
 
 namespace imp {
@@ -53,6 +55,13 @@ struct MoeFfnContext {
     // back to true. Default true so paths that never check it always see a
     // populated buffer.
     bool moe_gather_done = true;
+
+    // Host-resident NVFP4 experts staged into the device buffer for THIS
+    // layer. Filled by whichever prefill path reaches the layer first and
+    // reused by the later ones, so a layer is transferred once even when the
+    // CUTLASS attempt falls through to the legacy fallback.
+    StagedProj staged[kExpertProjCount]{};
+    bool staged_done = false;
 };
 
 }  // namespace imp

--- a/src/exec/moe_workspace.h
+++ b/src/exec/moe_workspace.h
@@ -151,6 +151,22 @@ struct MoEWorkspace {
     size_t layer_stage_size = 0;          // total allocation
     int layer_stage_experts = 0;          // n_experts the buffer was sized for
 
+    // CUTLASS device-args view of the staged layer. The grouped NVFP4 GEMM
+    // wants SfAtom-ordered scale factors and device arrays of per-expert
+    // pointers; the staged bytes carry the native per-16 layout instead, so
+    // the scales are converted once per staged layer into `layer_stage_sf`
+    // and the three pointer arrays are rebuilt to match.
+    //
+    // This is what lets a host-resident layer take the SAME prefill path as a
+    // resident one, instead of the per-expert dequant→cuBLAS fallback that was
+    // 52 % of this path's kernel time.
+    void* layer_stage_sf = nullptr;        // [kExpertProjCount][n_experts * sf_size]
+    size_t layer_stage_sf_proj_bytes = 0;  // per-projection span
+    size_t layer_stage_sf_size = 0;
+    const void** layer_stage_b_ptrs = nullptr;    // [kExpertProjCount * n_experts]
+    const void** layer_stage_sfb_ptrs = nullptr;  // [kExpertProjCount * n_experts]
+    float* layer_stage_alpha = nullptr;           // [kExpertProjCount * n_experts]
+
     // Slot indices for the host-offload decode path: [3 * top_k] int32, one
     // block per projection (gate, up, down). The fused MoE decode kernels
     // address an expert as `base + idx * stride`; with host-resident experts

--- a/src/exec/nvfp4_expert_offload.h
+++ b/src/exec/nvfp4_expert_offload.h
@@ -112,6 +112,9 @@ struct StagedProj {
     size_t packed_stride = 0;
     size_t ms_stride = 0;
     int n_experts = 0;
+    // SfAtom scales + per-expert pointer arrays were built for this
+    // projection, so it can take the CUTLASS device-args prefill.
+    bool cutlass_ready = false;
 
     bool valid() const { return packed != nullptr && ms != nullptr && n_experts > 0; }
     bool covers(int expert) const { return valid() && expert >= 0 && expert < n_experts; }

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -189,6 +189,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("moe.no_expert_cache", cfg.moe.no_expert_cache);
     I("moe.expert_cache_budget_pct", cfg.moe.expert_cache_budget_pct);
     B("moe.pin_host_experts", cfg.moe.pin_host_experts);
+    B("moe.staged_cutlass_prefill", cfg.moe.staged_cutlass_prefill);
     B("moe.expert_cache_debug_parity", cfg.moe.expert_cache_debug_parity);
     I("moe.prefetch_top_k", cfg.moe.prefetch_top_k);
     B("moe.allow_graphs_under_offload", cfg.moe.allow_graphs_under_offload);


### PR DESCRIPTION
Behind `moe.staged_cutlass_prefill`, **default off**.

## What

After #1412 fixed the transfers, `dequantize_nvfp4_kernel` was 52% of this path's
kernel time and ~53% of its prefill: the M>1 route dequantises each staged expert
to FP16 before cuBLAS, which the resident path never does. Converting a staged
layer's scales to SfAtom and building the per-expert pointer arrays lets a
host-resident layer enter the same CUTLASS grouped prefill a resident one uses.

## Measured

Six alternating paired rounds, all 48 MoE layers host-resident,
`moe.pin_host_experts` on in both arms:

| | pp512 | tg256 |
|---|---|---|
| off (staged + dequant→cuBLAS) | 663.2 | 59.4 |
| **on (staged + CUTLASS grouped)** | **1563.9 (+136%, 6/6)** | **37.7 (−36%, 6/6)** |

The prefill arm is tight — 1558-1568 across six runs, under 1% spread.
Cumulatively this path's prefill has gone **285 → 1564 tok/s** over this
campaign, and the gap to resident from 61x to **11x**.

## Why it is opt-in

**The decode figure is real but not understood.** All six pairs are negative, so
it is not the spread this path is known for. But it reverses with context: at
`--bench-pp 8` instead of 512 the same arms measure **25.5 → 30.6 tok/s, i.e.
the staged path is faster**.

This code only runs at `n > 1` and cannot touch the decode kernels, so what
differs is the state decode inherits — expert-cache hit rate is 91% against
92.9-98.4% after a long prefill, and 84.8% against 80.6% after a short one. A
2.4x prefill win does not get to impose an unexplained decode cost by default.
Explaining it is the next task here, ahead of further GEMM work.

## Checks

Both arms answer correctly with clean stderr after merging current `main`.
Resident NVFP4 unaffected (pp512 17612 vs 17508, tg 380 vs 395). Default arm
still takes the legacy fallback. `verify-fast` green (decode −5.8%, within the
8% threshold, healthy clocks), CI lane green, alloc-sites and file-size gates
green — the dispatch file stays under its limit by moving both new predicates
into `executor_forward_moe_nvfp4_host.cu`.