### PR TITLE
ci: green the Alloc sites gate, and record that MTP now pays

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -209,23 +209,68 @@ These have a code path and no gate. They may work; nothing proves it.
        request `temperature 0, think_budget 0`; acceptance from /metrics
        deltas (imp_spec_accepted_total / imp_spec_drafted_total), card idle]
 ```
-- **DISPUTED (2026-08-18): the entry below states a conclusion about the
-  technique that its evidence does not support.** Comparable engines report an
-  MTP k=2 *win* on comparable hardware for this class of model. If that holds,
-  then "MTP loses on a GDN hybrid" is wrong as written and the true statement is
-  "imp's MTP path loses", which makes the economics guard a workaround for a
-  defect rather than a correct refusal. The measurements below stand as
-  measurements; the heading and the last sentence do not. The deciding evidence
-  is a reference engine measured on this box, which is not yet done. Until then
-  do not cite this entry as a property of MTP or of GDN hybrids.
+- **RESOLVED (2026-08-18). MTP does not lose on a GDN hybrid. imp's MTP path
+  lost, and it no longer does.** The entry below stated a conclusion about the
+  technique that its evidence never supported, and the dispute is settled by
+  fixing the engine rather than by argument. Two defects, both in how work was
+  launched rather than what it computed (`ea547a53`):
 
-  The suspect cost, from the same tables: verify time grows **5.23 ms per extra
-  draft token** (46 % of a full decode step) on a fit through widths 2/3/5/7,
-  with a **15.4 ms intercept** against an 11.36 ms plain decode. On a batch-1
-  memory-bound forward an extra row should be nearly free, because the weights
-  are already streaming.
-- **MTP loses on a GDN hybrid at every chain length, and the guard is right to
-  disable it.** Measured on Qwen3.8-27B-NVFP4, greedy, 256 tokens, thinking off,
+  1. `ssm_conv1d_prefill_f32_silu_kernel` had a grid over tokens, so a two-row
+     verify chunk ran on two blocks of a 170-SM card while each block walked
+     every channel serially.
+  2. `executor_ssm_gdn.cu` built its `GemmContext` without `cur_spec_verify_`,
+     which FFN and attention both pass. The `M<=4` batched-GEMV branch from
+     #998/#1055 was therefore unreachable for **every GDN projection**, i.e. for
+     48 of 64 layers on this model.
+
+  | | before | after |
+  |---|---:|---:|
+  | no speculation | 84.47 tok/s | 86.21 tok/s |
+  | MTP k=2 | 75.26 tok/s | **104.06 tok/s** |
+  | kernel time per emitted token, k=2 | 11.35 ms | **8.93 ms** |
+  | CUTLASS launches per verify | 296.3 | 8.9 |
+
+  Speculation went from 10.9 % slower than not speculating to 20.7 % faster.
+  The kernel figure reproduces across two independent runs on different corpora
+  (8.93 and 8.93; the no-speculation arm reads 11.21 and 11.29).
+
+```
+[PROV: commit=ea547a53 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens,
+       2 alternating rounds, fresh process per arm, nsys per arm
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=0|2
+       --set speculative.mtp_econ_min_emit=0 --set server.prefix_cache=false`;
+       wall from usage.completion_tokens over request wall time, kernel from
+       cuda_gpu_kern_sum, both from the SAME arm]
+```
+
+  **This is not a cross-engine comparison and must not be read as one.** vLLM
+  0.27.1 was measured on this box only for MTP *acceptance*, where it reads
+  59.7 % against imp's 58-64 %: parity, which is what retired the drafter as a
+  suspect. Its throughput was not measured in a form worth trusting, so no
+  claim about imp against vLLM speed exists in either direction.
+
+  **What it cost to learn this**: six hypotheses about drafter accuracy, all
+  dead, and a published 87 % acceptance target chased for days that turned out
+  to describe an unpinned regime. Acceptance was never the problem. Detail in
+  the entry above.
+
+  **Not finished.** A marginal chunk row still costs 4.22 ms, 38 % of a full
+  decode step (down from 8.09 ms, 71 %), on a batch-1 memory-bound decode where
+  the weights are already streaming and it should be near-free. Remaining
+  levers, measured, in size order:
+
+  1. the per-row FMA work in `gemv_nvfp4_kpar_mb_fp16`, which scales by
+     construction; an HMMA tile kernel is the honest answer if it is the floor.
+  2. the capture-bucket floor of 3: a two-row chunk is padded to three and pays
+     ~17 % of its GEMV time for a row that does not exist.
+  3. the argmax + D2H + rollback host round-trip, which grows the non-kernel gap
+     from 0.31 to 0.68 ms/token and eats 16 % of the kernel win. Smallest of the
+     three, and the one with a named fix already in `roadmap.md`.
+
+- ~~**MTP loses on a GDN hybrid at every chain length, and the guard is right to
+  disable it.**~~ Superseded by the entry above; the measurements stand as a
+  record of the broken build. Measured on Qwen3.8-27B-NVFP4, greedy, 256 tokens, thinking off,
   economics guard disabled so it runs throughout, two alternating rounds with a
   fresh process per arm:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,12 +162,19 @@ how predictable the continuation is:
 | ordinary prose, MTP k=2 | 87.9 | 58 % | 2.3 |
 | **repeat a text verbatim** | **876.5** | **98.3 %** | **36.6** |
 
-**DISPUTED (2026-08-18):** the reading below treats imp's speculation economics
-as a property of speculation. Comparable engines report an MTP k=2 win on this
-class of model and hardware, so the more likely reading is that imp pays a cost
-they do not. Pending a reference-engine measurement on this box, treat every
-"speculation does not pay" statement in this section as "imp's speculation does
-not pay", and the guard that disables it as a workaround rather than a verdict.
+**RESOLVED (2026-08-18), and the section below is a record of the broken build.**
+The dispute is settled by fixing the engine: two launch defects, a grid over
+tokens and a `GemmContext` built without `cur_spec_verify_`, kept every GDN
+projection off the small-M batched GEMV. Fixed in `ea547a53`. MTP k=2 now runs
+**104.06 tok/s against 86.21 without speculation**, from 75.26 against 84.47,
+and kernel time per emitted token falls 11.35 to 8.93 ms. Every "speculation
+does not pay" statement below described imp, not speculation, and no longer
+describes imp either. Detail and the remaining levers:
+[`LIMITATIONS.md`](LIMITATIONS.md).
+
+Not a cross-engine claim: vLLM was measured here for MTP **acceptance** only
+(59.7 % against imp's 58-64 %, which is what cleared the drafter), and no
+trustworthy throughput comparison between the two engines exists.
 
 Speculation is worth **ten times** on the workload it was built for, and nothing
 on the one it was not. Where it pays, acceptance is near-total and the

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -146,12 +146,18 @@ bool Engine::ensure_spec_state_scratch_() {
     // pre-chunk state and re-forwarding a full model pass to reach it — that
     // re-forward measures 17.2 ms against a 28.5 ms verify. Optional: without
     // it the replay path stands, so an allocation failure is a warning.
-    if (spec_state_snap_ == nullptr && cudaMalloc(&spec_state_snap_, bytes) != cudaSuccess) {
-        IMP_LOG_WARN(
-            "spec-hybrid: snapshot slab alloc failed (%zu bytes) — partial acceptances "
-            "will re-forward instead of adopting the snapshot",
-            bytes);
-        spec_state_snap_ = nullptr;
+    // Through the VRAM allocator rather than cudaMalloc: invariant I1 keeps
+    // direct driver calls inside src/memory/, and the allowlist this file sits
+    // on only ever shrinks. #1459 added a raw pair here and pushed the file
+    // from its budgeted 13 sites to 15, which failed the blocking Alloc-sites
+    // gate on main from that commit onward.
+    if (spec_state_snap_ == nullptr) {
+        spec_state_snap_ = vram_alloc_.allocate(bytes, "spec_state_snapshot");
+        if (spec_state_snap_ == nullptr)
+            IMP_LOG_WARN(
+                "spec-hybrid: snapshot slab alloc failed (%zu bytes) — partial acceptances "
+                "will re-forward instead of adopting the snapshot",
+                bytes);
     }
     return true;
 }
@@ -167,7 +173,7 @@ int Engine::recurrent_slot_for_(int req_id) const {
 
 void Engine::free_spec_buffers_() {
     if (spec_state_snap_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(spec_state_snap_));
+        vram_alloc_.free(spec_state_snap_);
         spec_state_snap_ = nullptr;
     }
     // Captured verify graphs bake these buffer pointers — drop them first.

--- a/tests/test_nvfp4_batched_smallm_equiv.cu
+++ b/tests/test_nvfp4_batched_smallm_equiv.cu
@@ -11,6 +11,14 @@
 // change that reroutes 48 of 64 layers onto a different kernel family therefore
 // had no gate at all until this file.
 //
+// GPU-ONLY, AND CI NEVER RUNS IT. The `Test` job is skipped on the runners
+// (no GPU), so this file's protection is local-only: it ran once through a
+// pre-commit hook and nothing upstream will run it again. If you touch the
+// small-M verify dispatch, run it yourself before pushing:
+//
+//   docker run --rm --gpus all -v $PWD:/src -w /src imp:toolchain \
+//       ./build-dev/test-quant --gtest_filter='*BatchedSmallM*'
+//
 // Two invariants, both deterministic and both at the shapes a GDN hybrid
 // actually uses:
 //   1. row m of a batched M-row call equals the single-row call for that row,


### PR DESCRIPTION
Two commits: a red required check that has been failing on main for hours, and
the record for last night's result.

## The gate

The blocking **Alloc sites** check has failed on every commit since #1459, which
is mine. That PR added a raw `cudaMalloc`/`cudaFree` pair for the mid-chunk
snapshot slab directly in `engine_spec_ngram.cpp`, taking the file from its
budgeted 13 sites to 15. Invariant I1 keeps direct driver calls inside
`src/memory/`, and the allowlist header says the list only shrinks, so raising
the budget was the wrong repair. Both sites now go through the engine's
`VRAMAllocator`: **471 sites against 471 budgeted, allowlist untouched**.

Worth stating: a check labelled blocking did not block. #1467 auto-merged over it,
and a permanently red gate reads the same as a flaky one.

## The test that CI never runs

`tests/test_nvfp4_batched_smallm_equiv.cu` is the only gate on the GDN small-M
dispatch, because a no-speculation arm cannot exercise that path by construction.
The `Test` job is SKIPPED in CI for want of a GPU, so that coverage is local-only.
The header now says so, with the command, instead of leaving the next person to
assume CI has their back.

## The record

Resolves the DISPUTED markers by measurement:

| | before | after |
|---|---:|---:|
| no speculation | 84.47 tok/s | 86.21 tok/s |
| MTP k=2 | 75.26 tok/s | **104.06 tok/s** |
| kernel ms/token, k=2 | 11.35 | **8.93** |
| CUTLASS launches/verify | 296.3 | 8.9 |

Speculation went from 10.9 %% slower than not speculating to 20.7 %% faster. The
kernel figure reproduces across two independent runs on different corpora (8.93
and 8.93; the no-speculation arm reads 11.21 and 11.29).

**Not a cross-engine comparison.** vLLM 0.27.1 was measured here for MTP
acceptance only, 59.7 %% against imp's 58-64 %%, and that parity is what retired
the drafter as a suspect. Its throughput was not measured in a form worth
trusting, so no imp-against-vLLM speed claim exists in either direction.

**Not finished.** A marginal chunk row still costs 4.22 ms, 38 %% of a decode step,
down from 8.09 ms and 71 %%, where it should be near-free. The three remaining
levers are recorded with their measured sizes.