### PR TITLE
spec: give the verify chunk the whole GPU, and the GDN layers their fast path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -825,6 +825,7 @@ if(IMP_BUILD_TESTS)
         tests/test_cutlass_grouped_ref.cu
         tests/test_cutlass_nvfp4_alpha.cu
         tests/test_gemm_grouped_nvfp4_smallM.cu
+        tests/test_nvfp4_batched_smallm_equiv.cu
         tests/test_quantize_fp16_nvfp4_moe_native.cu
         tests/test_mxf4nvf4_probe.cu
         tests/test_mxf4nvf4_mma_bench.cu

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -146,6 +146,84 @@ These have a code path and no gate. They may work; nothing proves it.
   single-token path, and the two do not agree bit for bit. Predates the
   2026-08-17 verify work: the same two prompts diverge with the older eager
   replay.
+- **The MTP head accepts 75.0 % of its first draft, and six explanations for
+  the gap to published figures are dead.** Measured on Qwen3.8-27B-NVFP4 over a
+  10-prompt mixed corpus (exposition, code, arithmetic, enumeration), n-gram
+  disabled so the head is the only drafter, `mtp_k=1` so acceptance *is*
+  first-position acceptance, two rounds with a fresh process each:
+  **74.8 % and 75.2 %** (σ 1.2, >1200 drafts per cell), 84.7 and 85.8 tok/s
+  against ~88 without speculation. At `mtp_k=2` the aggregate is 58.0-64.1 %.
+
+```
+[PROV: commit=37cd1543 date=2026-08-17 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=10 prompts x 256 greedy tokens
+       per arm, 2 rounds, fresh process per arm, alternating
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=1|2
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       request `temperature 0, think_budget 0`; acceptance from /metrics
+       deltas (imp_spec_accepted_total / imp_spec_drafted_total), card idle]
+```
+
+  Ruled out as causes of the gap, each by measurement, so they do not need
+  running again:
+
+  1. **Draft lm_head precision.** `speculative.mtp_nvfp4_head` true vs false:
+     55.9/55.5 % against 51.6/56.6 %, fully overlapping. The NVFP4 head is ~8 %
+     faster and costs no acceptance, so the default is right.
+  2. **Quantised head weights.** The MTP tensors carry no scale companions in
+     the checkpoint: they are BF16.
+  3. **A missing `gamma = 1 + W` offset.** All seven MTP norms upload through
+     the offset-applying path (`up_norm` in `weight_upload.cu`).
+  4. **The hidden-state convention.** `diagnostics.mtp_prenorm_h` moves nothing
+     (62.8 % against 62.8 %), which follows from `pre_fc_norm_hidden`
+     normalising its input anyway.
+  5. **A RoPE defect.** Disabling rotation looked like a +7.6-point win on one
+     prompt set and reverses across prompt lengths: 72.7/55.6 at 112 tokens,
+     66.5/68.3 at 607, 77.7/67.9 at 2767 (on/off). Rotation is fine.
+  6. **An uninitialised MTP KV cache.** Zeroing it left the per-process spread
+     intact (12.6 points before, 10.1 after) and moved first-position
+     acceptance 73.2 → 75.0, which two samples per condition cannot separate
+     from noise.
+
+  **Two measurement errors of ours are in that list and are the reusable part.**
+  (a) Findings 5 and 6 both survived a first pass because a run was *repeated*
+  rather than *varied*: greedy decoding makes a run deterministic, so two
+  identical runs agreeing to the tenth of a point is a statement about
+  determinism, not about the effect. Vary the workload, not the repetition.
+  (b) The per-process spread in (6) was read as a defect signal when the
+  processes had generated **different text** — imp's forward is not
+  reproducible across processes, and acceptance depends on what was generated.
+  Spread across processes is only a defect signal once the output is identical.
+
+  **The 87 % reference is not yet comparable.** It is a published figure for
+  this architecture class from another engine, and the chain depth, batch size
+  and acceptance definition (per-token or per-chain) behind it are unpinned.
+  Pin the regime before treating the 12-point gap as a target.
+
+```
+[PROV: commit=37cd1543 date=2026-08-17 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=10 prompts x 256 greedy tokens
+       per arm, 2 rounds, fresh process per arm, alternating
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=1|2
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       request `temperature 0, think_budget 0`; acceptance from /metrics
+       deltas (imp_spec_accepted_total / imp_spec_drafted_total), card idle]
+```
+- **DISPUTED (2026-08-18): the entry below states a conclusion about the
+  technique that its evidence does not support.** Comparable engines report an
+  MTP k=2 *win* on comparable hardware for this class of model. If that holds,
+  then "MTP loses on a GDN hybrid" is wrong as written and the true statement is
+  "imp's MTP path loses", which makes the economics guard a workaround for a
+  defect rather than a correct refusal. The measurements below stand as
+  measurements; the heading and the last sentence do not. The deciding evidence
+  is a reference engine measured on this box, which is not yet done. Until then
+  do not cite this entry as a property of MTP or of GDN hybrids.
+
+  The suspect cost, from the same tables: verify time grows **5.23 ms per extra
+  draft token** (46 % of a full decode step) on a fit through widths 2/3/5/7,
+  with a **15.4 ms intercept** against an 11.36 ms plain decode. On a batch-1
+  memory-bound forward an extra row should be nearly free, because the weights
+  are already streaming.
 - **MTP loses on a GDN hybrid at every chain length, and the guard is right to
   disable it.** Measured on Qwen3.8-27B-NVFP4, greedy, 256 tokens, thinking off,
   economics guard disabled so it runs throughout, two alternating rounds with a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -221,10 +221,18 @@ would flip it from break-even to a win:
    | `gemv_nvfp4_kpar_mb_fp16` | 8919 ms (26.0 %) | 17045 ms (44.1 %) |
    | per launch | 38.7 us | 38.6 us |
 
