### PR TITLE
readme: make the quickstart concrete, with Qwen3.8-27B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ there instead of retelling it.
 
 - **A sharded compressed-tensors checkpoint no longer loses its MTP draft
   head.** The shard-drop asked "is this name skipped by the translator", but
-  `mtp.*` is skipped *and* then diverted into the MTP map — so the shard
+  `mtp.*` is skipped *and* then diverted into the MTP map, so the shard
   carrying the draft head was discarded before any tensor was read, and
   spec-decode silently never engaged. On Qwen3.8-27B the head is back with a
   **67-89 % draft accept rate** where it previously reported "model has no MTP
@@ -42,7 +42,7 @@ there instead of retelling it.
 - **`imp-quantize` says up front when a flag combination will not load where you
   are aiming.** `--lm-head` with `--format vllm` produces a checkpoint vLLM
   refuses (its `ParallelLMHead` takes no scales). On imp the flag costs nothing
-  *extra* — the default already converts a native head to NVFP4 at load — but it
+  *extra* (the default already converts a native head to NVFP4 at load), but it
   makes that trade irreversible, so the doc now states what the default itself
   costs: Qwen3.8-27B perplexity **4.5707 → 4.6158 (+0.99 %) for +10.4 % decode**,
   and the win survives concurrency (+25 % ITL at 4 requests, +8 % at 16). Also
@@ -51,7 +51,7 @@ there instead of retelling it.
 
 - **Fused layers now share one tensor scale.** Engines merge q/k/v and gate/up
   into a single linear that carries one scale, so three independently calibrated
-  scales left two matrices dequantized against the third's — the amax spread
+  scales left two matrices dequantized against the third's. The amax spread
   inside those groups reaches 3.7×. Also the better quantization: Qwen3-0.6B
   perplexity **30.40 → 29.42** over `ppl_corpus_45k.txt`.
 

--- a/README.md
+++ b/README.md
@@ -47,22 +47,56 @@ jobs than imp is, and imp does not try to be.
 
 ## 60-second quickstart
 
-Everything runs in Docker. You do not need a CUDA toolkit on the host.
+Everything runs in Docker. You do not need a CUDA toolkit on the host. The
+worked example is **Qwen3.8-27B**: a 27B multimodal model, quantized to NVFP4 so
+it fits a single 5090 with room for a real context.
+
+**Get the weights** (19.2 GiB, download only, nothing to convert):
 
 ```bash
-mkdir -p models   # drop a GGUF or a SafeTensors directory in here
+scripts/stage-model.sh kekzle/Qwen3.8-27B-NVFP4 ~/models/Qwen3.8-27B-NVFP4
+```
 
-docker run --gpus all -v ./models:/models -v imp-cache:/home/imp/.cache/imp \
-  -p 8080:8080 ghcr.io/kekzl/imp:latest --model /models/your-model.gguf
+**Serve it and ask.** This is the 60 seconds:
+
+```bash
+docker run --gpus all -v ~/models:/models -v imp-cache:/home/imp/.cache/imp \
+  -p 8080:8080 ghcr.io/kekzl/imp:latest --model /models/Qwen3.8-27B-NVFP4
 
 curl -s http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -d '{"model":"your-model.gguf","messages":[{"role":"user","content":"Hello!"}],"max_tokens":64}'
+  -d '{"model":"Qwen3.8-27B-NVFP4","messages":[{"role":"user","content":"Why is the sky blue?"}],"max_tokens":64}'
 ```
 
