### PR TITLE
imp-quantize: forecast the output size and whether it fits the card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ there instead of retelling it.
 
 ### Added
 
+- **`imp-quantize --dry-run` now forecasts the output size and whether it fits.**
+  It prints the same `size: A -> B` line the real run does, plus the card's
+  budget once the CUDA context and library reserve are subtracted. Verified on
+  Qwen3.8-27B: the forecast reads `51.75 GiB -> 18.58 GiB (2.79x)`, the figure
+  the write then produced, in seconds instead of 25 minutes. The writing path
+  now fails loudly if its actual buffers ever disagree with that arithmetic.
+
 - **Qwen3.8-27B runs, text and vision.** Its vision tower is the one imp already
   had, declared under a third `vision_config.model_type` (`qwen3_5`), so enabling
   it was one allowlist entry: 333 tensors, 878.8 MiB. Decode `tg256` 89.85 tok/s,

--- a/tests/test_quantize_policy.cpp
+++ b/tests/test_quantize_policy.cpp
@@ -189,5 +189,28 @@ TEST(FusedGateQProj, DoesNotGuessWhenTheLayerHasNoOProj) {
     EXPECT_TRUE(find_fused_gate_q_projections(ts).empty()) << "no reference — must not guess";
 }
 
+// The --dry-run size forecast is this arithmetic, and the writing path asserts
+// its real buffers against it. Pinning the three components separately means a
+// layout change breaks the test that explains the layout, not just a total.
+TEST(Nvfp4OutputBytes, CountsPackedNibblesMicroScalesAndTensorScale) {
+    // A real Qwen3.8 projection: [17408, 5120].
+    const int64_t N = 17408, K = 5120;
+    const size_t packed = size_t(N) * K / 2;   // two 4-bit values per byte
+    const size_t micro = size_t(N) * K / 16;   // one FP8 scale per 16 values
+    EXPECT_EQ(nvfp4_output_bytes(N, K), packed + micro + sizeof(float));
+
+    // The point of quantizing: 2 bytes per value become 0.5 + 0.0625.
+    const double ratio = double(size_t(N) * K * 2) / double(nvfp4_output_bytes(N, K));
+    EXPECT_NEAR(ratio, 32.0 / 9.0, 0.01) << "BF16 against packed+micro is 2 / (0.5 + 0.0625)";
+}
+
+TEST(Nvfp4OutputBytes, RefusesToInventBytesForAnEmptyMatrix) {
+    // Guards the forecast against a degenerate shape adding a phantom 4 bytes
+    // per tensor, which on a 1000-tensor checkpoint is a visible drift.
+    EXPECT_EQ(nvfp4_output_bytes(0, 5120), 0u);
+    EXPECT_EQ(nvfp4_output_bytes(17408, 0), 0u);
+    EXPECT_EQ(nvfp4_output_bytes(-1, 5120), 0u);
+}
+
 }  // namespace
 }  // namespace imp::quantize

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -67,6 +67,7 @@
 #include "tensor_policy.h"
 
 #include "core/tensor.h"
+#include "memory/plan.h"
 #include "model/safetensors_raw.h"
 #include "model/safetensors_writer.h"
 #include "quant/awq_transform.h"
