### PR TITLE
spec: split the drafter gate from the n-gram flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mrope_config.cpp
         tests/test_image_placeholders.cpp
         tests/test_ngram_draft.cpp
+        tests/test_spec_gates.cpp
         tests/test_suffix_draft.cpp
         tests/test_token_recycle_draft.cpp
         tests/test_routing_decision.cpp

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -570,7 +570,13 @@ struct Generation {
 };
 
 struct Speculative {
-    bool ngram = true;  // prompt-lookup speculation, default-on (batch-1, greedy, dense)
+    // Prompt-lookup speculation, default-on (batch-1, greedy, dense). This
+    // switches the HISTORY MATCHER only. It used to switch the whole verify
+    // step, which meant setting it false silently disabled MTP and token
+    // recycling too, with no diagnostic: mtp_k=2 drafted zero tokens. Entering
+    // the verify is now decided by spec_any_drafter (runtime/spec_gates.h),
+    // which asks all three sources.
+    bool ngram = true;
     // Context cap for DENSE chunk-verify drafting (#964). With the
     // verify_decode_attn route below (2026-07-12), dense n-gram WINS up
     // to at least 12k context on the captured-verify (server) path:
@@ -735,6 +741,9 @@ struct Speculative {
     // drafts fill verify steps where the suffix/ngram matcher has no
     // match (draft-poor prose — 78-94% depth-1 accept on Qwen3.6-35B-A3B,
     // PR #804). imp-cli equivalent: --mtp-spec-decode <k>.
+    // Independent of `ngram` above: with ngram=false and mtp_k=2 the head
+    // drafts and the matcher does not (measured 100 drafts over 50 verifies
+    // on Qwen3.8-27B, against 0 before the gate split).
     int mtp_k = 0;
     // Serve the MTP chain's full-vocab logits GEMV from the NVFP4 LM-head
     // decode cache when one exists (#847 lever 3). The chain re-reads the

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -309,7 +309,7 @@ struct RuntimeConfig {
     // decode. The verify loop runs eager (no async conditional graph loop);
     // burst_rearm + miss_burst keep draft-miss fragmentation ~free, so the old
     // tg128 -15% draft-poor downside no longer reproduces (-0.2%/-0.9% on
-    // dense Q8/NVFP4, 2026-06-16) — hence default-ON. spec_ngram_gates_ok_
+    // dense Q8/NVFP4, 2026-06-16) — hence default-ON. spec_verify_gates_ok_
     // confines engagement to batch-1 / greedy / no-penalty-window / no-json /
     // no-logprobs / non-recurrent requests (MoE additionally requires
     // native-NVFP4 experts, see `moe` below); everything else falls back

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -375,7 +375,7 @@ void Engine::finish_request_release_(std::shared_ptr<Request>& req) {
         constraints_return_(std::move(req->constraints));
     // Server visibility: the engine outlives requests, so cumulative
     // speculation telemetry is logged per request end (no-op when idle).
-    if (spec_ngram_enabled_(*req))
+    if (spec_any_drafter_enabled_(*req))
         log_spec_stats_();
 }
 

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -3,6 +3,7 @@
 #include "model/model.h"
 #include "model/chat_template.h"
 #include "runtime/scheduler.h"
+#include "runtime/spec_gates.h"
 #include "runtime/request.h"
 #include "runtime/batch.h"
 #include "runtime/green_ctx.h"
@@ -917,15 +918,39 @@ private:
         // says yes (engine_scheduler.cpp), so a model whose gates always fail
         // paid the chopping for drafts that could not happen — and the burst
         // boundaries, not the drafts, are what made greedy output depend on
-        // request history (#1299). The comment in spec_ngram_gates_ok_ already
+        // request history (#1299). The comment in spec_verify_gates_ok_ already
         // says GGUF-MoE "stays on the async conditional-graph loop"; this is
         // what makes that true.
-        if (!spec_ngram_model_capable_())
-            return false;
-        return req.spec_ngram_override >= 0 ? req.spec_ngram_override == 1
-                                            : runtime_config_.speculative.ngram;
+        return spec_ngram_source(spec_drafter_state_(req));
     }
-    // The model-level half of spec_ngram_gates_ok_: facts that cannot change
+    // Does ANY drafter exist for this request? The verify step is shared: the
+    // n-gram/suffix matcher, the trained MTP head and token recycling all feed
+    // the same chunk, and which one filled it is decided inside
+    // step_spec_verify_. So the decision to ENTER that step belongs to this
+    // predicate, not to any single source.
+    //
+    // Asking spec_ngram_enabled_ here instead is what made
+    // `speculative.ngram=false` silently disable MTP as well: mtp_k=2 drafted
+    // nothing at all, because the step that consumes its chain was never
+    // reached. One flag switched off a different feature, with no diagnostic.
+    // Keep the two questions apart: "is the n-gram source on" and "can anyone
+    // draft".
+    bool spec_any_drafter_enabled_(const Request& req) const {
+        return spec_any_drafter(spec_drafter_state_(req));
+    }
+    // The configuration half, split out so the rule itself lives in
+    // spec_gates.h as a pure function and CI can test its truth table without
+    // a GPU. The engine supplies the state; it does not own the rule.
+    SpecDrafterState spec_drafter_state_(const Request& req) const {
+        SpecDrafterState s;
+        s.model_capable = spec_ngram_model_capable_();
+        s.ngram_on = req.spec_ngram_override >= 0 ? req.spec_ngram_override == 1
+                                                  : runtime_config_.speculative.ngram;
+        s.mtp_on = mtp_spec_decode_enabled();
+        s.recycling_on = runtime_config_.speculative.token_recycling;
+        return s;
+    }
+    // The model-level half of spec_verify_gates_ok_: facts that cannot change
     // between requests or between steps — so it is computed once and cached.
     // spec_ngram_enabled_ sits on the per-step decode path; recomputing this
     // there (it reaches into supports_chunked_prefill_) would put avoidable
@@ -938,7 +963,7 @@ private:
     // determinism cases going from 0 failing back to 7.
     bool spec_ngram_model_capable_uncached_() const;
     bool spec_ngram_model_capable_flag_ = false;
-    bool spec_ngram_gates_ok_(const Request& req, bool ignore_think = false) const;
+    bool spec_verify_gates_ok_(const Request& req, bool ignore_think = false) const;
     bool spec_burst_launch_ok_(const Request& req) const;
     int spec_effective_miss_burst_(const Request& req) const;
     void spec_maybe_rearm_(Request& req) const;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1321,13 +1321,15 @@ void Engine::step_decode(cudaStream_t dec_stream) {
         return;
     }
 
-    // n-gram (prompt-lookup) speculation: when a draft is available, the
-    // verify step replaces this decode step entirely (it allocates its own
-    // KV blocks and emits accepted tokens). Falls through to the normal
-    // path on a draft miss or when any gate fails.
-    if (decode_batch.size() == 1 && spec_ngram_enabled_(*decode_batch[0])) {
+    // Speculation: when a draft is available, the verify step replaces this
+    // decode step entirely (it allocates its own KV blocks and emits accepted
+    // tokens). Falls through to the normal path on a draft miss or when any
+    // gate fails. The draft may come from the n-gram/suffix matcher, the MTP
+    // head or token recycling, so the entry gate asks whether ANY drafter is
+    // enabled — gating this on the n-gram flag alone left MTP unreachable.
+    if (decode_batch.size() == 1 && spec_any_drafter_enabled_(*decode_batch[0])) {
         spec_maybe_rearm_(*decode_batch[0]);
-        if (spec_ngram_gates_ok_(*decode_batch[0])) {
+        if (spec_verify_gates_ok_(*decode_batch[0])) {
             if (step_spec_verify_(decode_batch[0], dec_stream))
                 return;
         } else if (decode_batch[0]->spec_ngram_given_up &&
@@ -1341,7 +1343,7 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             if (try_launch_async_graph_loop(sreq, sreq->output_tokens.back(), dec_stream, lim))
                 return;
         } else if (decode_batch[0]->think_budget > 0.0f && decode_batch[0]->in_think_block &&
-                   spec_ngram_gates_ok_(*decode_batch[0], /*ignore_think=*/true) &&
+                   spec_verify_gates_ok_(*decode_batch[0], /*ignore_think=*/true) &&
                    spec_burst_launch_ok_(*decode_batch[0]) &&
                    // Budget exhausted → the EAGER step must run: it forces
                    // the </think> token. Launching the loop here instead
@@ -1405,7 +1407,7 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             if (!spec_ngram_enabled_(*r))
                 continue;
             spec_maybe_rearm_(*r);
-            if (!spec_ngram_gates_ok_(*r))
+            if (!spec_verify_gates_ok_(*r))
                 continue;
             const int id = r->id;
             if (id > spec_rr_last_id_ && id < best_id) {

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -15,7 +15,7 @@
 // draft blocks were appended this step and are never content-hashed (prefix
 // hashing only covers prompt prefill blocks).
 //
-// Phase 1 scope (gated in spec_ngram_gates_ok_): batch-1, greedy sampling,
+// Phase 1 scope (gated in spec_verify_gates_ok_): batch-1, greedy sampling,
 // no penalties / logit_bias / DRY / mirostat, no logprobs, no json/schema
 // constraints, no think budget, chunked-prefill-capable archs only. The
 // verify loop runs eager — the async conditional graph loop stays off while
@@ -272,7 +272,7 @@ bool Engine::spec_burst_launch_ok_(const Request& req) const {
     return true;
 }
 
-bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
+bool Engine::spec_verify_gates_ok_(const Request& req, bool ignore_think) const {
     if (req.spec_ngram_given_up) return false;
     // Greedy sampling only: verify compares argmax tokens.
     const bool greedy = (req.temperature <= 0.0f || req.top_k == 1);
@@ -328,7 +328,7 @@ bool Engine::spec_ngram_gates_ok_(const Request& req, bool ignore_think) const {
     return true;
 }
 
-// Model-level gates, split out of spec_ngram_gates_ok_ so spec_ngram_enabled_
+// Model-level gates, split out of spec_verify_gates_ok_ so spec_ngram_enabled_
 // can ask the same question without the per-request checks. Nothing here
 // depends on a request, so a false answer means "this model never speculates,
 // whatever the flag says".
@@ -403,7 +403,16 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     const int k = std::max(1, scfg.k);
     int draft_start = -1;
     std::vector<int32_t> draft;
-    if (scfg.suffix) {
+    // The history matcher is the n-gram source, so it answers to the n-gram
+    // flag alone. The step itself is entered whenever ANY drafter is enabled
+    // (spec_any_drafter_enabled_), which is what lets MTP and token recycling
+    // reach the verify with `speculative.ngram=false` — but they must not drag
+    // the matcher in with them, or turning n-gram off would stop meaning
+    // anything.
+    const bool ngram_source_on = spec_ngram_enabled_(*req);
+    if (!ngram_source_on) {
+        // fall through to the MTP / recycling sources below
+    } else if (scfg.suffix) {
         // Suffix index: input ++ prediction indexed at first use, output
         // tokens appended incrementally (every emit path lands in
         // output_tokens, so loop-burst tokens are picked up here too).

--- a/src/runtime/spec_gates.h
+++ b/src/runtime/spec_gates.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Which speculation sources are live, as a pure function of configuration.
+//
+// The verify step is shared: the n-gram/suffix matcher, the trained MTP head
+// and token recycling all fill the same draft chunk, and which one filled it
+// is decided inside step_spec_verify_. Entering that step is therefore a
+// question about ALL of them, while running the matcher is a question about
+// one. Conflating the two is how `speculative.ngram=false` came to disable
+// MTP outright: mtp_k=2 drafted nothing, because the step that consumes its
+// chain was never reached, and nothing in the logs said so.
+//
+// Kept here as a free function so the truth table is testable without a GPU
+// or a live Engine. The engine holds the state; this file holds the rule.
+
+namespace imp {
+
+struct SpecDrafterState {
+    bool ngram_on = false;      // speculative.ngram, after the per-request override
+    bool mtp_on = false;        // speculative.mtp_k > 0
+    bool recycling_on = false;  // speculative.token_recycling
+    // Model-level facts that no flag can overrule (recurrent state without
+    // speculative.hybrid, GGUF-MoE, no chunked prefill). False here means this
+    // model never speculates, whatever is switched on.
+    bool model_capable = false;
+};
+
+// Is any drafter able to feed the verify step for this request?
+constexpr bool spec_any_drafter(const SpecDrafterState& s) {
+    return s.model_capable && (s.ngram_on || s.mtp_on || s.recycling_on);
+}
+
+// Is the history matcher itself live? Narrower than spec_any_drafter on
+// purpose: with n-gram off but MTP on, the step runs and the matcher does not.
+constexpr bool spec_ngram_source(const SpecDrafterState& s) {
+    return s.model_capable && s.ngram_on;
+}
+
+}  // namespace imp

--- a/tests/test_spec_gates.cpp
+++ b/tests/test_spec_gates.cpp
@@ -1,0 +1,80 @@
+// Truth table for which speculation sources are live.
+//
+// Regression: `speculative.ngram=false` used to disable MTP outright, because
+// the entry gate to the shared verify step asked the n-gram question. With
+// mtp_k=2 the head drafted nothing at all and nothing in the logs said so; two
+// nsys profiles taken with the flag set came back with identical kernel
+// instance counts to the unit, which is what finally exposed it.
+//
+// These are CPU tests on purpose: the rule was previously an inline method on
+// Engine, so no CI lane could reach it, and CI has no GPU.
+
+#include "runtime/spec_gates.h"
+
+#include <gtest/gtest.h>
+
+using imp::spec_any_drafter;
+using imp::spec_ngram_source;
+using imp::SpecDrafterState;
+
+namespace {
+
+SpecDrafterState state(bool ngram, bool mtp, bool recycling, bool capable = true) {
+    SpecDrafterState s;
+    s.ngram_on = ngram;
+    s.mtp_on = mtp;
+    s.recycling_on = recycling;
+    s.model_capable = capable;
+    return s;
+}
+
+// The regression itself: MTP must reach the verify step with n-gram off.
+TEST(SpecGates, MtpDraftsWithNgramOff) {
+    EXPECT_TRUE(spec_any_drafter(state(false, true, false)));
+}
+
+// ...and the n-gram flag must still mean something while it does.
+TEST(SpecGates, NgramSourceStaysOffWhenOnlyMtpIsOn) {
+    EXPECT_FALSE(spec_ngram_source(state(false, true, false)));
+}
+
+TEST(SpecGates, TokenRecyclingAloneEntersTheVerify) {
+    EXPECT_TRUE(spec_any_drafter(state(false, false, true)));
+    EXPECT_FALSE(spec_ngram_source(state(false, false, true)));
+}
+
+TEST(SpecGates, NgramAloneIsUnaffected) {
+    EXPECT_TRUE(spec_any_drafter(state(true, false, false)));
+    EXPECT_TRUE(spec_ngram_source(state(true, false, false)));
+}
+
+// The reverse control: with nothing enabled the step must not be entered, or
+// "any drafter" would be true for everyone and the predicate would say nothing.
+TEST(SpecGates, NothingEnabledDraftsNothing) {
+    EXPECT_FALSE(spec_any_drafter(state(false, false, false)));
+    EXPECT_FALSE(spec_ngram_source(state(false, false, false)));
+}
+
+// Model capability overrules every flag: a model that cannot speculate must
+// not look enabled to anyone, or the decode loop chops itself into bursts for
+// drafts that can never happen (#1299).
+TEST(SpecGates, IncapableModelOverridesEveryFlag) {
+    for (int bits = 0; bits < 8; ++bits) {
+        const SpecDrafterState s =
+            state(bits & 1, bits & 2, bits & 4, /*capable=*/false);
+        EXPECT_FALSE(spec_any_drafter(s)) << "bits=" << bits;
+        EXPECT_FALSE(spec_ngram_source(s)) << "bits=" << bits;
+    }
+}
+
+// spec_ngram_source must never be true where spec_any_drafter is false: the
+// matcher runs strictly inside the step it is allowed to enter.
+TEST(SpecGates, NgramSourceImpliesTheVerifyIsEntered) {
+    for (int bits = 0; bits < 16; ++bits) {
+        const SpecDrafterState s = state(bits & 1, bits & 2, bits & 4, bits & 8);
+        if (spec_ngram_source(s))
+            EXPECT_TRUE(spec_any_drafter(s)) << "bits=" << bits;
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
`speculative.ngram=false` disabled MTP and token recycling as well, silently.
With the flag off, `mtp_k=2` drafted exactly zero tokens: the head was loaded,
its VRAM was spent, its metrics stayed at zero, and nothing in the logs said
why.

## How it was found

Two nsys profiles taken with `mtp_k=0` and `mtp_k=2`, everything else equal,
came back with identical kernel instance counts to the unit (522368 in both
arms, per-kernel times agreeing to 0.1 %). That is not MTP drafting less, it is
MTP never running. The flag was in the command line because it was meant to
isolate the arms.

## The cause

The entry gate to the shared verify step asked whether n-gram drafting was
enabled. But the verify is where *every* drafter's chunk is consumed: the
n-gram/suffix matcher, the trained MTP head and token recycling all fill the
same rows, and which one filled them is decided inside `step_spec_verify_`. So
one source's flag decided whether any source could run.

The function guarding it was called `spec_ngram_gates_ok_` while checking
nothing n-gram-specific at all: penalties, constrained decode, think budget,
context cap, model capability. The name is what made two different questions
look like one, and it read that way from outside the repo too.

## The change

**`src/runtime/spec_gates.h`** holds the rule as a pure function:

- `spec_any_drafter` answers whether anyone can draft, and decides entry into
  the verify.
- `spec_ngram_source` answers whether the matcher is live, and decides only
  whether the history matcher runs.

The matcher inside `step_spec_verify_` now checks the narrow one, so entering
the verify through MTP does not drag the matcher in and turning n-gram off
still means something. `spec_ngram_gates_ok_` is renamed
`spec_verify_gates_ok_`.

The rule moving out of `Engine` is the part that matters beyond this bug. As an
inline method it needed a live engine and a GPU, so no CI lane could reach it,
which is why a flag could disable a different feature for as long as it did. As
a free function it has a truth-table test in the CPU lane.

## Measured

Qwen3.8-27B-NVFP4, one 192-token greedy request per cell, `/metrics` deltas:

| config | drafted | verifies |
|---|---:|---:|
| `ngram=false mtp_k=2` | **100** | 50 |
| `ngram=false mtp_k=0` | 0 | 0 |
| `ngram=true mtp_k=2` | 176 | 88 |

The first row was 0 before this change. The second is the reverse control:
without it, "drafts moved" would not distinguish a working gate from a counter
that always moves.

A fourth cell, `ngram=true mtp_k=0`, drafts nothing on this prompt. That is the
matcher correctly finding no repeat in fresh prose, not a regression; my
harness had the wrong expectation for it, and a cell that means anything there
needs a repetitive prompt.

## Verification

- `tests/test_spec_gates.cpp`, 7 cases, CPU lane.
- **Mutation-validated**: restoring the old rule fails exactly
  `MtpDraftsWithNgramOff` and `TokenRecyclingAloneEntersTheVerify`, and no
  others. A green test on this file is otherwise not evidence, since the whole
  defect was a rule nothing could execute.
- `make verify-fast` green: decode and prefill within threshold, peak VRAM
  +0.01 %, graphs 2.47x, degeneration smoke clean.
- Full GPU suite green via the pre-commit hook.

## Consequence for earlier measurements

Any A/B that varied `speculative.ngram` to isolate speculation was varying
three drafters and the decode burst bound at once. Results taken that way
before this commit do not isolate what they appear to.
