### PR TITLE
Restore the MTP head on sharded checkpoints; measure what the lm_head default costs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A sharded compressed-tensors checkpoint no longer loses its MTP draft
+  head.** The shard-drop asked "is this name skipped by the translator", but
+  `mtp.*` is skipped *and* then diverted into the MTP map — so the shard
+  carrying the draft head was discarded before any tensor was read, and
+  spec-decode silently never engaged. On Qwen3.8-27B the head is back with a
+  **67-89 % draft accept rate** where it previously reported "model has no MTP
+  head loaded".
+
 ### Added
 
 - **`imp-quantize --format vllm` writes a checkpoint vLLM can serve.** The new
@@ -21,6 +31,13 @@ there instead of retelling it.
   [`quantization.md`](docs/quantization.md).
 
 ### Changed
+
+- **`imp-quantize` says up front when a flag combination will not load where you
+  are aiming.** `--lm-head` with `--format vllm` produces a checkpoint vLLM
+  refuses (its `ParallelLMHead` takes no scales); on imp the same flag is free,
+  measured byte-identical greedy output and **17 920 → 16 192 MiB** of weights
+  on Qwen3.8-27B. Also refuses a source with no `config.json` before converting
+  rather than after. See [`quantization.md`](docs/quantization.md).
 
 - **Fused layers now share one tensor scale.** Engines merge q/k/v and gate/up
   into a single linear that carries one scale, so three independently calibrated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,13 @@ there instead of retelling it.
 
 - **`imp-quantize` says up front when a flag combination will not load where you
   are aiming.** `--lm-head` with `--format vllm` produces a checkpoint vLLM
-  refuses (its `ParallelLMHead` takes no scales); on imp the same flag is free,
-  measured byte-identical greedy output and **17 920 → 16 192 MiB** of weights
-  on Qwen3.8-27B. Also refuses a source with no `config.json` before converting
-  rather than after. See [`quantization.md`](docs/quantization.md).
+  refuses (its `ParallelLMHead` takes no scales). On imp the flag costs nothing
+  *extra* — the default already converts a native head to NVFP4 at load — but it
+  makes that trade irreversible, so the doc now states what the default itself
+  costs: Qwen3.8-27B perplexity **4.5707 → 4.6158 (+0.99 %) for +10.4 % decode**,
+  and the win survives concurrency (+25 % ITL at 4 requests, +8 % at 16). Also
+  refuses a source with no `config.json` before converting rather than after.
+  See [`quantization.md`](docs/quantization.md).
 
 - **Fused layers now share one tensor scale.** Engines merge q/k/v and gate/up
   into a single linear that carries one scale, so three independently calibrated

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -90,6 +90,37 @@ The two differ in more than names, and each difference is silent when wrong:
   unquantized layer for each; a module missing from that list is one it looks for
   scales for that were never written.
 
