### PR TITLE
imp-quantize: read block-scaled FP8 checkpoints as a source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ there instead of retelling it.
 
 ### Added
 
+- **`imp-quantize` reads block-scaled FP8 checkpoints as a source.** Releases
+  published only in FP8 (DeepSeek-V3, Qwen3.8's FP8 line) were refused tensor by
+  tensor, because the accepted set was BF16/F16. Both conventions store the same
+  layout: an E4M3 weight beside a `weight_scale_inv` grid of 128x128 tiles,
+  differing only in the scale dtype. The tile size is derived from the two
+  shapes, so a grid no single block explains is refused rather than read with a
+  wrong stride. The write path is not yet exercised on a real FP8 checkpoint.
+
 - **`imp-quantize --dry-run` now forecasts the output size and whether it fits.**
   It prints the same `size: A -> B` line the real run does, plus the card's
   budget once the CUDA context and library reserve are subtracted. Verified on

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,6 +471,7 @@ if(IMP_BUILD_TOOLS)
     add_executable(imp-quantize
         tools/imp-quantize/main.cpp
         tools/imp-quantize/tensor_policy.cpp
+        tools/imp-quantize/fp8_source.cpp
         tools/imp-quantize/awq_plan.cpp
         tools/imp-quantize/awq.cu
     )
@@ -696,6 +697,12 @@ if(IMP_BUILD_TESTS)
         # checkpoint (#1159), so it is compiled into the CPU lane directly.
         tools/imp-quantize/tensor_policy.cpp
         tests/test_quantize_policy.cpp
+        # Reading FP8 as a quantization source. Host-only on purpose, so the
+        # bit-level decode is checked by the CPU lane rather than by looking at
+        # a converted checkpoint, where a wrong exponent bias or block stride
+        # produces plausible numbers.
+        tools/imp-quantize/fp8_source.cpp
+        tests/test_quantize_fp8_source.cpp
     )
     if(IMP_BUILD_SERVER)
         # Anthropic /v1/messages transform tests reuse the server's

--- a/docs/plans/2026-08-15-imp-quantize-roadmap.md
+++ b/docs/plans/2026-08-15-imp-quantize-roadmap.md
@@ -78,25 +78,40 @@ download:
 | Mixtral-8x7B-Instruct | BF16 | 2-D per expert | yes |
 | Qwen3-235B-A22B | BF16 | 2-D per expert | yes (too large to fit resident) |
 | Qwen3.8-27B | BF16 | dense | yes |
-| **DeepSeek-V3** | **F8_E4M3 + F32** | 2-D per expert | **no: dtype refused** |
+| **DeepSeek-V3** | **F8_E4M3 + F32** | 2-D per expert | read path landed 2026-08-15, write untested |
 | **Qwen3.8-2.4T-A95B** | BF16 | **3-D stack `[512, 4096, 8192]`** | **no: stack refused** |
 
-### 1. Read FP8 and F32 sources (largest reach)
+### 1. Read FP8 and F32 sources (largest reach): READ PATH LANDED 2026-08-15
 
-`is_float_dtype` accepts BF16 and F16, so a checkpoint published only in FP8 is
-rejected tensor by tensor as "already quantized or unsupported". DeepSeek-V3 is
-the clearest case: its weights are `F8_E4M3` with `F32` scale tensors alongside.
-FP8 is now a common *primary* release format for large models, so this is not an
-edge case, it is a whole class of releases the tool cannot open.
+**Status:** the decode and the wiring are in, host-side and covered by the CPU
+lane; what is untested is the write, because that needs a GPU and a staged FP8
+checkpoint. Both released conventions turned out to be the same layout, which
+made this smaller than the section below assumed: an E4M3 weight beside a
+`weight_scale_inv` grid of 128x128 tiles, differing only in the scale dtype
+(DeepSeek-V3 F32, Qwen3.8-27B-FP8 BF16). The block edge is derived from the two
+shapes rather than assumed. Remaining: run it end to end on a real FP8
+checkpoint, and answer the two measurement questions below.
 
-This is cheaper than it looks because the decode already exists in-tree:
-`dequantize_fp8_e4m3_to_fp16` (`src/quant/fp8_quant.cu:491`) has a raw-pointer
-API, and the quantizer already stages every tensor through the GPU. The work is
-in `raw_to_fp16`: recognise the FP8 dtype, find that tensor's scale (the
-companion `weight_scale_inv`-style F32 tensor, whose naming is per-exporter),
-and apply it while widening.
 
-Two things to settle by measurement, not assumption: whether FP8 to NVFP4
+The problem it solved: `is_float_dtype` accepted BF16 and F16, so a checkpoint
+published only in FP8 was rejected tensor by tensor as "already quantized or
+unsupported". FP8 is now a common *primary* release format for large models, so
+that was not an edge case but a whole class of releases the tool could not open.
+
+What was built: `fp8_source.{h,cpp}`, a host-only translation unit so the CPU
+lane can check the parts that fail silently when wrong. The E4M3 bit layout and
+the block stride both produce plausible magnitudes when misread, which is why
+they are pinned by test rather than by inspecting a converted checkpoint, and
+both are mutation-validated. `main.cpp` pairs each E4M3 weight with its grid
+across shards before the write loop, and **consumes** the grid: once the weight
+is NVFP4 the old scales describe nothing, and copying them through would leave a
+checkpoint whose scales contradict its weights. An E4M3 tensor with no grid is
+reported by name instead of falling into the generic dtype exclusion, because
+that case is a scalar-scale export needing different handling.
+
+Not done: the write path has only been exercised on a synthetic fixture, since
+quantizing needs a GPU. Two things still to settle by measurement, not
+assumption: whether FP8 to NVFP4
 re-quantization is worth doing at all against just running the FP8 checkpoint
 (sm_120 has no FP8 GEMM, so the runtime already expands FP8 to an FP16
 companion, `roadmap.md` line 474, which costs VRAM the NVFP4 path would not),

