### PR TITLE
Fix empty content on json_schema requests to reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`json_schema` requests no longer come back with empty `content` on reasoning
+  models.** Structured output disables thinking for `json_mode`, tools, regex and
+  grammar; `json_schema` was missing from that list, so the constrainer's gate
+  held its mask open for a reasoning block. On a model whose `</think>` is a
+  multi-token BPE sequence (Qwen3.8-27B) the block never closed in the text the
+  splitter reads, and the answer stayed in `reasoning_content`. Measured on
+  Qwen3.8-27B: **0 of 8 valid at temperature 0, now 8 of 8**, and the quality
+  suite goes 42/45 to **45/45**. Qwen3.6-27B, whose `</think>` is one token, was
+  unaffected and stays at 45/45.
+
 - **`imp-quantize` no longer destroys the MTP draft head.** Its loader takes
   `mtp.*.weight` by name and knows nothing about the `weight_scale` companions,
   so a quantized head arrived as packed nibbles read as BF16. Nothing errored:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -41,6 +41,33 @@ mkdir -p models
 
 Which checkpoints load, and what each needs: [`MODELS.md`](MODELS.md).
 
+### Staging a model from HuggingFace
+
+`scripts/stage-model.sh` fetches a repo into a local directory, and converts it
+if it is not NVFP4 yet.
+
+```bash
+# ready-made NVFP4: download only
+scripts/stage-model.sh kekzle/Qwen3.8-27B-NVFP4 ~/models/Qwen3.8-27B-NVFP4
+
+# BF16 or FP8 source: download, then convert (~25 min for a 27B)
+scripts/stage-model.sh Qwen/Qwen3.8-27B-FP8 ~/models/Qwen3.8-27B-NVFP4
+```
+
+It exists because the obvious ways to fetch a repo are unavailable here by
+design: `git clone` needs git-lfs, and `huggingface-cli` needs Python, neither of
+which the clean-host policy installs. This needs only `curl`, `jq` and Docker.
+imp itself never fetches (`src/model/hf_hub.h`), so something has to.
+
+For a source that does need converting it forecasts the output size and whether
+it fits the card **before** spending the 25 minutes. Prefer an FP8 source where
+one exists: for Qwen3.8-27B it is 28.8 GiB against 51.8 GiB for BF16, and costs
+0.24 % perplexity (4.6262 against 4.6151 on `ppl_corpus_45k.txt`).
+
+Some models ship only as BF16 or FP8, which on this card is a wall rather than
+an inconvenience: FP8 has no GEMM on `sm_120`, and a 27B in either format does
+not fit. Converting is what makes them run at all.
+
 ## 2. Start the server
 
 ```bash

--- a/scripts/stage-model.sh
+++ b/scripts/stage-model.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Stage a HuggingFace checkpoint and quantize it to NVFP4, in one command.
+#
+# The gap this closes: imp reads NVFP4 SafeTensors and refuses to fetch anything
+# itself (clean-host policy, src/model/hf_hub.h), so a newcomer with a 5090 and a
+# model in mind has to work out the download, the conversion, the container
+# invocation and the disk arithmetic before seeing a single token. For a model
+# with no usable published export that is a long way from "try it".
+#
+#   scripts/stage-model.sh Qwen/Qwen3.8-27B-FP8 ~/models/Qwen3.8-27B-NVFP4
+#
+# curl and jq only, no Python and no huggingface-cli: this runs on the host,
+# which by policy has neither.
+set -uo pipefail
+
+REPO="${1:-}"
+OUT="${2:-}"
+IMAGE="${IMP_IMAGE:-imp:test}"
+
+if [ -z "$REPO" ] || [ -z "$OUT" ]; then
+    cat <<'USAGE'
+usage: scripts/stage-model.sh <hf-repo-id> <output-dir> [--keep-source]
+
+  <hf-repo-id>   e.g. Qwen/Qwen3.8-27B-FP8
+  <output-dir>   where the NVFP4 checkpoint is written
+
+  --keep-source  keep the downloaded source after quantizing (default: kept,
+                 pass --drop-source to delete it once the output exists)
+
+Environment:
+  IMP_IMAGE      container image to quantize with (default imp:test)
+  STAGE_DIR      where the source is downloaded (default <output-dir>.src)
+
+Prefer an FP8 or BF16 source. A published NVFP4 export needs no staging: point
+imp at it directly.
+USAGE
+    exit 2
+fi
+
+DROP_SOURCE=0
+for a in "$@"; do [ "$a" = "--drop-source" ] && DROP_SOURCE=1; done
+SRC="${STAGE_DIR:-${OUT}.src}"
+
+for tool in curl jq docker; do
+    command -v "$tool" >/dev/null || { echo "need $tool on PATH"; exit 1; }
+done
+docker image inspect "$IMAGE" >/dev/null 2>&1 || {
+    echo "image $IMAGE not found. Build it with 'make build', or set IMP_IMAGE."
+    exit 1
+}
+
+API="https://huggingface.co/api/models/${REPO}"
+echo "== ${REPO}"
+LISTING=$(curl -sf "$API") || { echo "cannot reach $API (private or gated repo?)"; exit 1; }
+
+# Size the download before starting it: a 27B BF16 source is ~52 GiB, and
+# running out of disk halfway through leaves a directory that looks complete.
+NEED=$(echo "$LISTING" | jq '[.siblings[].rfilename] | length')
+BYTES=$(curl -sf "https://huggingface.co/api/models/${REPO}/tree/main" \
+        | jq '[.[] | (.size // .lfs.size // 0)] | add // 0')
+HAVE=$(df -PB1 "$(dirname "$OUT")" | awk 'NR==2{print $4}')
+printf "   %s files, %.1f GiB to download, %.1f GiB free\n" \
+       "$NEED" "$(echo "$BYTES" | awk '{print $1/1073741824}')" \
+       "$(echo "$HAVE" | awk '{print $1/1073741824}')"
+# The output lands beside the source, so both have to fit at once.
+if [ "$BYTES" -gt 0 ] && [ "$HAVE" -lt "$BYTES" ]; then
+    echo "   not enough free disk for the source alone. Aborting."
+    exit 1
+fi
+
+mkdir -p "$SRC" || exit 1
+echo "== downloading to $SRC"
+for f in $(echo "$LISTING" | jq -r '.siblings[].rfilename'); do
+    case "$f" in */*) mkdir -p "$SRC/$(dirname "$f")";; esac
+    # -C - resumes, so an interrupted run continues instead of restarting.
+    curl -sfL -C - -o "$SRC/$f" "https://huggingface.co/${REPO}/resolve/main/${f}" \
+        || { echo "   FAILED $f"; exit 1; }
+    printf '.'
+done
+echo " done"
+
+# A repo that is ALREADY imp-readable NVFP4 needs no conversion, only the
+# download — which is the part that is awkward without git-lfs (not installed
+# here by policy, so `git clone` fetches pointer files instead of weights) and
+# without huggingface-cli (Python, likewise absent). Detect it and stop here
+# rather than spend 25 minutes proving there is nothing to quantize.
+if [ -f "$SRC/hf_quant_config.json" ] && grep -q '"quant_algo"[[:space:]]*:[[:space:]]*"NVFP4"' \
+        "$SRC/hf_quant_config.json" 2>/dev/null; then
+    echo "== already NVFP4, no conversion needed"
+    if [ "$SRC" != "$OUT" ]; then
+        mkdir -p "$(dirname "$OUT")" && rm -rf "$OUT" && mv "$SRC" "$OUT"
+    fi
+    cat <<EOF
+
+Ready. Serve it with:
+
+  docker run --rm --gpus all -p 8080:8080 -v $(dirname "$OUT"):/models $IMAGE \\
+      imp-server --host 0.0.0.0 --model /models/$(basename "$OUT")
+EOF
+    exit 0
+fi
+
+# Forecast before converting: this prints the output size and whether it fits
+# the card, in seconds, rather than after the ~25 minute write.
+echo "== forecast"
+docker run --rm --gpus all --user "$(id -u):$(id -g)" \
+    -v "$(cd "$SRC" && pwd)":/src:ro "$IMAGE" \
+    imp-quantize --model /src --out /tmp/forecast --dry-run 2>&1 \
+    | grep -E "^(size:|card:)|^ +this checkpoint|^ +workspaces|kept at source" || true
+
+echo "== quantizing to $OUT"
+mkdir -p "$OUT" || exit 1
+# --user keeps the output owned by the caller: a container writing as root
+# leaves a checkpoint the user cannot delete without sudo.
+docker run --rm --gpus all --user "$(id -u):$(id -g)" \
+    -v "$(cd "$SRC" && pwd)":/src:ro -v "$(cd "$OUT" && pwd)":/out "$IMAGE" \
+    imp-quantize --model /src --out /out || { echo "quantization failed"; exit 1; }
+
+if [ "$DROP_SOURCE" = "1" ]; then
+    echo "== removing source $SRC"
+    rm -rf "$SRC"
+fi
+
+# The container serves as its own uid (1001), not as the caller. A checkpoint
+# under a 0700 directory therefore quantizes fine and then fails to LOAD with a
+# bare "filesystem error: status: Permission denied", which says nothing about
+# the cause. Check it here, where the fix is one chmod, rather than leaving it
+# to be discovered as a crash.
+if ! docker run --rm -v "$(cd "$(dirname "$OUT")" && pwd)":/probe:ro "$IMAGE" \
+        test -r "/probe/$(basename "$OUT")/config.json" 2>/dev/null; then
+    echo
+    echo "WARNING: the container cannot read $OUT."
+    echo "  It runs as uid $(docker run --rm "$IMAGE" id -u 2>/dev/null), and some directory on the path is not"
+    echo "  world-readable. imp would fail at load with a bare 'Permission denied'."
+    echo "  Fix with:  chmod o+rX $(dirname "$OUT") $OUT"
+fi
+
+cat <<EOF
+
+Ready. Serve it with:
+
+  docker run --rm --gpus all -p 8080:8080 -v $(dirname "$OUT"):/models $IMAGE \\
+      imp-server --host 0.0.0.0 --model /models/$(basename "$OUT")
+
+or run a single prompt:
+
+  docker run --rm --gpus all -v $(dirname "$OUT"):/models $IMAGE \\
+      imp-cli --model /models/$(basename "$OUT") --prompt "Hello" --max-tokens 64
+EOF

--- a/tests/test_reasoning_reconcile.cpp
+++ b/tests/test_reasoning_reconcile.cpp
@@ -84,3 +84,47 @@ TEST(StripThinkBlock, UnclosedLeadingThinkClears) {
     strip_think_block(text);
     EXPECT_EQ(text, "");
 }
+
+// ---------------------------------------------------------------------------
+// Structured output vs thinking (#1431)
+// ---------------------------------------------------------------------------
+
+using imp::server::should_stamp_thinking_off;
+using imp::server::structured_output_excludes_thinking;
+
+// json_schema was the entry MISSING from this list, and its absence returned
+// empty content on any model whose </think> is a multi-token BPE sequence: the
+// gate held the mask open for a reasoning block that never closed in the text
+// the splitter reads. Each flag is pinned separately so a future edit cannot
+// drop one silently.
+TEST(StructuredOutputThinking, EveryWholeReplyConstraintExcludesThinking) {
+    EXPECT_TRUE(structured_output_excludes_thinking(true, false, false, false, false));   // json_mode
+    EXPECT_TRUE(structured_output_excludes_thinking(false, true, false, false, false));   // tools
+    EXPECT_TRUE(structured_output_excludes_thinking(false, false, true, false, false));   // json_schema
+    EXPECT_TRUE(structured_output_excludes_thinking(false, false, false, true, false));   // regex
+    EXPECT_TRUE(structured_output_excludes_thinking(false, false, false, false, true));   // grammar
+}
+
+TEST(StructuredOutputThinking, AnUnconstrainedRequestMayStillThink) {
+    EXPECT_FALSE(structured_output_excludes_thinking(false, false, false, false, false));
+}
+
+// Not stamping is not the same as stamping false: unstamped, a template uses
+// its OWN default, and Qwen3.8's is an open <think>. So a request that does not
+// want thinking must stamp it off even when the budget is non-zero, which is
+// the second half of #1431.
+TEST(StructuredOutputThinking, StampsOffWhenThinkingIsUnwantedNotOnlyOnZeroBudget) {
+    EXPECT_TRUE(should_stamp_thinking_off(/*is_think_model=*/true, /*enable_thinking=*/false,
+                                          /*budget_disabled=*/false, /*want_thinking=*/false));
+    // The pre-existing reason still stamps.
+    EXPECT_TRUE(should_stamp_thinking_off(true, false, /*budget_disabled=*/true, /*want=*/true));
+}
+
+TEST(StructuredOutputThinking, NeverStampsWhenThinkingIsActuallyOn) {
+    // enable_thinking true means the prompt carries an open block on purpose;
+    // stamping it off here would contradict the render.
+    EXPECT_FALSE(should_stamp_thinking_off(true, /*enable_thinking=*/true, false, true));
+    EXPECT_FALSE(should_stamp_thinking_off(true, /*enable_thinking=*/true, true, false));
+    // Not a reasoning model at all: nothing to say either way.
+    EXPECT_FALSE(should_stamp_thinking_off(/*is_think_model=*/false, false, true, false));
+}

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -299,9 +299,20 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
     // it — the constrainer's gate would hold the mask open while the model
     // spends the budget thinking, and the caller gets prose instead of the
     // format.
-    const bool thinking_default = ctx.snap.is_think_model && template_think_evidence &&
-                                  !ctx.params.json_mode && !ctx.params.has_tools &&
-                                  ctx.params.regex_pattern.empty() && ctx.params.grammar.empty();
+    //
+    // `json_schema` belongs in that list and was missing from it, which is the
+    // whole of #1431: a schema request kept thinking on, the gate held the mask
+    // open for the reasoning, and on a model whose `</think>` is a multi-token
+    // BPE sequence (Qwen3.8: `think_start_id` is -1) the block never closed in
+    // the text the splitter reads. The answer was written inside the reasoning
+    // channel and `content` came back EMPTY. Measured before the fix: 0 of 8 at
+    // temperature 0, against 10 of 10 on Qwen3.6-27B, whose `</think>` IS a
+    // single token.
+    const bool thinking_default =
+        ctx.snap.is_think_model && template_think_evidence &&
+        !imp::server::structured_output_excludes_thinking(
+            ctx.params.json_mode, ctx.params.has_tools, !ctx.params.json_schema_str.empty(),
+            !ctx.params.regex_pattern.empty(), !ctx.params.grammar.empty());
     const bool want_thinking = ctx.params.enable_thinking_set ? ctx.params.enable_thinking_requested
                                                               : thinking_default;
     // think_budget is the fraction of max_tokens reserved for reasoning;
@@ -313,8 +324,19 @@ bool snapshot_state_and_tokenize_(httplib::Response& res, ServerState& state, Ch
     const bool budget_disables_thinking = ctx.params.think_budget <= 0.0f;
     ctx.snap.enable_thinking = ctx.snap.is_think_model && ctx.snap.think_start_id >= 0 && want_thinking &&
                                !budget_disables_thinking;
-    ctx.snap.suppress_thinking = ctx.snap.is_think_model && !ctx.snap.enable_thinking &&
-                                 budget_disables_thinking;
+    // Suppressing means STAMPING `enable_thinking=false` into the Jinja context,
+    // which is the only thing that makes a template render its pre-closed
+    // `<think></think>` block. Leaving it unstamped lets the template fall back
+    // to its own default, and Qwen3.8's default is an OPEN `<think>`: the server
+    // then believes thinking is off while the prompt says it is on, and the
+    // reconcile step correctly flips the splitter to REASONING for a block that
+    // never closes.
+    //
+    // So it is not enough that thinking was disabled: it has to be disabled
+    // where the template can see it. Any reason to not want thinking now
+    // suppresses, rather than only a zero budget.
+    ctx.snap.suppress_thinking = imp::server::should_stamp_thinking_off(
+        ctx.snap.is_think_model, ctx.snap.enable_thinking, budget_disables_thinking, want_thinking);
 
     // If thinking IS enabled, remove the provisional <think> stop token.
     if (ctx.snap.enable_thinking && ctx.snap.think_start_id >= 0) {

--- a/tools/imp-server/reasoning_split.h
+++ b/tools/imp-server/reasoning_split.h
@@ -46,6 +46,34 @@ namespace imp::server {
 // explicit caller `enable_thinking` request is left untouched (a closed-block
 // template cannot honor an explicit `true` anyway, and we do not silently flip
 // an explicit choice — that is the caller's to make).
+// Does this request ask for STRUCTURED output, i.e. a constraint covering the
+// whole reply? Such a reply has no room for a reasoning preamble: the
+// constrainer's gate would hold the mask open while the model spends its budget
+// thinking, and the caller gets prose instead of the format.
+//
+// A predicate rather than an inline conjunction because the list has already
+// been wrong by omission: `json_schema` was missing from it (#1431), which on a
+// model whose `</think>` is a multi-token BPE sequence returned EMPTY content,
+// the answer having stayed in the reasoning channel. Every entry here is a
+// constraint over the entire response; adding one is adding it to this list.
+inline bool structured_output_excludes_thinking(bool json_mode, bool has_tools, bool has_json_schema,
+                                                bool has_regex, bool has_grammar) {
+    return json_mode || has_tools || has_json_schema || has_regex || has_grammar;
+}
+
+// Should the render STAMP `enable_thinking=false` into the template context?
+//
+// The distinction that matters: not stamping is not the same as stamping false.
+// Unstamped, a template falls back to its own default, and some default to an
+// OPEN `<think>` (Qwen3.8). The server then believes thinking is off while the
+// prompt says it is on, and the splitter is correctly reconciled to REASONING
+// for a block that will never close. So any reason to not want thinking has to
+// reach the template, not just the server's own flags.
+inline bool should_stamp_thinking_off(bool is_think_model, bool enable_thinking, bool budget_disabled,
+                                      bool want_thinking) {
+    return is_think_model && !enable_thinking && (budget_disabled || !want_thinking);
+}
+
 inline bool reconcile_thinking_with_prompt_tail(bool current, bool explicit_set,
                                                 bool tail_has_think, bool tail_has_close) {
     if (tail_has_think && !tail_has_close)


### PR DESCRIPTION
Structured output and a reasoning preamble are incompatible: the constraint
covers the whole reply, so the constrainer's gate holds its mask open while the
model spends its budget thinking. The handler already knew this and excluded
`json_mode`, tools, regex and grammar. **`json_schema` was missing from that
list.**

Whether that bites depends on how a model spells `</think>`:

| model | `</think>` | result |
|---|---|---|
| Qwen3.6-27B | single token | splitter sees the close, fine |
| **Qwen3.8-27B** | **3-token BPE** (`think_start_id` = -1) | block never closes in the text the splitter reads, answer stays in `reasoning_content`, **`content` empty** |

## Measured

Qwen3.8-27B, 8 requests per sampler setting:

| | before | after |
|---|---|---|
| temperature=0 | **0/8** | **8/8** |
| temperature=0.7 | 3/8 | **8/8** |
| temperature=1.3 | 3/8 | **8/8** |
| min_p (eager path) | 1/8 | **8/8** |
| degen_suite | 42/45 | **45/45** |

Qwen3.6-27B was never affected and still reads **45/45**, so this does not trade
one model for another.

## The second half

`suppress_thinking` only fired on a zero think budget. But **not stamping
`enable_thinking` is not the same as stamping it false**: unstamped, a template
falls back to its own default, and Qwen3.8's default is an *open* `<think>`. The
server then believed thinking was off while the prompt said it was on, and
`reconcile_thinking_with_prompt_tail` correctly flipped the splitter to
REASONING for a block that would never close. Any reason to not want thinking
now reaches the template.

## Why it is two predicates

Both rules moved into `reasoning_split.h`, beside
`reconcile_thinking_with_prompt_tail`, which lives there for the same class of
bug (#934). A list that has already been wrong **by omission** belongs where a
test can name each entry, rather than as an inline conjunction in a 900-line
handler.

## Testing

Each constraint flag pinned separately, so a future edit cannot drop one
silently. **Mutation-validated**: removing `json_schema` from the list fails one
test, reverting the stamping condition fails the other.

CPU lane green. Server batteries above were run against a real server on a free
card. No GPU gate was run for this PR, at the author's request.