-   The per-launch cost is identical, so the chunk is not slower at three rows
-   and its bytes do not move at a worse rate. There are 92 % more launches. The
-   whole 12.8 % that MTP costs is that one kernel, which is the batched
-   spec-verify GEMM, and everything else stays within baseline growth.
+   The per-launch cost is identical, so the chunk is not slower at three rows.
+   ~~There are 92 % more launches [per emitted token].~~
+
+   **WITHDRAWN 2026-08-18 by its author.** The per-token normalisation behind
+   that claim divided by 16384 tokens, taken from the benchmark's
+   `tg 8192 tokens avg 0.00 ms ( 0.00 tok/s) [2 reps]` line. That line is the
+   REQUEST, and its `0.00 ms` says the phase produced no timing. At the measured
+   ~256 launches per forward, 230400 launches is about 1100 forwards, so the
+   arms emitted on the order of a thousand tokens, not 16384. The absolute
+   kernel times stand; every per-token figure derived from them does not, and
+   neither does the direction of the comparison. Superseded by the four-arm
+   table below, which counts tokens from the API responses.
 
    **The accounting error underneath all three items: a verify replaces a decode
    step only when the draft is accepted.** On rejection it is additional. So the
@@ -233,6 +241,75 @@ would flip it from break-even to a win:
    is why the repair path is not where the money is, and why the chain-length
    saturation in [`LIMITATIONS.md`](LIMITATIONS.md) is a consequence rather than
    a separate result.
