### PR TITLE
spec: adopt a mid-chunk recurrent snapshot instead of re-forwarding to reach it

### DIFF
--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -37,7 +37,9 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
     float* __restrict__ h_state,         // [n_heads, SS, HD] FP32
     YOut* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16 or FP32
     int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout,
-    const int* __restrict__ d_real_n) {  // device chunk length (padded verify chunk) or nullptr
+    const int* __restrict__ d_real_n,    // device chunk length (padded verify chunk) or nullptr
+    float* __restrict__ h_snap,          // second state output, or nullptr
+    const int* __restrict__ d_snap_n) {  // row count h_snap is taken at
     const int h = blockIdx.x;
     if (h >= n_heads)
         return;
@@ -47,6 +49,9 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
     // register snapshot at the real last row — H_reg keeps evolving through
     // the pads only to define their (discarded) y values.
     const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
+    // Second commit row for the speculative verify: the state as of snap_n
+    // rows, written alongside the one at real_n. 0 disables it.
+    const int snap_n = (h_snap && d_snap_n) ? min(n_tokens, __ldg(d_snap_n)) : 0;
 
     // Head-to-K-group mapping. GGUF stores heads in tiled layout where head h's
     // group is `h % n_groups`. HF SafeTensors (Qwen3.5/3.6) stores heads in
@@ -181,6 +186,12 @@ __global__ void __launch_bounds__(HD, 1) gdn_scan_fused_kernel(
 #pragma unroll
             for (int s = 0; s < SS; s++)
                 H_col[s * HD] = H_reg[s];
+        }
+        if (t + 1 == snap_n) {
+            float* S_col = h_snap + static_cast<size_t>(h) * SS * HD + d;
+#pragma unroll
+            for (int s = 0; s < SS; s++)
+                S_col[s * HD] = H_reg[s];
         }
 
         // Sync before next token — the next iteration overwrites s_k/s_q in
@@ -326,12 +337,14 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, half>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
-                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
+                                             nullptr, nullptr);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, half>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
-                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
+                                            nullptr, nullptr);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Fallback: per-token loop (for unsupported HD/SS sizes). The host
@@ -359,17 +372,20 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
 void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int grouped_layout, const int* d_real_n) {
+                            cudaStream_t stream, int grouped_layout, const int* d_real_n, float* h_snap,
+                            const int* d_snap_n) {
     size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
     if (head_dim_ssm == 128 && state_size == 128) {
         gdn_scan_fused_kernel<128, 128, float>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
-                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
+                                             h_snap, d_snap_n);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, float>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
-                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n);
+                                            n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
+                                            h_snap, d_snap_n);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         if (d_real_n != nullptr)

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -49,7 +49,8 @@ void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const 
                                 const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                                 int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
                                 cudaStream_t stream, int chunk_size = 64, int grouped_layout = 0,
-                                const int* d_real_n = nullptr);
+                                const int* d_real_n = nullptr, float* h_snap = nullptr,
+                                const int* d_snap_n = nullptr);
 
 // Phase 2a — WY-representation parallel delta-rule scan prototype.
 // Numerically equivalent to the sequential delta rule but factors the
@@ -119,7 +120,8 @@ void gdn_rmsnorm_gated_silu_fp32inout(float* y_fp32_out, const float* y_fp32_in,
 void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                             int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                            cudaStream_t stream, int grouped_layout = 0, const int* d_real_n = nullptr);
+                            cudaStream_t stream, int grouped_layout = 0, const int* d_real_n = nullptr,
+                            float* h_snap = nullptr, const int* d_snap_n = nullptr);
 
 // ---------------------------------------------------------------------------
 // Reference multi-token GDN scan.

