### PR TITLE
spec: replay the accepted prefix through the captured graph, not eagerly

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -66,6 +66,43 @@ These have a code path and no gate. They may work; nothing proves it.
   head drafts well (43.9 % top-1 accept) and still costs 32 % of decode, because
   the draft path runs outside CUDA graphs while the main decode does not. It is
   opt-in and self-disables after 8 verifies.
+- **Speculation is off for most real requests, by two rules that are easy to
+  miss.** It requires greedy sampling (`temperature: 0` or `top_k: 1`), so any
+  request with a temperature gets none; and a think budget disables it inside
+  the think block, which on a reasoning model is most of the answer. The server
+  sets `think_budget` to 0.5 by default, so on such a model speculation never
+  runs out of the box. Penalties are **not** a blocker at the default
+  `repeat_last_n: 0`: the verify replicates them for the unbounded window.
+  Other engines have neither rule, because rejection sampling makes a verify
+  distribution-preserving at any temperature and none of them force `</think>`.
+- **Speculative decoding does not reproduce the non-speculative greedy output on
+  a GDN hybrid.** Its contract is that it changes speed and not tokens; here it
+  changes tokens. Measured on Qwen3.8-27B-NVFP4 with
+  `runtime.deterministic_gemm=true` on both arms and a stable control (two
+  no-MTP processes, byte-identical): with `mtp_k=2`, two of three prompts
+  diverge from the no-MTP answer, the first at character 79 of 1026 — an early
+  token flip, not a rounding tail. Both answers are coherent and correct, but
+  they are different generations. The verify advances the recurrent state
+  through the chunk kernels while plain decode advances it through the
+  single-token path, and the two do not agree bit for bit. Predates the
+  2026-08-17 verify work: the same two prompts diverge with the older eager
+  replay.
+- **MTP loses on a GDN hybrid, and the guard is right to disable it.** Measured
+  on Qwen3.8-27B-NVFP4, greedy, 256 tokens, thinking off, economics guard
+  disabled so it runs throughout: 65.5 tok/s at `mtp_k=2` against **83.7
+  without MTP**, at 62.8 % draft acceptance and 2.26 emitted per verify. A
+  verify costs ~34.6 ms against an 11.8 ms decode step, because a partially
+  accepted draft restores the recurrent state slab and re-forwards the accepted
+  prefix — at that acceptance rate, most verifies. `mtp_k=4` is worse (55.4).
+  Enabling MTP at all costs ~17 % even when the drafter never fires.
+
+```
+[PROV: commit=a82dec8f date=2026-08-17 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 runs of 256 greedy tokens
+       cmd=`--set speculative.mtp_k=0|2|4 --set speculative.mtp_econ_min_emit=0
+       --set runtime.max_seq_len=8192`, request `temperature 0, think_budget 0`;
+       rates and acceptance from /metrics deltas, card idle at ~0.9 GiB]
+```
 - **`imp-cli --prompt` prints only about 10 tokens.** Byte-level comparisons have
   to go through the server's JSON.
 - **Prefill graph capture is disabled per model** when one NVFP4 weight exceeds

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -876,6 +876,19 @@ struct Diagnostics {
     bool log_gemm_algo = false;
     // MTP pattern logging (predicted, actual, match per step).
     bool mtp_pattern_log = false;
+    // Stage 0 tree-ceiling probe: ask the MTP head for its top-4 candidates on
+    // every chain step and tally, per depth, whether the true next token was
+    // within top-w. imp-cli prints the table at the end of a run.
+    //
+    // Off by default because it is not free, and it was not free in the serving
+    // path either: measured on Qwen3.8-27B, the top-4 kernel is a single
+    // <<<1,256>>> block scanning a 248 320-entry vocabulary once per width,
+    // 713 us per drafted token — twice the cost of the lm_head GEMV that
+    // produced the logits, and 12 % of all GPU time in an MTP run. Asking for
+    // it also forces a per-draft cudaStreamSynchronize, which is the very
+    // thing the device-side chain exists to avoid. Nothing in serving reads
+    // the result.
+    bool mtp_tree_probe = false;
     // MTP: pass main model's post-RMSNorm hidden to draft head (vLLM
     // variant).
     bool mtp_prenorm_h = false;

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -296,6 +296,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("diagnostics.spec_capture_probe", cfg.diagnostics.spec_capture_probe);
     B("diagnostics.log_gemm_algo", cfg.diagnostics.log_gemm_algo);
     B("diagnostics.mtp_pattern_log", cfg.diagnostics.mtp_pattern_log);
+    B("diagnostics.mtp_tree_probe", cfg.diagnostics.mtp_tree_probe);
     B("diagnostics.mtp_prenorm_h", cfg.diagnostics.mtp_prenorm_h);
     B("diagnostics.audit_nvfp4_scales", cfg.diagnostics.audit_nvfp4_scales);
     B("diagnostics.vram_audit", cfg.diagnostics.vram_audit);

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -2174,23 +2174,76 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             const void* chain_h_prev = h_for_mtp;
             std::vector<int32_t> chain_preds;
             chain_preds.reserve(K);
-            for (int k = 0; k < K; ++k) {
-                int prediction = -1;
-                int topk[Engine::kMtpMeasureW] = {-1, -1, -1, -1};
-                if (!mtp_draft_one(chain_prev_tok, chain_h_prev, hidden_dim, vocab_size,
-                                    &prediction, topk, Engine::kMtpMeasureW)) {
-                    break;
+            // The top-w probe is opt-in: it costs a single-block scan of the
+            // whole vocabulary per width plus a host sync, per drafted token,
+            // and only imp-cli's tree-ceiling table reads it.
+            const bool want_probe = runtime_config_.diagnostics.mtp_tree_probe;
+            // Device-side chain, the same one mtp_feed_pairs_ uses: each step's
+            // argmax lands in ws->d_chain_tokens[k] and feeds step k+1's
+            // embedding lookup on device, so ONE drain replaces K host
+            // round-trips. Without it every drafted token ends in a
+            // cudaStreamSynchronize and the GPU idles while the host issues the
+            // next step — measured on Qwen3.8-27B, ~6 ms of the 6.85 ms per
+            // drafted token was that dead time rather than kernel work.
+            //
+            // The probe needs its top-w on the host per step, so it keeps the
+            // round-trip path; it is a measurement mode, not a serving one.
+            const bool device_chain = !want_probe && ws->d_chain_tokens != nullptr && ws->n_experts == 0 &&
+                                      K <= imp::kMtpMaxChainK;
+            if (device_chain) {
+                int launched = 0;
+                for (int k = 0; k < K; ++k) {
+                    const bool first = (k == 0);
+                    if (!mtp_draft_one(first ? chain_prev_tok : -1, first ? chain_h_prev : ws->d_h_final,
+                                       hidden_dim, vocab_size, nullptr, nullptr, 0,
+                                       first ? nullptr : ws->d_chain_tokens + k - 1,
+                                       ws->d_chain_tokens + k)) {
+                        break;
+                    }
+                    launched++;
                 }
-                MtpChainEntry entry{prediction, k, cur_pos + 1 + k, {}};
-                for (int w = 0; w < Engine::kMtpMeasureW; ++w) entry.topk[w] = topk[w];
-                mtp_pending_chain_.push_back(entry);
-                chain_preds.push_back(prediction);
-                // For k=0 only, also feed pending_prediction_ (legacy 1-step
-                // accuracy counter remains in sync with chain_accept_[0]).
-                if (k == 0) mtp_pending_prediction_ = prediction;
-                // Chain: next iter uses this prediction + the MTP's own h_final.
-                chain_prev_tok = prediction;
-                chain_h_prev   = ws->d_h_final;
+                int32_t h_chain[imp::kMtpMaxChainK];
+                if (launched > 0 && cudaMemcpyAsync(h_chain, ws->d_chain_tokens,
+                                                    static_cast<size_t>(launched) * sizeof(int32_t),
+                                                    cudaMemcpyDeviceToHost, decode_stream()) == cudaSuccess) {
+                    cudaStreamSynchronize(decode_stream());
+                    for (int k = 0; k < launched; ++k) {
+                        const int prediction = h_chain[k];
+                        if (prediction < 0 || prediction >= vocab_size)
+                            break;  // NaN-logits guard — keep the valid prefix
+                        // topk stays unset: -1 is the "not a candidate"
+                        // sentinel the width tally compares against, and a
+                        // zero-filled array would count token id 0 as a hit.
+                        MtpChainEntry entry{prediction, k, cur_pos + 1 + k, {}};
+                        for (int w = 0; w < Engine::kMtpMeasureW; ++w)
+                            entry.topk[w] = -1;
+                        mtp_pending_chain_.push_back(entry);
+                        chain_preds.push_back(prediction);
+                        if (k == 0)
+                            mtp_pending_prediction_ = prediction;
+                    }
+                }
+            } else {
+                for (int k = 0; k < K; ++k) {
+                    int prediction = -1;
+                    int topk[Engine::kMtpMeasureW] = {-1, -1, -1, -1};
+                    if (!mtp_draft_one(chain_prev_tok, chain_h_prev, hidden_dim, vocab_size, &prediction,
+                                       want_probe ? topk : nullptr, want_probe ? Engine::kMtpMeasureW : 0)) {
+                        break;
+                    }
+                    MtpChainEntry entry{prediction, k, cur_pos + 1 + k, {}};
+                    for (int w = 0; w < Engine::kMtpMeasureW; ++w)
+                        entry.topk[w] = topk[w];
+                    mtp_pending_chain_.push_back(entry);
+                    chain_preds.push_back(prediction);
+                    // For k=0 only, also feed pending_prediction_ (legacy 1-step
+                    // accuracy counter remains in sync with chain_accept_[0]).
+                    if (k == 0)
+                        mtp_pending_prediction_ = prediction;
+                    // Chain: next iter uses this prediction + the MTP's own h_final.
+                    chain_prev_tok = prediction;
+                    chain_h_prev = ws->d_h_final;
+                }
             }
             // Roll back the speculative cache writes from K-1 chained steps.
             // The first chained step (k=0) IS the real "next step" prediction

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -1030,15 +1030,35 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         const int replay_ctx = p0 + 1 + matched;
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_spec_context_len_, &replay_ctx, sizeof(int),
                                            cudaMemcpyHostToDevice, stream));
-        state.n_tokens = matched + 1;
         state.max_context_len = replay_ctx;
-        // The replay is an unpadded eager forward of the accepted prefix —
-        // run it on the plain host-length chunk path, not the capture path.
-        state.ctx_capacity = 0;
-        state.d_past_len = nullptr;
-        state.d_chunk_len = nullptr;
         Tensor replay_logits;
-        executor_->forward_logits(state, replay_logits, stream);
+        bool replayed = false;
+        if (capture_on && !spec_capture_doomed_) {
+            // Reuse the captured chunk graph rather than forwarding eagerly.
+            // The graph reads its chunk length from device memory and the GDN
+            // scan commits h_state at that row, so the same recording serves a
+            // shorter prefix: keep the padded row count, tell the device the
+            // real one. Eager here cost 25.1 ms for one or two rows against
+            // 17.8 ms for the captured three-row chunk, measured over 300
+            // verifies on Qwen3.8-27B — the difference is launch pacing, not
+            // work.
+            const int real_rows = matched + 1;
+            if (check(cudaMemcpyAsync(d_spec_chunk_len_, &real_rows, sizeof(int), cudaMemcpyHostToDevice,
+                                      stream),
+                      "replay chunk len H2D")) {
+                state.n_tokens = chunk_pad;
+                replayed = spec_captured_forward_(state, replay_logits, stream);
+            }
+        }
+        if (!replayed) {
+            state.n_tokens = matched + 1;
+            // Fallback: an unpadded eager forward of the accepted prefix on the
+            // plain host-length chunk path.
+            state.ctx_capacity = 0;
+            state.d_past_len = nullptr;
+            state.d_chunk_len = nullptr;
+            executor_->forward_logits(state, replay_logits, stream);
+        }
     }
 
     spec_stats_.verify_steps++;

