### PR TITLE
imp-quantize: keep the MTP draft head out of NVFP4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`imp-quantize` no longer destroys the MTP draft head.** Its loader takes
+  `mtp.*.weight` by name and knows nothing about the `weight_scale` companions,
+  so a quantized head arrived as packed nibbles read as BF16. Nothing errored:
+  the head loaded, drafted, and every draft was rejected. On Qwen3.8-27B that
+  read **0 of 24 drafts accepted against 81% for a checkpoint whose head is
+  BF16**, and turning speculation on cost 17% decode. Excluding the head (810
+  MiB) restores acceptance to 48% and makes `--mtp-spec-decode` neutral instead
+  of harmful.
+
 ### Added
 
 - **FP8 sources verified end to end: an FP8-only release now runs where it could

--- a/tests/test_quantize_policy.cpp
+++ b/tests/test_quantize_policy.cpp
@@ -182,6 +182,19 @@ TEST(FusedGateQProj, FindsThemUnderTheNestedLanguageModelPrefix) {
     EXPECT_EQ(found[0]->name, "model.language_model.layers.31.self_attn.q_proj.weight");
 }
 
+// The MTP draft head. Its loader takes `mtp.*.weight` by name and never looks
+// for the scale companions, so quantizing it yields a head that loads, drafts,
+// and has every draft rejected. Measured: 81% acceptance to 0 of 24.
+TEST(ShouldQuantize, LeavesTheMtpDraftHeadAlone) {
+    EXPECT_FALSE(quantizes(tensor("mtp.fc.weight", {5120, 10240})));
+    EXPECT_FALSE(quantizes(tensor("mtp.layers.0.mlp.down_proj.weight", {5120, 17408})));
+    EXPECT_FALSE(quantizes(tensor("mtp.layers.0.self_attn.q_proj.weight", {12288, 5120})));
+
+    // Anchored at the start, so a main-model tensor whose name merely contains
+    // the letters is unaffected. Nothing should widen this by accident.
+    EXPECT_TRUE(quantizes(tensor("model.layers.0.mtp_like.weight", {5120, 5120})));
+}
+
 TEST(FusedGateQProj, DoesNotGuessWhenTheLayerHasNoOProj) {
     // Without the o_proj there is nothing to compare against, and a bare
     // "shape[0] is even" heuristic would flag every ordinary projection.

--- a/tools/imp-quantize/tensor_policy.cpp
+++ b/tools/imp-quantize/tensor_policy.cpp
@@ -11,6 +11,8 @@ bool ends_with(const std::string& s, const std::string& suf) {
 
 bool contains(const std::string& s, const char* what) { return s.find(what) != std::string::npos; }
 
+bool starts_with(const std::string& s, const char* p) { return s.rfind(p, 0) == 0; }
+
 bool is_float_dtype(const std::string& dtype) { return dtype == "BF16" || dtype == "F16"; }
 
 }  // namespace
@@ -60,6 +62,21 @@ bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why
     // `model.visual.*`; a text-only one has no such tensor and is unaffected.
     if (contains(t.name, "visual.") || contains(t.name, "vision_tower.")) {
         why_not = "vision tower (upload path takes source precision only)";
+        return false;
+    }
+    // The MTP draft head, for the same reason and with a worse failure mode.
+    // Its loader takes `mtp.*.weight` by name (safetensors_loader.cpp) and knows
+    // nothing about the `weight_scale` / `weight_scale_2` companions, so a
+    // quantized head arrives as packed nibbles with no scales: half the expected
+    // width, read as BF16. Nothing errors. The head loads, drafts, and every
+    // draft is rejected.
+    //
+    // Measured on Qwen3.8-27B: quantizing it took draft acceptance from 81% (the
+    // published Qwen3.6-27B checkpoint, whose head is BF16) to 0 of 24, which
+    // costs speed and never correctness, so there is no louder symptom than the
+    // accept rate. It is 0.22 GiB, and excluding it is the whole fix.
+    if (starts_with(t.name, "mtp.")) {
+        why_not = "MTP draft head (its loader reads the weight by name, without scales)";
         return false;
     }
     // Two weight roles that are 2-D and K-aligned — so every shape check waves


### PR DESCRIPTION
The MTP loader takes `mtp.*.weight` by name and knows nothing about the
`weight_scale` / `weight_scale_2` companions a quantized tensor carries. A
quantized head therefore arrives as packed nibbles at half the expected width,
read as BF16.

**Nothing errors.** The head loads, logs itself as loaded, drafts every step,
and every draft is rejected. A rejected draft is discarded, so output stays
correct and the only symptom is the accept rate, which nobody reads unless they
are already suspicious.

## Measured

On Qwen3.8-27B, against the published Qwen3.6-27B checkpoint whose head is BF16
and which is otherwise the same architecture:

| head | draft acceptance | tok/s at k=2 |
|---|---|---:|
| quantized (before) | **0 of 24** | 81.41 |
| source precision (after) | **48.1 %** | **97.61** |
| Qwen3.6-27B reference | 81.2 % | - |

So the defect turned `--mtp-spec-decode` from neutral into a **17 % decode
cost**.

## What this does not do

It does not make this model faster. 48 of its 64 layers are GDN, whose scan is
sequential per token, so a verify step costs roughly what it saves: 27.5 ms for
2.62 tokens against 11 ms for one. Across k=0..4 on the fixed checkpoint decode
sits at 97.2 / 97.3 / 97.6 / 85.8, i.e. flat until the chain gets long enough to
hurt.

The head being broken still mattered: on a model without that sequential scan
the same head is a real lever, and a silently useless drafter would have looked
like "speculation does not help here".

## Same class as #1422, one step worse

The vision tower's upload path refuses a dtype it cannot read. This loader reads
it as something else. Both are now excluded by `should_quantize`, and both cost
almost nothing: 810 MiB for the head.

## Testing

Pinned in `test_quantize_policy`, including that the match is anchored at the
start so a main-model tensor merely containing the letters is unaffected.
**Mutation-validated**: changing the matched prefix fails the test. CPU lane
green. The acceptance numbers above come from a requantized checkpoint on a free
card.

No GPU gate was run for this PR, at the author's request.