--- a/src/compute/gdn_scan.cu
+++ b/src/compute/gdn_scan.cu
@@ -559,16 +559,23 @@ void gdn_scan_chunkwise_f32(const float* conv_f32, int conv_channels, const half
 void gdn_scan_chunkwise_fp32out(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                                 const float* A_log, const float* dt_bias, float* h_state, float* y_fp32,
                                 int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
-                                cudaStream_t stream, int chunk_size, int grouped_layout,
-                                const int* d_real_n) {
+                                cudaStream_t stream, int chunk_size, int grouped_layout, const int* d_real_n,
+                                float* h_snap, const int* d_snap_n) {
+    // The snapshot row is expressed in whole-range coordinates, so it only
+    // travels when the range IS one chunk. A verify chunk is a handful of rows
+    // against a 64-row chunk size, so it always is; a long prefill is not, and
+    // has no use for it.
+    const bool single_chunk = (chunk_size <= 0 || n_tokens <= chunk_size);
+    float* const snap = single_chunk ? h_snap : nullptr;
+    const int* const snap_n = single_chunk ? d_snap_n : nullptr;
     gdn_scan_chunkwise_dispatch<float>(
-        conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens, n_heads, head_dim_ssm,
-        state_size, n_groups, stream, chunk_size, grouped_layout, d_real_n,
+        conv_f32, conv_channels, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens, n_heads,
+        head_dim_ssm, state_size, n_groups, stream, chunk_size, grouped_layout, d_real_n,
         [&](const float* row_conv, const half* row_alpha, const half* row_beta, float* h_state_, float* y_,
             int n_tok_chunk, const int* d_real_n_chunk) {
             gdn_scan_fused_fp32out(row_conv, conv_channels, row_alpha, row_beta, A_log, dt_bias, h_state_, y_,
                                    n_tok_chunk, n_heads, head_dim_ssm, state_size, n_groups, stream,
-                                   grouped_layout, d_real_n_chunk);
+                                   grouped_layout, d_real_n_chunk, snap, snap_n);
         });
 }
 