--- a/docs/plans/2026-08-15-imp-quantize-roadmap.md
+++ b/docs/plans/2026-08-15-imp-quantize-roadmap.md
@@ -1,0 +1,171 @@
+# imp-quantize roadmap: any open-weight model onto one RTX 5090
+
+**Goal:** make `imp-quantize` able to take an arbitrary open-weight release and
+produce a checkpoint that runs on a single 32 GB sm_120 card. Today it takes a
+BF16/FP16 SafeTensors checkpoint whose experts, if any, are stored one 2-D
+tensor per expert. Everything else is refused or excluded.
+
+**Status:** gap list with measurements, not a schedule. Written 2026-08-15
+against `a5ba92aa`. Builds on [`roadmap.md`](../roadmap.md) gap 1, which carries
+the quantization-quality history; this document is about *coverage*: which
+checkpoints can enter the tool at all, and which can come out small enough.
+
+---
+
+## What "any model" can arithmetically mean here
+
+Coverage is bounded before any code is written, and the bound should be stated
+so the roadmap is not chasing sizes that cannot fit.
+
+The card is 32 607 MiB. The CUDA primary context takes ~1 680 MiB and the
+cuBLAS/CUTLASS reserve a measured ~3 900 MiB (`kMeasuredLibraryReserveBytes`,
+`src/memory/plan.h`), both before imp allocates a weight. That leaves
+**~27 000 MiB** for weights, KV cache and workspaces, so realistically
+**22-24 GiB of weights** once a serving KV pool and workspaces are subtracted.
+
+NVFP4 stores 0.5 bytes per value plus one FP8 micro-scale per 16, i.e. **0.5625
+bytes against BF16's 2**, a 3.56x ratio on the tensors that qualify. Whole
+checkpoints land near 2.8x because embeddings, norms and biases are copied
+through (measured: Qwen3.8-27B, 51.75 GiB to 18.58 GiB, 2.79x).
+
+So the honest ceilings are:
+
+| shape | ceiling on this card |
+|---|---|
+| dense, fully resident | ~40B parameters (~80 GiB BF16 source) |
+| MoE, experts resident | same, counted on *total* parameters |
+| MoE, experts host-offloaded | bounded by host RAM (78 GiB here) and PCIe, not VRAM |
+
+"Any model" therefore means: **any model of a size that could fit, in any format
+it is published in.** Format coverage is the part that is fixable in this tool.
+Size coverage above ~40B dense is not a quantizer problem and is not in scope
+here; that is offload and the roadmap's own MoE work.
+
+---
+
+## Where it stands today
+
+Accepted source dtypes are **BF16 and F16 only** (`is_float_dtype`,
+`tensor_policy.cpp:14`). Eleven exclusion reasons and four hard refusals are
+implemented; the deliberate ones (MLA latent projections, MoE router, vision
+tower, norms, embeddings) are each backed by a measurement and should stay.
+
+`--dry-run` now forecasts the output size and the card budget (#1423), so
+whether a checkpoint can fit is a seconds-long question rather than a 25-minute
+one.
+
+Two things the existing roadmap already settled, which this document must not
+re-litigate:
+
+- **Calibrating a model too large to run is a solved problem.** A calibration
+  file is keyed by (layer, tensor kind) and the recording hook sits before the
+  tier switch, so it can be collected from *any* quantization of the same model
+  (roadmap gap 1, point g, 2026-08-01).
+- **`--calib` is not automatically an improvement.** On Qwen3-14B the full group
+  set costs +2.68 PPL; the damage is the attention pair, and `--calib-groups BD`
+  measures **better than round-to-nearest** there (point h, 2026-08-05).
+
+---
+
+## The gaps, ordered by reach per unit of work
+
+Reach was checked against real releases by reading their SafeTensors headers
+over HTTP range requests, which costs a few hundred bytes instead of the
+download:
+
+| release | dtypes in shard 1 | experts | enters the tool today |
+|---|---|---|---|
+| Mixtral-8x7B-Instruct | BF16 | 2-D per expert | yes |
+| Qwen3-235B-A22B | BF16 | 2-D per expert | yes (too large to fit resident) |
+| Qwen3.8-27B | BF16 | dense | yes |
+| **DeepSeek-V3** | **F8_E4M3 + F32** | 2-D per expert | **no: dtype refused** |
+| **Qwen3.8-2.4T-A95B** | BF16 | **3-D stack `[512, 4096, 8192]`** | **no: stack refused** |
+
+### 1. Read FP8 and F32 sources (largest reach)
+
+`is_float_dtype` accepts BF16 and F16, so a checkpoint published only in FP8 is
+rejected tensor by tensor as "already quantized or unsupported". DeepSeek-V3 is
+the clearest case: its weights are `F8_E4M3` with `F32` scale tensors alongside.
+FP8 is now a common *primary* release format for large models, so this is not an
+edge case, it is a whole class of releases the tool cannot open.
+
+This is cheaper than it looks because the decode already exists in-tree:
+`dequantize_fp8_e4m3_to_fp16` (`src/quant/fp8_quant.cu:491`) has a raw-pointer
+API, and the quantizer already stages every tensor through the GPU. The work is
+in `raw_to_fp16`: recognise the FP8 dtype, find that tensor's scale (the
+companion `weight_scale_inv`-style F32 tensor, whose naming is per-exporter),
+and apply it while widening.
+
+Two things to settle by measurement, not assumption: whether FP8 to NVFP4
+re-quantization is worth doing at all against just running the FP8 checkpoint
+(sm_120 has no FP8 GEMM, so the runtime already expands FP8 to an FP16
+companion, `roadmap.md` line 474, which costs VRAM the NVFP4 path would not),
+and how much quality a double quantization costs versus the BF16 route when both
+are available for the same model.
+
+### 2. Optional embedding and lm_head quantization (largest size lever)
+
+`embed_tokens` is never quantized and `lm_head` only under `--lm-head`. On a
+modern large vocabulary that is a quarter of the output: Qwen3.8-27B has
+248 320 x 5 120, i.e. **2.37 GiB each in BF16, 4.74 GiB of an 18.60 GiB
+checkpoint**. Vocabularies are growing, so this share grows with them.
+
+The exclusion is deliberate and reasoned ("quantizing them costs quality for no
+bandwidth win on the decode hot path") and that reasoning is about *speed*. When
+the question is whether the model fits at all, the trade is a different one and
+should be available as an opt-in with a measured price tag. Needs a PPL
+comparison per option before it ships, and `--dry-run` should show what each
+choice buys now that it reports size.
+
+### 3. Confirm `--calib-groups BD` above 14B (smallest work, named open question)
+
+The roadmap states the practical rule ("`BD` on wide-GQA models") and then says
+plainly that `n_rep` is 8 on most 70B-class checkpoints and **"whether `BD`
+still pays at that size is untested"**. Every large model this roadmap wants to
+reach is in that bracket. This is one measurement campaign on an existing code
+path, no new code, and it decides whether calibration is a recommendation or a
+warning for the sizes that matter most.
+
+### 4. Stacked MoE experts (largest reach among refusals, largest work)
+
+`[n_experts, N, K]` stacks are refused. This blocks Qwen3.8-2.4T-A95B, whose
+experts are `[512, 4096, 8192]` with `gate` and `up` fused into one tensor, and
+gpt-oss (whose HF release is already MXFP4, so it is not itself a candidate).
+
+The obvious idea, "split the stack into the per-expert 2-D layout the loader
+already reads", is worth stating precisely because it is *half* right. The
+target layout is real and proven: the local `Gemma-4-26B-A4B-it-NVFP4` is
+46 110 per-expert tensors. But `roadmap.md` line 52 already recorded why this is
+not a quantizer-only change: gpt-oss-style stacks carry **per-expert biases**
+(`experts.down_proj_bias`, `experts.gate_up_proj_bias`, both confirmed in the
+header scan) which the loader and the MoE forward do not support, and the fused
+`gate_up_proj` needs a per-model layout descriptor to split correctly. So the
+cost is loader plus forward plus quantizer, and it was deferred on that basis
+rather than on effort alone.
+
+Do not start this without a BF16 source checkpoint with stacks staged locally.
+No local model has one, and the axis order and naming cannot be inferred from
+the refusal message.
+
+---
+
+## Order, and why
+
+1. **FP8 sources.** Opens a release class that is currently entirely shut, and
+   the decode kernel already exists.
+2. **`BD` above 14B.** One measurement campaign, no new code, and it settles
+   whether the quality lever works where it is most needed.
+3. **Embedding/lm_head opt-in.** Biggest size lever, but it trades quality, so
+   it needs the measurement discipline that item 2 establishes.
+4. **Stacked experts.** Highest reach among the refusals and the only item that
+   needs loader and forward work; gate it behind a staged checkpoint.
+
+## Deliberately not proposed
+
+- **Removing the MLA, router, norm or vision-tower exclusions.** Each was found
+  by bisection on a checkpoint that loaded and then produced garbage.
+- **Chasing dense models beyond ~40B.** No quantizer setting makes them
+  resident; that is offload work.
+- **Replacing round-to-nearest as the default.** The measured record has
+  `--calib` losing at 14B with the full group set, so the default is correct
+  until item 2 says otherwise.

--- a/tests/test_quantize_fp8_source.cpp
+++ b/tests/test_quantize_fp8_source.cpp
@@ -1,0 +1,158 @@
+// Reading an FP8 checkpoint as a quantization source.
+//
+// The two things here that cannot be checked by looking at a converted
+// checkpoint: the E4M3 bit layout, and the block-scale stride. Both produce
+// numbers of a plausible magnitude when wrong, so a model built on a wrong
+// exponent bias or a transposed scale grid loads, generates, and is simply a
+// worse model than it should be.
+
+#include "../tools/imp-quantize/fp8_source.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace imp::quantize {
+namespace {
+
+float fp16_to_float(uint16_t h) {
+    const uint32_t sign = (h & 0x8000u) << 16;
+    const uint32_t e = (h >> 10) & 0x1Fu;
+    const uint32_t m = h & 0x3FFu;
+    uint32_t bits;
+    if (e == 0)
+        bits = m ? sign | ((127u - 15u + 1u) << 23) | (m << 13) : sign;
+    else if (e == 0x1Fu)
+        bits = sign | 0x7F800000u | (m << 13);
+    else
+        bits = sign | ((e + 127u - 15u) << 23) | (m << 13);
+    float f;
+    std::memcpy(&f, &bits, sizeof(float));
+    return f;
+}
+
+RawTensor make(const std::string& dtype, std::vector<int64_t> shape, const void* data) {
+    RawTensor t;
+    t.name = "w";
+    t.dtype = dtype;
+    t.shape = std::move(shape);
+    t.data = const_cast<void*>(data);
+    return t;
+}
+
+// --- E4M3 bit layout -------------------------------------------------------
+
+TEST(Fp8Source, DecodesTheE4M3Grid) {
+    EXPECT_EQ(e4m3_to_float(0x00), 0.0f);
+    EXPECT_EQ(e4m3_to_float(0x38), 1.0f);   // exp bias 7: e=7, m=0
+    EXPECT_EQ(e4m3_to_float(0xB8), -1.0f);  // same with the sign bit
+    EXPECT_EQ(e4m3_to_float(0x3C), 1.5f);   // e=7, m=4 -> 1 + 4/8
+    EXPECT_EQ(e4m3_to_float(0x40), 2.0f);   // e=8, m=0
+}
+
+TEST(Fp8Source, HandlesTheRangeEndsThatDistinguishE4M3) {
+    // 448 is E4M3's largest finite value. Getting the bias wrong by one moves
+    // this to 224 or 896 and nothing else in a checkpoint would look odd.
+    EXPECT_EQ(e4m3_to_float(0x7E), 448.0f);
+    // E4M3 has NO infinity: that encoding is spent on NaN.
+    EXPECT_TRUE(std::isnan(e4m3_to_float(0x7F)));
+    // Subnormals use a fixed 2^-6 scale with no implicit leading one.
+    EXPECT_FLOAT_EQ(e4m3_to_float(0x01), std::ldexp(1.0f / 8.0f, -6));
+    EXPECT_FLOAT_EQ(e4m3_to_float(0x07), std::ldexp(7.0f / 8.0f, -6));
+}
+
+// --- block geometry --------------------------------------------------------
+
+TEST(Fp8Source, DerivesTheBlockEdgeFromBothDimensions) {
+    // Qwen3.8-27B-FP8: weight [10240, 5120], scale [80, 40].
+    EXPECT_EQ(derive_block_edge(10240, 5120, 80, 40), 128);
+    // DeepSeek-V3: weight [1536, 7168], scale [12, 56].
+    EXPECT_EQ(derive_block_edge(1536, 7168, 12, 56), 128);
+}
+
+TEST(Fp8Source, RefusesAScaleGridNoSingleBlockExplains) {
+    // A transposed grid. Deriving the edge from the rows alone would accept
+    // this and then read the scales with a wrong stride.
+    EXPECT_EQ(derive_block_edge(10240, 5120, 40, 80), 0);
+    // Right shape, wrong count.
+    EXPECT_EQ(derive_block_edge(1536, 7168, 12, 55), 0);
+    EXPECT_EQ(derive_block_edge(0, 5120, 80, 40), 0);
+}
+
+TEST(Fp8Source, DerivesAnEdgeThatDoesNotDivideEvenly) {
+    // 300 rows in blocks of 128 is 3 scale rows, and the last one is partial.
+    EXPECT_EQ(derive_block_edge(300, 256, 3, 2), 128);
+}
+
+// --- end to end: each block gets its own scale -----------------------------
+
+TEST(Fp8Source, AppliesThePerBlockScaleToTheRightTile) {
+    // 2x2 blocks of edge 1, so every element has its own scale. That makes a
+    // row/column mix-up visible, which a uniform scale would hide.
+    const uint8_t w[4] = {0x38, 0x38, 0x38, 0x38};  // all 1.0
+    const float s[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    std::vector<uint16_t> out;
+    std::string err;
+    ASSERT_TRUE(fp8_block_scaled_to_fp16(make("F8_E4M3", {2, 2}, w), make("F32", {2, 2}, s), out, err))
+        << err;
+    ASSERT_EQ(out.size(), 4u);
+    EXPECT_FLOAT_EQ(fp16_to_float(out[0]), 1.0f);
+    EXPECT_FLOAT_EQ(fp16_to_float(out[1]), 2.0f);
+    EXPECT_FLOAT_EQ(fp16_to_float(out[2]), 3.0f);  // row 1 must take s[2], not s[1]
+    EXPECT_FLOAT_EQ(fp16_to_float(out[3]), 4.0f);
+}
+
+TEST(Fp8Source, ReadsABf16ScaleGridAsBf16) {
+    // Qwen ships the grid in BF16, DeepSeek in F32. Reading one as the other
+    // is a large silent factor, so both paths are pinned.
+    const uint8_t w[1] = {0x38};                      // 1.0
+    const uint16_t s_bf16[1] = {0x4040};              // 3.0 in BF16
+    std::vector<uint16_t> out;
+    std::string err;
+    ASSERT_TRUE(
+        fp8_block_scaled_to_fp16(make("F8_E4M3", {1, 1}, w), make("BF16", {1, 1}, s_bf16), out, err))
+        << err;
+    EXPECT_FLOAT_EQ(fp16_to_float(out[0]), 3.0f);
+}
+
+TEST(Fp8Source, OneScaleCoversItsWholeTile) {
+    // 2x2 weight under a single scale: the 1x1 grid means block edge 2.
+    const uint8_t w[4] = {0x38, 0x40, 0x38, 0x40};  // 1, 2, 1, 2
+    const float s[1] = {0.5f};
+    std::vector<uint16_t> out;
+    std::string err;
+    ASSERT_TRUE(fp8_block_scaled_to_fp16(make("F8_E4M3", {2, 2}, w), make("F32", {1, 1}, s), out, err))
+        << err;
+    EXPECT_FLOAT_EQ(fp16_to_float(out[0]), 0.5f);
+    EXPECT_FLOAT_EQ(fp16_to_float(out[1]), 1.0f);
+    EXPECT_FLOAT_EQ(fp16_to_float(out[3]), 1.0f);
+}
+
+TEST(Fp8Source, RefusesRatherThanReturningAPartialBuffer) {
+    const uint8_t w[4] = {0x38, 0x38, 0x38, 0x38};
+    const float s[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    std::vector<uint16_t> out{42, 42};  // caller's buffer must survive a refusal
+    std::string err;
+    // Wrong weight dtype.
+    EXPECT_FALSE(fp8_block_scaled_to_fp16(make("BF16", {2, 2}, w), make("F32", {2, 2}, s), out, err));
+    EXPECT_FALSE(err.empty());
+    // Unreadable scale dtype.
+    EXPECT_FALSE(fp8_block_scaled_to_fp16(make("F8_E4M3", {2, 2}, w), make("U8", {2, 2}, s), out, err));
+    // Scale grid that no block size explains.
+    EXPECT_FALSE(fp8_block_scaled_to_fp16(make("F8_E4M3", {2, 2}, w), make("F32", {3, 1}, s), out, err));
+    ASSERT_EQ(out.size(), 2u) << "a refused conversion must not touch the output";
+}
+
+TEST(Fp8Source, AcceptsTheDtypeSpellingsExportersUse) {
+    EXPECT_TRUE(is_fp8_e4m3_dtype("F8_E4M3"));
+    EXPECT_TRUE(is_fp8_e4m3_dtype("F8_E4M3FN"));
+    // E5M2 has a different exponent bias; decoding it as E4M3 would be silent.
+    EXPECT_FALSE(is_fp8_e4m3_dtype("F8_E5M2"));
+    EXPECT_FALSE(is_fp8_e4m3_dtype("BF16"));
+}
+
+}  // namespace
+}  // namespace imp::quantize

--- a/tools/imp-quantize/fp8_source.cpp
+++ b/tools/imp-quantize/fp8_source.cpp
@@ -1,0 +1,165 @@
+#include "fp8_source.h"
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace imp::quantize {
+
+namespace {
+
+// BF16 is the top 16 bits of the FP32 pattern, so widening is a shift.
+float bf16_to_float(uint16_t bits) {
+    const uint32_t w = static_cast<uint32_t>(bits) << 16;
+    float f;
+    std::memcpy(&f, &w, sizeof(float));
+    return f;
+}
+
+// FP32 -> FP16 with the round-to-nearest-even the rest of the tool relies on.
+// Written out rather than pulled from CUDA so this stays a host translation
+// unit the CPU test lane can link without a toolkit.
+uint16_t float_to_fp16(float f) {
+    uint32_t x;
+    std::memcpy(&x, &f, sizeof(float));
+    const uint16_t sign = static_cast<uint16_t>((x >> 16) & 0x8000u);
+    const int32_t exp = static_cast<int32_t>((x >> 23) & 0xFFu) - 127 + 15;
+    const uint32_t mant = x & 0x7FFFFFu;
+
+    if (((x >> 23) & 0xFFu) == 0xFFu)  // Inf / NaN
+        return static_cast<uint16_t>(sign | 0x7C00u | (mant ? 0x0200u : 0u));
+    if (exp >= 0x1F)  // overflows half's range
+        return static_cast<uint16_t>(sign | 0x7C00u);
+    if (exp <= 0) {
+        if (exp < -10)
+            return sign;  // underflows even subnormal half
+        const uint32_t m = mant | 0x800000u;
+        const int shift = 14 - exp;
+        uint32_t sub = m >> shift;
+        if ((m >> (shift - 1)) & 1u)
+            sub++;  // round half up on the discarded bit
+        return static_cast<uint16_t>(sign | sub);
+    }
+    uint16_t out = static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | (mant >> 13));
+    if ((mant & 0x1FFFu) > 0x1000u || ((mant & 0x1FFFu) == 0x1000u && ((mant >> 13) & 1u)))
+        out++;  // ties to even
+    return out;
+}
+
+int64_t ceil_div(int64_t a, int64_t b) { return b > 0 ? (a + b - 1) / b : 0; }
+
+}  // namespace
+
+bool is_fp8_e4m3_dtype(const std::string& dtype) {
+    // safetensors has spelled this both ways across exporter versions.
+    return dtype == "F8_E4M3" || dtype == "FP8_E4M3" || dtype == "F8_E4M3FN";
+}
+
+float e4m3_to_float(uint8_t bits) {
+    const uint32_t s = (bits >> 7) & 0x1u;
+    const uint32_t e = (bits >> 3) & 0xFu;
+    const uint32_t m = bits & 0x7u;
+    float v;
+    if (e == 0) {
+        // Subnormal: no implicit leading one, fixed 2^-6 scale.
+        v = std::ldexp(static_cast<float>(m) / 8.0f, -6);
+    } else if (e == 0xFu && m == 0x7u) {
+        // E4M3 spends the would-be infinity encoding on NaN; there is no Inf.
+        return std::numeric_limits<float>::quiet_NaN();
+    } else {
+        v = std::ldexp(1.0f + static_cast<float>(m) / 8.0f, static_cast<int>(e) - 7);
+    }
+    return s ? -v : v;
+}
+
+int derive_block_edge(int64_t n, int64_t k, int64_t scale_rows, int64_t scale_cols) {
+    if (n <= 0 || k <= 0 || scale_rows <= 0 || scale_cols <= 0)
+        return 0;
+    auto explains = [&](int64_t b) {
+        return b > 0 && ceil_div(n, b) == scale_rows && ceil_div(k, b) == scale_cols;
+    };
+    // Dividing the rows gives the edge exactly when the dimension is a multiple
+    // of it, which is the case in every released checkpoint seen.
+    const int64_t from_rows = ceil_div(n, scale_rows);
+    if (explains(from_rows))
+        return static_cast<int>(from_rows);
+    // When a dimension is NOT a multiple, the edge is underdetermined by the
+    // shapes: 300 rows in 3 scale rows is explained by any b from 100 to 150,
+    // and the division picks 100 rather than the 128 that produced the file.
+    // Trying the edges quantizers actually use resolves it; anything else still
+    // returns 0, because a wrong stride here is silent.
+    for (int64_t b : {128, 64, 256, 32, 512}) {
+        if (explains(b))
+            return static_cast<int>(b);
+    }
+    return 0;
+}
+
+bool fp8_block_scaled_to_fp16(const RawTensor& weight, const RawTensor& scale_inv,
+                              std::vector<uint16_t>& out, std::string& err) {
+    if (!is_fp8_e4m3_dtype(weight.dtype)) {
+        err = "weight dtype " + weight.dtype + " is not E4M3";
+        return false;
+    }
+    if (weight.shape.size() != 2 || scale_inv.shape.size() != 2) {
+        err = "block-scaled FP8 needs a 2-D weight and a 2-D scale grid";
+        return false;
+    }
+    const int64_t n = weight.shape[0], k = weight.shape[1];
+    const int block = derive_block_edge(n, k, scale_inv.shape[0], scale_inv.shape[1]);
+    if (block == 0) {
+        err = "no block size explains weight [" + std::to_string(n) + "," + std::to_string(k) +
+              "] against scale [" + std::to_string(scale_inv.shape[0]) + "," +
+              std::to_string(scale_inv.shape[1]) + "]";
+        return false;
+    }
+
+    // Read the scale grid once, in whichever precision it was stored.
+    const int64_t sr = scale_inv.shape[0], sc = scale_inv.shape[1];
+    std::vector<float> scales(static_cast<size_t>(sr * sc));
+    if (scale_inv.dtype == "F32") {
+        std::memcpy(scales.data(), scale_inv.data, scales.size() * sizeof(float));
+    } else if (scale_inv.dtype == "BF16") {
+        const auto* s16 = static_cast<const uint16_t*>(scale_inv.data);
+        for (size_t i = 0; i < scales.size(); i++)
+            scales[i] = bf16_to_float(s16[i]);
+    } else if (scale_inv.dtype == "F16") {
+        // Not seen in a released checkpoint, but cheap to accept correctly
+        // rather than to mis-read as BF16, which would be off by a factor.
+        const auto* s16 = static_cast<const uint16_t*>(scale_inv.data);
+        for (size_t i = 0; i < scales.size(); i++) {
+            const uint32_t h = s16[i];
+            const uint32_t sign = (h & 0x8000u) << 16;
+            const uint32_t e = (h >> 10) & 0x1Fu;
+            const uint32_t m = h & 0x3FFu;
+            uint32_t bits;
+            if (e == 0)
+                bits = m ? sign | ((127 - 15 + 1) << 23) | (m << 13) : sign;
+            else if (e == 0x1Fu)
+                bits = sign | 0x7F800000u | (m << 13);
+            else
+                bits = sign | ((e + 127 - 15) << 23) | (m << 13);
+            float f;
+            std::memcpy(&f, &bits, sizeof(float));
+            scales[i] = f;
+        }
+    } else {
+        err = "unsupported scale dtype " + scale_inv.dtype;
+        return false;
+    }
+
+    const auto* w = static_cast<const uint8_t*>(weight.data);
+    std::vector<uint16_t> tmp(static_cast<size_t>(n * k));
+    for (int64_t i = 0; i < n; i++) {
+        const int64_t br = i / block;
+        for (int64_t j = 0; j < k; j++) {
+            const float s = scales[static_cast<size_t>(br * sc + j / block)];
+            const float v = e4m3_to_float(w[static_cast<size_t>(i * k + j)]) * s;
+            tmp[static_cast<size_t>(i * k + j)] = float_to_fp16(v);
+        }
+    }
+    out.swap(tmp);
+    return true;
+}
+
+}  // namespace imp::quantize

--- a/tools/imp-quantize/fp8_source.h
+++ b/tools/imp-quantize/fp8_source.h
@@ -1,0 +1,51 @@
+#pragma once
+
+// Reading an FP8 checkpoint as a quantization SOURCE.
+//
+// A growing share of large models is published only in FP8 (DeepSeek-V3,
+// Qwen3.8's FP8 line), so refusing the dtype refuses whole release families
+// rather than an edge case. The tool's own accepted set was BF16/F16, which is
+// what this widens.
+//
+// Both conventions seen in the wild store the same thing: an E4M3 weight
+// [N, K] beside a `<prefix>.weight_scale_inv` block-scale grid [N/B, K/B],
+// where a scale entry multiplies its whole BxB tile. Only the scale's dtype
+// differs (DeepSeek-V3 F32, Qwen3.8-27B-FP8 BF16), and B is 128 in both.
+//
+// B is DERIVED from the two shapes rather than assumed, because a checkpoint
+// that used another tile would otherwise be read with a silently wrong stride:
+// the result still loads, still generates, and is simply wrong.
+//
+// Note this is a different layout from the scalar per-tensor `weight_scale`
+// imp's runtime already handles for Modelopt exports (pre_dequant_phase0).
+// `weight_scale_inv` appears nowhere else in the tree.
+
+#include "model/safetensors_raw.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp::quantize {
+
+// True for the FP8 dtypes safetensors spells for E4M3. E5M2 is deliberately
+// absent: no checkpoint seen stores weights in it, and guessing would decode
+// a different exponent bias into plausible-looking garbage.
+bool is_fp8_e4m3_dtype(const std::string& dtype);
+
+// One E4M3 byte as a float. Exposed for the test: the bit layout is the part
+// that cannot be checked by looking at a converted checkpoint.
+float e4m3_to_float(uint8_t bits);
+
+// The square block edge B implied by a weight [N, K] and a scale grid
+// [ceil(N/B), ceil(K/B)]. Returns 0 when no single B explains both dimensions,
+// which is the caller's signal to refuse rather than to pick one.
+int derive_block_edge(int64_t n, int64_t k, int64_t scale_rows, int64_t scale_cols);
+
+// Widen an FP8 weight to FP16 by multiplying each value with its block scale.
+// `out` is resized to N*K. Returns false with `err` set on any shape or dtype
+// mismatch; a partially converted buffer is never handed back.
+bool fp8_block_scaled_to_fp16(const RawTensor& weight, const RawTensor& scale_inv,
+                              std::vector<uint16_t>& out, std::string& err);
+
+}  // namespace imp::quantize

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -64,6 +64,7 @@
 // performance work where the weights only need to be the right shape.
 
 #include "awq.h"
