### PR TITLE
quantization: re-measure both sizes after the shared fused scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Changed
+
+- **Quantization quality improved on both measured sizes, calibrated and not.**
+  Sharing a tensor scale across fused layers helps the AWQ path as much as
+  round-to-nearest: Qwen3-0.6B perplexity 30.10 → **29.42** uncalibrated and
+  28.48 → **27.60** with `--calib`, Qwen3-1.7B 20.43 → **20.39** and 19.21 →
+  **18.71**, against BF16 references of 24.08 and 17.22. `--calib` with
+  `--format vllm` is measured for the first time here.
+
 ### Fixed
 
 - **A model whose `head_dim` no fused kernel serves no longer aborts on a long

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -329,8 +329,14 @@ calibration over 36 058 tokens of general prose. Full chain reproducible with
 
 | Model | BF16 | NVFP4 RTN | NVFP4 `--calib` | AWQ gain | gap to BF16 |
 |---|---:|---:|---:|---:|---|
-| Qwen3-0.6B | 24.06 | 30.10 | **28.48** | −5.4% | +25.1% → **+18.3%** |
-| Qwen3-1.7B (2 shards) | 17.22 | 20.43 | **19.21** | −6.0% | +18.6% → **+11.5%** |
+| Qwen3-0.6B | 24.08 | 29.42 | **27.60** | −6.2% | +22.2% → **+14.6%** |
+| Qwen3-1.7B (2 shards) | 17.22 | 20.39 | **18.71** | −8.2% | +18.4% → **+8.7%** |
+
+Re-measured 2026-08-17, after fused layers started sharing a tensor scale. Both
+arms moved: the same table read 30.10 / 28.48 and 20.43 / 19.21 before that
+change, so sharing the scale helps the calibrated path as much as the
+round-to-nearest one, and `--calib` still recovers roughly a third to a half of
+the remaining gap to BF16 on these two sizes.
 
 `degen_suite.py` reads 45/45 on every checkpoint in that table (the AWQ ones
 re-run three and two times respectively). `--calib` closes about a quarter of

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -46,8 +46,12 @@
 // Measured over tools/analysis/ppl_corpus_45k.txt (13 537 tokens), calibrated
 // on general prose that is NOT the scoring corpus:
 //
-//   Qwen3-0.6B  BF16 24.06 -> RTN 30.10 (+25%) -> AWQ 28.48 (+18%)
-//   Qwen3-1.7B  BF16 17.22 -> RTN 20.43 (+19%) -> AWQ 19.21 (+12%)
+//   Qwen3-0.6B  BF16 24.08 -> RTN 29.42 (+22%) -> AWQ 27.60 (+15%)
+//   Qwen3-1.7B  BF16 17.22 -> RTN 20.39 (+18%) -> AWQ 18.71 (+9%)
+//
+// Both arms improved when fused layers started sharing a tensor scale
+// (2026-08-17). The figures this file carried before that change were
+// 30.10 / 28.48 and 20.43 / 19.21.
 //
 // Use a corpus of that size to judge this. The same model over the 199-token
 // ppl_corpus.txt reads wildly different numbers and inverts the size trend —


### PR DESCRIPTION
The perplexity figures in `imp-quantize`'s header and in `quantization.md` predate #1433, where fused layers started sharing a tensor scale. They were stale in the good direction, which is still stale.

Re-measured over `ppl_corpus_45k` with `deterministic_gemm`, calibrated arms rebuilt from fresh statistics:

| model | BF16 | RTN before → now | `--calib` before → now |
|---|---:|---|---|
| Qwen3-0.6B | 24.08 | 30.10 → **29.42** | 28.48 → **27.60** |
| Qwen3-1.7B | 17.22 | 20.43 → **20.39** | 19.21 → **18.71** |

So sharing the scale helps the calibrated path as much as the round-to-nearest one, and the remaining gap to BF16 on these sizes is +14.6 % and +8.7 %.

## The reason I ran this

`--calib` together with `--format vllm` had never executed. The scale planner has to measure each fused group **after** the AWQ transform, otherwise the scales describe weights that no longer exist, and the result would be quietly worse rather than broken. It does, and the two layouts land within 0.5 % of each other (27.60 vllm against 27.74 modelopt), which is the reciprocal rounding rather than a path difference.

Same method as #1443: take a path of my own earlier work that had never run, and run it.