### PR TITLE
fix: clamp the prefill chunk when no fused kernel serves the head_dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A model whose `head_dim` no fused kernel serves no longer aborts on a long
+  prompt.** The prefill dispatch knows the tiled FMHA covers head dims 64/96/
+  128/256/512; the chunk clamp did not ask, and returned the chunk unclamped
+  whenever the context crossed `attention.fmha_prefill_threshold`. On MLA
+  models (`head_dim` 192) nothing then bounded the chunk and the cuBLAS
+  fallback hit its own S-matrix limit, killing the process with
+  `engine should have prevented this`. Reproduced on DeepSeek-V2-Lite, a
+  perplexity run over 45k tokens: `std::abort()` before, 13.2787 after. Both
+  sides now read the rule from one header.
+
 ### Added
 
 - **The server now says when an answer was lost to thinking.** A reply with an

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -709,6 +709,10 @@ if(IMP_BUILD_TESTS)
         # share a scale, a config.json with two quantization_config keys.
         tools/imp-quantize/checkpoint_out.cpp
         tests/test_quantize_checkpoint_out.cpp
+        # Attention-family capability rules: the prefill dispatch and the
+        # chunk clamp must answer 'can this head_dim skip the S-matrix' the
+        # same way, or nothing bounds the chunk and cuBLAS aborts.
+        tests/test_attention_dispatch_rules.cpp
     )
     if(IMP_BUILD_SERVER)
         # Anthropic /v1/messages transform tests reuse the server's

--- a/src/exec/attention_dispatch_rules.h
+++ b/src/exec/attention_dispatch_rules.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// Which attention kernel families can serve a given head_dim.
+//
+// These two questions are asked in two places that must agree: the prefill
+// dispatch (executor_attention_prefill.cu), which picks the kernel, and
+// max_safe_prefill_chunk (executor_workspace_buffers.cu), which decides how
+// large a chunk the engine may hand it. When the second believes a family will
+// take the chunk and the first cannot, nothing clamps the chunk and the cuBLAS
+// fallback runs off the end of its S-matrix.
+//
+// That is not hypothetical. The clamp used to return `desired` unclamped
+// whenever the context crossed `attention.fmha_prefill_threshold`, without
+// asking whether the tiled FMHA serves this head_dim at all. On DeepSeek-V2-Lite
+// (MLA, head_dim 192, served by neither FA2 nor FMHA) a perplexity run over a
+// 45k-token corpus reached chunk 2048 at ctx 6144, needing 12 582 912 S-matrix
+// elements against the 3536x3536 = 12 503 296 allocated, and the defense-in-depth
+// check in the dispatch aborted the process with "engine should have prevented
+// this". It was right: the engine should have, and could not, because the two
+// sides disagreed about FMHA.
+//
+// Header is CUDA-free on purpose so the CPU lane can test the rules directly.
+
+namespace imp {
+
+// The tiled WMMA FMHA dispatch. Covers the fused head dims, including 512 for
+// Gemma-4's global layers.
+inline bool fmha_serves_head_dim(int head_dim) {
+    return head_dim == 64 || head_dim == 96 || head_dim == 128 || head_dim == 256 || head_dim == 512;
+}
+
+// FP16-QK FlashAttention-2. hd=256 rides the stage-1 port and is gated by
+// `attention.fa2_hd256`; `attention.fa2_fp16qk == "never"` is the caller's
+// opt-out and is checked there, not here.
+inline bool fa2_serves_head_dim(int head_dim, bool fa2_hd256_enabled) {
+    return head_dim == 128 || (head_dim == 256 && fa2_hd256_enabled);
+}
+
+// True when some O(n) family takes this head_dim, i.e. when no S-matrix is
+// needed and the chunk size is unconstrained by its capacity.
+inline bool o_n_attention_serves_head_dim(int head_dim, bool fa2_hd256_enabled) {
+    return fa2_serves_head_dim(head_dim, fa2_hd256_enabled) || fmha_serves_head_dim(head_dim);
+}
+
+}  // namespace imp

--- a/src/exec/executor_attention_internal.h
+++ b/src/exec/executor_attention_internal.h
@@ -5,6 +5,7 @@
 // gate). Included only by executor_attention.cu and its dispatch fragments;
 // the static helpers below assume single-TU inclusion.
 
