### PR TITLE
troubleshooting: the thinking budget is not one model's quirk

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -118,6 +118,11 @@ Measured on Qwen3.8-27B, one session grown to ~8k tokens over 74 turns:
 | 260 | several turns with empty `content`, one reply that was a single non-Latin token |
 | 600 | **74 of 74 turns clean**, every recall correct |
 
+Not one model's quirk either: Qwen3.6-35B-A3B runs the same 54-turn probe with
+53 turns clean at `max_tokens` 600, and its one failure is the same shape, a
+`wrapup` turn cut off mid-sentence at `finish_reason: length` with 2 395
+characters of thinking behind it.
+
 It is the model, not the engine: the same conversation on vLLM with the same
 checkpoint degenerates the same way, only visibly, because vLLM has no reasoning
 parser and streams the thinking into `content` instead. A fixed conversation


### PR DESCRIPTION
The empty-answer case was documented from Qwen3.8-27B alone, which reads as a property of that checkpoint rather than of thinking models.

Ran the same probe against **Qwen3.6-35B-A3B-NVFP4** (54 turns, `max_tokens` 600): 53 clean, and the one failure is the same shape rather than a different one, a `wrapup` turn cut off mid-sentence at `finish_reason: length` with 2 395 characters of thinking behind it.

Context: the nina session on this host reported a coding turn on that model degenerating into 18 780 characters of looping reasoning. I could not reproduce that with generic coding prompts (3 of 3 clean, real code out, 433 characters), so that one stays attributed to its specific agent turn, which I do not have. What did reproduce is the budget shape above, on a second model.

Docs-only.