### PR TITLE
fix(build): pin CUTLASS as v4.7.0 and gate the pins so a cold cache cannot hide a break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,14 @@ jobs:
           echo "$diff"
           echo "::warning::clang-format would change the above changed lines — run 'make format' (advisory, not blocking)"
           exit 0
+      # Dependency pins. BLOCKING, and deliberately here rather than in the CUDA
+      # Build job: Build restores a Docker layer cache, which is exactly what
+      # hides a broken pin. On 2026-08-14 the CUTLASS pin read `4.7.0` while the
+      # tag upstream is `v4.7.0`, so every build from a cold cache failed while
+      # cached ones stayed green; three of the four Dockerfile ARG defaults had
+      # also drifted behind the pins they mirror.
+      - name: Dependency pins (drift + upstream tags)
+        run: bash scripts/check_dep_pins.sh --online
 
   # File-size gate (recompile blast-radius smell). Own ubuntu job — independent of
   # the slow CUDA Build, needs no toolchain, just Python 3.11+ for tomllib. Two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Builds from a cold Docker cache were broken.** The CUTLASS pin read `4.7.0`
+  while every tag in that repository carries a `v` prefix, so
+  `git clone --branch 4.7.0` failed; cached builds kept working, which is why CI
+  stayed green. Three of the four Dockerfile `ARG` defaults had also drifted
+  behind the pins they mirror (GoogleTest, cpp-httplib, CUTLASS), so building
+  with plain `docker build` used different dependencies than the gate.
+  `scripts/check_dep_pins.sh` now enforces both: `make build` runs the offline
+  drift half, CI's Lint job additionally resolves every tag upstream.
+
 - **A failed first graph replay skipped that step's forward pass entirely**, so the
   sampler read the previous step's logits and greedy decoding repeated a token for
   as long as the failure lasted. The step now runs eagerly, as every other capture

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ ENV CUDA_HOME=/usr/local/cuda
 # Tags are authoritative in cmake/imp-deps.cmake; `make build` injects them as
 # --build-arg from that file. The defaults below keep a bare `docker build .`
 # working and MUST match cmake/imp-deps.cmake.
-ARG IMP_DEP_GOOGLETEST_TAG=v1.17.0
-ARG IMP_DEP_CUTLASS_TAG=v4.6.2
-ARG IMP_DEP_HTTPLIB_TAG=v0.50.1
+ARG IMP_DEP_GOOGLETEST_TAG=v1.18.0
+ARG IMP_DEP_CUTLASS_TAG=v4.7.0
+ARG IMP_DEP_HTTPLIB_TAG=v0.53.0
 ARG IMP_DEP_NLOHMANN_JSON_TAG=v3.12.0
 RUN git clone --depth=1 --branch ${IMP_DEP_GOOGLETEST_TAG} https://github.com/google/googletest.git /deps/googletest \
  && git clone --depth=1 --branch ${IMP_DEP_CUTLASS_TAG}    https://github.com/NVIDIA/cutlass.git    /deps/cutlass    \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that no other process is using the GPU (games, other inference, etc.)
 check-gpu:
@@ -31,7 +31,19 @@ check-gpu:
 	fi; \
 	echo "GPU is free (utilization: $${GPU_UTIL:-0}%)"
 
-build:
+# Dependency-pin gate. Local builds run the OFFLINE half (Dockerfile ARG
+# defaults vs cmake/imp-deps.cmake): it is instant and cannot fail because the
+# network is down, which matters since the pre-commit hook reaches `build`
+# through `test-gpu`. CI's Lint job runs it with --online, which additionally
+# resolves every tag upstream -- that is the check that would have caught the
+# CUTLASS `4.7.0` vs `v4.7.0` break before a cold cache did.
+check-deps:
+	@bash scripts/check_dep_pins.sh
+
+check-deps-online:
+	@bash scripts/check_dep_pins.sh --online
+
+build: check-deps
 	docker build $(BUILD_ARGS) $(DEP_ARGS) -t $(DOCKER_IMG) .
 
 # ---------------------------------------------------------------------------

--- a/cmake/imp-deps.cmake
+++ b/cmake/imp-deps.cmake
@@ -8,6 +8,6 @@
 # Used by: CMakeLists.txt FetchContent_Declare GIT_TAG entries.
 
 set(IMP_DEP_GOOGLETEST_TAG    v1.18.0  CACHE STRING "googletest git tag")