+#include "exec/attention_dispatch_rules.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
 #include "exec/executor_gemv_helpers.h"

--- a/src/exec/executor_attention_prefill.cu
+++ b/src/exec/executor_attention_prefill.cu
@@ -47,8 +47,7 @@
             const bool shapes_uniform = !per_layer_shapes || attn_shapes_uniform();
             // hd=256 rides the stage-1 FA2 port (attention.fa2_hd256, default
             // on since #932): same fp16-qk kernel family, Bq=64/TWOSLOT instance.
-            const bool fa2_hd_ok =
-                hd == 128 || (hd == 256 && runtime_config().attention.fa2_hd256);
+            const bool fa2_hd_ok = fa2_serves_head_dim(hd, runtime_config().attention.fa2_hd256);
             // FA2 is chosen per-layer: heterogeneous Gemma-4 SWA layers (hd=256)
             // qualify even though the model is not uniform — the gather and the
             // attention are per-layer, so only THIS layer's head_dim matters.
@@ -60,8 +59,7 @@
             // this dispatch), per-layer — so Gemma-4 global layers (hd=512)
             // qualify too. Only learned sinks below the threshold still require
             // cuBLAS (folded into the WMMA FMHA above the threshold, #992).
-            const bool fmha_hd_ok =
-                (hd == 64 || hd == 96 || hd == 128 || hd == 256 || hd == 512);
+            const bool fmha_hd_ok = fmha_serves_head_dim(hd);
             const bool chunk_fmha_ok = fmha_hd_ok;
             // attn_scores_ is sized [nh, s_cap, s_cap] (square). Chunked cuBLAS stores
             // an [nh, n, ctx_len] FP16 matrix (or FP32 = 2× when use_fp32_s). The

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -4,6 +4,7 @@
 
 #include "core/dispatch_policy.h"
 #include "exec/executor.h"
+#include "exec/attention_dispatch_rules.h"
 #include "memory/vram_query.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_helpers.h"
@@ -1650,8 +1651,12 @@ int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) co
     if (uniform && !sinks && hd_u == 128 && att.fa2_fp16qk != "never")
         return desired;
     // The tiled FMHA dispatch serves chunks whose ctx_len crosses the
