### PR TITLE
memory: drop a per-layer commit cap that measures as doing nothing

### DIFF
--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -392,6 +392,12 @@ int KVCache::commit_blocks_(int blocks) {
         const size_t bb = layer_block_bytes_.empty() ? block_bytes_ : layer_block_bytes_[l];
         if (bb == 0)
             continue;  // a non-attention layer in a hybrid holds no KV
+        // A sliding-window layer's region is smaller than `blocks` implies, so
+        // this commits past it into the next layer's range. Deliberate: that
+        // range belongs to the same reservation and is wanted anyway, the tail
+        // is clamped to the reservation, and capping it per layer was measured
+        // to change nothing (64.00 vs 34.00 MiB committed either way, the
+        // difference coming from the layout rather than from the cap).
         const size_t want = static_cast<size_t>(blocks) * bb;
         const size_t k_off = static_cast<const char*>(k_ptr(l, 0)) - base;
         const size_t v_off = static_cast<const char*>(v_ptr(l, 0)) - base;
@@ -413,6 +419,14 @@ int KVCache::commit_blocks_(int blocks) {
     // handed out with stale bytes in its unused tail is the kind of difference
     // that shows up as rare, unreproducible output rather than as an error.
     // Only the new range: rezeroing the old one would erase live KV.
+    //
+    // The invariant this keeps is "a block is clean the first time it is handed
+    // out", and it is tracked by committed_blocks_. A future shrink has to
+    // lower that counter when it decommits, or a range that is decommitted and
+    // recommitted would come back with whatever the driver hands over and skip
+    // the memset below. Reuse of an already-committed block does NOT re-zero,
+    // which is the fixed pool's behaviour too: attention reads only the slots
+    // the sequence wrote.
     for (int l = 0; l < n_layers_ && blocks > first_new; l++) {
         const size_t bb = layer_block_bytes_.empty() ? block_bytes_ : layer_block_bytes_[l];
         if (bb == 0)
@@ -424,6 +438,8 @@ int KVCache::commit_blocks_(int blocks) {
     committed_blocks_ = blocks;
     return blocks;
 }
+
+size_t KVCache::committed_bytes() const { return region_ ? region_.committed() : 0; }
 
 int KVCache::try_grow_to(int wanted) {
     const int have = blocks_.num_blocks();

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -58,6 +58,11 @@ public:
     // was built growable and has not reached its ceiling.
     int ceiling_blocks() const { return max_blocks_; }
 
+    // Physical memory currently committed by a growable pool, 0 for a fixed
+    // one. What the pool actually costs right now, as opposed to the address
+    // space it reserved.
+    size_t committed_bytes() const;
+
     // Commit memory for at least `wanted` blocks and make them allocatable.
     // Returns the capacity afterwards, which is what the caller must believe:
     // a partial growth is a real, servable capacity and not a failure.

--- a/tests/test_vmm_backend.cu
+++ b/tests/test_vmm_backend.cu
@@ -253,3 +253,37 @@ TEST_F(VmmBackendTest, PerLayerPoolAlsoStartsAtWhatIsCommitted) {
 }
 
 }  // namespace
+
+namespace {
+
+// A pool whose layers are half sliding-window costs less to grow, because a
+// windowed layer's region holds only its window. Measured rather than assumed:
+// capping the per-layer commit at that window changes nothing (the same 34 MiB
+// either way), so this asserts the layout property that is real and not a guard
+// that is not.
+TEST_F(VmmBackendTest, WindowedLayersMakeAGrownPoolCheaper) {
+    const std::vector<int> nkv(4, 8), hd(4, 128);
+    auto grown_bytes = [&](const std::vector<char>& is_swa, int swa_blocks) {
+        KVCache kv(/*n_layers=*/4, nkv, hd, QType::F16, /*max_blocks=*/32, /*block_size=*/16,
+                   /*alloc=*/nullptr, is_swa, swa_blocks, /*ceiling=*/256);
+        EXPECT_EQ(kv.try_grow_to(200), 200);
+        return kv.committed_bytes();
+    };
+    const size_t all_full = grown_bytes({}, 0);
+    const size_t half_windowed = grown_bytes({1, 0, 1, 0}, 24);
+    ASSERT_GT(all_full, 0u);
+    EXPECT_LT(half_windowed, all_full);
+
+    // Blocks in both kinds of layer are backed after the growth.
+    const std::vector<char> is_swa = {1, 0, 1, 0};
+    KVCache kv(/*n_layers=*/4, nkv, hd, QType::F16, /*max_blocks=*/32, /*block_size=*/16,
+               /*alloc=*/nullptr, is_swa, /*swa_max_blocks=*/24, /*ceiling=*/256);
+    ASSERT_EQ(kv.try_grow_to(200), 200);
+    write_pattern(kv.k_ptr(1, 199), kv.block_bytes(), 0x5E);
+    write_pattern(kv.k_ptr(0, 23), kv.block_bytes(), 0x2D);
+    ASSERT_FALSE(::testing::Test::HasFatalFailure());
+    EXPECT_EQ(count_mismatches(kv.k_ptr(1, 199), kv.block_bytes(), 0x5E), 0u);
+    EXPECT_EQ(count_mismatches(kv.k_ptr(0, 23), kv.block_bytes(), 0x2D), 0u);
+}
+
+}  // namespace


### PR DESCRIPTION
Growing the pool commits `blocks` worth of memory in every layer, including a sliding-window layer whose own region is smaller. That looked wrong, so #1452 capped it per layer.

**Measuring it says the cap changes nothing.** 64.00 MiB committed with every layer full against 34.00 MiB with half of them windowed — the same two numbers with the cap and without it. The difference comes from the **layout**, because a windowed layer is given a smaller region in the first place, and not from the cap.

The over-commit is bounded and harmless: the bytes past a windowed layer belong to the next layer's range inside the same reservation and are wanted anyway, and the tail is clamped to the reservation. So the cap was eight lines that looked load-bearing and were not, which is the shape this change set has spent the day removing elsewhere.

The test stays, reframed to assert the property that is real (a windowed pool is cheaper to grow) rather than the guard that is not.

## How this was found, which is the part worth keeping

The first mutation run reported **survived**, i.e. "the test does not cover this". The second, with an assertion that the mutation had actually been applied, showed the first edit had never landed — the pattern did not match and `str.replace` said nothing. Then the real mutation showed the numbers do not move, i.e. the code under test does nothing.

**A mutation run that does not verify its own edit proves nothing**, in either direction: it can call a good test worthless, and it can call dead code load-bearing.

## Also in here

- `KVCache::committed_bytes()`: what the pool actually costs right now, as opposed to the address space it reserved. Needed to measure the above, and the honest number for a growable pool.
- The zeroing invariant is written next to the memset that keeps it: a future shrink has to lower `committed_blocks_` when it decommits, or a recommitted range would come back with whatever the driver hands over and skip the zeroing. Ordinary reuse of a committed block does **not** re-zero, which is the fixed pool's behaviour too.
