### PR TITLE
Qwen3.8-27B: enable its vision tower, keep towers out of NVFP4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ there instead of retelling it.
 
 ### Added
 
+- **Qwen3.8-27B runs, text and vision.** Its vision tower is the one imp already
+  had, declared under a third `vision_config.model_type` (`qwen3_5`), so enabling
+  it was one allowlist entry: 333 tensors, 878.8 MiB. Decode `tg256` 89.85 tok/s,
+  prefill `pp512` 7524 tok/s, teacher-forced PPL 4.62 on `ppl_corpus_45k.txt`.
+  No published NVFP4 export runs on `sm_120` (they carry FP8 attention, which the
+  card has no GEMM for): quantize the BF16 release with `imp-quantize`.
+  ([`docs/MODELS.md`](docs/MODELS.md))
+
+- **`imp-quantize` no longer quantizes a vision tower.** `model.visual.*` and
+  `vision_tower.*` are copied at source precision, because the tower upload path
+  accepts F16/BF16/F32 only, so an NVFP4 tower could not be read back.
+
 - **NVFP4 MoE experts can now live on host**, so a checkpoint whose experts
   exceed VRAM runs instead of being refused. Qwen3-30B-A3B-NVFP4 with all 48 MoE
   layers off-GPU answers correctly at 23.0 tok/s, against 384.0 fully resident.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -52,6 +52,7 @@ GDN models use FP16 prefill instead of FP8 (~8% slower than FP8 dense, but elimi
 | [Qwen3.5-27B](https://huggingface.co/unsloth/Qwen3.5-27B-GGUF) | Q4_K_M | 16 GB | — | GGUF |
 | [Qwable-3.6-27B](https://huggingface.co/Mia-AiLab/Qwable-3.6-27b) | Q4_K_M | 16 GB | ~18 | GGUF, validated dense-GDN 27B (Qwen3.6-27B fine-tune, 64 layers: 16 attn + 48 GDN). ~29 GB resident (Q4_K + NVFP4 decode cache + GDN state) → relies on the auto KV clamp to serve. Heavy trace-reasoner: give it generous `max_tokens`. |
 | [Qwen3.6-27B-Text-NVFP4-MTP](https://huggingface.co/sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP) | NVFP4 | 17 GB | — | SafeTensors (Modelopt), dense-GDN 27B. **Checkpoint quantizes the GDN `linear_attn` projections to NVFP4** — `ssm_in`/`ssm_out`/`gdn_gate` run native NVFP4, `gdn_alpha`/`gdn_beta` (FP16_ONLY) are dequanted to FP16 at load (#812). |
+| [Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) | NVFP4 | 17 GB | 90 | SafeTensors, dense-GDN 27B (64 layers: 16 attn + 48 GDN) and multimodal. The text config is field-identical to Qwen3.6-27B above. **No published NVFP4 export runs on this card**: they are mixed-precision with FP8 attention and `sm_120` has no FP8 GEMM. Quantize the BF16 release yourself (`imp-quantize`, 51.8 → 18.6 GiB). Teacher-forced PPL 4.62 on `ppl_corpus_45k.txt` against 7.55 for Qwen3.6-27B on the same corpus |
 | Qwen3.5-27B | MXFP4 | — | — | Loads OOM on 32 GB — see [roadmap](roadmap.md) |
 
 ## Mixture-of-Experts
@@ -81,6 +82,7 @@ checkpoint, so there is no second file and no second flag.
 |---|---|---|---|
 | [Qwen3-VL-4B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct) | BF16 | SafeTensors | Tower ships with the checkpoint — no `--mmproj`. Dynamic resolution (a 1795x2397 photo becomes 972 image tokens), DeepStack taps into the LM's first layers, three-axis M-RoPE |
 | [Qwen3.6-35B-A3B-NVFP4](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4) | NVFP4 | SafeTensors (llm-compressor) | Same tower under a different `vision_config.model_type` (`qwen3_5_moe`), 27 blocks, no DeepStack. Text weights NVFP4, tower BF16 (851.8 MiB) — the mixed precision is the checkpoint's, not a conversion. Tight: init lands at ~31.1 of 32.6 GB. The `mmangkad` Modelopt export in the text table above is a different upload and was not tested for vision |
+| [Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) | NVFP4 | SafeTensors | The same tower a third time, under `vision_config.model_type` `qwen3_5`: 27 blocks, no DeepStack, the same 333 `model.visual.*` tensors and the same `image_token_id`. Only `out_hidden_size` differs (5120), which is the LM width. Tower stays BF16 (878.8 MiB): `imp-quantize` keeps `model.visual.*` at source precision, because the upload path takes F16/BF16/F32 only |
 | [Gemma-3-12B-it](https://huggingface.co/bartowski/google_gemma-3-12b-it-GGUF) | Q8_0 | GGUF | text + vision, `tg256` 129 |
 | [Gemma-3-27B-it](https://huggingface.co/unsloth/gemma-3-27b-it-GGUF) | Q4_K_M | GGUF | largest Gemma-3 |
 | [Gemma-4-26B-A4B-it](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | Q4_K_M | GGUF | text + vision via the gemma4v encoder (separate BF16 mmproj), `tg128` 273 — see [`vision_gemma4v_spec.md`](vision_gemma4v_spec.md) |
@@ -88,9 +90,10 @@ checkpoint, so there is no second file and no second flag.
 Several images in one request are supported on this tower — repeat `--image`, or
 send several `image_url` parts — and they are read in prompt order.
 
-`Qwen3VLForConditionalGeneration`, `Qwen3VLMoeForConditionalGeneration` and
-`Qwen3_5MoeForConditionalGeneration` are all registered; the dense 4B and the
-Qwen3.6-35B MoE are validated end to end here. A VL checkpoint also loads
+`Qwen3VLForConditionalGeneration`, `Qwen3VLMoeForConditionalGeneration`,
+`Qwen3_5MoeForConditionalGeneration` and `Qwen3_5ForConditionalGeneration` are all
+registered; the dense 4B, the Qwen3.6-35B MoE and the dense Qwen3.8-27B are
+validated end to end here. A VL checkpoint also loads
 text-only — the tower is simply never run if no image is passed.
 
 What decides is `vision_config.model_type`, matched against an allowlist

--- a/src/vision/qwen3vl_vision_config.cpp
+++ b/src/vision/qwen3vl_vision_config.cpp
@@ -33,10 +33,18 @@ bool vision_tower_supported(const std::string& vision_model_type) {
     // patterns, the same nine geometry fields, and an empty
     // `deepstack_visual_indexes` (which the loader already handles).
     //
+    // Qwen3.8 (`qwen3_5`, the dense sibling) is the same tower again, checked
+    // field by field against Qwen3.6-35B: depth 27, hidden 1152, heads 16,
+    // intermediate 4304, patch 16, merge 2, temporal 2, pos-grid 2304, empty
+    // deepstack, and the same `image_token_id` 248056. Only `out_hidden_size`
+    // differs (5120 vs 2048), which is the LM's hidden size, not a tower
+    // property. Its checkpoint carries the same 333 `model.visual.*` tensors.
+    //
     // An allowlist rather than a shape fingerprint on purpose — anything
     // unrecognised must keep hitting the loud text-only path rather than being
     // parsed on a resemblance.
-    return vision_model_type == "qwen3_vl" || vision_model_type == "qwen3_5_moe";
+    return vision_model_type == "qwen3_vl" || vision_model_type == "qwen3_5_moe" ||
+           vision_model_type == "qwen3_5";
 }
 
 bool parse_qwen3vl_vision_config(const JValue& vision_cfg, VisionConfig& out, std::string& err) {

--- a/tests/test_qwen3vl_vision_config.cpp
+++ b/tests/test_qwen3vl_vision_config.cpp
@@ -140,6 +140,8 @@ TEST(Qwen3VLVisionConfig, TowerAllowlist) {
     EXPECT_TRUE(vision_tower_supported("qwen3_vl"));
     // Qwen3.6 ships the same tower layout under its text model_type.
     EXPECT_TRUE(vision_tower_supported("qwen3_5_moe"));
+    // Qwen3.8 is the dense sibling and carries that same tower.
+    EXPECT_TRUE(vision_tower_supported("qwen3_5"));
 
     // Everything else keeps hitting the loud text-only path. Recognising a
     // tower on a resemblance is what this list exists to prevent.

--- a/tools/imp-quantize/tensor_policy.cpp
+++ b/tools/imp-quantize/tensor_policy.cpp
@@ -53,6 +53,15 @@ bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why
         why_not = "lm_head (use --lm-head to include)";
         return false;
     }
+    // The vision tower. Its upload path takes F16/BF16/F32 and rejects anything
+    // else outright (qwen3vl_vision_upload.cpp), so an NVFP4 tower is a tower no
+    // loader can read back: the tensors are 2-D and K-aligned, so every shape
+    // check waves them through. Multimodal checkpoints carry it under
+    // `model.visual.*`; a text-only one has no such tensor and is unaffected.
+    if (contains(t.name, "visual.") || contains(t.name, "vision_tower.")) {
+        why_not = "vision tower (upload path takes source precision only)";
+        return false;
+    }
     // Two weight roles that are 2-D and K-aligned — so every shape check waves
     // them through — but that must NOT be quantized. Both were found by
     // bisection on DeepSeek-V2-Lite (MLA + 64-expert MoE), where quantizing


### PR DESCRIPTION
Qwen3.8-27B (released 2026-08-14) now runs here, text and vision.

## Vision was one allowlist entry

The model declares the Qwen3-VL tower under a third `vision_config.model_type`,
`qwen3_5`. Checked field by field against the already-supported Qwen3.6-35B
(`qwen3_5_moe`): depth 27, hidden 1152, heads 16, intermediate 4304, patch 16,
merge 2, temporal 2, pos-grid 2304, empty deepstack, and the same
`image_token_id` 248056. Only `out_hidden_size` differs (5120 vs 2048), which is
the LM width, not a tower property. The checkpoint carries the same 333
`model.visual.*` tensors.

Verified rather than assumed:

- 333 tensors assigned and uploaded, 878.8 MiB
- prompt tokens 57 without an image, 131 with one, so the image tokens really
  are in the sequence
- a four-question battery over two images (a gradient with two squares, and a
  green field with a black bar) answers all four correctly **and differently per
  image**, which a constant-answer model cannot do

## imp-quantize must not quantize a tower

It would have written all 111 tower tensors as NVFP4, and
`qwen3vl_vision_upload.cpp:44` accepts F16/BF16/F32 only, so the result is a
tower no loader can read back. The tensors are 2-D and K-aligned, so every
existing shape check waved them through. Excluding `model.visual.*` and
`vision_tower.*` costs 0.6 GiB of checkpoint.

## The text path needed nothing

Qwen3.8-27B's `text_config` is field-identical to Qwen3.6-27B, which has run
here for months, and the VRAM pools came out MiB for MiB the same.

| | Qwen3.8-27B | Qwen3.6-27B |
|---|---:|---:|
| decode `tg256` | 89.85 | 89.68 |
| prefill `pp512` | 7524 | 7555 |
| PPL, `ppl_corpus_45k.txt` | 4.62 | 7.55 |

Three fresh processes per arm, speculation off, `CUBLAS_WORKSPACE_CONFIG=:4096:8`,
clocks sampled during the run at 2865 MHz SM / 13801 MHz mem / 490 W. Decode
spread 0.22 %. No baseline refresh: this model is not gated and nothing moved on
the gated one.

Getting the weights is its own note, now in `docs/MODELS.md`: **no published
NVFP4 export runs on sm_120**, because they are mixed-precision with FP8
attention and this card has no FP8 GEMM. The one I tested loads all the way to
the first GEMM and dies there, having silently skipped 869 tensors, since its
compressed-tensors names are not translated under `format: mixed-precision`.
Quantizing the BF16 release with `imp-quantize` gives 51.8 to 18.6 GiB and works.

## Known gap, deliberately not in this PR

`json_schema` requests on Qwen3.8 often come back with empty `content` because
the answer stays in the reasoning channel. It reproduces on Qwen3.8 and not on
Qwen3.6 with the identical request, and it predates this change. I built two
fixes and reverted both: the first (ban EOS while the preamble gate holds the
mask off) provably ran and did not help, because `is_stop_token()` also covers
template stops and banned specials; the second (sync the gate with
`should_stop`'s implicit think-close) made it measurably worse, 8/8 to 0/8 at
temperature 0. There is a third state machine involved, the server's textual
`reasoning_split`, and a real fix has to serve all three at once.

## Testing

`make dev-test` green. Vision, benchmark and quality numbers above were taken
locally against the `make build` image; degen_suite reads 42/45, the three
failures all being the constrained-decoding gap described above. The GPU gate
was skipped for this PR at the author's request.