--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -14,6 +14,8 @@ Categories (select with --only / --skip):
   special-tokens   raw template/control markers in content
   adherence        prompt-blindness + gross hallucination (exact-answer tasks)
   long-context     needle echo at ~2-3k tokens (catches RoPE/echo bugs)
+  kv-growth        same greedy answer before and after the KV pool grows
+                   (skips unless kv_cache.growable left room to grow)
   multi-turn       state carry across turns, turn-2 garble
   stream           stream/non-stream consistency, SSE termination
 
@@ -556,6 +558,66 @@ class Suite:
                     needle in r["content"],
                     f"content={r['content'][:140]!r}")
 
+    # -- KV pool growth ------------------------------------------------------
+    def cat_kv_growth(self):
+        """The same greedy prompt before and after the KV pool grows.
+
+        A growable pool (kv_cache.growable) commits memory while the server is
+        serving. Nothing about that is visible to a client except through the
+        answers, and a pool that grew badly does not error: it returns text
+        that is subtly wrong, which every downstream instrument scores as the
+        MODEL being wrong. Byte-identity of a greedy answer across a growth
+        event is the only check at this layer.
+
+        Skips unless the pool can actually still grow, which /health reports as
+        kv_ceiling_blocks > kv_blocks_total.
+        """
+        try:
+            with urllib.request.urlopen(self.srv.url + "/health", timeout=30) as h:
+                health = json.loads(h.read())
+        except Exception as e:                      # noqa: BLE001
+            self.skip("kv-growth", "same answer across a growth event", f"/health: {e}")
+            return
+        blocks = health.get("kv_blocks_total", -1)
+        ceiling = health.get("kv_ceiling_blocks", -1)
+        if blocks < 0 or ceiling <= blocks:
+            self.skip("kv-growth", "same answer across a growth event",
+                      f"pool is fixed ({blocks} blocks, ceiling {ceiling})")
+            return
+
+        probe = "List the first eight prime numbers, separated by commas, nothing else."
+        n = 1000 if self.is_reasoning else 60
+        before = self.srv.chat([{"role": "user", "content": probe}], max_tokens=n)["content"]
+
+        # Outgrow the pool: one token per ~4 characters, so ask for more
+        # characters than the pool currently holds tokens.
+        unit = ("The paged attention mechanism stores keys and values in fixed-size "
+                "blocks so that sequences of different lengths share one pool. ")
+        # 1.5x the pool, not 1.0x: at parity the prompt lands inside the pool
+        # and nothing grows, and the check then passes without ever having
+        # established the state it is about to assert over.
+        need_chars = int(blocks * health.get("kv_block_size", 16) * 4.5 * 1.5)
+        big = unit * (need_chars // len(unit) + 1) + "\n\nAnswer in one word: fine?"
+        try:
+            self.srv.chat([{"role": "user", "content": big}], max_tokens=16)
+        except urllib.error.HTTPError as e:
+            self.skip("kv-growth", "same answer across a growth event",
+                      f"server rejected the growth prompt: {e}")
+            return
+
+        with urllib.request.urlopen(self.srv.url + "/health", timeout=30) as h:
+            grown = json.loads(h.read()).get("kv_blocks_total", blocks)
+        if grown <= blocks:
+            # Refuse to report a verdict on a growth that did not happen. A pass
+            # here would be a statement about two ordinary requests.
+            self.skip("kv-growth", "same answer across a growth event",
+                      f"pool did not grow ({blocks} -> {grown} blocks); prompt was too small")
+            return
+        after = self.srv.chat([{"role": "user", "content": probe}], max_tokens=n)["content"]
+        self.record("kv-growth", f"greedy answer identical across growth ({blocks} -> {grown} blocks)",
+                    after == before and bool(before.strip()),
+                    f"before={before[:60]!r} after={after[:60]!r}")
+
     # -- multi-turn state ----------------------------------------------------
     def cat_multi_turn(self):
         n = 1000 if self.is_reasoning else 100
@@ -865,6 +927,7 @@ CATEGORIES = {
     "special-tokens": Suite.cat_special_tokens,
     "adherence": Suite.cat_adherence,
     "long-context": Suite.cat_long_context,
+    "kv-growth": Suite.cat_kv_growth,
     "multi-turn": Suite.cat_multi_turn,
     "stream": Suite.cat_stream,
     "constrained": Suite.cat_constrained,


### PR DESCRIPTION
Three changes to the MTP path, prompted by a report that a 16 GB card gets +85 % from MTP-2 on Qwen3.8-27B while imp measured a loss on a 5090.

## The verify was paying for an eager forward it did not need

On a hybrid, a partially accepted draft restores the recurrent state slab and re-forwards the accepted prefix. That re-forward was pinned to the eager path — and it cost **more than the chunk it was repairing**. Measured over 300 verifies:

| phase | before | after |
|---|---:|---:|
| chunk forward (captured, 3 rows) | 17.8 ms | 17.8 ms |
| **replay (1-2 rows)** | **25.1 ms** | **17.2 ms** |
| tail (argmax + D2H + rollback) | 16.4 ms | 10.7 ms |
| **decode, k=2** | **64.3 tok/s** | **84.4 tok/s** |

Nothing required it to be eager. The captured graph reads its chunk length from device memory and the GDN scan commits `h_state` at that row, which is exactly what a shorter prefix needs: keep the padded row count, write the real one to `d_spec_chunk_len_`, replay the same recording. The eager forward stays as the fallback.

**+31 %**, which takes MTP on this model from costing 22 % to costing nothing (83.7 tok/s without MTP). Not yet a win: the remaining replay fires in ~37 % of verifies and the chunk itself is 17.8 ms against an 11.8 ms decode step.

## A research probe was running in the serving path

Every drafted token asked the MTP head for its top-4 candidates: a `<<<1, 256>>>` kernel scanning a 248 320-entry vocabulary once per width, **713 us per drafted token**, 12 % of all GPU time in an MTP run, twice the cost of the lm_head GEMV that produced the logits. The engine's own argmax over the same vocabulary costs 7.5 us. Only imp-cli's tree-ceiling table reads the result. Now `diagnostics.mtp_tree_probe`, default off.

Asking for it also forced a `cudaStreamSynchronize` per drafted token, bypassing the device-side chain that exists to avoid exactly that. The serving path uses the device chain now.

## What this did NOT fix, measured and documented

- **Speculation does not reproduce the non-speculative greedy output on this model.** Two of three prompts diverge, the first at character 79 of 1026, with `deterministic_gemm=true` on both arms and a **stable control** (two no-MTP processes, byte-identical). It predates this work: the same two prompts diverge with the eager replay. In `LIMITATIONS.md`.
- **MTP still loses at the default guard**, and the guard is right: 2.26 emitted per verify against a 4.0 break-even. I suspected the constant was stale because the verify is graph-captured; measuring refuted that.
- Enabling MTP at all costs ~17 % even when the drafter never fires.
- On a reasoning model with server defaults, speculation never runs at all: `think_budget` defaults to 0.5 and disables it inside the think block. Other engines have no such rule, and none require greedy — vLLM's spec-decode subsystem mentions neither "think" nor "reason", and its rejection sampling is distribution-preserving at any temperature.

## Verification

- Stage-1 GPU suite green, `make dev-test` green.
- Output coherence checked on three prompts across the change.
- No perf-baseline movement expected: MTP is off by default (`speculative.mtp_k = 0`).