@@ -137,7 +138,8 @@ void usage() {
         "                half carries #1273's divergence, but excluding it measured\n"
         "                ~1.5%% WORSE on perplexity, not better, and costs 1-4% of\n"
         "                the checkpoint. Kept for models with a higher gate share.\n"
-        "  --dry-run     report what would be quantized, write nothing\n");
+        "  --dry-run     report what would be quantized and how large the result\n"
+        "                will be, against what the card has left. Writes nothing.\n");
 }
 
 bool ends_with(const std::string& s, const std::string& suf) {
@@ -280,6 +282,44 @@ bool write_quant_config(const Options& opt, const std::vector<std::string>& excl
         f << (i ? ", " : "") << '"' << excluded[i] << '"';
     f << "]\n  }\n}\n";
     return static_cast<bool>(f);
+}
+
+// What is gone from the card before imp allocates a single weight. Both are
+// measurements on this target, not headroom guesses: the library reserve is
+// kMeasuredLibraryReserveBytes (src/memory/plan.h, re-measure after a CUDA or
+// driver bump), and the CUDA primary context is the figure the same header
+// records for this WSL2/WDDM box.
+constexpr size_t kContextBytes = 1680ull * 1024 * 1024;
+
+// Report the checkpoint against the card it is meant to run on. Deliberately
+// states the ON-DISK size against the budget rather than predicting VRAM:
+// what the engine actually resides is the weights PLUS a scale-factor cache and
+// MINUS whatever the loader skips (a vision tower is uploaded separately, an MTP
+// sidecar may not be loaded at all). Measured on Qwen3.8-27B: 18.60 GiB on disk
+// arrived as 16.08 GiB of weights plus a 1.49 GiB CUTLASS scale cache. So the
+// disk figure is the right order and the wrong decimal, and this prints the
+// budget the reader needs rather than a number that looks exact and is not.
+void report_card_fit(size_t bytes_out) {
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess || total_b == 0)
+        return;  // no device visible: the size line above still stands on its own
+    const double mib = 1024.0 * 1024.0;
+    const size_t overhead = kContextBytes + kMeasuredLibraryReserveBytes;
+    if (total_b <= overhead)
+        return;
+    const double budget = double(total_b - overhead) / mib;
+    const double ckpt = double(bytes_out) / mib;
+    printf("\ncard: %.0f MiB total, less %.0f context and %.0f library reserve leaves %.0f MiB",
+           double(total_b) / mib, kContextBytes / mib, kMeasuredLibraryReserveBytes / mib, budget);
+    if (ckpt >= budget)
+        printf("\n      this checkpoint is %.0f MiB on disk and does NOT fit: %.0f MiB short before"
+               "\n      any KV cache or workspace",
+               ckpt, ckpt - budget);
+    else
+        printf("\n      this checkpoint is %.0f MiB on disk, leaving %.0f MiB for the KV cache and"
+               "\n      workspaces. On-disk size is not the resident figure: a scale-factor cache is"
+               "\n      built on top, and a vision tower or MTP sidecar may load separately or not at all",
+               ckpt, budget - ckpt);
 }
 
 }  // namespace
@@ -563,6 +603,7 @@ int main(int argc, char** argv) {
             const int64_t N = t.shape[0], K = t.shape[1];
             if (opt.dry_run) {
                 printf("  QUANT %-58s [%lld,%lld]\n", t.name.c_str(), (long long)N, (long long)K);
+                bytes_out += quantize::nvfp4_output_bytes(N, K);
                 n_quantized++;
                 continue;
             }
@@ -581,7 +622,18 @@ int main(int argc, char** argv) {
             out.push_back({t.name, "U8", {N, K / 2}, q.packed.data(), q.packed.size()});
             out.push_back({base + ".weight_scale", "F8_E4M3", {N, K / 16}, q.micro.data(), q.micro.size()});
             out.push_back({base + ".weight_scale_2", "F32", {1}, &scale_store.back(), sizeof(float)});
-            bytes_out += q.packed.size() + q.micro.size() + sizeof(float);
+            const size_t written = q.packed.size() + q.micro.size() + sizeof(float);
+            // The forecast --dry-run printed is this same arithmetic. If the two
+            // ever disagree the forecast has quietly become a guess, so say so
+            // here rather than let a wrong size be published as a measurement.
+            if (written != quantize::nvfp4_output_bytes(N, K)) {
+                fprintf(stderr,
+                        "  %s: quantized to %zu bytes but the size forecast says %zu. The NVFP4\n"
+                        "output layout changed without nvfp4_output_bytes() following it\n",
+                        t.name.c_str(), written, quantize::nvfp4_output_bytes(N, K));
+                return 1;
+            }
+            bytes_out += written;
             n_quantized++;
         }
 
@@ -647,9 +699,9 @@ int main(int argc, char** argv) {
                    : "");
     if (n_moe_skipped)
         printf(", %zu MoE expert stacks left unquantized (not supported yet)", n_moe_skipped);
-    if (!opt.dry_run)
-        printf("\nsize: %.2f GiB -> %.2f GiB (%.2fx)", bytes_in / 1073741824.0, bytes_out / 1073741824.0,
-               bytes_in ? double(bytes_in) / double(bytes_out) : 0.0);
+    printf("\nsize: %.2f GiB -> %.2f GiB (%.2fx)%s", bytes_in / 1073741824.0, bytes_out / 1073741824.0,
+           bytes_out ? double(bytes_in) / double(bytes_out) : 0.0, opt.dry_run ? " (forecast)" : "");
+    report_card_fit(bytes_out);
     printf("\n");
     return 0;
 }

