### PR TITLE
roadmap: withdraw #1465's per-token claim, record the four-arm table

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -146,6 +146,84 @@ These have a code path and no gate. They may work; nothing proves it.
   single-token path, and the two do not agree bit for bit. Predates the
   2026-08-17 verify work: the same two prompts diverge with the older eager
   replay.
+- **The MTP head accepts 75.0 % of its first draft, and six explanations for
+  the gap to published figures are dead.** Measured on Qwen3.8-27B-NVFP4 over a
+  10-prompt mixed corpus (exposition, code, arithmetic, enumeration), n-gram
+  disabled so the head is the only drafter, `mtp_k=1` so acceptance *is*
+  first-position acceptance, two rounds with a fresh process each:
+  **74.8 % and 75.2 %** (σ 1.2, >1200 drafts per cell), 84.7 and 85.8 tok/s
+  against ~88 without speculation. At `mtp_k=2` the aggregate is 58.0-64.1 %.
+
+```
+[PROV: commit=37cd1543 date=2026-08-17 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=10 prompts x 256 greedy tokens
+       per arm, 2 rounds, fresh process per arm, alternating
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=1|2
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       request `temperature 0, think_budget 0`; acceptance from /metrics
+       deltas (imp_spec_accepted_total / imp_spec_drafted_total), card idle]
+```
+
+  Ruled out as causes of the gap, each by measurement, so they do not need
+  running again:
+
+  1. **Draft lm_head precision.** `speculative.mtp_nvfp4_head` true vs false:
+     55.9/55.5 % against 51.6/56.6 %, fully overlapping. The NVFP4 head is ~8 %
+     faster and costs no acceptance, so the default is right.
+  2. **Quantised head weights.** The MTP tensors carry no scale companions in
+     the checkpoint: they are BF16.
+  3. **A missing `gamma = 1 + W` offset.** All seven MTP norms upload through
+     the offset-applying path (`up_norm` in `weight_upload.cu`).
+  4. **The hidden-state convention.** `diagnostics.mtp_prenorm_h` moves nothing
+     (62.8 % against 62.8 %), which follows from `pre_fc_norm_hidden`
+     normalising its input anyway.
+  5. **A RoPE defect.** Disabling rotation looked like a +7.6-point win on one
+     prompt set and reverses across prompt lengths: 72.7/55.6 at 112 tokens,
+     66.5/68.3 at 607, 77.7/67.9 at 2767 (on/off). Rotation is fine.
+  6. **An uninitialised MTP KV cache.** Zeroing it left the per-process spread
+     intact (12.6 points before, 10.1 after) and moved first-position
+     acceptance 73.2 → 75.0, which two samples per condition cannot separate
+     from noise.
+
+  **Two measurement errors of ours are in that list and are the reusable part.**
+  (a) Findings 5 and 6 both survived a first pass because a run was *repeated*
+  rather than *varied*: greedy decoding makes a run deterministic, so two
+  identical runs agreeing to the tenth of a point is a statement about
+  determinism, not about the effect. Vary the workload, not the repetition.
+  (b) The per-process spread in (6) was read as a defect signal when the
+  processes had generated **different text** — imp's forward is not
+  reproducible across processes, and acceptance depends on what was generated.
+  Spread across processes is only a defect signal once the output is identical.
+
+  **The 87 % reference is not yet comparable.** It is a published figure for
+  this architecture class from another engine, and the chain depth, batch size
+  and acceptance definition (per-token or per-chain) behind it are unpinned.
+  Pin the regime before treating the 12-point gap as a target.
+
+```
+[PROV: commit=37cd1543 date=2026-08-17 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=10 prompts x 256 greedy tokens
+       per arm, 2 rounds, fresh process per arm, alternating
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=1|2
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       request `temperature 0, think_budget 0`; acceptance from /metrics
+       deltas (imp_spec_accepted_total / imp_spec_drafted_total), card idle]
+```
+- **DISPUTED (2026-08-18): the entry below states a conclusion about the
+  technique that its evidence does not support.** Comparable engines report an
+  MTP k=2 *win* on comparable hardware for this class of model. If that holds,
+  then "MTP loses on a GDN hybrid" is wrong as written and the true statement is
+  "imp's MTP path loses", which makes the economics guard a workaround for a
+  defect rather than a correct refusal. The measurements below stand as
+  measurements; the heading and the last sentence do not. The deciding evidence
+  is a reference engine measured on this box, which is not yet done. Until then
+  do not cite this entry as a property of MTP or of GDN hybrids.
+
+  The suspect cost, from the same tables: verify time grows **5.23 ms per extra
+  draft token** (46 % of a full decode step) on a fit through widths 2/3/5/7,
+  with a **15.4 ms intercept** against an 11.36 ms plain decode. On a batch-1
+  memory-bound forward an extra row should be nearly free, because the weights
+  are already streaming.
 - **MTP loses on a GDN hybrid at every chain length, and the guard is right to
   disable it.** Measured on Qwen3.8-27B-NVFP4, greedy, 256 tokens, thinking off,
   economics guard disabled so it runs throughout, two alternating rounds with a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -221,10 +221,18 @@ would flip it from break-even to a win:
    | `gemv_nvfp4_kpar_mb_fp16` | 8919 ms (26.0 %) | 17045 ms (44.1 %) |
    | per launch | 38.7 us | 38.6 us |
 