+#include "fp8_source.h"
 #include "tensor_policy.h"
 
 #include "core/tensor.h"
@@ -539,6 +540,45 @@ int main(int argc, char** argv) {
         }
     }
 
+    // FP8 sources. A checkpoint published only in FP8 (DeepSeek-V3, Qwen3.8's
+    // FP8 line) stores an E4M3 weight beside a `weight_scale_inv` block grid.
+    // Pairing them up front, across shards, because the two are not guaranteed
+    // to share a file and should_quantize sees one tensor at a time.
+    //
+    // The scale tensors are then CONSUMED: once the weight is NVFP4 they
+    // describe nothing, and copying them through would leave a checkpoint whose
+    // scales contradict its weights.
+    std::map<std::string, const RawTensor*> fp8_scale_of;
+    std::set<std::string> fp8_scale_names;
+    {
+        std::map<std::string, const RawTensor*> by_name;
+        for (const auto& src : opened)
+            for (const auto& t : src->tensors())
+                by_name[t.name] = &t;
+        static const std::string kW = ".weight";
+        for (const auto& [name, t] : by_name) {
+            if (!quantize::is_fp8_e4m3_dtype(t->dtype) || !ends_with(name, kW))
+                continue;
+            const auto it = by_name.find(name.substr(0, name.size() - kW.size()) + ".weight_scale_inv");
+            if (it == by_name.end()) {
+                // Without its grid the tensor is unreadable, and the generic
+                // dtype exclusion below would report it as merely "unsupported".
+                // Say which scale is missing: a scalar-scale FP8 export
+                // (Modelopt style) lands here and needs different handling.
+                fprintf(stderr,
+                        "note: %s is E4M3 but has no .weight_scale_inv beside it, so it is copied\n"
+                        "      through unquantized. Block-scaled FP8 is what this reads.\n",
+                        name.c_str());
+                continue;
+            }
+            fp8_scale_of[name] = it->second;
+            fp8_scale_names.insert(it->first);
+        }
+        if (!fp8_scale_of.empty())
+            printf("FP8 source: %zu block-scaled E4M3 tensor(s) will be widened before quantizing\n",
+                   fp8_scale_of.size());
+    }
+
     size_t n_quantized = 0, n_copied = 0, n_moe_skipped = 0;
     size_t bytes_in = 0, bytes_out = 0;
     std::vector<std::string> excluded_modules;