--- a/tools/imp-quantize/tensor_policy.cpp
+++ b/tools/imp-quantize/tensor_policy.cpp
@@ -96,6 +96,15 @@ bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why
     return true;
 }
 
+size_t nvfp4_output_bytes(int64_t N, int64_t K) {
+    if (N <= 0 || K <= 0)
+        return 0;
+    const size_t n = static_cast<size_t>(N), k = static_cast<size_t>(K);
+    return n * k / 2       // packed FP4 nibbles, two per byte
+           + n * k / 16    // one FP8 E4M3 micro-scale per 16 values
+           + sizeof(float);  // the per-tensor F32 scale
+}
+
 std::vector<const RawTensor*> find_fused_gate_q_projections(const std::vector<RawTensor>& tensors) {
     static const std::string kQ = ".q_proj.weight";
     static const std::string kO = ".o_proj.weight";

--- a/tools/imp-quantize/tensor_policy.h
+++ b/tools/imp-quantize/tensor_policy.h
@@ -21,6 +21,15 @@ namespace imp::quantize {
 // copies the tensor through untouched.
 bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why_not);
 
+// Bytes an [N, K] matrix occupies once quantized: the packed nibbles [N, K/2],
+// the FP8 micro-scales [N, K/16], and one F32 tensor scale.
+//
+// Exists so the --dry-run forecast and the real write agree by construction
+// rather than by two people keeping two expressions in step. The writing path
+// checks its actual buffers against this and fails loudly on a mismatch, so a
+// layout change cannot silently turn the forecast into a guess.
+size_t nvfp4_output_bytes(int64_t N, int64_t K);
+
 // MoE experts stored as one 3-D [n_experts, N, K] stack rather than a 2-D
 // tensor per expert.
 //


### PR DESCRIPTION
`--dry-run` listed which tensors it would touch and stayed silent about the one
thing you run it for. The only way to learn the output size was to do the real
write: on Qwen3.8-27B that is 25 minutes and 18.6 GiB of disk before you find
out whether the checkpoint was ever going to fit on the card.

It now prints the same line the write produces, plus the budget:

```
size: 51.75 GiB -> 18.58 GiB (2.79x) (forecast)
card: 32607 MiB total, less 1680 context and 3900 library reserve leaves 27027 MiB
      this checkpoint is 19024 MiB on disk, leaving 8002 MiB for the KV cache and
      workspaces. On-disk size is not the resident figure: a scale-factor cache is
      built on top, and a vision tower or MTP sidecar may load separately or not at all
```

Both subtracted constants are measurements already in the tree, not invented
headroom: `kMeasuredLibraryReserveBytes` from `src/memory/plan.h` and the CUDA
primary context figure the same header records for this box.

**Verified against the real run.** Forecast and write both read
`51.75 GiB -> 18.58 GiB (2.79x)` on Qwen3.8-27B, the write having been done
earlier today.

## Why it cannot drift

The arithmetic moved into `nvfp4_output_bytes()` in `tensor_policy`, which is
the file whose own header says a rule with a history "belongs somewhere a test
can reach it". The writing path now compares its actual buffers against the same
function and **fails loudly** on a mismatch, so a change to the NVFP4 output
layout cannot quietly turn the forecast into a guess.

## What it deliberately does not do

It states the **on-disk** size against the budget rather than predicting resident
VRAM. The engine builds a scale-factor cache on top of the weights, and a vision
tower or MTP sidecar may be uploaded separately or skipped entirely. Measured on
Qwen3.8-27B: 18.60 GiB on disk arrived as 16.08 GiB of weights plus a 1.49 GiB
CUTLASS scale cache. A single predicted VRAM number would look exact and be
wrong, so the report gives the reader the budget and names what else lands in it.

## Testing

`nvfp4_output_bytes` is pinned component by component (packed nibbles,
micro-scales, tensor scale) plus the resulting BF16 ratio, and the degenerate
shapes are pinned separately so a zero dimension cannot add a phantom four bytes
per tensor. **Mutation-validated**: changing the micro-scale divisor from 16 to 8
fails the test.

CPU lane green. No GPU gate was run for this PR, at the author's request.