-   The per-launch cost is identical, so the chunk is not slower at three rows
-   and its bytes do not move at a worse rate. There are 92 % more launches. The
-   whole 12.8 % that MTP costs is that one kernel, which is the batched
-   spec-verify GEMM, and everything else stays within baseline growth.
+   The per-launch cost is identical, so the chunk is not slower at three rows.
+   ~~There are 92 % more launches [per emitted token].~~
+
+   **WITHDRAWN 2026-08-18 by its author.** The per-token normalisation behind
+   that claim divided by 16384 tokens, taken from the benchmark's
+   `tg 8192 tokens avg 0.00 ms ( 0.00 tok/s) [2 reps]` line. That line is the
+   REQUEST, and its `0.00 ms` says the phase produced no timing. At the measured
+   ~256 launches per forward, 230400 launches is about 1100 forwards, so the
+   arms emitted on the order of a thousand tokens, not 16384. The absolute
+   kernel times stand; every per-token figure derived from them does not, and
+   neither does the direction of the comparison. Superseded by the four-arm
+   table below, which counts tokens from the API responses.
 
    **The accounting error underneath all three items: a verify replaces a decode
    step only when the draft is accepted.** On rejection it is additional. So the
@@ -233,6 +241,75 @@ would flip it from break-even to a win:
    is why the repair path is not where the money is, and why the chain-length
    saturation in [`LIMITATIONS.md`](LIMITATIONS.md) is a consequence rather than
    a separate result.