+
+### The four-arm table (2026-08-18)
+
+Four server arms, `speculative.ngram=false` so the MTP head is the only drafter,
+`server.prefix_cache=false`, same three prompts, nsys per arm, **tokens counted
+from the API responses**:
+
+| arm | rows in chunk | tokens | verifies | kernel ms/token | emitted/verify | cost/verify |
+|---|---:|---:|---:|---:|---:|---:|
+| k=0 (no speculation) | 1 | 723 | 0 | 11.39 | n/a | 11.39 ms |
+| k=1 | 2 | 729 | 424 | 11.33 | 1.715 | 19.43 ms |
+| k=2 | 3 | 721 | 334 | 11.35 | 2.153 | 24.44 ms |
+| k=3 | 4 | 768 | 291 | 11.98 | 2.629 | 31.50 ms |
+
+Two facts, neither depending on a fit:
+
+- **Speculation buys no GPU time.** Kernel time per emitted token is flat across
+  k=0..2 and worse at k=3, while emitted-per-verify climbs 1.72 → 2.63. Each
+  verify costs in proportion to what it emits.
+- **Cost per verify is linear in chunk rows**: `5.36 ms + 6.53 ms x rows`, fitted
+  on four points against two parameters, residuals -0.50 / +1.01 / -0.52 / +0.01.
+  **An extra row costs 6.53 ms, 57 % of a full decode step**, where on a
+  bandwidth-bound batch-1 decode it should be near-free.
+
+At k=1 the accepted-prefix repair is structurally unreachable (it is gated on
+`0 < matched < K`), so that row is free of repair effects: a 2-row verify costs
+19.43 ms against an 11.39 ms decode, i.e. **the second row alone costs 8.04 ms**.
+
+```
+[PROV: commit=196a3384 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens per
+       arm cmd=`--set speculative.ngram=false --set speculative.mtp_k=0|1|2|3
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`,
+       nsys -t cuda --cuda-graph-trace=node; kernel time = cuda_gpu_kern_sum
+       total, tokens from usage.completion_tokens, verifies from /metrics]
+```
+
+### Externally measured, and it closes the drafter question
+
+**vLLM 0.27.1 reaches 59.7 % MTP acceptance (418/700) on this box, this card and
+this checkpoint family** (`method: qwen3_next_mtp, num_speculative_tokens: 2`,
+resolved architecture `Qwen3_5MTP`), against imp's 58.0-64.1 % at k=2. Parity.
+Another engine gets the same acceptance from the same head, so the drafter is not
+imp's problem and the published 87 % figure describes a regime nobody has pinned.
+
+### Buried, so they are not re-run
+
+- Six drafter-accuracy hypotheses: draft lm_head precision, quantised head
+  weights, a missing `gamma = 1 + W` offset, the hidden-state convention, a RoPE
+  defect, an uninitialised MTP KV cache. All measured, all dead; detail in
+  [`LIMITATIONS.md`](LIMITATIONS.md).
+- **MoE draft head**: this checkpoint's MTP head has no experts and no router,
+  only `mlp.gate_proj/up_proj/down_proj`. The per-expert host loop cannot run.
+- **An unfused verify chunk**: per-launch cost is flat at 32.5 us across 2 and 3
+  rows, so the batched GEMV amortises its weight read as designed.
+- **The repair forward as the main cost**: unreachable at k=1, and consistent
+  with ~21 % of verifies at k=2.
+- **The async conditional-graph loop**, which MTP switches off: worth 1.0 %
+  measured (87.28 against 86.44 tok/s), not the 27-45 % assumed. The condition at
+  `engine_scheduler.cpp` that trades it for telemetry coverage is still wrong on
+  its own terms, but it is a 1 % wrong.
+
+### Withdrawn by their author
+
+- "0.72 forwards per emitted token, so speculation moves fewer bytes": the launch
+  count fell and the GPU time did not, so counting launches never measured cost.
+- The launch-count framing generally, including the 22.3 % CUTLASS share quoted
+  from a broken CSV parse (nsys kernel names contain commas inside template
+  arguments; the field must be read with a real CSV reader).
 
 Two findings that are not speed:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,12 +162,39 @@ how predictable the continuation is:
 | ordinary prose, MTP k=2 | 87.9 | 58 % | 2.3 |
 | **repeat a text verbatim** | **876.5** | **98.3 %** | **36.6** |
 
+**DISPUTED (2026-08-18):** the reading below treats imp's speculation economics
+as a property of speculation. Comparable engines report an MTP k=2 win on this
+class of model and hardware, so the more likely reading is that imp pays a cost
+they do not. Pending a reference-engine measurement on this box, treat every
+"speculation does not pay" statement in this section as "imp's speculation does
+not pay", and the guard that disables it as a workaround rather than a verdict.
+
 Speculation is worth **ten times** on the workload it was built for, and nothing
 on the one it was not. Where it pays, acceptance is near-total and the
 partial-acceptance repair path never runs, so the verify work below is inert
 there; where that work helps, speculation does not pay in the first place.