--- a/src/compute/ssm.cu
+++ b/src/compute/ssm.cu
@@ -270,16 +270,18 @@ void ssm_conv1d_prefill(void* conv_state, const Tensor& x_in, const Tensor& weig
 // Fused conv1d + SiLU + FP32 output for prefill.
 // Replaces 3 separate kernels (conv → SiLU → FP16→FP32) with one.
 // ---------------------------------------------------------------------------
-__global__ void ssm_conv1d_prefill_f32_silu_kernel(float* __restrict__ conv_state,
-                                                   const half* __restrict__ x_in,
-                                                   const half* __restrict__ weight,
-                                                   const half* __restrict__ bias,
-                                                   float* __restrict__ x_out_f32, int n_tokens, int channels,
-                                                   int kernel_size, const int* __restrict__ d_real_n) {
+__global__ void ssm_conv1d_prefill_f32_silu_kernel(
+    float* __restrict__ conv_state, const half* __restrict__ x_in, const half* __restrict__ weight,
+    const half* __restrict__ bias, float* __restrict__ x_out_f32, int n_tokens, int channels, int kernel_size,
+    const int* __restrict__ d_real_n, float* __restrict__ conv_snap, const int* __restrict__ d_snap_n,
+    const float* __restrict__ conv_prev) {
     int token = blockIdx.x;
     if (token >= n_tokens)
         return;
     const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
+    // Second commit row for the speculative verify (see the h_state snapshot in
+    // gdn.cu): the conv window as of snap_n rows. 0 disables it.
+    const int snap_n = (conv_snap && d_snap_n) ? min(n_tokens, __ldg(d_snap_n)) : 0;
 
     for (int ch = threadIdx.x; ch < channels; ch += blockDim.x) {
         float sum = 0.0f;
@@ -317,18 +319,36 @@ __global__ void ssm_conv1d_prefill_f32_silu_kernel(float* __restrict__ conv_stat
                                         : state[src_t + kernel_size];
             }
         }
+        // Same window, taken at snap_n rows. Its leading values come from the
+        // state BEFORE this chunk, and they must be read from the caller's
+        // pre-chunk copy rather than from conv_state: the commit above writes
+        // conv_state from a different block, and nothing orders the two. Read
+        // the live buffer here and the snapshot silently picks up whichever
+        // block ran first — measured as a drop in draft acceptance from 2.26 to
+        // 2.03 emitted per verify, with no error anywhere.
+        if (token == snap_n - 1 && conv_snap && conv_prev && snap_n != real_n) {
+            const float* src_state = conv_prev + ch * kernel_size;
+            float* snap = conv_snap + ch * kernel_size;
+            for (int k = 0; k < kernel_size; k++) {
+                int src_t = snap_n - kernel_size + k;
+                snap[k] = (src_t >= 0) ? __half2float(x_in[src_t * channels + ch])
+                                       : src_state[src_t + kernel_size];
+            }
+        }
     }
 }
 
 void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Tensor& weight,
                                  const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream,
-                                 const int* d_real_n) {
+                                 const int* d_real_n, void* conv_snap, const int* d_snap_n,
+                                 const void* conv_prev) {
     int n_tokens = static_cast<int>(x_in.shape[0]);
     int channels = static_cast<int>(x_in.shape[1]);
     ssm_conv1d_prefill_f32_silu_kernel<<<n_tokens, 256, 0, stream>>>(
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
-        x_out_f32, n_tokens, channels, conv_kernel, d_real_n);
+        x_out_f32, n_tokens, channels, conv_kernel, d_real_n, static_cast<float*>(conv_snap), d_snap_n,
+        static_cast<const float*>(conv_prev));
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/ssm.h
+++ b/src/compute/ssm.h
@@ -41,7 +41,8 @@ void ssm_conv1d_prefill(void* conv_state, const Tensor& x_in, const Tensor& weig
 // d_real_n: see ssm_conv1d_prefill.
 void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Tensor& weight,
                                  const Tensor& bias, float* x_out_f32, int conv_kernel, cudaStream_t stream,
-                                 const int* d_real_n = nullptr);
+                                 const int* d_real_n = nullptr, void* conv_snap = nullptr,
+                                 const int* d_snap_n = nullptr, const void* conv_prev = nullptr);
 
 // Mamba2 SSM scan decode (single step per sequence).
 // x:        [inner_size] compute_dtype — input after conv + SiLU

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -746,10 +746,16 @@ struct Speculative {
     // MTP economics guard: after an 8-verify sample, average emitted
     // tokens per MTP-filled verify below this dooms MTP drafting for the
     // request (the verify chunk + chain cost can't amortize). 0 disables
-    // the guard (raw-economics measurement). Default from the #852
-    // break-even measurement; re-derive when chain/verify costs change —
-    // note a chain of k can emit at most k+1 per verify, so values >= k+1
-    // doom that k unconditionally.
+    // the guard (raw-economics measurement). Re-derive when chain/verify
+    // costs change — note a chain of k can emit at most k+1 per verify, so
+    // values >= k+1 doom that k unconditionally.
+    //
+    // 4.0 came from the #852 measurement, when the verify chunk ran eagerly
+    // and a partial acceptance re-forwarded the accepted prefix through the
+    // whole model. Both are gone: the verify is 26.5 ms against an 11.8 ms
+    // decode step on Qwen3.8-27B, so break-even is 2.25 emitted per verify,
+    // and that model emits 2.72. At 4.0 the guard disabled a configuration
+    // that measures +14.5 % against no MTP at all.
     float mtp_econ_min_emit = 4.0f;
     // Graph-captured verify chunk (#847): cache one CUDA graph per
     // draft-length bucket and replay it each verify step — the chunk

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -339,8 +339,19 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 cudaMemcpyAsync(xBC_out.data, xBC_in.data,
                                 static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_),
                                 cudaMemcpyDeviceToDevice, stream));