-    // threshold (and any chunk the S-matrix cannot hold) with no S-matrix.
-    if (uniform && !sinks && att.fmha_prefill_threshold > 0 &&
+    // threshold (and any chunk the S-matrix cannot hold) with no S-matrix --
+    // but only for head dims it actually covers. Without that check this
+    // returned `desired` unclamped on any model whose head_dim FMHA cannot
+    // serve (MLA is head_dim 192), and the cuBLAS fallback then aborted on its
+    // own S-matrix bound. See attention_dispatch_rules.h.
+    if (uniform && !sinks && fmha_serves_head_dim(hd_u) && att.fmha_prefill_threshold > 0 &&
         offset + desired >= att.fmha_prefill_threshold)
         return desired;
     // Heterogeneous per-layer shapes (Gemma-4 dual head_dim 256/512): every
@@ -1667,8 +1672,8 @@ int GraphExecutor::max_safe_prefill_chunk(int offset, int desired, int kv_bs) co
         for (int x : cfg.head_dim_per_layer) {
             if (x <= 0)
                 continue;  // non-attention layers (GDN/Mamba2 hybrids)
-            const bool fa2 = (x == 128 || (x == 256 && att.fa2_hd256)) && att.fa2_fp16qk != "never";
-            const bool fmha = x == 64 || x == 96 || x == 128 || x == 256 || x == 512;
+            const bool fa2 = fa2_serves_head_dim(x, att.fa2_hd256) && att.fa2_fp16qk != "never";
+            const bool fmha = fmha_serves_head_dim(x);
             if (!fa2 && !fmha) {
                 all_served = false;
                 break;

--- a/tests/test_attention_dispatch_rules.cpp
+++ b/tests/test_attention_dispatch_rules.cpp
@@ -1,0 +1,44 @@
+// Which attention family serves which head_dim, asked in one place.
+//
+// The prefill dispatch picks the kernel; max_safe_prefill_chunk decides how big
+// a chunk it may hand it. When the second assumes a family that the first
+// cannot use, nothing clamps the chunk and the cuBLAS fallback runs past its
+// S-matrix. That happened: the clamp trusted `fmha_prefill_threshold` without
+// asking whether FMHA serves the head_dim, and a perplexity run on
+// DeepSeek-V2-Lite (MLA, head_dim 192) aborted the process with
+// "engine should have prevented this".
+
+#include "exec/attention_dispatch_rules.h"
+
+#include <gtest/gtest.h>
+
+using namespace imp;
+
+TEST(AttentionDispatchRules, FmhaCoversTheFusedHeadDims) {
+    for (int hd : {64, 96, 128, 256, 512})
+        EXPECT_TRUE(fmha_serves_head_dim(hd)) << "hd=" << hd;
+}
+
+TEST(AttentionDispatchRules, FmhaDoesNotCoverMla) {
+    // DeepSeek-V2 MLA: qk_nope 128 + qk_rope 64. Neither family serves it, so
+    // the chunk MUST stay bounded by the S-matrix.
+    EXPECT_FALSE(fmha_serves_head_dim(192));
+    EXPECT_FALSE(fa2_serves_head_dim(192, true));
+    EXPECT_FALSE(o_n_attention_serves_head_dim(192, /*fa2_hd256_enabled=*/true));
+}
+
+TEST(AttentionDispatchRules, Fa2IsHd128AndOptionallyHd256) {
+    EXPECT_TRUE(fa2_serves_head_dim(128, false));
+    EXPECT_TRUE(fa2_serves_head_dim(256, true));
+    EXPECT_FALSE(fa2_serves_head_dim(256, false));  // gated by attention.fa2_hd256
+    EXPECT_FALSE(fa2_serves_head_dim(512, true));   // hd=512 is FMHA/cuBLAS only
+}
+
+TEST(AttentionDispatchRules, OnlyUnservedHeadDimsNeedTheSmatrix) {
+    // The union is what decides whether a chunk is unconstrained. Anything
+    // outside it is served by materialising [n, ctx_len] and must be clamped.
+    for (int hd : {128, 256, 512, 64, 96})
+        EXPECT_TRUE(o_n_attention_serves_head_dim(hd, true)) << "hd=" << hd;
+    for (int hd : {192, 80, 160, 320})
+        EXPECT_FALSE(o_n_attention_serves_head_dim(hd, true)) << "hd=" << hd;
+}


### PR DESCRIPTION
`std::abort()` on a legitimate run, found by exercising a path of my own last PR that had never actually executed.

## The defect

The prefill dispatch knows the tiled FMHA covers head dims 64/96/128/256/512 and falls back to cuBLAS otherwise. `max_safe_prefill_chunk` **did not ask**: it returned the chunk unclamped whenever the context crossed `attention.fmha_prefill_threshold`, assuming FMHA would take it.

On a model FMHA cannot serve, nothing bounded the chunk. DeepSeek-V2-Lite is MLA with `head_dim` 192 (qk_nope 128 + qk_rope 64). A perplexity run over `ppl_corpus_45k` reached chunk 2048 at ctx 6144, needing 12 582 912 S-matrix elements against the 3536×3536 = 12 503 296 allocated, and the defense-in-depth check killed the process:

```
chunked_prefill: attn_scores_ capacity 3536×3536=12503296 too small for
n=2048 × ctx_len=6144 = 12582912 at L0 — engine should have prevented this
```

It was right. **`std::abort()` before, perplexity 13.2787 after.**

## The shape of it

Two places answering the same question differently, which is the same shape as the shard-drop fix in #1439. Both sides now read from `src/exec/attention_dispatch_rules.h`; the dispatch's inline copies of the head-dim lists are gone, so they cannot drift again. The header is CUDA-free so the CPU lane tests the rules directly: 4 cases, mutation-validated (making FMHA claim every head_dim fails 6 assertions).

## How it surfaced

I went looking for it: my #1433 added per-expert fused-scale grouping for MoE, and I had only ever tested it on Qwen3.8, which is **dense**. Running `--format vllm` on DeepSeek-V2-Lite exercised that path for the first time: 5127 tensors, 1691 groups keyed per expert, MLA and router correctly excluded, and the grouping verified as correct (expert 0's scale is 15.2 against expert 1's 30.1, so grouping experts together would have been wrong by 2×). The abort came from loading the result.

`make verify-fast` green (decode -0.43 %, inside noise), `docs_lint` and the file-size gate clean.