-Acceptance is the lever: 11 % to 98 % is 10x, and the entire verify cost is a
-few percent. Spend on drafters, not on the repair path.
+~~Acceptance is the lever: 11 % to 98 % is 10x, and the entire verify cost is a
+few percent. Spend on drafters, not on the repair path.~~
+
+**Retracted 2026-08-18: that sentence does not survive k=1.** It was written
+from the k=2 row above, where a poor drafter and an expensive verify are
+confounded. Measured at k=1 on a mixed corpus, the MTP head already accepts
+**75.0 %** and emits 1.748 per verify, and it still loses: 84.7-85.8 tok/s
+against ~88 without speculation. From those numbers a verify costs 20.6 ms
+against an 11.36 ms decode step, and the two levers price out as:
+
+| close this gap | result |
+|---|---|
+| acceptance 75 % → 87 % (the published figure) | 90.8 tok/s, **+3.2 %** |
+| verify 20.6 ms → 13.6 ms (1.2x a decode step) | 128.2 tok/s, **+45.7 %** |
+
+So the verify price is worth an order of magnitude more than the acceptance
+gap at k=1, and the retracted sentence had it backwards. The two are not
+independent either: verify cost grows **5.23 ms per extra draft token**, which
+is 46 % of a full decode step, and that slope is what caps chain length, which
+caps emitted-per-verify, which caps what any acceptance number can be worth.
+Where the slope lives — the forward, or the recurrent state machinery around
+it — is unmeasured and is the open question.
 
 **Three levers remain in the verify, each worth 4-6 ms of a 28.5 ms verify.** MTP needs the
 verify below 26.7 ms to pay at 2.26 emitted per verify, so any one of them

