### PR TITLE
fix(memory): a running sequence can grow the pool too, or it is cancelled instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ there instead of retelling it.
   31.4 GiB took its full 10.2 GiB of KV anyway, i.e. spilled into host memory
   with nothing reporting an error. End to end on Qwen3-14B-NVFP4: started at
   810 of 8192 blocks, grew to 1582 to serve a 25 222-token prompt, answered
-  coherently. See [`MEMORY.md`](docs/internals/MEMORY.md) A7 step 7.
+  coherently, and decode measured 358.6 against 352.4 tok/s for a fixed pool,
+  i.e. no cost inside the host's own variance. See
+  [`MEMORY.md`](docs/internals/MEMORY.md) A7 step 7.
 
 - **`/health` reports the KV pool, and refuses to call a clamped server
   healthy.** A server started while another process still held the card comes

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -92,6 +92,7 @@ Source: `src/core/qtype.h`.
 | TMA bulk-tensor loads | ✅ | `gemm_grouped_nvfp4_smallM.cu:65`, emits UTMALDG |
 | FlashAttention-2 style prefill, hd=128 and hd=256 | ✅ | default since #930 |
 | Paged KV cache | ✅ | default block `n=16`; the geometry is per-configuration |
+| Growable KV pool | ✅ opt-in | `kv_cache.growable`: reserves address space for the planned pool, commits what the card can spare, grows on demand. Needs CUDA virtual memory management |
 | CUDA graphs, decode | ✅ | gate asserts ≥1.3x, measured 2.28x |
 | CUDA graphs, prefill | ✅ | default on; disabled per-model when one NVFP4 weight exceeds the dequant-workspace cap |
 | continuous batching, concurrent decode | ✅ | |

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1511,6 +1511,23 @@ void Engine::step_decode(cudaStream_t dec_stream) {
 
         if (blocks_needed > blocks_have) {
             int new_block = kv_manager_->append_block(req->id);
+            if (new_block < 0 && kv_cache_raw_ != nullptr) {
+                // A growable pool gets one chance to answer with memory before
+                // the sequence is cancelled. Admission alone is not enough: a
+                // generation that was admitted can still outgrow the pool
+                // block by block, and without this a pool that started small
+                // cancelled every long generation mid-decode — measured, a
+                // synthetic 8192-token run produced ZERO tokens where a fixed
+                // pool produced 354 tok/s.
+                //
+                // Grown in coarse steps rather than one block at a time: the
+                // cost is per driver mapping call, not per byte.
+                const int have = kv_cache_raw_->total_blocks();
+                if (kv_cache_raw_->ceiling_blocks() > have) {
+                    kv_cache_raw_->try_grow_to(have + std::max(64, have / 4));
+                    new_block = kv_manager_->append_block(req->id);
+                }
+            }
             if (new_block < 0) {
                 // KV exhausted: append_block already reclaimed cached blocks, so
                 // the free pool AND all reclaimable cached blocks are empty. The


### PR DESCRIPTION
## The gap

#1452 wired growth into **admission** only. A generation that was admitted can still outgrow the pool block by block, and the decode path cancelled it instead:

```
KV pool exhausted at decode: seq N needs block M but the 204-block pool has 0 free/reclaimable
```

So a pool that starts small served the prompt and then produced nothing.

Measured on Qwen3-14B-NVFP4, `--bench`, `growable_initial_pct=10`:

| | tg 8192 tokens |
|---|---|
| before | **0.00 tok/s** — zero tokens, the sequence is cancelled |
| after | **358.56 tok/s** |

## The number that had to be settled anyway

The same runs answer the question that has to be closed before anyone turns this on: **a VMM-backed pool that has grown costs nothing measurable at decode.** Three alternating rounds, medians **352.4 tok/s** fixed against **358.6 tok/s** growable, inside this host's own 4 % between-session variance.

```
[PROV: commit=be88ec1e date=2026-08-17 hw=RTX5090 model=Qwen3-14B-NVFP4 quant=NVFP4
       cuda=13.3 cmd=`imp-cli --bench --bench-reps 1 --set runtime.max_seq_len=32768
       [--set kv_cache.growable=true --set kv_cache.growable_initial_pct=10]`
       n=3 alternating rounds, card idle at 810 MiB]
```

## Why nothing caught it

The seven unit tests exercise the pool, not the scheduler. The end-to-end server run in #1452 fit after a single growth **at admission**, so it never reached this path: only a generation long enough to outgrow the pool *while running* does. The synthetic benchmark found it on the first try, which is the argument for running the thing rather than testing around it.

Growth here is coarse (a quarter of the current pool, at least 64 blocks) because the cost is per driver mapping call, not per byte.

Also in here: `FEATURES.md` lists the capability, and the CHANGELOG entry carries the decode measurement.