-set(IMP_DEP_CUTLASS_TAG       4.7.0    CACHE STRING "NVIDIA/cutlass git tag")
+set(IMP_DEP_CUTLASS_TAG       v4.7.0   CACHE STRING "NVIDIA/cutlass git tag")
 set(IMP_DEP_HTTPLIB_TAG       v0.53.0  CACHE STRING "cpp-httplib git tag")
 set(IMP_DEP_NLOHMANN_JSON_TAG v3.12.0  CACHE STRING "nlohmann/json git tag")

--- a/scripts/check_dep_pins.sh
+++ b/scripts/check_dep_pins.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Dependency-pin gate.
+#
+# Two failures this catches, both of which happened on 2026-08-14 and were
+# invisible until a Docker layer cache went cold:
+#
+#   1. DRIFT. The pins live in cmake/imp-deps.cmake and are injected into the
+#      Docker build by scripts/dep_build_args.sh, but the Dockerfile also
+#      carries ARG defaults for anyone running `docker build` directly. Those
+#      defaults had fallen a release behind (CUTLASS v4.6.2 vs the pinned
+#      4.7.0), so the same tree built two different dependency sets depending on
+#      how it was invoked. AGENTS.md says "bump both dep-pin sites together";
+#      nothing enforced it.
+#
+#   2. A TAG THAT DOES NOT EXIST UPSTREAM. The CUTLASS pin read `4.7.0` while
+#      every tag in that repo carries a `v` prefix. `git clone --branch 4.7.0`
+#      fails, so every build from a cold cache died -- while cached builds kept
+#      working and CI stayed green.
+#
+# Both checks read the real sources (cmake/imp-deps.cmake and the Dockerfile's
+# own clone lines) rather than keeping a third copy of the truth here.
+#
+# usage: check_dep_pins.sh [--online]
+#   default : drift check only, no network
+#   --online: additionally resolve every tag against its upstream remote
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CMAKE_FILE="$ROOT/cmake/imp-deps.cmake"
+DOCKERFILE="$ROOT/Dockerfile"
+ONLINE=0
+[ "${1:-}" = "--online" ] && ONLINE=1
+
+fail=0
+note() { printf '%s\n' "$*"; }
+bad() { printf 'FAIL  %s\n' "$*"; fail=1; }
+
+# name -> tag, from the single source of truth
+declare -A PINNED
+while IFS='=' read -r name tag; do
+    [ -n "$name" ] && PINNED["$name"]="$tag"
+done < <(sed -n 's/^set(IMP_DEP_\([A-Z_]*\)_TAG[ \t]*\([^ \t)]*\).*/\1=\2/p' "$CMAKE_FILE")
+
+if [ ${#PINNED[@]} -eq 0 ]; then
+    bad "no IMP_DEP_*_TAG entries parsed from cmake/imp-deps.cmake"
+    exit 1
+fi
+
+# name -> ARG default, from the Dockerfile
+declare -A ARGDEF
+while IFS='=' read -r name tag; do
+    [ -n "$name" ] && ARGDEF["$name"]="$tag"
+done < <(sed -n 's/^ARG IMP_DEP_\([A-Z_]*\)_TAG=\(.*\)$/\1=\2/p' "$DOCKERFILE")
+
+# name -> clone URL, from the Dockerfile's own clone lines
+declare -A URL
+while read -r name url; do
+    [ -n "$name" ] && URL["$name"]="$url"
+done < <(grep -oE '\-\-branch \$\{IMP_DEP_[A-Z_]+_TAG\}[[:space:]]+https://[^[:space:]]+' "$DOCKERFILE" \
+         | sed -E 's/--branch \$\{IMP_DEP_([A-Z_]+)_TAG\}[[:space:]]+(https:\/\/[^[:space:]]+)/\1 \2/')
+
+note "dependency pins (source: cmake/imp-deps.cmake)"
+for name in $(printf '%s\n' "${!PINNED[@]}" | sort); do
+    tag="${PINNED[$name]}"
+    printf '  %-16s %s\n' "$name" "$tag"
+
+    # 1. drift: the Dockerfile ARG default must match the pin exactly
+    if [ -z "${ARGDEF[$name]:-}" ]; then
+        bad "$name: pinned in cmake but no 'ARG IMP_DEP_${name}_TAG=' default in the Dockerfile"
+    elif [ "${ARGDEF[$name]}" != "$tag" ]; then
+        bad "$name: Dockerfile default '${ARGDEF[$name]}' != cmake pin '$tag' (bump both, AGENTS.md)"
+    fi
+
+    # 2. existence: the tag must resolve upstream, or a cold build cannot clone it
+    if [ "$ONLINE" = "1" ]; then
+        u="${URL[$name]:-}"
+        if [ -z "$u" ]; then
+            bad "$name: no clone URL found in the Dockerfile; cannot verify the tag exists"
+        elif ! git ls-remote --exit-code "$u" "refs/tags/$tag" >/dev/null 2>&1 \
+             && ! git ls-remote --exit-code "$u" "refs/heads/$tag" >/dev/null 2>&1; then
+            bad "$name: '$tag' resolves to no tag or branch at $u (a cold 'git clone --branch' would fail here)"
+        fi
+    fi
+done
+
+# Every Dockerfile ARG must be backed by a pin, or it is a fourth source of truth.
+for name in "${!ARGDEF[@]}"; do
+    [ -z "${PINNED[$name]:-}" ] && bad "$name: Dockerfile ARG default with no matching pin in cmake/imp-deps.cmake"
+done
+
+if [ "$fail" = "0" ]; then
+    note "OK ($([ "$ONLINE" = "1" ] && echo 'drift + upstream tags' || echo 'drift only; pass --online to resolve tags'))"
+else
+    note ""
+    note "Pins are the one thing a cached Docker layer will happily hide."
+fi
+exit "$fail"


### PR DESCRIPTION
Building this tree from a cold Docker cache has been broken since the CUTLASS
4.7.0 bump. Cached builds kept working, so CI never saw it.

## The break

```
git clone --depth=1 --branch 4.7.0 https://github.com/NVIDIA/cutlass.git
fatal: Remote branch 4.7.0 not found in upstream origin
```

Upstream tags that repository `v4.7.0`, like every other 4.x release
(`v4.4.0` … `v4.6.2`). `cmake/imp-deps.cmake` pinned it without the prefix, and
`scripts/dep_build_args.sh` passes the pin through verbatim, so the clone in the
`toolchain` stage failed. It surfaced only when a layer aged out of the cache
mid-session; before that, every `make build` and `make dev` reused the layer
built back when the unprefixed tag still resolved.

## Two more drifts, found by writing the check

The Dockerfile carries `ARG` defaults mirroring the pins, for anyone running
`docker build` directly. Three of four had fallen behind:

| dependency | Dockerfile ARG | pin |
|---|---|---|
| GoogleTest | v1.17.0 | **v1.18.0** |
| cpp-httplib | v0.50.1 | **v0.53.0** |
| CUTLASS | v4.6.2 | **4.7.0** (itself invalid) |

So the same tree built two different dependency sets depending on how it was
invoked. `AGENTS.md` already says "bump both dep-pin sites together" — nothing
enforced it.

## The gate

`scripts/check_dep_pins.sh` checks two properties, reading the real sources
(`cmake/imp-deps.cmake` for pins, the Dockerfile's own clone lines for URLs) so
it does not become a third copy of the truth:

- **drift** — every `ARG IMP_DEP_*_TAG` default equals its pin, and every ARG has
  a pin behind it
- **exists** (`--online`) — every tag resolves to a tag or branch at its upstream
  remote, i.e. a cold `git clone --branch` would succeed

Wiring follows what each half needs:

- `make build` depends on the **offline** half. It is instant and cannot fail
  because the network is down, which matters because the pre-commit hook reaches
  `build` through `test-gpu`.
- CI's **Lint** job runs `--online`. Deliberately *not* the CUDA `Build` job:
  that one restores a layer cache, which is exactly what masked this.
- `make check-deps-online` for running the full check by hand.

## Verified against the bug

Restoring the `4.7.0` pin makes the check report both defects:

```
FAIL  CUTLASS: Dockerfile default 'v4.7.0' != cmake pin '4.7.0' (bump both, AGENTS.md)
FAIL  CUTLASS: '4.7.0' resolves to no tag or branch at https://github.com/NVIDIA/cutlass.git
```

And a `--no-cache-filter toolchain` rebuild now clones `v4.7.0` (`dcf215a`)
cleanly. The images this session measured against already contained 4.7.0, so no
published number is affected.

Full GPU suite green via the pre-commit hook.