--- a/src/compute/ssm.cu
+++ b/src/compute/ssm.cu
@@ -283,7 +283,17 @@ __global__ void ssm_conv1d_prefill_f32_silu_kernel(
     // gdn.cu): the conv window as of snap_n rows. 0 disables it.
     const int snap_n = (conv_snap && d_snap_n) ? min(n_tokens, __ldg(d_snap_n)) : 0;
 
-    for (int ch = threadIdx.x; ch < channels; ch += blockDim.x) {
+    // Channels are split across blockIdx.y as well as threads. With the grid
+    // keyed on tokens alone, a speculative verify chunk launched 2-4 blocks
+    // total and left 166 of 170 SMs idle while each block walked every channel:
+    // measured 2.10 ms for a 2-row chunk against 0.10 ms for the single-token
+    // decode kernel, a 21x ratio on two rows. Tokens are independent here (each
+    // reads its own window from x_in, and conv_state only for the leading
+    // positions), and the two state commits below are per channel, so widening
+    // the grid changes no result. Prefill keeps the same mapping, with more
+    // blocks.
+    for (int ch = blockIdx.y * blockDim.x + threadIdx.x; ch < channels;
+         ch += gridDim.y * blockDim.x) {
         float sum = 0.0f;
         for (int k = 0; k < kernel_size; k++) {
             int src_t = token - (kernel_size - 1) + k;
@@ -344,7 +354,12 @@ void ssm_conv1d_prefill_f32_silu(void* conv_state, const Tensor& x_in, const Ten
                                  const void* conv_prev) {
     int n_tokens = static_cast<int>(x_in.shape[0]);
     int channels = static_cast<int>(x_in.shape[1]);
-    ssm_conv1d_prefill_f32_silu_kernel<<<n_tokens, 256, 0, stream>>>(
+    // Grid over (tokens, channel tiles). A 2-row verify chunk used to occupy
+    // two SMs; the y extent gives it the whole card, the same way the
+    // single-token decode launcher already does.
+    constexpr int kThreads = 256;
+    dim3 grid(n_tokens, (channels + kThreads - 1) / kThreads);
+    ssm_conv1d_prefill_f32_silu_kernel<<<grid, kThreads, 0, stream>>>(
         static_cast<float*>(conv_state), static_cast<const half*>(x_in.data),
         static_cast<const half*>(weight.data), bias.data ? static_cast<const half*>(bias.data) : nullptr,
         x_out_f32, n_tokens, channels, conv_kernel, d_real_n, static_cast<float*>(conv_snap), d_snap_n,

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -64,8 +64,17 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     rmsnorm(h, ly.attn_norm, no, eps, stream, norm_w_off_);
 
     // GemmContext for all weight GEMM dispatches in this function.
+    //
+    // cur_spec_verify_ is load-bearing here and was missing until 2026-08-18:
+    // without it ctx.spec_verify_small_m stays false, the M<=4 batched-GEMV
+    // branch (#998/#1055) is unreachable, and every GDN projection in a
+    // speculative verify chunk takes the CUTLASS prefill path instead. FFN and
+    // attention already threaded it; this path did not, and on a GDN hybrid it
+    // is 48 of 64 layers, so the small-M verify optimisation never reached the
+    // layers that dominate the architecture. Measured at 148 CUTLASS launches
+    // and 4.26 ms per verify.
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config(), cur_force_fp16_,
-                                 model_->config().overrides.gemma4.force_mmvq);
+                                 model_->config().overrides.gemma4.force_mmvq, cur_spec_verify_);
 
     // 2. ssm_in projection: [n, d_model] @ ssm_in^T -> [n, ssm_in_dim]
     //    ssm_in_dim = inner(z) + conv_channels(xBC) + n_heads(dt)
@@ -278,7 +287,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     int head_dim_ssm = (n_heads > 0) ? inner / n_heads : 0;
 
     auto ctx = GemmContext::make(stream, wcache_, qscratch_, runtime_config(), cur_force_fp16_,
-                                 model_->config().overrides.gemma4.force_mmvq);
+                                 model_->config().overrides.gemma4.force_mmvq, cur_spec_verify_);
 
     Tensor h = view_tokens(hidden_, n);
     Tensor r = view_tokens(residual_, n);

--- a/tests/test_nvfp4_batched_smallm_equiv.cu
+++ b/tests/test_nvfp4_batched_smallm_equiv.cu
@@ -1,0 +1,170 @@
+// tests/test_nvfp4_batched_smallm_equiv.cu
+//
+// Gate for the small-M batched NVFP4 GEMV that speculative verify chunks route
+// into (`gemm_nvfp4_batched`, #998/#1055).
+//
+// It exists because the end-to-end equivalence check for that routing cannot
+// see it. `ctx.spec_verify_small_m` is only true inside a verify chunk, so a
+// no-speculation arm exercises the OLD path by construction and comes back
+// byte-identical whatever the new path computes, while the speculative arms are
+// not reproducible across processes (#1457) and cannot be diffed either. A
+// change that reroutes 48 of 64 layers onto a different kernel family therefore
+// had no gate at all until this file.
+//
+// Two invariants, both deterministic and both at the shapes a GDN hybrid
+// actually uses:
+//   1. row m of a batched M-row call equals the single-row call for that row,
+//      which is what the MR bucket selection (<1>/<2>/<3>/<4>) must preserve;
+//   2. the result matches a dequantise-then-multiply reference, so "both paths
+//      agree" cannot be satisfied by both being wrong the same way.
+
+#include <gtest/gtest.h>
+
+#include "core/tensor.h"
+#include "quant/nvfp4_gemm.h"
+#include "quant/nvfp4_quant.h"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace {
+
+bool has_sm120() {
+    int dev = 0;
+    if (cudaGetDevice(&dev) != cudaSuccess)
+        return false;
+    cudaDeviceProp p{};
+    if (cudaGetDeviceProperties(&p, dev) != cudaSuccess)
+        return false;
+    return p.major == 12;
+}
+
+// Shapes from Qwen3.8-27B's GDN layers, which are the ones the verify chunk
+// routes: d_model 5120 into the in/out projections. K stays a multiple of 16.
+constexpr int kK = 5120;
+constexpr int kN = 512;  // one N tile; the kernel walks N in blocks anyway
+
+struct Fixture {
+    imp::NvFP4QuantResult w{};
+    std::vector<half> w_fp16;  // dequantised reference weight, [kN, kK]
+    ~Fixture() { imp::free_nvfp4_result(w); }
+};
+
+// Quantise a random weight and keep its dequantised form as the reference.
+void build(Fixture& f) {
+    std::mt19937 rng(1234);
+    std::normal_distribution<float> dist(0.0f, 0.05f);
+    std::vector<half> host(static_cast<size_t>(kN) * kK);
+    for (auto& h : host)
+        h = __float2half(dist(rng));
+
+    void* d_w = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_w, host.size() * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_w, host.data(), host.size() * sizeof(half), cudaMemcpyHostToDevice),
+              cudaSuccess);
+    int64_t shape[2] = {kN, kK};
+    imp::Tensor wt(d_w, imp::QType::F16, 2, shape, /*on_device=*/true);
+    imp::quantize_fp16_to_nvfp4(wt, f.w, nullptr);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // The reference multiplies the weight the kernel actually holds, not the
+    // pre-quantisation one: this test gates the GEMV, not the quantiser.
+    void* d_deq = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_deq, host.size() * sizeof(half)), cudaSuccess);
+    imp::dequantize_nvfp4_to_fp16(f.w, d_deq, nullptr);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    f.w_fp16.resize(host.size());
+    ASSERT_EQ(cudaMemcpy(f.w_fp16.data(), d_deq, host.size() * sizeof(half), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    cudaFree(d_deq);
+    cudaFree(d_w);
+}
+
+std::vector<half> run_batched(const imp::NvFP4QuantResult& w, const std::vector<half>& x, int m) {
+    half *d_x = nullptr, *d_y = nullptr;
+    EXPECT_EQ(cudaMalloc(&d_x, x.size() * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMalloc(&d_y, static_cast<size_t>(m) * kN * sizeof(half)), cudaSuccess);
+    EXPECT_EQ(cudaMemcpy(d_x, x.data(), x.size() * sizeof(half), cudaMemcpyHostToDevice), cudaSuccess);
+    EXPECT_EQ(cudaMemset(d_y, 0, static_cast<size_t>(m) * kN * sizeof(half)), cudaSuccess);
+    imp::gemm_nvfp4_batched(w, d_x, d_y, kN, kK, m, nullptr);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<half> y(static_cast<size_t>(m) * kN);
+    EXPECT_EQ(cudaMemcpy(y.data(), d_y, y.size() * sizeof(half), cudaMemcpyDeviceToHost), cudaSuccess);
+    cudaFree(d_x);
+    cudaFree(d_y);
+    return y;
+}
+
+class BatchedSmallM : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        if (!has_sm120())
+            GTEST_SKIP() << "sm_120 required";
+        build(f_);
+    }
+    Fixture f_;
+};
+
+// Invariant 1: the MR bucket must not change what a row computes. A 2-, 3- or
+// 4-row call has to reproduce the 1-row call for each of its rows, which is
+// exactly what a wrong bucket or a wrong activation stride would break.
+TEST_F(BatchedSmallM, RowsMatchTheSingleRowCall) {
+    std::mt19937 rng(99);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    std::vector<half> x(static_cast<size_t>(4) * kK);
+    for (auto& h : x)
+        h = __float2half(dist(rng));
+
+    // Reference: each row through the M=1 path.
+    std::vector<std::vector<half>> single;
+    for (int r = 0; r < 4; ++r) {
+        std::vector<half> row(x.begin() + static_cast<size_t>(r) * kK,
+                              x.begin() + static_cast<size_t>(r + 1) * kK);
+        single.push_back(run_batched(f_.w, row, 1));
+    }
+
+    for (int m = 2; m <= 4; ++m) {
+        std::vector<half> xm(x.begin(), x.begin() + static_cast<size_t>(m) * kK);
+        const std::vector<half> got = run_batched(f_.w, xm, m);
+        for (int r = 0; r < m; ++r)
+            for (int n = 0; n < kN; ++n) {
+                const float a = __half2float(single[r][n]);
+                const float b = __half2float(got[static_cast<size_t>(r) * kN + n]);
+                ASSERT_NEAR(a, b, 1e-2f * std::max(1.0f, std::fabs(a)))
+                    << "m=" << m << " row=" << r << " n=" << n;
+            }
+    }
+}
+
+// Invariant 2: absolute correctness against dequantise-then-multiply, so both
+// paths agreeing while both being wrong is not a passing state.
+TEST_F(BatchedSmallM, MatchesDequantisedReference) {
+    std::mt19937 rng(7);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    for (int m = 1; m <= 4; ++m) {
+        std::vector<half> x(static_cast<size_t>(m) * kK);
+        for (auto& h : x)
+            h = __float2half(dist(rng));
+        const std::vector<half> got = run_batched(f_.w, x, m);
+
+        for (int r = 0; r < m; ++r)
+            for (int n = 0; n < kN; n += 37) {  // stride: full N is 512x4 dot products
+                double acc = 0.0;
+                for (int k = 0; k < kK; ++k)
+                    acc += static_cast<double>(__half2float(x[static_cast<size_t>(r) * kK + k])) *
+                           static_cast<double>(__half2float(f_.w_fp16[static_cast<size_t>(n) * kK + k]));
+                const float ref = static_cast<float>(acc);
+                const float out = __half2float(got[static_cast<size_t>(r) * kN + n]);
+                // FP16 accumulation over 5120 terms: tolerance scales with the
+                // magnitude, not an absolute epsilon.
+                ASSERT_NEAR(out, ref, 0.05f * std::max(1.0f, std::fabs(ref)))
+                    << "m=" << m << " row=" << r << " n=" << n;
+            }
+    }
+}
+
+}  // namespace


