### PR TITLE
fix(graph): run the forward when the first replay fails, and log why prefill capture is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,23 @@ there instead of retelling it.
 
 ### Fixed
 
-- **`ghcr.io/kekzl/imp:latest` pointed at v0.22.0**, three releases behind, because
+- **A failed first graph replay skipped that step's forward pass entirely**, so the
+  sampler read the previous step's logits and greedy decoding repeated a token for
+  as long as the failure lasted. The step now runs eagerly, as every other capture
+  failure path in the same function already did.
+
+- **Prefill graph capture now says why it did not happen.** `runtime.prefill_graph`
+  has defaulted to on since 2026-05-17, but seven conditions gate the capture and
+  none of them logged anything, so a model that never captures looked exactly like
+  one that does. Measured: on Qwen3-8B-Q8_0 and Qwen3-Coder-30B-A3B-NVFP4 the LM
+  head (vocab x d_model x 2 B = 1187 and 594 MiB) exceeds the 512 MiB dequant
+  workspace cap, and FP8 KV closes a second gate.
+
+### Changed
+
+- **`diagnostics.prefill_graph_ignore_dequant_cap`** (default off) lets a probe run
+  keep prefill capture enabled when only the dequant-workspace cap blocks it, so
+  the guarded path's reachability can be measured from one binary.
   that release was published after v0.25.0 and the image workflow moved `latest`
   (and `0`) on every publish regardless of version. The moving tags now only
   advance when the release really is the newest.

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -828,6 +828,17 @@ struct Diagnostics {
     // semantics. Distinct from nvfp4_force_dequant, which dequantizes
     // the already-NVFP4-quantized cache and so keeps NVFP4 values.
     bool no_nvfp4_decode_cache = false;
+    // Do not let the NVFP4 dequant-workspace cap disable prefill-graph
+    // capture (`executor_workspace_buffers.cu`, kCap = 512 MiB). Probe
+    // tool: the cap is compared against the largest dequant target,
+    // which for every model with a big vocabulary is the LM head
+    // (vocab x d_model x 2 B — 593 MiB on Qwen3-Coder-30B, 1187 MiB on
+    // Qwen3-8B), so prefill capture is off for every model above ~1B.
+    // Whether the M>1 NVFP4 dequant fallback can actually be reached
+    // under prefill capture is the open question; with this set, the
+    // existing fail-loud in gemm_nvfp4 answers it — capture succeeds if
+    // the path never fires, and fails cleanly if it does.
+    bool prefill_graph_ignore_dequant_cap = false;
     // #847 graph-captured-verify feasibility probe: stream-capture every
     // spec verify chunk forward, instantiate + launch the graph (falls
     // back to the eager forward on any failure). Logs per-attempt

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -753,7 +753,18 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
 
     // Fused gate GEMV + topk only profitable when n_experts ≤ warps (8).
     // Higher expert counts (e.g. 128 in Qwen3-Coder) prefer separate
-    // gemv_gate_fp32 (128 parallel blocks).
+    // gemv_gate_fp32, which puts one warp on each expert row: 128 parallel
+    // WARPS in 16 blocks of 8 (not 128 blocks — kGemvThreads is 256).
+    //
+    // 16 blocks looks like under-occupancy (16 of this card's 170 SMs, 0.02
+    // waves/SM, 205 GB/s = 11.4% of peak) and it is not worth "fixing" by
+    // narrowing the block: measured 2026-08-14, 32 threads/block gives 128
+    // blocks and 128/170 SMs, and the kernel gets SLOWER (4320 -> 4480 ns at
+    // base clock, occupancy 16.3% -> 2.1%) for 0.9993x paired e2e on two 128-
+    // expert models. The work is pinned at 128 warps by one-warp-per-row, so
+    // redistributing them only removes each SM's ability to hide DRAM latency
+    // across warps. Making this kernel faster needs K split across several
+    // warps per row — an algorithm change, not a launch-config change.
     constexpr int kMaxFusedExperts = 8;
     const std::string& dl = runtime_config().diagnostics.dump_logits_dir;
     bool dump_logits = !dl.empty() && (layer == 29 || dl == "all");

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -22,6 +22,7 @@
 #include "memory/vram_allocator.h"
 #include "memory/engine_arena.h"
 #include "exec/workspace_sizes.h"
+#include "runtime/process_diag.h"  // process_diag_prefill_graph_ignore_dequant_cap
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -1270,13 +1271,16 @@ bool GraphExecutor::allocate_nvfp4_dequant_workspace() {
     // non-captured streams; hitting one of them under capture now throws
     // (gemm_nvfp4) and the capture fails cleanly.
     if (max_bytes > kCap) {
+        const bool ignore_cap = imp::process_diag_prefill_graph_ignore_dequant_cap();
         IMP_LOG_WARN(
             "gemm_nvfp4 dequant workspace: largest NVFP4 weight is %.2f MiB > %.0f MiB cap "
-            "(covered: %.2f MiB) — prefill graph capture disabled (a captured M>1 fallback "
+            "(covered: %.2f MiB) — prefill graph capture %s (a captured M>1 fallback "
             "on the oversized weight fails loud).",
             max_bytes / (1024.0 * 1024.0), kCap / (1024.0 * 1024.0),
-            covered_bytes / (1024.0 * 1024.0));
-        nvfp4_dequant_uncapturable_ = true;  // scheduler will skip prefill-graph capture
+            covered_bytes / (1024.0 * 1024.0),
+            ignore_cap ? "KEPT ENABLED by diagnostics.prefill_graph_ignore_dequant_cap" : "disabled");
+        if (!ignore_cap)
+            nvfp4_dequant_uncapturable_ = true;  // scheduler will skip prefill-graph capture
     }
     if (covered_bytes == 0)
         return !nvfp4_dequant_uncapturable_;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -290,6 +290,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("diagnostics.graph_dump_dir", cfg.diagnostics.graph_dump_dir);
     B("diagnostics.nvfp4_force_dequant", cfg.diagnostics.nvfp4_force_dequant);
     B("diagnostics.no_nvfp4_decode_cache", cfg.diagnostics.no_nvfp4_decode_cache);
+    B("diagnostics.prefill_graph_ignore_dequant_cap", cfg.diagnostics.prefill_graph_ignore_dequant_cap);
     B("diagnostics.spec_capture_probe", cfg.diagnostics.spec_capture_probe);
     B("diagnostics.log_gemm_algo", cfg.diagnostics.log_gemm_algo);
     B("diagnostics.mtp_pattern_log", cfg.diagnostics.mtp_pattern_log);

--- a/src/runtime/cuda_graph.cu
+++ b/src/runtime/cuda_graph.cu
@@ -447,12 +447,30 @@ bool CudaGraphRunner::execute(cudaStream_t stream) {
         step_count_++;
         // During graph capture the kernels are recorded but NOT executed.
         // Replay immediately so this step produces actual results.
-        if (!graph_.replay(stream)) {
+        // Short-circuit order matters: the injected failure must PREVENT the
+        // replay, not follow a successful one. Launching the graph and then
+        // resetting it destroys the graphExec while the async replay is still
+        // in flight.
+        const bool inject_fail = fail_next_replay_for_test_;
+        fail_next_replay_for_test_ = false;
+        const bool replay_ok = !inject_fail && graph_.replay(stream);
+        if (!replay_ok) {
             IMP_LOG_ERROR(
                 "CudaGraphRunner: first replay after capture failed — falling back "
                 "to per-step decode (up to 15x slower).");
             graph_.reset();
-            return false;
+            // The capture recorded the launches WITHOUT executing them (see the
+            // comment above), so this step has produced nothing yet. Every other
+            // failure path in this function re-runs decode_fn_ for exactly that
+            // reason; this one used to return false instead, and four of the five
+            // execute() call sites ignore the return value. engine_scheduler.cpp
+            // then finds logits_out.data == nullptr and falls back to
+            // get_logits_view(), i.e. the PREVIOUS step's logits — greedy repeats
+            // the token. capture_failed_ marks it eager for good: a first-replay
+            // failure is structural, so retrying would skip a forward every step.
+            capture_failed_ = true;
+            decode_fn_(stream);
+            return true;
         }
         replay_count_++;
         return true;

--- a/src/runtime/cuda_graph.h
+++ b/src/runtime/cuda_graph.h
@@ -138,6 +138,14 @@ public:
             step_count_ = warmup_steps_;
     }
 
+    // Test-only: make the next post-capture replay report failure, so the
+    // first-replay-failure path can be exercised. A genuine cudaGraphLaunch
+    // failure right after a successful cudaGraphInstantiate cannot be provoked
+    // from outside without relying on undefined behaviour, and that path used to
+    // skip the forward pass entirely (see cuda_graph.cu). Never set in
+    // production code.
+    void set_fail_next_replay_for_test() { fail_next_replay_for_test_ = true; }
+
 private:
     DecodeFn decode_fn_;
     CudaGraphCapture graph_;
@@ -147,6 +155,7 @@ private:
     int replay_count_ = 0;
     int capture_count_ = 0;
     bool capture_failed_ = false;  // Set when capture fails; prevents infinite retry
+    bool fail_next_replay_for_test_ = false;  // see set_fail_next_replay_for_test()
 
     // Track batch config to detect changes
     int last_batch_size_ = -1;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1087,6 +1087,24 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
                 logits_out = executor_->get_logits_view(/*n=*/1);
             }
         } else {
+            // `runtime.prefill_graph` defaults to true, but seven conditions
+            // gate the capture and none of them logged anything, so a model
+            // that never captures looked exactly like one that does. Report
+            // the failing condition once per process: measured on
+            // Qwen3-8B-Q8_0 and Qwen3-Coder-30B-A3B-NVFP4, neither ever
+            // captured a prefill chunk, and finding out which gate closed
+            // took a source read plus three A/Bs.
+            static bool logged_no_prefill_capture = false;
+            if (prefill_graph_enabled && !logged_no_prefill_capture) {
+                logged_no_prefill_capture = true;
+                IMP_LOG_INFO(
+                    "prefill graph: not capturing (runtime.prefill_graph=true) — "
+                    "pf_pool=%d cuda_graphs=%d kv_append_f16=%d offset0=%d "
+                    "not_snapshot_end=%d nvfp4_dequant_capturable=%d moe_capturable=%d",
+                    (int)pf_pool_used, (int)config_.use_cuda_graphs, (int)kv_append_capturable,
+                    (int)(offset == 0), (int)!ends_at_snapshot, (int)!executor_->nvfp4_dequant_uncapturable(),
+                    (int)!executor_->moe_prefill_uncapturable());
+            }
             executor_->forward_logits(state, logits_out, pf_stream);
         }
 

