### PR TITLE
limitations: scope the history-dependence entry to the greedy path

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -86,6 +86,15 @@ These have a code path and no gate. They may work; nothing proves it.
   A peer's conformance tier had been carrying this as an unexplained sporadic
   divergence. Not a defect on its own, but a golden-output test has to pin
   `speculative.ngram` and `speculative.mtp_k`, or it is testing the history too.
+
+  **Only on the greedy path.** Speculation requires `temperature: 0` or
+  `top_k: 1`, so a sampled request never drafts and none of this reaches it —
+  measured as `imp_spec_drafted_total` not moving at all on a
+  `temperature: 0.8` request with the drafter enabled. A sampled request that
+  diverges between identical runs is a different mechanism: without
+  `runtime.deterministic_gemm` the forward is not bit-reproducible, and at a
+  temperature a last-bit difference in the logits moves the sampled token
+  whenever the top candidates are close.
 - **Speculative decoding does not reproduce the non-speculative greedy output on
   a GDN hybrid.** Its contract is that it changes speed and not tokens; here it
   changes tokens. Measured on Qwen3.8-27B-NVFP4 with


### PR DESCRIPTION
#1457 said the same request can differ on its second pass through one process, and named speculation's carried-over state as the carrier. That is true **and only for greedy requests**: speculation requires `temperature: 0` or `top_k: 1`, so a sampled request never drafts and none of it reaches that path.

Measured by a peer while testing the entry: `imp_spec_drafted_total` did not move at all on a `temperature: 0.8` request with the drafter enabled. Their sporadic-divergence finding lives on the sampled path, so speculation cannot be its carrier — the hypothesis I helped them write died to a counter-measurement rather than a shrug.

Without the scope the entry invites the wrong diagnosis for the more common case. A sampled request that differs between identical runs is the forward not being bit-reproducible without `runtime.deterministic_gemm`: a last-bit logit difference moves the sampled token whenever the top candidates are close, which is exactly the shape of "sporadic, and much more often on some prompts than others".

Docs only.