### PR DESCRIPTION
Speculation was slower than not speculating on this model at every chain length.
It is now faster: **k=2 runs 91.08 tok/s against 84.70** for the no-speculation arm
of the same session, and 75.26 before these two fixes.

Neither cause was a limit of the technique. **vLLM 0.27.1 reaches 59.7 % MTP
acceptance (418/700) on this box, this card and this checkpoint family, against
imp at 58.0-64.1 %.** Parity. The drafter was never the problem, and the published
87 % figure this investigation chased describes a regime nobody has pinned. What
the reference engines have is a cheap marginal chunk row; ours cost 71 % of a full
decode step.

## Two causes, both in how work was launched

**1. The conv1d grid.** `ssm_conv1d_prefill_f32_silu_kernel` launched as
`<<<n_tokens, 256>>>`, so a two-row verify chunk got two blocks on a 170-SM card
and left 166 idle while each block walked every channel serially: 2.10 ms against
0.10 ms for the single-token decode kernel, 21x on two rows. The grid now spans
(tokens, channel tiles). Tokens were already independent and both state commits
are per channel, so no result changes; prefill keeps the same mapping with more
blocks.

**2. Two missing arguments.** `executor_ssm_gdn.cu` built its `GemmContext`
without `cur_spec_verify_`. `executor_ffn.cu` and `executor_attention.cu` both
pass it. So `ctx.spec_verify_small_m` stayed false for every GDN projection and
the `M<=4` batched-GEMV branch from #998/#1055 was unreachable for them. On a GDN
hybrid that is **48 of 64 layers**: the small-M verify optimisation had never once
reached the layers that dominate the architecture. Cost: 148 CUTLASS launches and
4.26 ms per verify.

