### PR TITLE
build: the local GPU gates say when they cannot judge

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -32,5 +32,14 @@ if ! command -v nvidia-smi >/dev/null 2>&1; then
     exit 0
 fi
 
+# A co-tenant on the card makes this stage judge the host instead of the commit,
+# and it takes a Docker build plus the full suite to say so. One rule, read by
+# this hook and by pre-push, because both end in a CUDA run.
+# Guarded: an installed hook outlives the branch it came from, and a checkout
+# that predates this script must still run the gate rather than die on it.
+if [ -x "$ROOT/scripts/require_free_gpu.sh" ]; then
+    "$ROOT/scripts/require_free_gpu.sh" "pre-commit (Stage 1 / GPU)" || exit 1
+fi
+
 echo "pre-commit (Stage 1 / GPU): staged source changes → make test-gpu"
 exec make -s test-gpu

--- a/scripts/pre-push.hook
+++ b/scripts/pre-push.hook
@@ -60,6 +60,15 @@ if [ "$NEEDS_VERIFY" -eq 0 ]; then
     exit 0
 fi
 
+# Both tiers below run kernels, so neither can judge anything on a busy card.
+# Checked after the "no source changes" exit above: a docs-only push must not
+# wait for a card it never touches.
+# Guarded: an installed hook outlives the branch it came from, and a checkout
+# that predates this script must still run the gate rather than die on it.
+if [ -x "$ROOT/scripts/require_free_gpu.sh" ]; then
+    "$ROOT/scripts/require_free_gpu.sh" "pre-push" || exit 1
+fi
+
 if [ "$NEEDS_PERF" -eq 1 ]; then
     echo "pre-push: source changes touch the measured paths → make verify-fast (with perf gate)"
     exec make -s verify-fast

--- a/scripts/require_free_gpu.sh
+++ b/scripts/require_free_gpu.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Refuse a GPU gate that would judge the host instead of the change.
+#
+# Both local gates end in a CUDA run: pre-commit executes the full suite, and
+# pre-push executes verify-fast. A co-tenant on the card turns either of them
+# into a statement about the box. VramQueryTest sizes its budget against free
+# VRAM and fails outright, the perf gate reads a card it does not have to
+# itself, and the report points at the diff, which is the wrong place to look.
+# Before this check that cost a Docker build plus the whole suite to find out.
+#
+# The occupied memory is the tell, not the process list: on WSL2 nvidia-smi does
+# not show a container holding the card, so a busy GPU can look idle there.
+#
+# Silent and successful when there is no GPU at all: that case is the caller's
+# to decide, and the two callers decide it differently.
+#
+# Usage: scripts/require_free_gpu.sh "<gate name>"
+set -uo pipefail
+
+GATE="${1:-gpu gate}"
+THRESHOLD="${IMP_GPU_FREE_MIB:-2000}"
+
+command -v nvidia-smi >/dev/null 2>&1 || exit 0
+
+USED=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1)
+USED="${USED// /}"
+case "$USED" in
+    '' | *[!0-9]*) exit 0 ;;  # unreadable: do not block on a parse
+esac
+[ "$USED" -le "$THRESHOLD" ] && exit 0
+
+echo "$GATE: the card is not free (${USED} MiB in use, threshold ${THRESHOLD})." >&2
+echo "         Running it now would report the host rather than the change." >&2
+# Order matters: >&2 first, so stdout follows the real stderr rather than the
+# /dev/null that 2>/dev/null would have just installed.
+docker ps --format '         running container: {{.Names}} ({{.Image}})' >&2 2>/dev/null
+echo "         Wait for the card and try again. On WSL2 nvidia-smi does not list a" >&2
+echo "         container holding the GPU, so 'docker ps' above is part of the answer." >&2
+exit 1


### PR DESCRIPTION
Both local gates end in a CUDA run: pre-commit executes the full suite, pre-push executes `verify-fast`. Neither asked whether the card was free first, so a co-tenant turned either of them into a statement about the box. `VramQueryTest.BudgetCapsTotalAndTracksOwnUsage` sizes its budget against free VRAM and fails outright, and the red then points at the diff, which is the wrong place to look.

Found by paying for it: a Docker build plus the full suite, to learn that another process held the card.

`scripts/require_free_gpu.sh` answers it once for both hooks. One rule read from two places is the shape that keeps going wrong in this repo, so it is a file rather than a copy in each hook.

- **Refuses rather than skips.** A gate that waves a commit through on a busy card is worse than one that waits.
- **Reads occupied memory, not the process list.** On WSL2 `nvidia-smi` does not show a container holding the card, so the refusal prints `docker ps` too.
- **Guarded call.** An installed hook outlives the branch it came from; a checkout that predates the script must still run the gate rather than die on it. That one is not hypothetical, it broke a commit here before this line existed.
- Threshold is the quiet-host figure the perf gate already uses, overridable with `IMP_GPU_FREE_MIB`.

Scripts only, no engine change.