+
+### The four-arm table (2026-08-18)
+
+Four server arms, `speculative.ngram=false` so the MTP head is the only drafter,
+`server.prefix_cache=false`, same three prompts, nsys per arm, **tokens counted
+from the API responses**:
+
+| arm | rows in chunk | tokens | verifies | kernel ms/token | emitted/verify | cost/verify |
+|---|---:|---:|---:|---:|---:|---:|
+| k=0 (no speculation) | 1 | 723 | 0 | 11.39 | n/a | 11.39 ms |
+| k=1 | 2 | 729 | 424 | 11.33 | 1.715 | 19.43 ms |
+| k=2 | 3 | 721 | 334 | 11.35 | 2.153 | 24.44 ms |
+| k=3 | 4 | 768 | 291 | 11.98 | 2.629 | 31.50 ms |
+
+Two facts, neither depending on a fit:
+
+- **Speculation buys no GPU time.** Kernel time per emitted token is flat across
+  k=0..2 and worse at k=3, while emitted-per-verify climbs 1.72 → 2.63. Each
+  verify costs in proportion to what it emits.
+- **Cost per verify is linear in chunk rows**: `5.36 ms + 6.53 ms x rows`, fitted
+  on four points against two parameters, residuals -0.50 / +1.01 / -0.52 / +0.01.
+  **An extra row costs 6.53 ms, 57 % of a full decode step**, where on a
+  bandwidth-bound batch-1 decode it should be near-free.
+
+At k=1 the accepted-prefix repair is structurally unreachable (it is gated on
+`0 < matched < K`), so that row is free of repair effects: a 2-row verify costs
+19.43 ms against an 11.39 ms decode, i.e. **the second row alone costs 8.04 ms**.
+
+```
+[PROV: commit=196a3384 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens per
+       arm cmd=`--set speculative.ngram=false --set speculative.mtp_k=0|1|2|3
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       nsys -t cuda --cuda-graph-trace=node; kernel time = cuda_gpu_kern_sum
+       total, tokens from usage.completion_tokens, verifies from /metrics]
+```
+
+### Externally measured, and it closes the drafter question
+
+**vLLM 0.27.1 reaches 59.7 % MTP acceptance (418/700) on this box, this card and
+this checkpoint family** (`method: qwen3_next_mtp, num_speculative_tokens: 2`,
+resolved architecture `Qwen3_5MTP`), against imp's 58.0-64.1 % at k=2. Parity.
+Another engine gets the same acceptance from the same head, so the drafter is not
+imp's problem and the published 87 % figure describes a regime nobody has pinned.
+
+### Buried, so they are not re-run
+
+- Six drafter-accuracy hypotheses: draft lm_head precision, quantised head
+  weights, a missing `gamma = 1 + W` offset, the hidden-state convention, a RoPE
+  defect, an uninitialised MTP KV cache. All measured, all dead; detail in
+  [`LIMITATIONS.md`](LIMITATIONS.md).
+- **MoE draft head**: this checkpoint's MTP head has no experts and no router,
+  only `mlp.gate_proj/up_proj/down_proj`. The per-expert host loop cannot run.
+- **An unfused verify chunk**: per-launch cost is flat at 32.5 us across 2 and 3
+  rows, so the batched GEMV amortises its weight read as designed.
+- **The repair forward as the main cost**: unreachable at k=1, and consistent
+  with ~21 % of verifies at k=2.
+- **The async conditional-graph loop**, which MTP switches off: worth 1.0 %
+  measured (87.28 against 86.44 tok/s), not the 27-45 % assumed. The condition at
+  `engine_scheduler.cpp` that trades it for telemetry coverage is still wrong on
+  its own terms, but it is a 1 % wrong.
+
+### Withdrawn by their author
+
+- "0.72 forwards per emitted token, so speculation moves fewer bytes": the launch
+  count fell and the GPU time did not, so counting launches never measured cost.
+- The launch-count framing generally, including the 22.3 % CUTLASS share quoted
+  from a broken CSV parse (nsys kernel names contain commas inside template
+  arguments; the field must be read with a real CSV reader).
 
 Two findings that are not speed:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,12 +162,39 @@ how predictable the continuation is:
 | ordinary prose, MTP k=2 | 87.9 | 58 % | 2.3 |
 | **repeat a text verbatim** | **876.5** | **98.3 %** | **36.6** |
 
+**DISPUTED (2026-08-18):** the reading below treats imp's speculation economics
+as a property of speculation. Comparable engines report an MTP k=2 win on this
+class of model and hardware, so the more likely reading is that imp pays a cost
+they do not. Pending a reference-engine measurement on this box, treat every
+"speculation does not pay" statement in this section as "imp's speculation does
+not pay", and the guard that disables it as a workaround rather than a verdict.
+
 Speculation is worth **ten times** on the workload it was built for, and nothing
 on the one it was not. Where it pays, acceptance is near-total and the
 partial-acceptance repair path never runs, so the verify work below is inert
 there; where that work helps, speculation does not pay in the first place.
-Acceptance is the lever: 11 % to 98 % is 10x, and the entire verify cost is a
-few percent. Spend on drafters, not on the repair path.
+~~Acceptance is the lever: 11 % to 98 % is 10x, and the entire verify cost is a
+few percent. Spend on drafters, not on the repair path.~~
+
+**Retracted 2026-08-18: that sentence does not survive k=1.** It was written
+from the k=2 row above, where a poor drafter and an expensive verify are
+confounded. Measured at k=1 on a mixed corpus, the MTP head already accepts
+**75.0 %** and emits 1.748 per verify, and it still loses: 84.7-85.8 tok/s
+against ~88 without speculation. From those numbers a verify costs 20.6 ms
+against an 11.36 ms decode step, and the two levers price out as:
+
+| close this gap | result |
+|---|---|
+| acceptance 75 % → 87 % (the published figure) | 90.8 tok/s, **+3.2 %** |
+| verify 20.6 ms → 13.6 ms (1.2x a decode step) | 128.2 tok/s, **+45.7 %** |
+
+So the verify price is worth an order of magnitude more than the acceptance
+gap at k=1, and the retracted sentence had it backwards. The two are not
+independent either: verify cost grows **5.23 ms per extra draft token**, which
+is 46 % of a full decode step, and that slope is what caps chain length, which
+caps emitted-per-verify, which caps what any acceptance number can be worth.
+Where the slope lives — the forward, or the recurrent state machinery around
+it — is unmeasured and is the open question.
 
 **Three levers remain in the verify, each worth 4-6 ms of a 28.5 ms verify.** MTP needs the
 verify below 26.7 ms to pay at 2.26 emitted per verify, so any one of them


### PR DESCRIPTION
An hour of measurement that existed only in a session context window, plus one
withdrawal that should not wait for the fix commit. Facts and withdrawals only,
no new conclusions about what to do next.

## Withdrawn, by its author

The claim in #1465 that there are **92 % more launches per emitted token** with
MTP on. The normalisation divided by 16384 tokens read off the benchmark line

    tg  8192 tokens  avg     0.00 ms  (   0.00 tok/s)  [2 reps]

That line is the REQUEST, and its `0.00 ms` says the phase produced no timing. At
the measured ~256 launches per forward, 230400 launches is about 1100 forwards,
so those arms emitted on the order of a thousand tokens, not 16384. The absolute
kernel times stand; every per-token figure derived from them does not, and
neither does the direction of the comparison.

## Recorded

Four server arms, `speculative.ngram=false` so the MTP head is the only drafter,
prefix cache off, same prompts, nsys per arm, tokens counted from the API
responses rather than from a benchmark banner:

| arm | rows | tokens | verifies | kernel ms/token | emitted/verify | cost/verify |
|---|---:|---:|---:|---:|---:|---:|
| k=0 (no spec) | 1 | 723 | 0 | 11.39 | n/a | 11.39 ms |
| k=1 | 2 | 729 | 424 | 11.33 | 1.715 | 19.43 ms |
| k=2 | 3 | 721 | 334 | 11.35 | 2.153 | 24.44 ms |
| k=3 | 4 | 768 | 291 | 11.98 | 2.629 | 31.50 ms |

- **Speculation buys no GPU time.** Kernel time per emitted token is flat across
  k=0..2 and worse at k=3, while emitted-per-verify climbs 1.72 to 2.63.
- **Cost per verify is linear in chunk rows**: 5.36 ms + 6.53 ms x rows, four
  points against two parameters, residuals -0.50 / +1.01 / -0.52 / +0.01. An
  extra row costs 57 % of a full decode step where it should be near-free.
- At k=1 the repair forward is structurally unreachable (gated on
  `0 < matched < K`), so that row is clean of it: the second row alone costs
  8.04 ms.

## External, and it closes the drafter question

**vLLM 0.27.1 reaches 59.7 % MTP acceptance (418/700)** on this box, this card
and this checkpoint family, against imp at 58.0-64.1 %. Parity. Another engine
gets the same acceptance from the same head.

## Buried so they are not re-run

The six drafter-accuracy hypotheses; a MoE draft head (this head has no experts);
an unfused verify chunk (per-launch cost flat at 32.5 us across 2 and 3 rows);
the repair forward as the main cost; the async conditional-graph loop that MTP
switches off (1.0 %% measured, not the 27-45 %% assumed).

## Also withdrawn, mine

The "0.72 forwards per emitted token" framing, and the 22.3 %% CUTLASS share,
which came from a CSV parse that split nsys kernel names on the commas inside
their template arguments.

Docs only, no code change, so no perf gate.