### PR TITLE
changelog: merge the two Unreleased Fixed blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ there instead of retelling it.
   **67-89 % draft accept rate** where it previously reported "model has no MTP
   head loaded".
 
+- **compressed-tensors checkpoints without a `recipe.yaml` are no longer read as
+  Modelopt.** imp detected the format from that file alone, but the checkpoint's
+  declaration is `quantization_config` in `config.json`, and the two formats
+  store the tensor scale as reciprocals of each other. Such a checkpoint loaded
+  and generated with every weight scaled by `absmax²/36`: perplexity **1.2e47**
+  against 31.05.
+
 ### Added
 
 - **`imp-quantize --format vllm` writes a checkpoint vLLM can serve.** The new
@@ -47,15 +54,6 @@ there instead of retelling it.
   scales left two matrices dequantized against the third's — the amax spread
   inside those groups reaches 3.7×. Also the better quantization: Qwen3-0.6B
   perplexity **30.40 → 29.42** over `ppl_corpus_45k.txt`.
-
-### Fixed
-
-- **compressed-tensors checkpoints without a `recipe.yaml` are no longer read as
-  Modelopt.** imp detected the format from that file alone, but the checkpoint's
-  declaration is `quantization_config` in `config.json`, and the two formats
-  store the tensor scale as reciprocals of each other. Such a checkpoint loaded
-  and generated with every weight scaled by `absmax²/36`: perplexity **1.2e47**
-  against 31.05.
 
 ## [0.26.0] - 2026-08-15
 


### PR DESCRIPTION
`check-release.sh` refuses a repeated `###` heading inside `[Unreleased]`, and #1434 added a second `### Fixed` block instead of appending to the existing one. That turned the `Release hygiene` check red on main.

Both entries kept verbatim, now under one heading. `SKIP_VERIFY=1 bash scripts/check-release.sh` passes all gates.

The other red check on #1434, `Real API contract`, is unrelated: the runner could not resolve `archive.ubuntu.com` and failed to install python3. Rerun triggered.