### PR TITLE
imp-quantize: report which bytes did not shrink, and why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ there instead of retelling it.
 
 ### Added
 
+- **`imp-quantize` reports which bytes did not shrink, and why.** The ratio
+  answers "did it work", not "why is it still this big", and those have
+  different fixes. On Qwen3.8-27B the breakdown reads 5.60 GiB kept at source
+  precision, 30% of the output: 2425 MiB embedding, 2425 MiB lm_head, 875 MiB
+  vision tower. Every line is a role deliberately left in source precision, so
+  it doubles as the list of what could be traded when a checkpoint misses the
+  card.
+
 - **`imp-quantize` reads block-scaled FP8 checkpoints as a source.** Releases
   published only in FP8 (DeepSeek-V3, Qwen3.8's FP8 line) were refused tensor by
   tensor, because the accepted set was BF16/F16. Both conventions store the same

--- a/docs/plans/2026-08-15-imp-quantize-roadmap.md
+++ b/docs/plans/2026-08-15-imp-quantize-roadmap.md
@@ -129,8 +129,14 @@ The exclusion is deliberate and reasoned ("quantizing them costs quality for no
 bandwidth win on the decode hot path") and that reasoning is about *speed*. When
 the question is whether the model fits at all, the trade is a different one and
 should be available as an opt-in with a measured price tag. Needs a PPL
-comparison per option before it ships, and `--dry-run` should show what each
-choice buys now that it reports size.
+comparison per option before it ships.
+
+**Landed 2026-08-15:** the reporting half, which is what makes the trade
+visible. `--dry-run` now breaks down the bytes that did NOT shrink, by reason,
+largest first. On Qwen3.8-27B that reads 5.60 GiB, **30 % of the output**: 2 425
+MiB embedding, 2 425 MiB lm_head, 875 MiB vision tower. The compression ratio
+never says this, and "why is it still this big" has a different fix from "did
+quantization work". The opt-in itself still waits on the measurement.
 
 ### 3. Confirm `--calib-groups BD` above 14B (smallest work, named open question)
 

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -292,6 +292,30 @@ bool write_quant_config(const Options& opt, const std::vector<std::string>& excl
 // records for this WSL2/WDDM box.
 constexpr size_t kContextBytes = 1680ull * 1024 * 1024;
 
+// Where the bytes that did not shrink went, largest first.
+//
+// The compression ratio answers "did it work" and not "why is it still this
+// big", and those have different fixes. Every line here is a role deliberately
+// left in source precision, so the table doubles as the list of what could be
+// traded if a checkpoint misses the card: on a modern vocabulary the embedding
+// pair is a quarter of the output, which no ratio reveals.
+void report_copied_breakdown(const std::map<std::string, size_t>& by_reason, size_t bytes_out) {
+    if (by_reason.empty() || bytes_out == 0)
+        return;
+    std::vector<std::pair<std::string, size_t>> rows(by_reason.begin(), by_reason.end());
+    std::sort(rows.begin(), rows.end(), [](const auto& a, const auto& b) { return a.second > b.second; });
+    size_t total = 0;
+    for (const auto& [_, b] : rows)
+        total += b;
+    printf("\nkept at source precision: %.2f GiB, %.0f%% of the output", total / 1073741824.0,
+           100.0 * double(total) / double(bytes_out));
+    const double mib = 1024.0 * 1024.0;
+    for (size_t i = 0; i < rows.size() && i < 5; i++)
+        printf("\n      %8.0f MiB  %s", double(rows[i].second) / mib, rows[i].first.c_str());
+    if (rows.size() > 5)
+        printf("\n      %8s   (%zu smaller reasons)", "", rows.size() - 5);
+}
+
 // Report the checkpoint against the card it is meant to run on. Deliberately
 // states the ON-DISK size against the budget rather than predicting VRAM:
 // what the engine actually resides is the weights PLUS a scale-factor cache and
@@ -581,6 +605,11 @@ int main(int argc, char** argv) {
 
     size_t n_quantized = 0, n_copied = 0, n_moe_skipped = 0;
     size_t bytes_in = 0, bytes_out = 0;
+    // Where the bytes that did NOT shrink went. A checkpoint that misses the
+    // card by a gigabyte is a question about this table, not about the ratio:
+    // on a modern vocabulary the embedding pair alone is a quarter of the
+    // output, and the ratio never says so.
+    std::map<std::string, size_t> copied_bytes_by_reason;
     std::vector<std::string> excluded_modules;
     std::vector<std::pair<std::string, std::string>> tensor_to_shard;
 
@@ -623,6 +652,7 @@ int main(int argc, char** argv) {
                 if (gated_fp8 || !quantize::should_quantize(as_bf16, opt.quantize_lm_head, why_fp8)) {
                     out.push_back({t.name, t.dtype, t.shape, t.data, t.nbytes});
                     bytes_out += t.nbytes;
+                    copied_bytes_by_reason[gated_fp8 ? "fused Q+gate projection" : why_fp8] += t.nbytes;
                     n_copied++;
                     continue;
                 }
@@ -691,6 +721,7 @@ int main(int argc, char** argv) {
                 }
                 out.push_back({t.name, t.dtype, t.shape, data, t.nbytes});
                 bytes_out += t.nbytes;
+                copied_bytes_by_reason[why] += t.nbytes;
                 n_copied++;
                 continue;
             }
@@ -796,6 +827,7 @@ int main(int argc, char** argv) {
         printf(", %zu MoE expert stacks left unquantized (not supported yet)", n_moe_skipped);
     printf("\nsize: %.2f GiB -> %.2f GiB (%.2fx)%s", bytes_in / 1073741824.0, bytes_out / 1073741824.0,
            bytes_out ? double(bytes_in) / double(bytes_out) : 0.0, opt.dry_run ? " (forecast)" : "");
+    report_copied_breakdown(copied_bytes_by_reason, bytes_out);
     report_card_fit(bytes_out);
     printf("\n");
     return 0;


### PR DESCRIPTION
The compression ratio answers "did quantization work". It does not answer "why
is this still too big for the card", and those have different fixes. Until now
the only way to find out was to reason about the exclusion list by hand.

`--dry-run` now groups the copied-through bytes by the reason they were
excluded, largest first, with the share of the output they account for. On
Qwen3.8-27B:

```
size: 51.75 GiB -> 18.58 GiB (2.79x) (forecast)
kept at source precision: 5.60 GiB, 30% of the output
          2425 MiB  embedding
          2425 MiB  lm_head (use --lm-head to include)
           875 MiB  vision tower (upload path takes source precision only)
             4 MiB  3-D stacked tensor, needs the per-expert 2-D layout
             3 MiB  5-D
                 (2 smaller reasons)
```

Three things that table does which the ratio cannot:

- **It is arithmetic, not an estimate.** 2425 MiB is exactly
  248 320 x 5 120 x 2 bytes.
- **It makes an existing lever discoverable where it matters.** The lm_head row
  carries the flag that would include it.
- **Every row is a deliberate exclusion**, so it doubles as the list of what
  could be traded when a checkpoint misses the card. Nearly a third of this
  output does not shrink at all, and nothing said so before.

This is the reporting half of roadmap item 2. The opt-in for quantizing the
embedding pair still waits on a perplexity measurement, deliberately: the
exclusion is reasoned, and trading it needs a price tag rather than a flag.

## Testing

CPU lane green. Verified against the real Qwen3.8-27B checkpoint **without a
GPU**, since `--dry-run` only reads headers, and against the synthetic FP8
fixture from #1424 to confirm the FP8 copy path feeds the same table.

No GPU gate was run for this PR, at the author's request.