## Measured

| arm | old | both fixes |
|---|---:|---:|
| k=0 (no speculation) | 84.47 | 84.70 |
| k=1 | 75.58 | 85.55 |
| **k=2** | **75.26** | **91.08** |

conv1d alone was worth a measured 1.77 ms per verify against 1.99 predicted from
the per-kernel profile, which is what made the CUTLASS estimate worth acting on.

## Why the test exists

`spec_verify_small_m` is only true inside a verify chunk, so a no-speculation arm
exercises the OLD path by construction and returns byte-identical whatever the new
path computes, while speculative arms are not reproducible across processes
(#1457). A change rerouting 48 of 64 layers had no gate at all.

`tests/test_nvfp4_batched_smallm_equiv.cu` pins the kernel instead, at real GDN
shapes (K=5120), M = 1..4: row m of a batched call must equal the single-row call,
and the result must match dequantise-then-multiply so that both paths agreeing
while both are wrong is not a passing state.

**Mutation-validated, and the first attempt was equivalent**: mutating the
launcher per-tile activation offset changes nothing at `n_act <= 4`, where the
loop runs once and the offset is always zero. Mutating the in-kernel row index
fails both tests.

## Gate

`make verify-fast` green: decode and prefill within threshold, peak VRAM +0.01 %,
graphs 2.53x, degeneration smoke clean. Full GPU suite green via the pre-commit
hook.