### PR TITLE
fix: an FP8 weight this tool refuses must not travel without its scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Converting an FP8 checkpoint no longer writes weights whose scales were
+  thrown away.** `imp-quantize` pairs each E4M3 weight with its block-scale grid
+  and consumes the grid, but a weight the tool keeps at full precision was then
+  copied through as raw E4M3 bytes, which are still valid E4M3 and simply mean
+  something else. On Qwen3.8-27B-FP8 that is the whole MTP draft head, the one
+  part whose corruption costs only draft acceptance and so has no loud symptom.
+  Such weights are widened to full precision now and declared unquantized;
+  the forecast for that checkpoint goes from 18.80 to 19.15 GiB.
+
 - **A model whose `head_dim` no fused kernel serves no longer aborts on a long
   prompt.** The prefill dispatch knows the tiled FMHA covers head dims 64/96/
   128/256/512; the chunk clamp did not ask, and returned the chunk unclamped

--- a/docs/quantization.md
+++ b/docs/quantization.md
@@ -46,8 +46,9 @@ Calibrated per-tensor scales using AWQ or SmoothQuant. Two upstream tools produc
 > published Modelopt export. Use it to get a model onto the NVFP4 path for
 > evaluation or performance work — not to produce a checkpoint you ship.
 
-`imp-quantize` turns a dense BF16/FP16 SafeTensors checkpoint into an NVFP4 one
-without leaving the repo, for models nobody has published an export for:
+`imp-quantize` turns a dense BF16/FP16 or block-scaled FP8 SafeTensors
+checkpoint into an NVFP4 one without leaving the repo, for models nobody has
+published an export for:
 
 ```bash
 # 1. one calibration pass over a corpus — writes per-channel activation stats
@@ -64,6 +65,15 @@ what would be quantized without touching the GPU.
 It copies the tokenizer and config files, rebuilds the shard index when the
 source is sharded, and leaves embeddings, norms and (unless `--lm-head`) the LM
 head at full precision.
+
+A **block-scaled FP8 source** works too, which is what makes the FP8-only
+release lines reachable (DeepSeek-V3, Qwen3.8's FP8 line): each E4M3 weight is
+paired with its `weight_scale_inv` grid and widened before quantizing. The pair
+is read as one unit, so a weight this tool keeps at full precision is widened as
+well rather than copied: the grid is consumed either way, and raw E4M3 without
+its scales is still valid E4M3 that simply means something else. On
+Qwen3.8-27B-FP8 that is the MTP draft head, whose corruption costs draft
+acceptance and nothing louder, and honesty there costs 350 MiB of output.
 
 #### Which layout it writes (`--format`)
 

--- a/tests/test_quantize_policy.cpp
+++ b/tests/test_quantize_policy.cpp
@@ -217,6 +217,56 @@ TEST(Nvfp4OutputBytes, CountsPackedNibblesMicroScalesAndTensorScale) {
     EXPECT_NEAR(ratio, 32.0 / 9.0, 0.01) << "BF16 against packed+micro is 2 / (0.5 + 0.0625)";
 }
 
+// An FP8 source pairs each E4M3 weight with a block-scale grid, and the grid is
+// consumed whatever happens to the weight. So "leave this one alone" cannot mean
+// "copy its bytes": E4M3 without its scales is still valid E4M3 that means
+// something else, and nothing downstream can tell. Every refusal here must be a
+// widen.
+TEST(Fp8SourceAction, RefusedWeightsAreWidenedRatherThanCopiedRaw) {
+    std::string why;
+    const RawTensor lm_head = tensor("lm_head.weight", {248320, 5120}, "F8_E4M3");
+    EXPECT_EQ(fp8_source_action(lm_head, false, false, why), Fp8SourceAction::WidenToFullPrecision);
+    EXPECT_NE(why.find("lm_head"), std::string::npos) << "the byte report prints this reason";
+
+    // The #1159 roles, in the dtype the family that needs them ships in:
+    // DeepSeek-V3 stores its MLA latent projections as block-scaled E4M3.
+    EXPECT_EQ(fp8_source_action(tensor("model.layers.0.self_attn.kv_a_proj_with_mqa.weight", {576, 2048},
+                                       "F8_E4M3"),
+                                false, false, why),
+              Fp8SourceAction::WidenToFullPrecision);
+    EXPECT_EQ(fp8_source_action(tensor("model.layers.0.mlp.gate.weight", {64, 2048}, "F8_E4M3"), false, false,
+                                why),
+              Fp8SourceAction::WidenToFullPrecision);
+}
+
+// The caller knows this and the policy cannot: a q_proj carrying a fused output
+// gate needs its layer's o_proj to be recognised.
+TEST(Fp8SourceAction, TakesTheGatedFlagFromTheCaller) {
+    std::string why;
+    const RawTensor q = tensor("model.layers.0.self_attn.q_proj.weight", {8192, 2048}, "F8_E4M3");
+    EXPECT_EQ(fp8_source_action(q, false, false, why), Fp8SourceAction::Quantize);
+    EXPECT_EQ(fp8_source_action(q, true, false, why), Fp8SourceAction::WidenToFullPrecision);
+    EXPECT_NE(why.find("gate"), std::string::npos);
+}
+
+// The dtype gate in should_quantize refuses every FP8 tensor as "already
+// quantized". Asking it directly, rather than about the widened form, would
+// widen the entire checkpoint and quantize nothing.
+TEST(Fp8SourceAction, AsksAboutTheWidenedFormNotTheStoredDtype) {
+    std::string why;
+    const RawTensor proj = tensor("model.layers.0.mlp.down_proj.weight", {5120, 17408}, "F8_E4M3");
+    EXPECT_EQ(fp8_source_action(proj, false, false, why), Fp8SourceAction::Quantize);
+    EXPECT_FALSE(quantizes(proj)) << "the stored dtype alone says no, which is why this call exists";
+}
+
+// `--lm-head` has to reach the FP8 path too, or the flag silently does nothing
+// on an FP8 source while working on a BF16 one.
+TEST(Fp8SourceAction, HonoursTheLmHeadFlag) {
+    std::string why;
+    const RawTensor lm_head = tensor("lm_head.weight", {248320, 5120}, "F8_E4M3");
+    EXPECT_EQ(fp8_source_action(lm_head, false, true, why), Fp8SourceAction::Quantize);
+}
+
 TEST(Nvfp4OutputBytes, RefusesToInventBytesForAnEmptyMatrix) {
     // Guards the forecast against a degenerate shape adding a phantom 4 bytes
     // per tensor, which on a 1000-tensor checkpoint is a visible drift.

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -611,15 +611,16 @@ int main(int argc, char** argv) {
             for (const auto& t : src->tensors()) {
                 if (fp8_scale_names.count(t.name) || gated_q_proj.count(t.name))
                     continue;
-                // Ask the policy about the widened form, exactly as the writer
-                // does, so a tensor the writer copies through is not given a
-                // scale here — and, worse, does not drag a fused sibling's
-                // scale up with an absmax that was never quantized.
-                RawTensor probe = t;
-                if (fp8_scale_of.count(t.name))
-                    probe.dtype = "BF16";
+                // Ask the policy exactly as the writer does, so a tensor the
+                // writer keeps at full precision is not given a scale here -
+                // and, worse, does not drag a fused sibling's scale up with an
+                // absmax that was never quantized.
                 std::string why;
-                if (!quantize::should_quantize(probe, opt.quantize_lm_head, why))
+                const bool refused = fp8_scale_of.count(t.name)
+                                         ? quantize::fp8_source_action(t, false, opt.quantize_lm_head, why) !=
+                                               quantize::Fp8SourceAction::Quantize
+                                         : !quantize::should_quantize(t, opt.quantize_lm_head, why);
+                if (refused)
                     continue;
                 const std::string key = quantize::fusion_group_key(t.name);
                 if (!key.empty())
@@ -687,9 +688,13 @@ int main(int argc, char** argv) {
         std::vector<Quantized> quant_store;
         std::vector<float> scale_store;
         std::vector<std::vector<unsigned char>> folded_store;
+        // FP8 weights this tool refuses: widened here, so the buffer must outlive
+        // the descriptor that points at it.
+        std::vector<std::vector<uint16_t>> widened_store;
         quant_store.reserve(src.tensors().size());
         scale_store.reserve(src.tensors().size());
         folded_store.reserve(src.tensors().size());
+        widened_store.reserve(src.tensors().size());
         std::vector<SafeTensorsOut> out;
 
         for (const auto& t : src.tensors()) {
@@ -709,15 +714,30 @@ int main(int argc, char** argv) {
                 // must stay full precision here; only the dtype gate differs, so
                 // ask the policy about the widened form rather than duplicating
                 // the rule. An FP8 tensor it refuses is copied through as-is.
-                RawTensor as_bf16 = t;
-                as_bf16.dtype = "BF16";
                 std::string why_fp8;
-                const bool gated_fp8 = gated_q_proj.count(t.name) != 0;
-                if (gated_fp8 || !quantize::should_quantize(as_bf16, opt.quantize_lm_head, why_fp8)) {
-                    out.push_back({t.name, t.dtype, t.shape, t.data, t.nbytes});
-                    bytes_out += t.nbytes;
-                    copied_bytes_by_reason[gated_fp8 ? "fused Q+gate projection" : why_fp8] += t.nbytes;
+                if (quantize::fp8_source_action(t, gated_q_proj.count(t.name) != 0, opt.quantize_lm_head,
+                                                why_fp8) != quantize::Fp8SourceAction::Quantize) {
+                    // Its block grid was dropped above, so the E4M3 bytes cannot
+                    // travel as they are. Widen and write full precision.
+                    const size_t widened_bytes = static_cast<size_t>(t.numel()) * sizeof(uint16_t);
+                    copied_bytes_by_reason[why_fp8] += widened_bytes;
+                    bytes_out += widened_bytes;
                     n_copied++;
+                    if (ends_with(t.name, ".weight") && t.shape.size() >= 2)
+                        excluded_modules.push_back(t.name.substr(0, t.name.size() - strlen(".weight")));
+                    if (opt.dry_run) {
+                        printf("  COPY  %-58s widened from FP8: %s\n", t.name.c_str(), why_fp8.c_str());
+                        continue;
+                    }
+                    std::vector<uint16_t> h;
+                    std::string werr;
+                    if (!tensor_as_fp16(t, fp8_scale_of, plan, h, werr)) {
+                        fprintf(stderr, "  %s: %s\n", t.name.c_str(), werr.c_str());
+                        return 1;
+                    }
+                    widened_store.push_back(std::move(h));
+                    const std::vector<uint16_t>& w = widened_store.back();
+                    out.push_back({t.name, "F16", t.shape, w.data(), w.size() * sizeof(uint16_t)});
                     continue;
                 }
                 if (opt.dry_run) {

--- a/tools/imp-quantize/tensor_policy.cpp
+++ b/tools/imp-quantize/tensor_policy.cpp
@@ -113,6 +113,21 @@ bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why
     return true;
 }
 
+Fp8SourceAction fp8_source_action(const RawTensor& weight, bool gated, bool quantize_lm_head,
+                                  std::string& why_not) {
+    if (gated) {
+        why_not = "fused Q+gate projection (--keep-attn-gate)";
+        return Fp8SourceAction::WidenToFullPrecision;
+    }
+    // Ask about the widened form. The dtype gate in should_quantize would
+    // otherwise refuse every FP8 tensor as "already quantized" before it ever
+    // looked at the role, and the roles are the whole point of this call.
+    RawTensor widened = weight;
+    widened.dtype = "BF16";
+    return should_quantize(widened, quantize_lm_head, why_not) ? Fp8SourceAction::Quantize
+                                                               : Fp8SourceAction::WidenToFullPrecision;
+}
+
 size_t nvfp4_output_bytes(int64_t N, int64_t K) {
     if (N <= 0 || K <= 0)
         return 0;

--- a/tools/imp-quantize/tensor_policy.h
+++ b/tools/imp-quantize/tensor_policy.h
@@ -21,6 +21,27 @@ namespace imp::quantize {
 // copies the tensor through untouched.
 bool should_quantize(const RawTensor& t, bool quantize_lm_head, std::string& why_not);
 
+// What happens to an FP8 weight that was paired with a block-scale grid.
+//
+// The pair is one unit. The grid is consumed either way, because a grid that
+// outlives the weight it described says nothing true, so a weight this tool
+// refuses to quantize cannot travel in its source dtype either: raw E4M3 bytes
+// without their scales are still valid E4M3 and simply mean something else,
+// which no loader can detect. It is widened to full precision instead, and the
+// caller declares the module unquantized.
+//
+// This exists because the question was being asked in two places that could
+// disagree. The pairing pass consumed every grid it could match, while the
+// writer asked `should_quantize` and, on a refusal, copied the weight through
+// untouched. On a DeepSeek-V3-style FP8 checkpoint that is every MLA latent
+// projection in the model.
+//
+// `gated` is the caller's knowledge that this q_proj carries a fused output
+// gate; `should_quantize` sees one tensor and cannot know that.
+enum class Fp8SourceAction { Quantize, WidenToFullPrecision };
+Fp8SourceAction fp8_source_action(const RawTensor& weight, bool gated, bool quantize_lm_head,
+                                  std::string& why_not);
+
 // Bytes an [N, K] matrix occupies once quantized: the packed nibbles [N, K/2],
 // the FP8 micro-scales [N, K/16], and one F32 tensor scale.
 //


### PR DESCRIPTION
## What was wrong

`imp-quantize` pairs each E4M3 weight with its `weight_scale_inv` block grid and consumes the grid, because the weight is about to become NVFP4. The writer then asks `should_quantize`, and on a refusal it copied the weight through **in its source dtype**. The grid was already dropped, so the output carried raw E4M3 bytes without the scales that give them meaning.

Nothing downstream can detect that: `safetensors_loader.cpp` maps `F8_E4M3` to `QType::FP8_E4M3` and reads the bytes. They are valid E4M3 and mean something else.

Two places answered the same question and could disagree: the pairing pass consumed every grid it could match, the writer asked the policy. Fourth instance of that shape here after #1384, the two NVFP4 layouts, and #1443.

## Reachable on a checkpoint that is on this box

Qwen3.8-27B-FP8 stores its **MTP draft head** as block-scaled E4M3, and the MTP head is precisely what the policy refuses: quantizing it takes draft acceptance from 81 % to 0 of 24, which costs speed and never correctness, so there is no loud symptom. `--dry-run` on `/models/Qwen3.8-27B-FP8 --format vllm`:

| | MTP draft head | total forecast |
|---|---|---|
| before | 455 MiB, raw E4M3, no scales, printed nothing | 18.80 GiB |
| after | 810 MiB, widened, named in the copy report | 19.15 GiB |

The 350 MiB is what correctness costs on this checkpoint. A DeepSeek-V3-style FP8 source hits the same branch on every MLA latent projection.

## The fix

`fp8_source_action` in `tensor_policy` answers once: quantize, or widen to full precision. Copying the raw bytes was never a third option, because the grid is consumed either way. The writer widens and declares the module unquantized; the fused-scale pass reads the same answer instead of rolling its own `dtype = "BF16"` probe.

## Verification

- 4 new CPU-lane tests, mutation-validated: removing the widening kills all four, removing the `gated` branch kills the one that covers it.
- Stage-1 GPU suite green on a quiet card.
- Not run: the end-to-end write of a 28.75 GiB FP8 checkpoint. What is measured above is the plan, on the real checkpoint, through the same code path.

Conversion tool only, no runtime change, no perf impact.