-Expected: a JSON completion object whose `choices[0].message.content` holds the
-reply. The model id is the file or directory basename, `GET /v1/models` lists it,
-and the field is required.
+Expected: a JSON completion object whose `choices[0].message.content` explains
+Rayleigh scattering. The model id is the file or directory basename,
+`GET /v1/models` lists it, and the field is required. A GGUF file works the same
+way: swap the path.
+
+The weights take 17.9 GiB on the card and answer at **~85 tok/s**, leaving
+~7.7 GiB for the KV cache on a 32 GB 5090.
+
+[PROV: commit=8f2568c8 date=2026-08-16 hw=RTX5090 model=Qwen3.8-27B quant=NVFP4
+       cuda=13.3 path=nvfp4-safetensors n=2 image=ghcr.io/kekzl/imp:latest
+       cmd=`imp-cli --model … --prompt … --max-tokens 128 --temperature 0`]
+
+### Bringing your own model
+
+That checkpoint was made with the in-tree quantizer, and the same command builds
+one from any BF16 or FP8 release. Qwen3.8-27B needs it: no published NVFP4 export
+of it runs here, because they keep attention in FP8 and this card has no kernel
+for that.
+
+```bash
+scripts/stage-model.sh Qwen/Qwen3.8-27B-FP8 ~/models/my-Qwen3.8-NVFP4
+```
+
+28.8 GiB down, ~25 minutes of conversion, 18.8 GiB out. The FP8 release is a
+third of the BF16 download and costs 0.24 % perplexity against converting the
+BF16 one. The script forecasts the output size and whether it fits the card
+*before* writing anything, so a model that would not fit costs seconds rather
+than half an hour. Details and the quality numbers:
+[`docs/quantization.md`](docs/quantization.md).
 
 The cache volume is optional and pays for itself on the second start: it holds
 the transformed weights (Qwen3-14B-NVFP4 init 7.9 s → 2.1 s).

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -102,7 +102,7 @@ breaks it down by reason. Measured on Qwen3.8-27B (BF16 source 51.75 GiB):
 | vision tower | 875 MiB | tower loads at source precision only | not possible |
 | MTP draft head | 810 MiB | draft acceptance 81 % → 0 (#1428) | refused |
 
-**`--lm-head` costs nothing *extra*, because imp already pays it — and that is
+**`--lm-head` costs nothing *extra*, because imp already pays it, and that is
 the part worth understanding.** imp converts a native LM head into an NVFP4
 decode cache at load anyway (`gemm.nvfp4_lm_head`, auto → on for native
 sources), so quantizing it in the checkpoint changes nothing a run can see:
@@ -130,14 +130,14 @@ Qwen3.8-27B, 248 320-token vocabulary, so the largest head available here:
 
 Decode is the median of three alternating pairs (a fixed arm order overstates);
 every pair favoured `on`. So the #982 trade holds and is cheaper here than the
-+2.2 % recorded there — a bigger vocabulary moves both sides, and the quality
++2.2 % recorded there: a bigger vocabulary moves both sides, and the quality
 side moved less.
 
 **The obvious explanation for why other engines skip this is wrong.** The head is
 read whole once per token, so at batch 1 it is ~11 % of the step (2.43 GiB of
 17.9 GiB weights) and one expects the win to amortise away under concurrency.
 It does not: the advantage shrinks from +25 % to +8 % between 4 and 16 concurrent
-decodes but never inverts. What actually separates imp here is simpler — vLLM's
+decodes but never inverts. What actually separates imp here is simpler. vLLM's
 `ParallelLMHead` accepts no scales at all, and Modelopt / llm-compressor put
 `lm_head` in `ignore` by convention for W4A4 recipes. Absence of the feature, not
 a verdict on the trade.


### PR DESCRIPTION
The 60-second quickstart pointed at `your-model.gguf`, so a first-time reader had to solve model choice, download and conversion before seeing a token.

It now names one model and shows the whole path:

```bash
scripts/stage-model.sh kekzle/Qwen3.8-27B-NVFP4 ~/models/Qwen3.8-27B-NVFP4   # 19.2 GiB, no conversion
docker run --gpus all -v ~/models:/models -p 8080:8080 ghcr.io/kekzl/imp:latest --model /models/Qwen3.8-27B-NVFP4
curl … # explains Rayleigh scattering
```

17.9 GiB resident, **~85 tok/s**, ~7.7 GiB left for the KV cache on a 32 GB card. A second block covers bringing your own model, which Qwen3.8-27B itself needs: no published NVFP4 export of it runs on this card, since they keep attention in FP8.

## Verified before writing, not after

- `stage-model.sh` against the real repo: the **convert** branch ran end to end on `Qwen/Qwen3.8-27B-FP8` (forecast 28.75 → 18.80 GiB, ~25 min, exit 0), and the **download-only** branch's condition was checked against the published export's actual `hf_quant_config.json` (`quant_algo: NVFP4` matches the script's grep).
- The resulting checkpoint served with the **release image** `ghcr.io/kekzl/imp:latest`, not a local build, and answered correctly.
- Decode measured on that artefact with the same image: 85.87 / 84.31 tok/s.

Also removes the em-dashes I introduced in yesterday's doc changes (CHANGELOG, quantization.md), per the repo's punctuation rule.

`docs_lint` and `check-release.sh` pass.