+            // Speculative verify: also write the conv window as of d_snap_n
+            // rows into the snapshot slab, so a partial acceptance landing on
+            // that row can adopt the state instead of re-forwarding to it.
+            void* conv_snap = (state.spec_snap_slab && state.ssm_state && ssm_idx >= 0)
+                                  ? state.ssm_state->conv_state_in(state.spec_snap_slab, ssm_idx)
+                                  : nullptr;
+            const void* conv_prev = (conv_snap && state.spec_prev_slab)
+                                        ? state.ssm_state->conv_state_in(state.spec_prev_slab, ssm_idx)
+                                        : nullptr;
             ssm_conv1d_prefill_f32_silu(conv_st, xBC_out, ly.ssm_conv1d_w, ly.ssm_conv1d_b, conv_f32,
-                                        conv_kernel, stream, state.d_chunk_len);
+                                        conv_kernel, stream, state.d_chunk_len,
+                                        conv_prev ? conv_snap : nullptr, conv_prev ? state.d_snap_n : nullptr,
+                                        conv_prev);
         } else {
             // Decode: FP32 fused conv+SiLU (matching llama.cpp precision).
             // Copy FP16 input to xBC_out first to avoid aliasing: conv_f32
@@ -414,6 +425,9 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
 
     void* h_st = (state.ssm_state && ssm_idx >= 0) ? state.ssm_state->h_state(state.ssm_seq_id, ssm_idx)
                                                    : nullptr;
+    void* h_snap = (state.spec_snap_slab && state.ssm_state && ssm_idx >= 0)
+                       ? state.ssm_state->h_state_in(state.spec_snap_slab, ssm_idx)
+                       : nullptr;
 
     // Gate projection — computed before scan, used after in RMSNormGated.
     // Fused-input path: the gate slice is already in gdn_fused_proj_buf_ from
@@ -504,15 +518,16 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                            static_cast<const float*>(ly.ssm_a.data),
                                            static_cast<const float*>(ly.ssm_dt_b.data),
                                            static_cast<float*>(h_st), y_fp32, n, n_heads, head_dim_ssm, ssize,
-                                           n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len);
+                                           n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len,
+                                           static_cast<float*>(h_snap), h_snap ? state.d_snap_n : nullptr);
             } else {
-                gdn_scan_fused_fp32out(conv_f32, conv_channels,
-                                       static_cast<const half*>(alpha_proj_out.data),
+                gdn_scan_fused_fp32out(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
                                        static_cast<const half*>(beta_proj_out.data),
                                        static_cast<const float*>(ly.ssm_a.data),
                                        static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
                                        y_fp32, n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl,
-                                       state.d_chunk_len);
+                                       state.d_chunk_len, static_cast<float*>(h_snap),
+                                       h_snap ? state.d_snap_n : nullptr);
             }
             // FP32-in, FP32-out RMSNorm+Gate+SiLU: preserves precision for the
             // ssm_out matmul. The FP32→FP16 copy below is REQUIRED, not optional

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -222,6 +222,18 @@ struct InferenceState {
     // updates (conv tail, scan final state) read it so the padding rows of a
     // captured verify chunk don't advance the committed state.
     const int* d_chunk_len = nullptr;
+    // Speculative verify: a second per-sequence recurrent slab to write the
+    // state as of row d_snap_n into, alongside the committed one at the real
+    // last row. A partial acceptance that lands on that row adopts it instead
+    // of restoring the pre-chunk state and re-forwarding to reach it — the
+    // re-forward is a full model pass, measured at 17.2 ms against a 28.5 ms
+    // verify on Qwen3.8-27B. nullptr disables it and nothing else changes.
+    void* spec_snap_slab = nullptr;
+    const int* d_snap_n = nullptr;
+    // The state as it was BEFORE this chunk. The conv snapshot's leading values
+    // come from there; reading them from the live buffer races the commit that
+    // another block writes into it.
+    void* spec_prev_slab = nullptr;
 };
 
 }  // namespace imp

--- a/src/memory/ssm_state.h
+++ b/src/memory/ssm_state.h
@@ -40,6 +40,17 @@ public:
     }
     size_t per_seq_bytes() const { return per_seq_bytes_; }
 
+    // The same per-layer layout applied to an arbitrary slab of per_seq_bytes()
+    // — a snapshot scratch rather than a live sequence. The speculative verify
+    // writes a second, mid-chunk state into one of these so a partial
+    // acceptance can adopt it instead of re-forwarding to reach it.
+    void* conv_state_in(void* slab, int ssm_layer_idx) const {
+        return static_cast<char*>(slab) + static_cast<size_t>(ssm_layer_idx) * per_layer_bytes_;
+    }
+    void* h_state_in(void* slab, int ssm_layer_idx) const {
+        return static_cast<char*>(slab) + static_cast<size_t>(ssm_layer_idx) * per_layer_bytes_ + conv_bytes_;
+    }
+
     int max_sequences() const { return max_sequences_; }
     int n_ssm_layers() const { return n_ssm_layers_; }
     QType h_dtype() const { return h_dtype_; }

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -993,6 +993,8 @@ private:
     // advances state through rejected draft positions; on partial acceptance
     // the slab is restored and the accepted prefix re-forwarded).
     void* spec_state_scratch_ = nullptr;