@@ -561,6 +601,61 @@ int main(int argc, char** argv) {
 
         for (const auto& t : src.tensors()) {
             bytes_in += t.nbytes;
+            // A consumed FP8 scale grid: its weight is about to become NVFP4
+            // with scales of its own, so this tensor must not reach the output.
+            if (fp8_scale_names.count(t.name)) {
+                if (opt.dry_run)
+                    printf("  DROP  %-58s FP8 block scale, consumed by its weight\n", t.name.c_str());
+                continue;
+            }
+            const auto fp8_it = fp8_scale_of.find(t.name);
+            if (fp8_it != fp8_scale_of.end()) {
+                const int64_t N = t.shape.size() == 2 ? t.shape[0] : 0;
+                const int64_t K = t.shape.size() == 2 ? t.shape[1] : 0;
+                // The same roles that must stay full precision in a BF16 source
+                // must stay full precision here; only the dtype gate differs, so
+                // ask the policy about the widened form rather than duplicating
+                // the rule. An FP8 tensor it refuses is copied through as-is.
+                RawTensor as_bf16 = t;
+                as_bf16.dtype = "BF16";
+                std::string why_fp8;
+                const bool gated_fp8 = gated_q_proj.count(t.name) != 0;
+                if (gated_fp8 || !quantize::should_quantize(as_bf16, opt.quantize_lm_head, why_fp8)) {
+                    out.push_back({t.name, t.dtype, t.shape, t.data, t.nbytes});
+                    bytes_out += t.nbytes;
+                    n_copied++;
+                    continue;
+                }
+                if (opt.dry_run) {
+                    printf("  QUANT %-58s [%lld,%lld] (from FP8)\n", t.name.c_str(), (long long)N,
+                           (long long)K);
+                    bytes_out += quantize::nvfp4_output_bytes(N, K);
+                    n_quantized++;
+                    continue;
+                }
+                std::vector<uint16_t> h;
+                std::string ferr;
+                if (!quantize::fp8_block_scaled_to_fp16(t, *fp8_it->second, h, ferr)) {
+                    fprintf(stderr, "  %s: %s\n", t.name.c_str(), ferr.c_str());
+                    return 1;
+                }
+                awq_apply_matrix(h, N, K, plan_vec(plan.row_div, t.name), plan_vec(plan.col_scale, t.name));
+                quant_store.emplace_back();
+                Quantized& q = quant_store.back();
+                if (!quantize_one(h, N, K, q, err)) {
+                    fprintf(stderr, "  %s: %s\n", t.name.c_str(), err.c_str());
+                    return 1;
+                }
+                scale_store.push_back(q.tensor_scale);
+                const std::string base = t.name.substr(0, t.name.size() - strlen(".weight"));
+                out.push_back({t.name, "U8", {N, K / 2}, q.packed.data(), q.packed.size()});
+                out.push_back(
+                    {base + ".weight_scale", "F8_E4M3", {N, K / 16}, q.micro.data(), q.micro.size()});
+                out.push_back({base + ".weight_scale_2", "F32", {1}, &scale_store.back(), sizeof(float)});
+                bytes_out += q.packed.size() + q.micro.size() + sizeof(float);
+                n_quantized++;
+                continue;
+            }
             std::string why;
             // Checked before should_quantize, which sees one tensor and cannot
             // know a q_proj is gated — that needs the layer's o_proj too.


### PR DESCRIPTION
Two commits: the roadmap this work came from, and its first item.

## The roadmap

`docs/plans/2026-08-15-imp-quantize-roadmap.md`, scoped to **coverage** rather
than quality, since `roadmap.md` gap 1 already carries the quality history.

It states the arithmetic ceiling first so the plan is not chasing sizes that
cannot fit: ~27 GiB left after the CUDA context and library reserve, 3.56x on
qualifying tensors and 2.8x on whole checkpoints, hence **~40B dense**. Anything
larger is offload work, not a quantizer problem.

Reach was checked against real releases by reading their SafeTensors headers
over HTTP range requests, a few hundred bytes each instead of the download. That
survey is what set the order, and it corrected two of my own assumptions:

- The largest gap is the **source** format, not the target.
- The missing test artifact for stacked experts exists: Qwen3.8-2.4T-A95B at
  `[512, 4096, 8192]`. It also confirmed those stacks carry the per-expert
  biases `roadmap.md` line 52 already named as the reason that item is loader
  plus forward plus quantizer, not a quantizer change.

## Item 1: FP8 sources

A checkpoint published only in FP8 was refused tensor by tensor, because the
accepted set was BF16/F16. DeepSeek-V3 ships `F8_E4M3` + `F32`; Qwen3.8 has a
whole FP8 line. At the sizes this tool exists for, FP8 is now a primary release
format, so this was a whole class of releases it could not open.

Both conventions turned out to be **one layout**, which made this smaller than
the roadmap assumed: an E4M3 weight beside a `weight_scale_inv` grid of 128x128
tiles, differing only in the scale dtype (DeepSeek-V3 F32, Qwen3.8-27B-FP8
BF16). Note this is *not* the scalar per-tensor `weight_scale` the runtime
already handles for Modelopt exports; `weight_scale_inv` appeared nowhere in the
tree before this.

**The tile edge is derived, not assumed**, and cross-checked against both
dimensions. A transposed or mismatched grid is refused rather than read with a
wrong stride, which would produce a model that loads, generates, and is quietly
worse.

**The grids are consumed, not copied.** Once the weight is NVFP4 they describe
nothing, and passing them through would leave a checkpoint whose scales
contradict its weights. An E4M3 tensor with no grid beside it is reported by
name rather than falling into the generic "unsupported dtype" exclusion, because
that case is a scalar-scale export that needs different handling.

## Testing

`fp8_source` is a host-only translation unit on purpose. The E4M3 bit layout and
the block stride are exactly the two things that produce plausible magnitudes
when wrong, so they are pinned by the CPU lane instead of being judged by looking
at a converted checkpoint. 10 tests covering the bit grid (including 448 as the
largest finite value and the NaN encoding E4M3 spends its infinity on),
subnormals, block derivation, both scale dtypes, tile assignment, and that a
refused conversion leaves the caller's buffer untouched.

**Mutation-validated:** shifting the exponent bias by one fails five tests;
dropping the block row index fails the tile-assignment test.

End to end on a synthetic FP8 fixture, **without a GPU**: the FP8 weight is
quantized "(from FP8)", its grid is dropped as consumed, a BF16 control tensor
takes the normal path, and a norm is copied.

**Not verified:** the write path on a real FP8 checkpoint, which needs a GPU and
a staged model. The roadmap entry says so, and the CHANGELOG entry says so.

CPU lane green. No GPU gate was run for this PR, at the author's request.
