### PR TITLE
limitations: the same request can differ on its second pass through one process

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -75,6 +75,17 @@ These have a code path and no gate. They may work; nothing proves it.
   `repeat_last_n: 0`: the verify replicates them for the unbounded window.
   Other engines have neither rule, because rejection sampling makes a verify
   distribution-preserving at any temperature and none of them force `</think>`.
+- **The same request can produce different output on its second pass through
+  one process.** Two things speculation keeps across requests carry it: the
+  n-gram drafter's corpus, and the MTP head's own KV cache, which resumes over
+  the longest common prefix of the previous history. Draft acceptance therefore
+  depends on what the process has served before, and accepted drafts change
+  which tokens are emitted. Observed here as three prompts run twice in one
+  server, where the first differed on the second pass while two fresh processes
+  running the same three prompts in the same order were byte-identical.
+  A peer's conformance tier had been carrying this as an unexplained sporadic
+  divergence. Not a defect on its own, but a golden-output test has to pin
+  `speculative.ngram` and `speculative.mtp_k`, or it is testing the history too.
 - **Speculative decoding does not reproduce the non-speculative greedy output on
   a GDN hybrid.** Its contract is that it changes speed and not tokens; here it
   changes tokens. Measured on Qwen3.8-27B-NVFP4 with


### PR DESCRIPTION
Speculation keeps two things across requests: the n-gram drafter's corpus, and the MTP head's KV cache, which resumes over the longest common prefix of the previous history. Draft acceptance therefore depends on what the process has served before, and accepted drafts change which tokens come out.

**Observed:** three prompts run twice in one server — the first differed on the second pass, while two fresh processes running the same three prompts in the same order were byte-identical.

A peer's conformance tier had been carrying exactly this shape as an unexplained sporadic divergence (identical requests, different outcomes, no state visible from outside), and had already ruled out the prefix cache and load. The experiment that settles it is `deterministic_gemm=true` in both arms with `speculative.ngram` as the only difference; it has not been run yet, so this entry describes the carriers and the observation, not a proven mechanism.

Why it is worth an entry rather than a note: a golden-output test has to pin `speculative.ngram` and `speculative.mtp_k` or it is testing the history too, and an agent loop that re-sends its conversation every turn meets a warm MTP state on every turn but the first — the common path, not an edge case.

Docs only.