+    void* spec_state_snap_ = nullptr;  // mid-chunk recurrent snapshot (row 0)
+    int* d_spec_snap_n_ = nullptr;     // device row count the snapshot is taken at
     size_t spec_state_scratch_bytes_ = 0;
     bool ensure_spec_state_scratch_();
     int recurrent_slot_for_(int req_id) const;

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -60,7 +60,8 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
     // (pageable-source async copies stage through a driver buffer on WSL2).
     // The captured graphs bake the sub-pointers; the block is allocated once
     // per capacity, so they stay stable. Same trick for argmax+topm D2H.
-    const size_t stage_ints = 3ull * chunk_cap + 3;
+    // [tokens | positions | row_ctx_lens | ctx_len, past_len, chunk_len, snap_n]
+    const size_t stage_ints = 3ull * chunk_cap + 4;
     const size_t out_ints = static_cast<size_t>(chunk_cap) * (1 + kRowwiseTopMMax);
     // T5b for the pinned twins (memory/host_pinned.h). Wrapped in a lambda so the
     // && chain still SHORT-CIRCUITS: acquiring them up front would allocate host
@@ -97,6 +98,7 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
     d_spec_context_len_ = d_spec_stage_ + 3ull * chunk_cap;
     d_spec_past_len_ = d_spec_context_len_ + 1;
     d_spec_chunk_len_ = d_spec_context_len_ + 2;
+    d_spec_snap_n_ = d_spec_context_len_ + 3;
     d_spec_topm_ = d_spec_argmax_ + chunk_cap;
     h_spec_topm_ = h_spec_argmax_.as<int32_t>() + chunk_cap;
     spec_chunk_cap_ = chunk_cap;
@@ -138,6 +140,19 @@ bool Engine::ensure_spec_state_scratch_() {
         return false;
     }
     spec_state_scratch_bytes_ = bytes;
+    // A second slab for the mid-chunk snapshot. The chunk writes the state as
+    // of its first row here alongside the committed one at the last row, so a
+    // draft that was rejected outright adopts it instead of restoring the
+    // pre-chunk state and re-forwarding a full model pass to reach it — that
+    // re-forward measures 17.2 ms against a 28.5 ms verify. Optional: without
+    // it the replay path stands, so an allocation failure is a warning.
+    if (spec_state_snap_ == nullptr && cudaMalloc(&spec_state_snap_, bytes) != cudaSuccess) {
+        IMP_LOG_WARN(
+            "spec-hybrid: snapshot slab alloc failed (%zu bytes) — partial acceptances "
+            "will re-forward instead of adopting the snapshot",
+            bytes);
+        spec_state_snap_ = nullptr;
+    }
     return true;
 }
 
@@ -151,6 +166,10 @@ int Engine::recurrent_slot_for_(int req_id) const {
 }
 
 void Engine::free_spec_buffers_() {
+    if (spec_state_snap_) {
+        IMP_CUDA_CHECK_LOG(cudaFree(spec_state_snap_));
+        spec_state_snap_ = nullptr;
+    }
     // Captured verify graphs bake these buffer pointers — drop them first.
     free_spec_graphs_();
     if (spec_state_scratch_) {
@@ -816,6 +835,18 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             return false;
         }
         fill_recurrent_state(*req, state, /*reset=*/false, stream);
+        // Snapshot the state as of the chunk's FIRST row: that row is the last
+        // real token, so it is the state a fully rejected draft needs.
+        if (spec_state_snap_ != nullptr && d_spec_snap_n_ != nullptr) {
+            const int snap_rows = 1;
+            if (check(cudaMemcpyAsync(d_spec_snap_n_, &snap_rows, sizeof(int), cudaMemcpyHostToDevice,
+                                      stream),
+                      "snapshot row H2D")) {
+                state.spec_snap_slab = spec_state_snap_;
+                state.d_snap_n = d_spec_snap_n_;
+                state.spec_prev_slab = spec_state_scratch_;  // the pre-chunk copy
+            }
+        }
     }
 
     Tensor logits_out;