--- a/src/runtime/process_diag.cpp
+++ b/src/runtime/process_diag.cpp
@@ -12,6 +12,7 @@ struct ProcessDiag {
     bool debug_template = false;
     bool graph_diag = false;
     bool nvfp4_force_dequant = false;
+    bool prefill_graph_ignore_dequant_cap = false;
     bool log_gemm_algo = false;
     bool audit_nvfp4_scales = false;
     std::string dump_hidden_dir;
@@ -84,6 +85,7 @@ void process_diag_install(const RuntimeConfig& cfg) {
     d.debug_template = cfg.diagnostics.debug_template;
     d.graph_diag = cfg.diagnostics.graph_diag;
     d.nvfp4_force_dequant = cfg.diagnostics.nvfp4_force_dequant;
+    d.prefill_graph_ignore_dequant_cap = cfg.diagnostics.prefill_graph_ignore_dequant_cap;
     d.log_gemm_algo = cfg.diagnostics.log_gemm_algo;
     d.audit_nvfp4_scales = cfg.diagnostics.audit_nvfp4_scales;
     d.dump_hidden_dir = cfg.diagnostics.dump_hidden_dir;
@@ -126,6 +128,7 @@ bool process_diag_debug_forward() { return slot().debug_forward; }
 bool process_diag_debug_template() { return slot().debug_template; }
 bool process_diag_graph_diag() { return slot().graph_diag; }
 bool process_diag_nvfp4_force_dequant() { return slot().nvfp4_force_dequant; }
+bool process_diag_prefill_graph_ignore_dequant_cap() { return slot().prefill_graph_ignore_dequant_cap; }
 bool process_diag_log_gemm_algo() { return slot().log_gemm_algo; }
 bool process_diag_audit_nvfp4_scales() { return slot().audit_nvfp4_scales; }
 const char* process_diag_dump_hidden_dir() {

--- a/src/runtime/process_diag.h
+++ b/src/runtime/process_diag.h
@@ -29,6 +29,7 @@ bool process_diag_debug_forward();
 bool process_diag_debug_template();
 bool process_diag_graph_diag();
 bool process_diag_nvfp4_force_dequant();
+bool process_diag_prefill_graph_ignore_dequant_cap();
 bool process_diag_log_gemm_algo();
 bool process_diag_audit_nvfp4_scales();
 const char* process_diag_dump_hidden_dir();   // nullptr when unset; "1"/"all" → "/tmp"

--- a/tests/test_capture_abort.cu
+++ b/tests/test_capture_abort.cu
@@ -69,3 +69,46 @@ TEST(CaptureAbort, ThrowDuringCaptureLeavesStreamUsable) {
     cudaFree(d);
     cudaStreamDestroy(stream);
 }
+
+// A capture records launches without executing them, so the replay that follows
+// it IS that step's execution. When that first replay fails, the step has run
+// nothing — and the path used to `return false` without re-running decode_fn_.
+// Four of the five execute() call sites ignore the return value; the batched
+// decode one (engine_scheduler.cpp) then sees logits_out.data == nullptr and
+// falls back to get_logits_view(), which still holds the PREVIOUS step's logits,
+// so greedy decoding repeats the token instead of failing.
+TEST(CaptureAbort, FirstReplayFailureStillExecutesTheStep) {
+    SKIP_IF_NO_CUDA();
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), cudaSuccess);
+    int* d = nullptr;
+    ASSERT_EQ(cudaMalloc(&d, sizeof(int)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d, 0, sizeof(int)), cudaSuccess);
+
+    CudaGraphRunner runner;
+    runner.set_warmup_steps(0);  // capture on the first execute
+    int calls = 0;
+    runner.set_decode_fn([&](cudaStream_t s) {
+        calls++;
+        touch_kernel<<<1, 1, 0, s>>>(d);
+    });
+
+    runner.set_fail_next_replay_for_test();
+    EXPECT_TRUE(runner.execute(stream)) << "a step whose work ran eagerly is not a failure";
+    EXPECT_EQ(calls, 2) << "capture pass + eager re-run after the failed first replay";
+
+    // The work must have actually reached the device, not just been recorded.
+    int h = 0;
+    EXPECT_EQ(cudaMemcpyAsync(&h, d, sizeof(int), cudaMemcpyDeviceToHost, stream), cudaSuccess);
+    EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+    EXPECT_EQ(h, 42) << "the failed replay left the step unexecuted";
+
+    // A first-replay failure is structural: stay eager instead of re-capturing
+    // (and skipping a forward) on every later step.
+    EXPECT_TRUE(runner.execute(stream));
+    EXPECT_EQ(calls, 3);
+    EXPECT_EQ(runner.capture_count(), 1) << "must not retry capture after a failed first replay";
+
+    cudaFree(d);
+    cudaStreamDestroy(stream);
+}


### PR DESCRIPTION
Three findings from a graph/launch-overhead investigation, batched because they
all came out of the same profile. Two are fixes, one is a corrected comment.
The perf hypothesis that motivated the investigation was refuted and is not here.

## A failed first replay skipped the step's forward pass

`CudaGraphRunner::execute` captures, then replays immediately, because a capture
records launches *without executing them*, so the replay IS that step's execution.
When that first replay failed, the path did `graph_.reset(); return false;`
without re-running `decode_fn_`. Every other capture-failure path in the same
function re-runs it; this one did not, and it also left `capture_failed_` unset,
so each later step re-captured and skipped the forward again.

Four of the five `execute()` call sites ignore the return value. The batched
decode one (`engine_scheduler.cpp:1986`) then finds `logits_out.data == nullptr`
and falls back to `get_logits_view()`, which still holds the **previous step's**
logits. Under greedy that repeats a token for as long as the failure lasts,
while the only symptom is one ERROR line.

Fixed by running the step eagerly and marking the runner eager for good (a
first-replay failure right after a successful instantiate is structural, so
retrying would skip a forward every step).

**Test, mutation-validated.** `CaptureAbort.FirstReplayFailureStillExecutesTheStep`
follows the existing `ThrowDuringCaptureLeavesStreamUsable` pattern in that file
and asserts the device actually saw the work (`h == 42`), not just that the call
returned. With the fix reverted it fails at 5 assertions. A genuine
`cudaGraphLaunch` failure cannot be provoked from outside without relying on
undefined behaviour, so there is a named test-only hook; its short-circuit order
matters, because injecting the failure *after* the launch destroys the graphExec
while the async replay is still in flight.

## Prefill graph capture never happened, and nothing said so

`runtime.prefill_graph` has defaulted to `true` since 2026-05-17. `can_capture`
has seven conditions and logged nothing when it was false, so a model that never
captures a prefill chunk was indistinguishable from one that does.

Measured on this box, both models log capture disabled:

| model | largest NVFP4 dequant target | = vocab x d_model x 2 B |
|---|---|---|
| Qwen3-8B-Q8_0 | 1187.00 MiB | 151936 x 4096 x 2 |
| Qwen3-Coder-30B-A3B-NVFP4 | 593.50 MiB | 151936 x 2048 x 2 |

`kCap` is 512 MiB, so any model whose LM head lands in an NVFP4 weight cache is
over it. Only sub-1B models stay under. The three models in the A/B that flipped
the default (Gemma-4-26B, Qwen3.6-35B, Qwen3-Coder-30B) are all over it, and that
sweep's own note reads "prefill pp is variance-dominated but the candidate never
regressed below baseline", which is what a no-op looks like.

The gates also interlock: lifting the cap alone changes nothing because FP8 KV is
the qwen3 auto-default and `kv_append_capturable` requires F16, and forcing
`--kv-fp16` doubles bytes/token, which pushes the cache over the 90 % mark and
makes StreamingLLM demote graphs mid-run (`CUDA graphs disabled:
streaming_kv_kv_pressure`, decode 251.87 -> 126.88 tok/s in that arm).

This PR does not change any of those decisions, it makes them visible. One INFO
line per process names the failing conditions.
`diagnostics.prefill_graph_ignore_dequant_cap` (default off) lifts only the cap,
so its reachability can be probed from a single binary.

## A comment that justified a dispatch decision with a wrong number

`executor_forward_moe_batch.cu` justified `kMaxFusedExperts = 8` with
"gemv_gate_fp32 (128 parallel blocks)". It launches **16** blocks of 8 warps:
one warp per expert row, `kGemvThreads = 256`.

16 blocks looks like under-occupancy (16 of 170 SMs, 0.02 waves/SM, 205 GB/s =
11.4 % of peak) and I tried to fix it. Narrowing the block to 32 threads does
give 128 blocks and 128/170 SMs, and it is **worse**: kernel 4320 -> 4480 ns at
base clock, occupancy 16.3 % -> 2.1 %, paired e2e tg256 **0.9993x** on
Qwen3-Coder-30B-A3B and Qwen3-30B-A3B-Modelopt (dense control flat at 1.0005x).
One-warp-per-row pins the work at 128 warps either way, so redistributing them
only removes each SM's ability to hide DRAM latency across warps. The comment now
records that, so the next person does not repeat it. Code reverted.

## Gate

`make verify-fast` on this tree, Qwen3-8B-Q8_0 on one RTX 5090:

| | measured | baseline | delta |
|---|---|---|---|
| decode tg128 | 287.56 tok/s | 287.19 | +0.13 % |
| prefill pp512 | 12471.64 tok/s | 12406.87 | +0.52 % |
| prefill pp4096 | 15413.74 tok/s | 15324.70 | +0.58 % |
| own peak VRAM | 20718 MiB | 20716 | +0.01 % |

Graphs on/off gate 2.58x (threshold 1.3x), degeneration smoke pass. No baseline
refresh needed. Full GPU suite green via the pre-commit hook; `CaptureAbort`
confirmed green from the built image.
