### PR TITLE
limitations: hybrid prefix caching makes a request depend on the server's history

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -95,6 +95,35 @@ These have a code path and no gate. They may work; nothing proves it.
   `runtime.deterministic_gemm` the forward is not bit-reproducible, and at a
   temperature a last-bit difference in the logits moves the sampled token
   whenever the top candidates are close.
+- **On a recurrent model, a sampled request can differ depending on what the
+  server answered before it, and hybrid prefix caching is the carrier.** A GDN
+  model's recurrent state is cumulative, so reusing KV blocks alone cannot skip
+  prefill; imp therefore saves the recurrent state at block boundaries in a
+  `RecurrentSnapshotStore` and restores it on a prefix hit, in which case the
+  state slab is overwritten from the snapshot instead of being reset
+  (`src/runtime/engine_sampling_stop.cpp:297`). The lookup keys on the KV prefix
+  hash, so it only fires on genuinely identical tokens, but **every chat request
+  begins with the same chat-template header**, so the first block matches across
+  unrelated prompts. The restored state is then the one another prompt's prefill
+  produced under different chunk boundaries, which is not what recomputing would
+  give on a forward that is not bit-reproducible.
+
+  Measured on Qwen3.8-27B-NVFP4, temperature 0.8, fixed seed, sequential
+  requests, keyed on `reasoning_content` plus `content`: 12 identical requests
+  give one distinct answer in a fresh process, and one distinct answer even with
+  prefix caching on, but **three distinct answers when 12 requests of an
+  unrelated prompt precede them in the same process**. Setting
+  `server.recurrent_snapshot_mb=0` returns it to 1 of 12, twice, against 3 of 12
+  three times at the 256 MiB default.
+
+  This is a mode to select, not a defect: the tokens really do match, so the
+  reused state is legitimate for that prefix, and disabling the store also
+  disables hybrid prefix caching. It is the recurrent path paying the
+  reproducibility price prefix caching charges everywhere. Consequence for
+  callers: a harness that pins a seed to make two runs comparable does not get
+  that guarantee from the seed alone if both runs share a long-lived server with
+  other traffic between them. Pin `server.recurrent_snapshot_mb=0`, or use a
+  fresh process per arm.
 - **Speculative decoding does not reproduce the non-speculative greedy output on
   a GDN hybrid.** Its contract is that it changes speed and not tokens; here it
   changes tokens. Measured on Qwen3.8-27B-NVFP4 with

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -116,6 +116,16 @@ These have a code path and no gate. They may work; nothing proves it.
   `server.recurrent_snapshot_mb=0` returns it to 1 of 12, twice, against 3 of 12
   three times at the 256 MiB default.
 
+  **Characterised with `speculative.ngram=false`.** Every divergent cell above
+  had speculation disabled; the same 12-then-12 structure with speculation at
+  its default was stable across 24 requests. That is a weak negative against a
+  3-in-12 effect, so it does not establish that the default is immune, only
+  that the effect has not been observed there. It matters because the flag does
+  not merely switch n-gram drafting: it also selects the burst bound of the
+  on-device decode loop (`speculative.miss_burst` against
+  `runtime.decode_burst`), so the two settings are different decode
+  configurations even on a sampled request that never drafts.
+
   This is a mode to select, not a defect: the tokens really do match, so the
   reused state is legitimate for that prefix, and disabling the store also
   disables hybrid prefix caching. It is the recurrent path paying the


### PR DESCRIPTION
Documents a reproducibility carrier that neither our reproducibility checks
nor a peer session's eval harness could see, because every check either of us
had written starts a fresh process and asks one prompt repeatedly.

## What happens

A GDN model's recurrent state is cumulative, so reusing KV blocks alone cannot
skip prefill. imp saves the recurrent state at block boundaries in a
`RecurrentSnapshotStore` and restores it on a prefix hit; in that branch the
state slab is overwritten from the snapshot rather than reset
(`src/runtime/engine_sampling_stop.cpp:297`).

The lookup keys on the KV prefix hash, so it only fires on genuinely identical
tokens. That looks safe until you notice **every chat request begins with the
same chat-template header**, so the first block matches across completely
unrelated prompts. The restored state is then the one another prompt's prefill
produced, under different chunk boundaries, which on a forward that is not
bit-reproducible is not what recomputing would give.

## Measured

Qwen3.8-27B-NVFP4, temperature 0.8, fixed seed, strictly sequential, keyed on
`reasoning_content` plus `content`, no empty answers:

| preceding traffic in the same process | distinct answers |
|---|---|
| none, fresh process, prefix cache off | 1/12 |
| none, fresh process, prefix cache on | 1/12 (twice) |
| 12 requests of an unrelated prompt | **3/12** (three times) |
| same, `server.recurrent_snapshot_mb=0` | 1/12 (twice) |

## Why this is documentation and not a fix

The tokens really do match, so the reused state is legitimate state for that
prefix, and disabling the store also disables hybrid prefix caching. This is the
recurrent path paying the reproducibility price that prefix caching charges
everywhere. What was missing is that nobody had written it down, and the
consequence is not hypothetical: a harness that pins a seed so two runs are
comparable does not get that from the seed alone when both runs share a
long-lived server with other traffic between them.

Found jointly with a peer session, which reproduced it three times and confirmed
the negative arm twice on a card verified quiet.

Docs only, no code change, so no perf gate.