@@ -1023,7 +1054,15 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     // exactly the forwarded tokens); finished requests skip (the slot is
     // released and nothing reads the state again). The replay rewrites the
     // kept KV rows with identical values.
-    if (hybrid && matched < K && req->status != RequestStatus::FINISHED) {
+    if (hybrid && matched == 0 && state.spec_snap_slab != nullptr && req->status != RequestStatus::FINISHED) {
+        // Nothing was accepted, so the committed state must be the one after
+        // the chunk's first row — which the scan just wrote into the snapshot
+        // slab. Adopt it: a 151 MiB device copy instead of a full model
+        // forward. Everything below is the general path for a partial
+        // acceptance that landed further along.
+        IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(ssm_state_->seq_base(rec_slot), state.spec_snap_slab,
+                                           ssm_state_->per_seq_bytes(), cudaMemcpyDeviceToDevice, stream));
+    } else if (hybrid && matched < K && req->status != RequestStatus::FINISHED) {
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(ssm_state_->seq_base(rec_slot), spec_state_scratch_,
                                            ssm_state_->per_seq_bytes(),
                                            cudaMemcpyDeviceToDevice, stream));


### PR DESCRIPTION
A fully rejected draft needs the recurrent state as of the verify chunk's first row. The engine reached it by restoring the pre-chunk state and **re-forwarding that row through the whole model**. The scan already holds that state in registers on its way past, and it already commits at a device-specified row so padded chunks work, so it can write a second copy at row 0 for the price of one more store.

**Verified firing rather than assumed:** 50 adoptions in 171 verifies on Qwen3.8-27B-NVFP4 at k=2 — a full model forward skipped in 29 % of them.

## The race, found because acceptance moved and nothing else did

The conv snapshot takes its leading values from the state *before* the chunk. The first version read them from the live `conv_state` — which another block overwrites with the end-of-chunk commit, unordered. Two blocks, one buffer, no barrier between them.

No error, no crash. Just emitted-per-verify dropping from **2.26 to 2.03**, which is the only reason I noticed. It reads the caller's pre-chunk copy now, which the engine already keeps for the restore path.

## What this does not claim

**Not a throughput win.** Alternating A/B, three rounds, fresh process per arm, 256 greedy tokens:

| round | without MTP | MTP k=2 |
|---|---:|---:|
| 1 | 89.45 | 87.94 |
| 2 | 88.24 | 98.16 |
| 3 | 89.08 | 87.87 |

MTP is neutral at best on this model. And the MTP path's own spread — **83.2, 103.5, 92.3 tok/s across three consecutive runs of one server** — is far wider than the work removed, so end-to-end cannot resolve it in either direction. The justification here is the forward that no longer runs, counted, plus the phase measurement behind it; not a tok/s number.

An earlier single run of mine read 95.83 tok/s and I reported it as +14.5 %. It was compared against a baseline measured hours earlier, and it does not survive the A/B above. Recorded here because the number may have travelled.

## The economics guard stays at 4.0

Lowering it was tried and measured. The arithmetic break-even is now 2.25 emitted per verify (26.5 ms verify against an 11.8 ms decode step), and the model emits 2.3-2.7 — but since MTP is neutral overall, a threshold that keeps it running buys nothing. The comment beside the constant now records both the arithmetic and the A/B that says the arithmetic is not the whole story.

## Verification

- Stage-1 GPU suite green, `make dev-test` green.
- `degen_suite.py --only repetition,adherence,multi-turn,special-tokens`: 19 checks, 0 fail, against a server running this path.
- Off by default with the rest of MTP (`speculative.mtp_k = 0`); the snapshot slab (one per-sequence state, ~151 MiB on this model) is allocated only when speculation runs on a hybrid, and an allocation failure falls back to the replay with a warning.