+#### Making the checkpoint smaller: what each exclusion costs
+
+A third of the output is weights left at source precision, and `--dry-run`
+breaks it down by reason. Measured on Qwen3.8-27B (BF16 source 51.75 GiB):
+
+| what | size in the output | quantizing it costs | quantizing it is |
+|---|---:|---|---|
+| `lm_head` | 2 425 MiB | **nothing measurable in imp** | `--lm-head`, but see below |
+| `embed_tokens` | 2 425 MiB | +0.94 % perplexity | not possible: no NVFP4 lookup |
+| vision tower | 875 MiB | tower loads at source precision only | not possible |
+| MTP draft head | 810 MiB | draft acceptance 81 % → 0 (#1428) | refused |
+
+**`--lm-head` is free on imp and breaks vLLM.** imp converts a native LM head
+into an NVFP4 decode cache at load anyway (`gemm.nvfp4_lm_head`, auto → on for
+native sources), so quantizing it in the checkpoint changes nothing except what
+is on disk. Measured on Qwen3.8-27B: perplexity **4.6158 either way**, greedy
+output **byte-identical over four prompts**, weights **17 920 → 16 192 MiB**,
+checkpoint 19.15 → 17.44 GiB. But vLLM's `ParallelLMHead` takes no scales and
+stops at `no module or parameter named lm_head.weight_global_scale`, so the flag
+belongs with `--format modelopt`. The tool warns when the two are combined.
+
+**Embeddings stay at source precision, and the price is now known.** imp's
+embedding lookup handles F32/F16/BF16/Q8_0/Q6_K and not NVFP4, so a quantized
+table cannot be read back; vLLM leaves embeddings unquantized too. Rather than
+write the kernel first, the table was pushed through the exact round trip the
+quantizer would apply and written back at source precision, which measures the
+quality loss without needing a reader: Qwen3-0.6B perplexity **29.4204 →
+29.6982, +0.94 %**, for what would be ~10 % off a 27B checkpoint. So the trade
+is real but modest, and it costs the interoperability the compressed-tensors
+format was added for.
+
 #### Fused layers share one tensor scale
 
 Inference engines merge `q_proj`/`k_proj`/`v_proj` into one linear and

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -97,19 +97,59 @@ breaks it down by reason. Measured on Qwen3.8-27B (BF16 source 51.75 GiB):
 
 | what | size in the output | quantizing it costs | quantizing it is |
 |---|---:|---|---|
-| `lm_head` | 2 425 MiB | **nothing measurable in imp** | `--lm-head`, but see below |
+| `lm_head` | 2 425 MiB | nothing **on top of what imp already pays** | `--lm-head`, but see below |
 | `embed_tokens` | 2 425 MiB | +0.94 % perplexity | not possible: no NVFP4 lookup |
 | vision tower | 875 MiB | tower loads at source precision only | not possible |
 | MTP draft head | 810 MiB | draft acceptance 81 % → 0 (#1428) | refused |
 
-**`--lm-head` is free on imp and breaks vLLM.** imp converts a native LM head
-into an NVFP4 decode cache at load anyway (`gemm.nvfp4_lm_head`, auto → on for
-native sources), so quantizing it in the checkpoint changes nothing except what
-is on disk. Measured on Qwen3.8-27B: perplexity **4.6158 either way**, greedy
-output **byte-identical over four prompts**, weights **17 920 → 16 192 MiB**,
-checkpoint 19.15 → 17.44 GiB. But vLLM's `ParallelLMHead` takes no scales and
-stops at `no module or parameter named lm_head.weight_global_scale`, so the flag
-belongs with `--format modelopt`. The tool warns when the two are combined.
+**`--lm-head` costs nothing *extra*, because imp already pays it — and that is
+the part worth understanding.** imp converts a native LM head into an NVFP4
+decode cache at load anyway (`gemm.nvfp4_lm_head`, auto → on for native
+sources), so quantizing it in the checkpoint changes nothing a run can see:
+Qwen3.8-27B reads perplexity **4.6158 either way**, greedy output
+**byte-identical over four prompts**, weights **17 920 → 16 192 MiB**,
+checkpoint 19.15 → 17.44 GiB.
+
+That comparison is NVFP4 against NVFP4, so it says nothing about the default
+itself. The honest question is what the default costs against a real BF16 head
+(`gemm.nvfp4_lm_head=off`), which is how every other engine runs it. Measured on
+Qwen3.8-27B, 248 320-token vocabulary, so the largest head available here:
+
+| `gemm.nvfp4_lm_head` | perplexity | decode, 128 tokens greedy | ITL @4 | ITL @16 |
+|---|---:|---:|---:|---:|
+| `off` (BF16 head) | **4.5707** | 78.56 tok/s | 53.1 ms | 206.2 ms |
+| `on` (default here) | 4.6158 (**+0.99 %**) | **86.70 tok/s (+10.4 %)** | **39.7 ms** | **190.1 ms** |
+
+```
+[PROV: commit=bca9e9e date=2026-08-16 hw=RTX5090 model=Qwen3.8-27B quant=NVFP4
+       cuda=13.3 path=nvfp4-decode-cache n=3-alternating-pairs
+       cmd=`imp-cli --prompt … --max-tokens 128 --temperature 0 --set gemm.nvfp4_lm_head=off|on`;
+       ITL from `tools/agent_bench.py --concurrency 1,4,16`, one run per arm;
+       perplexity over ppl_corpus_45k.txt with runtime.deterministic_gemm=true]
+```
+
+Decode is the median of three alternating pairs (a fixed arm order overstates);
+every pair favoured `on`. So the #982 trade holds and is cheaper here than the
++2.2 % recorded there — a bigger vocabulary moves both sides, and the quality
+side moved less.
+
+**The obvious explanation for why other engines skip this is wrong.** The head is
+read whole once per token, so at batch 1 it is ~11 % of the step (2.43 GiB of
+17.9 GiB weights) and one expects the win to amortise away under concurrency.
+It does not: the advantage shrinks from +25 % to +8 % between 4 and 16 concurrent
+decodes but never inverts. What actually separates imp here is simpler — vLLM's
+`ParallelLMHead` accepts no scales at all, and Modelopt / llm-compressor put
+`lm_head` in `ignore` by convention for W4A4 recipes. Absence of the feature, not
+a verdict on the trade.
+
+**What `--lm-head` really costs is the option.** With a BF16 head in the
+checkpoint the trade stays reversible: `--set gemm.nvfp4_lm_head=off` buys the
+0.99 % back. Quantized in the checkpoint, it cannot. So use it when the model
+would otherwise not fit, not as a default.
+
+vLLM's `ParallelLMHead` takes no scales at all and stops at `no module or
+parameter named lm_head.weight_global_scale`, so the flag belongs with
+`--format modelopt`. The tool warns when the two are combined.
 
 **Embeddings stay at source precision, and the price is now known.** imp's
 embedding lookup handles F32/F16/BF16/Q8_0/Q6_K and not NVFP4, so a quantized

--- a/src/model/llm_compressor_loader.cpp
+++ b/src/model/llm_compressor_loader.cpp
@@ -96,10 +96,20 @@ bool name_is_vision(const std::string& in) {
            starts_with(in, "vision_tower.") || starts_with(in, "multi_modal_projector.");
 }
 
+bool name_is_mtp(const std::string& in) { return starts_with(in, "mtp.") || starts_with(in, "model.mtp."); }
+
 bool name_is_skipped(const std::string& in, bool keep_vision) {
     if (name_is_vision(in))
         return !keep_vision;
-    return starts_with(in, "mtp.") || starts_with(in, "model.mtp.");
+    return name_is_mtp(in);
+}
+
+bool name_is_unused(const std::string& in, bool keep_vision, bool keep_mtp) {
+    if (name_is_vision(in))
+        return !keep_vision;
+    if (name_is_mtp(in))
+        return !keep_mtp;  // skipped by translate_name, but diverted, not dropped
+    return false;
 }
 
 NameTranslation translate_name(const std::string& in, TranslationCounters& counters, bool keep_vision) {

--- a/src/model/llm_compressor_loader.h
+++ b/src/model/llm_compressor_loader.h
@@ -48,6 +48,24 @@ bool name_is_skipped(const std::string& in, bool keep_vision = false);
 // so the skip rule and the keep rule read from one list.
 bool name_is_vision(const std::string& in);
 
+// True if the name belongs to an embedded MTP draft head.
+bool name_is_mtp(const std::string& in);
+
+// True when NOTHING in this load will read the tensor, so a shard made only of
+// such names can be dropped unread.
+//
+// This is a DIFFERENT question from name_is_skipped(), and conflating the two
+// is what lost the MTP head on every sharded compressed-tensors checkpoint:
+// translate_name() SKIPs `mtp.*` because those tensors do not belong in the
+// main tensor map, but load_shard() then diverts them into the MTP map — they
+// are skipped and still used. A drop predicate that asks "is it skipped" throws
+// away the shard carrying the draft head before anyone looks at it, and the
+// only symptom is that spec-decode silently never engages.
+//
+// `keep_mtp` is the caller's `load_mtp_head`, i.e. whether an MTP map is being
+// collected at all; `keep_vision` mirrors it for the tower.
+bool name_is_unused(const std::string& in, bool keep_vision, bool keep_mtp);
+
 // Emit one INFO log summarizing what translate_name() did across a shard.
 // Call once at the end of the enumerate-tensors loop in load_shard().
 void log_summary(const TranslationCounters& counters);

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -477,8 +477,7 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             // unknown wire types when the tensor is actually emitted.
             if (tensor_data_offset + offset_end > file_size) {
                 n_dropped_offset_validation++;
-                warn_drop(tensor_name.c_str(),
-                          "offset_end past EOF (unknown wire dtype, lenient check)");
+                warn_drop(tensor_name.c_str(), "offset_end past EOF (unknown wire dtype, lenient check)");
                 continue;
             }
         } else {
@@ -487,8 +486,8 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
                 nelem *= shape[d];
             uint64_t expected_nbytes = static_cast<uint64_t>(nelem) * static_cast<uint64_t>(wire_bytes);
             std::string vt_err;
-            if (!safetensors_internal::validate_tensor_offsets(
-                    offset_start, offset_end, expected_nbytes, tensor_data_offset, file_size, &vt_err)) {
+            if (!safetensors_internal::validate_tensor_offsets(offset_start, offset_end, expected_nbytes,
+                                                               tensor_data_offset, file_size, &vt_err)) {
                 n_dropped_offset_validation++;
                 warn_drop(tensor_name.c_str(), vt_err.c_str());
                 continue;
@@ -509,10 +508,11 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
     int n_total_dropped = n_dropped_no_dtype + n_dropped_no_shape + n_dropped_too_many_dims +
                           n_dropped_no_offsets + n_dropped_offset_validation;
     if (n_total_dropped > 0) {
-        IMP_LOG_WARN("SafeTensors %s: dropped %d malformed tensors (no_dtype=%d no_shape=%d "
-                     "too_many_dims=%d no_offsets=%d offset_validation=%d)",
-                     path.c_str(), n_total_dropped, n_dropped_no_dtype, n_dropped_no_shape,
-                     n_dropped_too_many_dims, n_dropped_no_offsets, n_dropped_offset_validation);
+        IMP_LOG_WARN(
+            "SafeTensors %s: dropped %d malformed tensors (no_dtype=%d no_shape=%d "
+            "too_many_dims=%d no_offsets=%d offset_validation=%d)",
+            path.c_str(), n_total_dropped, n_dropped_no_dtype, n_dropped_no_shape, n_dropped_too_many_dims,
+            n_dropped_no_offsets, n_dropped_offset_validation);
     }
 
     return true;
@@ -520,8 +520,16 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
 
 // ---- Sharded SafeTensors loading ----
 
+// mtp_out: same contract as load_shard's — non-null means an embedded MTP head
+// is wanted, so `mtp.*` tensors are collected instead of discarded, and a shard
+// made only of them is NOT dropped. Passing nullptr here (which this function
+// used to do implicitly, having no parameter at all) loses the draft head on
+// every sharded llm-compressor checkpoint, silently: translate_name SKIPs the
+// names, so they never reach the main map either, and the fallback that
+// harvests them from there finds nothing.
 static bool load_sharded(const std::string& model_dir, std::unordered_map<std::string, Tensor>& tensor_map,
-                         std::vector<ShardInfo>& shards, bool keep_vision) {
+                         std::vector<ShardInfo>& shards, bool keep_vision,
+                         std::unordered_map<std::string, Tensor>* mtp_out) {
     std::string index_path = model_dir + "/model.safetensors.index.json";
 
     // Read the index file
@@ -563,11 +571,13 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
     // tower usually ships as its own shard (`model_visual.safetensors`), so the
     // drop decides the tower's fate before any tensor is looked at.
     std::set<std::string> shard_files;
+    const bool keep_mtp = mtp_out != nullptr;
     for (auto& [fname, tensors] : shard_tensors) {
         bool all_skip = !tensors.empty() &&
-                        std::all_of(tensors.begin(), tensors.end(), [keep_vision](const std::string& n) {
-                            return imp::llm_compressor::name_is_skipped(n, keep_vision);
-                        });
+                        std::all_of(tensors.begin(), tensors.end(),
+                                    [keep_vision, keep_mtp](const std::string& n) {
+                                        return imp::llm_compressor::name_is_unused(n, keep_vision, keep_mtp);
+                                    });
         if (all_skip) {
             IMP_LOG_INFO("Skipping shard %s (%zu tensors are MTP/vision-only and unused)", fname.c_str(),
                          tensors.size());
@@ -590,6 +600,9 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
     std::vector<std::unordered_map<std::string, Tensor>> per_shard_maps(shard_list.size());
     std::vector<ShardInfo> per_shard_info(shard_list.size());
     std::vector<imp::llm_compressor::TranslationCounters> per_shard_counters(shard_list.size());
+    // Per-shard MTP collection, merged below: the head's tensors are not
+    // guaranteed to share one shard, and the maps are filled in parallel.
+    std::vector<std::unordered_map<std::string, Tensor>> per_shard_mtp(shard_list.size());
     std::atomic<bool> any_failure{false};
 
     std::atomic<size_t> shards_done{0};
@@ -597,13 +610,13 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
     auto worker = [&](size_t i) {
         std::string shard_path = model_dir + "/" + shard_list[i];
         if (!load_shard(shard_path, per_shard_maps[i], per_shard_info[i], llm_compressor_format, keep_vision,
-                        per_shard_counters[i])) {
+                        per_shard_counters[i], keep_mtp ? &per_shard_mtp[i] : nullptr)) {
             IMP_LOG_ERROR("Failed to load shard: %s", shard_path.c_str());
             any_failure.store(true);
         }
         const size_t done = shards_done.fetch_add(1) + 1;
-        IMP_LOG_INFO("  [%zu/%zu] mmap'd shard: %s (%zu tensors)", done, total_shards,
-                     shard_list[i].c_str(), per_shard_maps[i].size());
+        IMP_LOG_INFO("  [%zu/%zu] mmap'd shard: %s (%zu tensors)", done, total_shards, shard_list[i].c_str(),
+                     per_shard_maps[i].size());
     };
 
     {
@@ -622,6 +635,9 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
     for (size_t i = 0; i < shard_list.size(); ++i) {
         for (auto& kv : per_shard_maps[i])
             tensor_map.emplace(kv.first, kv.second);
+        if (keep_mtp)
+            for (auto& kv : per_shard_mtp[i])
+                mtp_out->emplace(kv.first, kv.second);
         shards.push_back(per_shard_info[i]);
         const auto& c = per_shard_counters[i];
         tcounters.suffix_renames += c.suffix_renames;
@@ -693,7 +709,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         // Directory mode: try sharded first, then single
         std::string index_path = model_dir + "/model.safetensors.index.json";
         if (fs::exists(index_path)) {
-            loaded = load_sharded(model_dir, tensor_map, shards, keep_vision);
+            loaded = load_sharded(model_dir, tensor_map, shards, keep_vision, mtp_collect);
         }
         if (!loaded) {
             std::string st_path = model_dir + "/model.safetensors";
@@ -744,12 +760,13 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     auto dispatch_mtp = [](std::unordered_map<std::string, Tensor>& tm, const std::string& src,
                            size_t bytes) -> imp::MtpHead {
         imp::MtpHead head;
-        head.info.path       = src;
+        head.info.path = src;
         head.info.file_bytes = bytes;
-        head.info.n_tensors  = static_cast<int>(tm.size());
+        head.info.n_tensors = static_cast<int>(tm.size());
         auto take = [&](const char* key, Tensor& dst) -> bool {
             auto it = tm.find(key);
-            if (it == tm.end()) return false;
+            if (it == tm.end())
+                return false;
             dst = it->second;
             return true;
         };
@@ -820,9 +837,9 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
 
         bool ok = true;
         ok &= take("mtp.pre_fc_norm_embedding.weight", head.pre_fc_norm_embedding);
-        ok &= take("mtp.pre_fc_norm_hidden.weight",    head.pre_fc_norm_hidden);
-        ok &= take("mtp.fc.weight",                    head.fc);
-        ok &= take("mtp.layers.0.input_layernorm.weight",          head.input_layernorm);
+        ok &= take("mtp.pre_fc_norm_hidden.weight", head.pre_fc_norm_hidden);
+        ok &= take("mtp.fc.weight", head.fc);
+        ok &= take("mtp.layers.0.input_layernorm.weight", head.input_layernorm);
         ok &= take("mtp.layers.0.post_attention_layernorm.weight", head.post_attention_layernorm);
         ok &= take("mtp.layers.0.self_attn.q_proj.weight", head.q_proj);
         ok &= take("mtp.layers.0.self_attn.k_proj.weight", head.k_proj);
@@ -832,28 +849,29 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         ok &= take("mtp.layers.0.self_attn.k_norm.weight", head.k_norm);
         ok &= take("mtp.norm.weight", head.final_norm);
 
-        const bool moe =
-            take("mtp.layers.0.mlp.gate.weight", head.router) &&
-            take("mtp.layers.0.mlp.experts.gate_up_proj", head.experts_gate_up_packed) &&
-            take("mtp.layers.0.mlp.experts.down_proj", head.experts_down_packed) &&
-            take("mtp.layers.0.mlp.shared_expert.gate_proj.weight", head.shared_expert_gate_proj) &&
-            take("mtp.layers.0.mlp.shared_expert.up_proj.weight", head.shared_expert_up_proj) &&
-            take("mtp.layers.0.mlp.shared_expert.down_proj.weight", head.shared_expert_down_proj) &&
-            take("mtp.layers.0.mlp.shared_expert_gate.weight", head.shared_expert_gate);
-        const bool dense =
-            !moe &&
-            take("mtp.layers.0.mlp.gate_proj.weight", head.shared_expert_gate_proj) &&
-            take("mtp.layers.0.mlp.up_proj.weight", head.shared_expert_up_proj) &&
-            take("mtp.layers.0.mlp.down_proj.weight", head.shared_expert_down_proj);
+        const bool moe = take("mtp.layers.0.mlp.gate.weight", head.router) &&
+                         take("mtp.layers.0.mlp.experts.gate_up_proj", head.experts_gate_up_packed) &&
+                         take("mtp.layers.0.mlp.experts.down_proj", head.experts_down_packed) &&
+                         take("mtp.layers.0.mlp.shared_expert.gate_proj.weight",
+                              head.shared_expert_gate_proj) &&
+                         take("mtp.layers.0.mlp.shared_expert.up_proj.weight", head.shared_expert_up_proj) &&
+                         take("mtp.layers.0.mlp.shared_expert.down_proj.weight",
+                              head.shared_expert_down_proj) &&
+                         take("mtp.layers.0.mlp.shared_expert_gate.weight", head.shared_expert_gate);
+        const bool dense = !moe && take("mtp.layers.0.mlp.gate_proj.weight", head.shared_expert_gate_proj) &&
+                           take("mtp.layers.0.mlp.up_proj.weight", head.shared_expert_up_proj) &&
+                           take("mtp.layers.0.mlp.down_proj.weight", head.shared_expert_down_proj);
         ok &= (moe || dense);
 
         head.loaded = ok;
         if (ok) {
-            IMP_LOG_INFO("MTP head loaded: %s (%d tensors, %s MLP, BF16)", src.c_str(),
-                         head.info.n_tensors, moe ? "MoE" : "dense");
+            IMP_LOG_INFO("MTP head loaded: %s (%d tensors, %s MLP, BF16)", src.c_str(), head.info.n_tensors,
+                         moe ? "MoE" : "dense");
         } else {
-            IMP_LOG_WARN("MTP head detected at %s but some expected tensors were missing; "
-                         "spec-decode disabled for this model", src.c_str());
+            IMP_LOG_WARN(
+                "MTP head detected at %s but some expected tensors were missing; "
+                "spec-decode disabled for this model",
+                src.c_str());
         }
         return head;
     };
@@ -891,7 +909,8 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             }
             if (!embedded_mtp_map.empty()) {
                 size_t bytes = 0;
-                for (const auto& kv : embedded_mtp_map) bytes += kv.second.nbytes();
+                for (const auto& kv : embedded_mtp_map)
+                    bytes += kv.second.nbytes();
                 mtp_local = dispatch_mtp(embedded_mtp_map, path + " (embedded mtp.*)", bytes);
             }
         }
@@ -944,8 +963,8 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     // prompt-blind output with preserved magnitudes). Force NeoX for the
     // SafeTensors path so HF-native Q/K rotate correctly. Arches that already
     // keep the default (rope_neox=true: QWEN3/GEMMA/...) are unaffected.
-    if (cfg.arch == ModelArch::LLAMA || cfg.arch == ModelArch::MISTRAL ||
-        cfg.arch == ModelArch::MIXTRAL || cfg.arch == ModelArch::LLAMA4) {
+    if (cfg.arch == ModelArch::LLAMA || cfg.arch == ModelArch::MISTRAL || cfg.arch == ModelArch::MIXTRAL ||
+        cfg.arch == ModelArch::LLAMA4) {
         cfg.rope_neox = true;
     }
 
@@ -1007,9 +1026,10 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         cfg.is_mxfp4_prequant = true;
         cfg.mxfp4_block_size = mxfp4_cfg.block_size;
         if (cfg.arch == ModelArch::GPT_OSS) {
-            IMP_LOG_INFO("MXFP4 SafeTensors (block_size=%d): gpt-oss experts will be "
-                         "transcoded MXFP4→NVFP4 at init (native decode).",
-                         cfg.mxfp4_block_size);
+            IMP_LOG_INFO(
+                "MXFP4 SafeTensors (block_size=%d): gpt-oss experts will be "
+                "transcoded MXFP4→NVFP4 at init (native decode).",
+                cfg.mxfp4_block_size);
         } else {
             IMP_LOG_WARN(
                 "MXFP4 SafeTensors detected (block_size=%d) — imp has no SafeTensors "
@@ -1032,8 +1052,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             "version=%s) — imp does not yet have an AWQ dequant kernel. "
             "Weights load as their wire dtype and inference will be "
             "incorrect. Use a GPTQ or NVFP4 export instead.",
-            awq_cfg.bits, awq_cfg.group_size,
-            awq_cfg.zero_point ? "true" : "false",
+            awq_cfg.bits, awq_cfg.group_size, awq_cfg.zero_point ? "true" : "false",
             awq_cfg.version.empty() ? "unspecified" : awq_cfg.version.c_str());
     }
 
@@ -1060,15 +1079,14 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     // HFConfigLoader::load_config) against the actual lm_head.weight
     // presence. Mismatch is a real surprise — most models tie, so silent
     // tying when the author said `tie=false` would mask a missing lm_head.
-    const bool out_proj_missing =
-        (model->out_proj_.data == nullptr && model->tok_emb_.data != nullptr);
+    const bool out_proj_missing = (model->out_proj_.data == nullptr && model->tok_emb_.data != nullptr);
     if (cfg.tie_word_embeddings == 0 && out_proj_missing) {
         IMP_LOG_WARN(
             "config.json declares tie_word_embeddings=false but lm_head.weight "
             "is absent in the SafeTensors files; tying anyway as a fallback.");
     }
-    if (cfg.tie_word_embeddings == 1 && model->out_proj_.data != nullptr &&
-        model->tok_emb_.data != nullptr && model->out_proj_.data != model->tok_emb_.data) {
+    if (cfg.tie_word_embeddings == 1 && model->out_proj_.data != nullptr && model->tok_emb_.data != nullptr &&
+        model->out_proj_.data != model->tok_emb_.data) {
         IMP_LOG_INFO(
             "config.json declares tie_word_embeddings=true but lm_head.weight "
             "was loaded as a separate tensor; honoring the file (no tying).");
@@ -1251,18 +1269,20 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
     if (cfg.attention_bias == 1) {
         int missing_q = 0, missing_k = 0, missing_v = 0;
         for (const auto& layer : model->layers_) {
-            if (layer.q_bias.data == nullptr) missing_q++;
-            if (layer.k_bias.data == nullptr) missing_k++;
-            if (layer.v_bias.data == nullptr) missing_v++;
+            if (layer.q_bias.data == nullptr)
+                missing_q++;
+            if (layer.k_bias.data == nullptr)
+                missing_k++;
+            if (layer.v_bias.data == nullptr)
+                missing_v++;
         }
         if (missing_q || missing_k || missing_v) {
             IMP_LOG_WARN(
                 "config.json says attention_bias=true but %d/%d Q-biases, "
                 "%d/%d K-biases, %d/%d V-biases are missing from the SafeTensors "
                 "export. Inference will proceed without those biases.",
-                missing_q, static_cast<int>(model->layers_.size()),
-                missing_k, static_cast<int>(model->layers_.size()),
-                missing_v, static_cast<int>(model->layers_.size()));
+                missing_q, static_cast<int>(model->layers_.size()), missing_k,
+                static_cast<int>(model->layers_.size()), missing_v, static_cast<int>(model->layers_.size()));
         }
     }
 
@@ -1309,8 +1329,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             layer.expert_gate_bias = Tensor(g, QType::BF16, 2, bshape, /*on_device=*/false);
             layer.expert_up_bias = Tensor(u, QType::BF16, 2, bshape, /*on_device=*/false);
         }
-        IMP_LOG_INFO("gpt-oss: expert gate_up biases de-interleaved for %zu layers",
-                     model->layers_.size());
+        IMP_LOG_INFO("gpt-oss: expert gate_up biases de-interleaved for %zu layers", model->layers_.size());
 
         // Residual-stream 2^-4 rescale (#547): gpt-oss's massive BF16
         // activations overflow the FP16 hidden state (hidden L2 jumps ~12x at
@@ -1350,8 +1369,8 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         };
         bool rescale_ok = true;
         for (auto& layer : model->layers_) {
-            rescale_ok = rescale_ok && scale_bf16_pow2(layer.wo, 4) &&
-                         scale_bf16_pow2(layer.o_bias, 4) && scale_bf16_pow2(layer.expert_down_bias, 4);
+            rescale_ok = rescale_ok && scale_bf16_pow2(layer.wo, 4) && scale_bf16_pow2(layer.o_bias, 4) &&
+                         scale_bf16_pow2(layer.expert_down_bias, 4);
         }
         if (!rescale_ok) {
             IMP_LOG_ERROR("gpt-oss: residual-stream rescale failed");

--- a/tests/test_llm_compressor_loader.cpp
+++ b/tests/test_llm_compressor_loader.cpp
@@ -605,9 +605,8 @@ TEST(LlmCompressorFormatDetect, RecipeYamlStillWinsOverConfigJson) {
     // one with history behind it, so it stays first.
     std::string dir = tmpdir() + "/fmt_ctboth_" + std::to_string(::getpid());
     std::filesystem::create_directories(dir);
-    std::ofstream(dir + "/recipe.yaml")
-        << "default_stage:\n  default_modifiers:\n    QuantizationModifier:\n"
-           "      ignore: [lm_head]\n      scheme: NVFP4\n";
+    std::ofstream(dir + "/recipe.yaml") << "default_stage:\n  default_modifiers:\n    QuantizationModifier:\n"
+                                           "      ignore: [lm_head]\n      scheme: NVFP4\n";
     std::ofstream(dir + "/config.json") << R"({
   "quantization_config": {
     "config_groups": {"group_0": {"weights": {"num_bits": 4, "type": "float", "group_size": 16,
@@ -623,4 +622,66 @@ TEST(LlmCompressorFormatDetect, RecipeYamlStillWinsOverConfigJson) {
 
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
+}
+
+// ---- the drop predicate is a different question from the skip predicate ----
+//
+// translate_name() SKIPs `mtp.*` because those tensors do not belong in the
+// main tensor map — and load_shard() then diverts them into the MTP map. They
+// are skipped and still used. The shard-drop asked "is it skipped", so on a
+// sharded llm-compressor checkpoint the draft head was discarded before any
+// tensor was read, and the only symptom was spec-decode never engaging.
+
+TEST(LlmCompressorUnused, MtpIsSkippedButNotUnusedWhenWanted) {
+    const char* mtp[] = {"mtp.fc.weight", "model.mtp.layers.0.self_attn.q_proj.weight"};
+    for (const char* n : mtp) {
+        // Skipped by the translator either way: it does not go in the main map.
+        EXPECT_TRUE(name_is_skipped(n)) << n;
+        // But only unused when nobody is collecting the head.
+        EXPECT_TRUE(name_is_unused(n, /*keep_vision=*/false, /*keep_mtp=*/false)) << n;
+        EXPECT_FALSE(name_is_unused(n, /*keep_vision=*/false, /*keep_mtp=*/true)) << n;
+    }
+}
+
+TEST(LlmCompressorUnused, VisionKeepsItsExistingMeaning) {
+    const char* v = "model.visual.blocks.0.attn.qkv.weight";
+    EXPECT_TRUE(name_is_unused(v, /*keep_vision=*/false, /*keep_mtp=*/false));
+    EXPECT_FALSE(name_is_unused(v, /*keep_vision=*/true, /*keep_mtp=*/false));
+    // A tower is unaffected by the MTP flag and vice versa.
+    EXPECT_TRUE(name_is_unused(v, /*keep_vision=*/false, /*keep_mtp=*/true));
+}
+
+TEST(LlmCompressorUnused, OrdinaryWeightsAreNeverUnused) {
+    for (bool kv : {false, true})
+        for (bool km : {false, true}) {
+            EXPECT_FALSE(name_is_unused("model.layers.0.self_attn.q_proj.weight_packed", kv, km));
+            EXPECT_FALSE(name_is_unused("model.embed_tokens.weight", kv, km));
+            EXPECT_FALSE(name_is_unused("lm_head.weight_packed", kv, km));
+        }
+}
+
+// A tensor is dropped only if NOTHING would read it: the union of the main map
+// (translate_name EMITs) and the MTP map (load_shard diverts). Stated as one
+// property so the two predicates cannot drift apart again.
+TEST(LlmCompressorUnused, DropOnlyWhenNeitherConsumerTakesIt) {
+    const char* names[] = {
+        "model.visual.blocks.0.attn.qkv.weight",
+        "multi_modal_projector.linear_1.weight",
+        "mtp.fc.weight",
+        "model.mtp.layers.0.mlp.up_proj.weight",
+        "model.layers.0.self_attn.q_proj.weight_packed",
+        "model.embed_tokens.weight",
+    };
+    for (bool keep_vision : {false, true}) {
+        for (bool keep_mtp : {false, true}) {
+            for (const char* n : names) {
+                TranslationCounters c{};
+                const bool main_map_takes_it = translate_name(n, c, keep_vision).action ==
+                                               NameTranslation::EMIT;
+                const bool mtp_map_takes_it = keep_mtp && name_is_mtp(n);
+                EXPECT_EQ(name_is_unused(n, keep_vision, keep_mtp), !main_map_takes_it && !mtp_map_takes_it)
+                    << "name=" << n << " keep_vision=" << keep_vision << " keep_mtp=" << keep_mtp;
+            }
+        }
+    }
 }

--- a/tests/test_quantize_checkpoint_out.cpp
+++ b/tests/test_quantize_checkpoint_out.cpp
@@ -329,8 +329,10 @@ TEST(QuantizeCheckpointOut, RefusesCompressedTensorsWithoutAConfigJson) {
 }
 
 // Measured 2026-08-16: vLLM refuses `lm_head.weight_global_scale` outright,
-// while imp reads a quantized head with byte-identical greedy output. So the
-// combination is legitimate for an imp-only checkpoint and useless for a
+// while imp reads a quantized head with byte-identical greedy output — because
+// its own default already quantizes a native head at load (which itself costs
+// +0.99 % perplexity for +10.4 % decode; see docs/quantization.md). So the
+// combination is defensible for an imp-only checkpoint and useless for a
 // portable one, and the caller has to hear that before the conversion, not
 // after it.
 TEST(QuantizeCheckpointOut, WarnsOnlyWhenLmHeadMeetsCompressedTensors) {

--- a/tests/test_quantize_checkpoint_out.cpp
+++ b/tests/test_quantize_checkpoint_out.cpp
@@ -327,3 +327,21 @@ TEST(QuantizeCheckpointOut, RefusesCompressedTensorsWithoutAConfigJson) {
     std::error_code ec;
     std::filesystem::remove_all(dir, ec);
 }
+
+// Measured 2026-08-16: vLLM refuses `lm_head.weight_global_scale` outright,
+// while imp reads a quantized head with byte-identical greedy output. So the
+// combination is legitimate for an imp-only checkpoint and useless for a
+// portable one, and the caller has to hear that before the conversion, not
+// after it.
+TEST(QuantizeCheckpointOut, WarnsOnlyWhenLmHeadMeetsCompressedTensors) {
+    EXPECT_NE(portability_warning(OutputFormat::CompressedTensors, /*quantize_lm_head=*/true), nullptr);
+    EXPECT_EQ(portability_warning(OutputFormat::CompressedTensors, false), nullptr);
+    EXPECT_EQ(portability_warning(OutputFormat::Modelopt, true), nullptr);
+    EXPECT_EQ(portability_warning(OutputFormat::Modelopt, false), nullptr);
+
+    const std::string w = portability_warning(OutputFormat::CompressedTensors, true);
+    // Names the flag, the format and the symptom, so the reader can act on it.
+    EXPECT_NE(w.find("--lm-head"), std::string::npos);
+    EXPECT_NE(w.find("lm_head.weight_global_scale"), std::string::npos);
+    EXPECT_NE(w.find("modelopt"), std::string::npos);
+}

--- a/tools/imp-quantize/checkpoint_out.cpp
+++ b/tools/imp-quantize/checkpoint_out.cpp
@@ -234,9 +234,11 @@ const char* portability_warning(OutputFormat fmt, bool quantize_lm_head) {
     if (fmt == OutputFormat::CompressedTensors && quantize_lm_head)
         return "--lm-head with --format vllm: vLLM cannot load the result. Its ParallelLMHead\n"
                "takes no scales, so loading stops at 'no module or parameter named\n"
-               "lm_head.weight_global_scale'. imp reads it fine and it is measurably free there\n"
-               "(byte-identical greedy output, 1.7 GiB smaller on Qwen3.8-27B) — so use it with\n"
-               "--format modelopt, or drop it for a checkpoint both engines read.";
+               "lm_head.weight_global_scale'. imp reads it fine and costs nothing EXTRA there,\n"
+               "because its default already quantizes a native head at load — but that also\n"
+               "makes the trade irreversible (gemm.nvfp4_lm_head=off can no longer buy the\n"
+               "0.99%% perplexity back). Use it with --format modelopt when the model would\n"
+               "otherwise not fit, or drop it for a checkpoint both engines read.";
     return nullptr;
 }
 

--- a/tools/imp-quantize/checkpoint_out.cpp
+++ b/tools/imp-quantize/checkpoint_out.cpp
@@ -230,6 +230,16 @@ float export_tensor_scale(float absmax) {
     return absmax / kFp4E2M1Max;
 }
 
+const char* portability_warning(OutputFormat fmt, bool quantize_lm_head) {
+    if (fmt == OutputFormat::CompressedTensors && quantize_lm_head)
+        return "--lm-head with --format vllm: vLLM cannot load the result. Its ParallelLMHead\n"
+               "takes no scales, so loading stops at 'no module or parameter named\n"
+               "lm_head.weight_global_scale'. imp reads it fine and it is measurably free there\n"
+               "(byte-identical greedy output, 1.7 GiB smaller on Qwen3.8-27B) — so use it with\n"
+               "--format modelopt, or drop it for a checkpoint both engines read.";
+    return nullptr;
+}
+
 std::string fusion_group_key(const std::string& weight_name) {
     static const std::string kW = ".weight";
     if (!ends_with(weight_name, kW))

--- a/tools/imp-quantize/checkpoint_out.h
+++ b/tools/imp-quantize/checkpoint_out.h
@@ -144,8 +144,8 @@ bool patch_config_json(const std::string& src, const std::string& quant_config_o
 // `ParallelLMHead` takes no scales ("There is no module or parameter named
 // lm_head.weight_global_scale ... available: {'lm_head.weight'}"), so the
 // checkpoint fails to load there — loudly, but only after the conversion. It is
-// the right choice for an imp-only checkpoint, where it is measurably free, so
-// this warns rather than refuses.
+// a defensible choice for an imp-only checkpoint, where it costs nothing on top
+// of what the runtime already spends, so this warns rather than refuses.
 const char* portability_warning(OutputFormat fmt, bool quantize_lm_head);
 
 // -- the files themselves --------------------------------------------------

--- a/tools/imp-quantize/checkpoint_out.h
+++ b/tools/imp-quantize/checkpoint_out.h
@@ -137,6 +137,17 @@ std::string compressed_tensors_quant_config(const std::vector<std::string>& igno
 bool patch_config_json(const std::string& src, const std::string& quant_config_obj, std::string& out,
                        std::string& err);
 
+// A combination that produces a checkpoint the target engine cannot load, or
+// nullptr when there is nothing to say. Reported before the conversion runs.
+//
+// Today there is one: `--lm-head` with compressed-tensors output. vLLM's
+// `ParallelLMHead` takes no scales ("There is no module or parameter named
+// lm_head.weight_global_scale ... available: {'lm_head.weight'}"), so the
+// checkpoint fails to load there — loudly, but only after the conversion. It is
+// the right choice for an imp-only checkpoint, where it is measurably free, so
+// this warns rather than refuses.
+const char* portability_warning(OutputFormat fmt, bool quantize_lm_head);
+
 // -- the files themselves --------------------------------------------------
 
 // Whether this source can carry the declaration the chosen format needs.

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -101,7 +101,7 @@ namespace {
 
 struct Options {
     std::string in_dir, out_dir;
-    std::string calib_file;         // --calib: activation statistics for AWQ scaling
+    std::string calib_file;  // --calib: activation statistics for AWQ scaling
     // --calib-groups: which AWQ scale groups run, for attributing a bad result.
     std::string calib_groups = awq::kAwqAllGroups;
     bool quantize_lm_head = false;  // imp has its own lm_head NVFP4 policy (#982)
@@ -209,10 +209,9 @@ bool quantize_one(const std::vector<uint16_t>& h_fp16, int64_t N, int64_t K, flo
     Tensor in(d_in, QType::F16, 2, shape, /*on_device=*/true);
 
     NvFP4QuantResult q;
-    const float scale = forced_scale > 0.0f
-                            ? forced_scale
-                            : quantize::export_tensor_scale(
-                                  quantize::fp16_absmax(h_fp16.data(), h_fp16.size()));
+    const float scale = forced_scale > 0.0f ? forced_scale
+                                            : quantize::export_tensor_scale(
+                                                  quantize::fp16_absmax(h_fp16.data(), h_fp16.size()));
     quantize_fp16_to_nvfp4_with_scale(in, scale, q);
     if (cudaDeviceSynchronize() != cudaSuccess) {
         cudaFree(d_in);
@@ -309,14 +308,16 @@ void report_card_fit(size_t bytes_out) {
     printf("\ncard: %.0f MiB total, less %.0f context and %.0f library reserve leaves %.0f MiB",
            double(total_b) / mib, kContextBytes / mib, kMeasuredLibraryReserveBytes / mib, budget);
     if (ckpt >= budget)
-        printf("\n      this checkpoint is %.0f MiB on disk and does NOT fit: %.0f MiB short before"
-               "\n      any KV cache or workspace",
-               ckpt, ckpt - budget);
+        printf(
+            "\n      this checkpoint is %.0f MiB on disk and does NOT fit: %.0f MiB short before"
+            "\n      any KV cache or workspace",
+            ckpt, ckpt - budget);
     else
-        printf("\n      this checkpoint is %.0f MiB on disk, leaving %.0f MiB for the KV cache and"
-               "\n      workspaces. On-disk size is not the resident figure: a scale-factor cache is"
-               "\n      built on top, and a vision tower or MTP sidecar may load separately or not at all",
-               ckpt, budget - ckpt);
+        printf(
+            "\n      this checkpoint is %.0f MiB on disk, leaving %.0f MiB for the KV cache and"
+            "\n      workspaces. On-disk size is not the resident figure: a scale-factor cache is"
+            "\n      built on top, and a vision tower or MTP sidecar may load separately or not at all",
+            ckpt, budget - ckpt);
 }
 
 }  // namespace
@@ -342,8 +343,7 @@ int main(int argc, char** argv) {
                 fprintf(stderr, "imp-quantize: unknown --format '%s' (modelopt | vllm)\n", f.c_str());
                 return 2;
             }
-        }
-        else if (a == "--calib-groups") {
+        } else if (a == "--calib-groups") {
             opt.calib_groups = next();
             for (char& c : opt.calib_groups)
                 c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
@@ -391,6 +391,10 @@ int main(int argc, char** argv) {
             fprintf(stderr, "%s\n", derr.c_str());
             return 1;
         }
+        // Same reason: a combination that will not load where the caller is
+        // aiming should be said now, not after the conversion.
+        if (const char* warn = quantize::portability_warning(opt.format, opt.quantize_lm_head))
+            fprintf(stderr, "note: %s\n\n", warn);
         fs::create_directories(opt.out_dir, ec);
         if (ec) {
             fprintf(stderr, "cannot create %s: %s\n", opt.out_dir.c_str(), ec.message().c_str());
@@ -841,18 +845,17 @@ int main(int argc, char** argv) {
         // Modelopt declares itself in a file of its own; compressed-tensors put
         // its declaration into the config.json copy_aux_files just patched, and
         // repeats it in recipe.yaml for readers that look only there.
-        const bool declared =
-            opt.format == quantize::OutputFormat::Modelopt
-                ? quantize::write_modelopt_quant_config(opt.out_dir, excluded_modules, calibrated, err)
-                : quantize::write_recipe_yaml(opt.out_dir, excluded_modules, err);
+        const bool declared = opt.format == quantize::OutputFormat::Modelopt
+                                  ? quantize::write_modelopt_quant_config(opt.out_dir, excluded_modules,
+                                                                          calibrated, err)
+                                  : quantize::write_recipe_yaml(opt.out_dir, excluded_modules, err);
         if (!declared) {
             fprintf(stderr, "%s\n", err.c_str());
             return 1;
         }
         // Single-shard checkpoints load off model.safetensors directly; sharded
         // ones need the index, and it must describe the tensors we wrote.
-        if (shards.size() > 1 &&
-            !quantize::write_shard_index(opt.out_dir, tensor_to_shard, bytes_out, err)) {
+        if (shards.size() > 1 && !quantize::write_shard_index(opt.out_dir, tensor_to_shard, bytes_out, err)) {
             fprintf(stderr, "%s\n", err.c_str());
             return 1;
         }
@@ -875,15 +878,16 @@ int main(int argc, char** argv) {
         // the harm is the ATTENTION groups on wide GQA, and mostly their
         // interaction (A x C +1.36). BD alone GAINS 0.13 there, so the warning
         // names the way out instead of just the hazard.
-        printf("\n\nAWQ-calibrated: %d groups scaled, %d left at round-to-nearest.%s"
-               "\n      Score this checkpoint with --perplexity against the uncalibrated one"
-               "\n      before using it; see docs/quantization.md.",
-               plan.groups_scaled, plan.groups_rtn,
-               opt.calib_groups == std::string(awq::kAwqAllGroups)
-                   ? "\n      NOTE: the full set is validated on Qwen3-0.6B/1.7B but measured HARMFUL"
-                     "\n      on Qwen3-14B (PPL 9.93 -> 12.3-12.6). The attention groups are the cause:"
-                     "\n      on wide-GQA models prefer --calib-groups BD (14B: 9.79, better than RTN)."
-                   : "");
+        printf(
+            "\n\nAWQ-calibrated: %d groups scaled, %d left at round-to-nearest.%s"
+            "\n      Score this checkpoint with --perplexity against the uncalibrated one"
+            "\n      before using it; see docs/quantization.md.",
+            plan.groups_scaled, plan.groups_rtn,
+            opt.calib_groups == std::string(awq::kAwqAllGroups)
+                ? "\n      NOTE: the full set is validated on Qwen3-0.6B/1.7B but measured HARMFUL"
+                  "\n      on Qwen3-14B (PPL 9.93 -> 12.3-12.6). The attention groups are the cause:"
+                  "\n      on wide-GQA models prefer --calib-groups BD (14B: 9.79, better than RTN)."
+                : "");
     if (n_moe_skipped)
         printf(", %zu MoE expert stacks left unquantized (not supported yet)", n_moe_skipped);
     printf("\nsize: %.2f GiB -> %.2f GiB (%.2fx)%s", bytes_in / 1073741824.0, bytes_out / 1073741824.0,


### PR DESCRIPTION
Two things, both found by measuring a claim I had made too loosely.

## A sharded compressed-tensors checkpoint lost its MTP draft head, silently

The shard-drop in `load_sharded()` asked `name_is_skipped()`. But `mtp.*` is
skipped by `translate_name()` **and then diverted** into the MTP map by
`load_shard()`: skipped and still used. So the shard carrying the draft head was
discarded before a tensor was read, and `load_sharded()` never passed the
collector down either. Spec-decode simply never engaged; asking for it printed
`model has no MTP head loaded`.

On Qwen3.8-27B the head is back with a **67-89 % draft accept rate**. The
Modelopt path is unaffected and re-verified (it harvested `mtp.*` from the main
tensor map, which is why this only ever bit compressed-tensors).

`name_is_unused(name, keep_vision, keep_mtp)` now answers the drop question
("will anything read this") separately from the translate question, and a
property test ties it to both consumers so the two cannot drift apart again —
the same shape as the #1384 fix. Mutation-validated: reverting it to the old
answer fails exactly the two tests that claim to cover it.

## What imp's `lm_head` default actually costs

I reported `--lm-head` as "free". That measurement compared **NVFP4 against
NVFP4**: imp converts a native head into an NVFP4 decode cache at load anyway
(`gemm.nvfp4_lm_head`, auto → on), so byte-identical output only showed that the
export reproduces imp's own cache. It said nothing about the default.

Measured against a real BF16 head (`gemm.nvfp4_lm_head=off`, which is how every
other engine runs it), Qwen3.8-27B, 248 320-token vocabulary:

| | perplexity | decode 128 tok greedy | ITL @4 | ITL @16 |
|---|---:|---:|---:|---:|
| `off` (BF16 head) | 4.5707 | 78.56 tok/s | 53.1 ms | 206.2 ms |
| `on` (default) | 4.6158 (+0.99 %) | 86.70 tok/s (+10.4 %) | 39.7 ms | 190.1 ms |

Decode is the median of three alternating pairs; every pair favoured `on`. So
the #982 trade holds and is **cheaper here than the +2.2 % recorded there**.

**The obvious explanation for why other engines skip this is wrong.** The head is
read whole once per token, so at batch 1 it is ~11 % of the step and one expects
batching to amortise the win away. It does not: the advantage shrinks from +25 %
to +8 % between 4 and 16 concurrent decodes and never inverts. What actually
separates them is that vLLM's `ParallelLMHead` accepts no scales at all, and the
quantizers put `lm_head` in `ignore` by convention for W4A4 recipes.

Consequence for the flag, now stated in the docs and in the tool's warning:
`--lm-head` costs nothing *extra*, but it makes the trade **irreversible** —
with a BF16 head in the checkpoint, `gemm.nvfp4_lm_head=off` buys the 0.99 %
back; quantized in, it cannot. Use it when the model would otherwise not fit.

## Also measured, and deliberately not built

Quantizing `embed_tokens` would take ~10 % off a 27B checkpoint. imp's embedding
lookup handles F32/F16/BF16/Q8_0/Q6_K and not NVFP4, so rather than write the
kernel and then learn the price, the table was pushed through the quantizer's
own round trip and written back at source precision: **+0.94 % perplexity** on
Qwen3-0.6B. Real but modest, and it would cost the interoperability
compressed-tensors was added for. Recorded in `quantization.md` instead of taken.

`make dev-test` green, `make verify-fast` green on a quiet card, `docs_lint`
clean, 62 CPU-lane cases in the two touched suites.
