### PR TITLE
tests: the N-tiled small-M GEMV is a wash, and why three earlier runs said otherwise

### DIFF
--- a/tests/test_nvfp4_batched_smallm_equiv.cu
+++ b/tests/test_nvfp4_batched_smallm_equiv.cu
@@ -35,6 +35,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
 #include <cmath>
 #include <random>
 #include <vector>
@@ -173,6 +174,87 @@ TEST_F(BatchedSmallM, MatchesDequantisedReference) {
                     << "m=" << m << " row=" << r << " n=" << n;
             }
     }
+}
+
+
+// DISABLED by default: a measurement, not an assertion. Run it with
+//   ./build-dev/test-quant --gtest_also_run_disabled_tests \\
+//       --gtest_filter='*MarginalRowCost*'
+//
+// TWO METHOD REQUIREMENTS ARE BAKED IN HERE BECAUSE GETTING EITHER WRONG
+// PRODUCED CONFIDENT NONSENSE (2026-08-18):
+//
+//  1. Warm up past the clock ramp. With a 20-iteration warmup the SAME
+//     unchanged code path measured 20.59, 15.54 and 8.82 us across three runs,
+//     purely because it was always timed first. Burn a full second.
+//  2. Compare implementations PAIRED AND ALTERNATING INSIDE ONE PROCESS. Across
+//     two builds the same unchanged path read 11.30 and 13.88 us, so any
+//     difference under ~25 % is drift, and a 2-5 us delta on a 10 us kernel is
+//     not resolvable that way.
+//
+// An N-tiled variant of this kernel (one activation read shared across several
+// output rows) was built and measured this way: +0.55, +0.23 and -0.20 us at
+// MR = 2, 3, 4. A wash, so it was not kept. The per-verify marginal row cost of
+// 4.22 ms is real and comes from server measurements, but its cause is NOT the
+// activation re-read, and it remains unattributed.
+TEST_F(BatchedSmallM, DISABLED_MarginalRowCost) {
+    std::mt19937 rng(5);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    std::vector<half> x(static_cast<size_t>(4) * kK);
+    for (auto& h : x) h = __float2half(dist(rng));
+
+    // A real GDN projection shape: at the fixture's N=512 only 512 blocks reach
+    // a 170-SM card and the kernel is latency-bound, which is not the regime a
+    // verify chunk runs in.
+    constexpr int kBenchN = 5120;
+    imp::NvFP4QuantResult bw{};
+    {
+        std::vector<half> hw(static_cast<size_t>(kBenchN) * kK);
+        std::normal_distribution<float> wd(0.0f, 0.05f);
+        for (auto& h : hw) h = __float2half(wd(rng));
+        void* d_bw = nullptr;
+        ASSERT_EQ(cudaMalloc(&d_bw, hw.size() * sizeof(half)), cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(d_bw, hw.data(), hw.size() * sizeof(half), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        int64_t sh[2] = {kBenchN, kK};
+        imp::Tensor wt(d_bw, imp::QType::F16, 2, sh, true);
+        imp::quantize_fp16_to_nvfp4(wt, bw, nullptr);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        cudaFree(d_bw);
+    }
+
+    half *d_x = nullptr, *d_y = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, static_cast<size_t>(4) * kBenchN * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_x, x.data(), x.size() * sizeof(half), cudaMemcpyHostToDevice), cudaSuccess);
+
+    cudaEvent_t a, b;
+    cudaEventCreate(&a); cudaEventCreate(&b);
+    for (int i = 0; i < 80000; ++i)  // > 1 s, see requirement 1 above
+        imp::gemm_nvfp4_batched(bw, d_x, d_y, kBenchN, kK, 2, nullptr);
+    cudaDeviceSynchronize();
+
+    printf("\n  N=%d K=%d  (weight ~%.2f MB)\n", kBenchN, kK, kBenchN * kK * 0.5 / 1e6);
+    float prev = 0.0f;
+    for (int m = 1; m <= 4; ++m) {
+        float best = 1e9f;
+        for (int rep = 0; rep < 5; ++rep) {
+            constexpr int kIter = 300;
+            cudaEventRecord(a);
+            for (int i = 0; i < kIter; ++i)
+                imp::gemm_nvfp4_batched(bw, d_x, d_y, kBenchN, kK, m, nullptr);
+            cudaEventRecord(b);
+            cudaEventSynchronize(b);
+            float ms = 0.0f; cudaEventElapsedTime(&ms, a, b);
+            best = std::min(best, ms * 1000.0f / kIter);
+        }
+        printf("  MR=%d  %8.2f us  marginal %+7.2f us  %.0f GB/s of weight\n",
+               m, best, m == 1 ? 0.0f : best - prev, (kBenchN * kK * 0.5) / (best * 1e3));
+        prev = best;
+    }
+    cudaEventDestroy(a); cudaEventDestroy(b);
+    cudaFree(d_x); cudaFree(d_y);
+    imp::free_nvfp4_result(bw);
 }
 
 }  // namespace


### PR DESCRIPTION
A negative result, plus the two measurement failures that produced three
confident wrong answers before it.

## The kernel

An N-tiled variant of `gemv_nvfp4_kpar_mb_fp16` was built to amortise the
activation read across several output rows, on the theory that the per-verify
marginal row cost of 4.22 ms is each block re-reading the activation slab.
Measured paired and alternating in one process, min of five:

| MR | per-row | N-tiled | delta |
|---|---:|---:|---:|
| 2 | 8.93 | 9.48 | +0.55 us |
| 3 | 11.74 | 11.96 | +0.23 us |
| 4 | 12.71 | 12.51 | -0.20 us |

A wash, so it is not kept. The theory does not survive either: the "+2.19 us per
row, flat" that motivated it came from a benchmark measuring its own clock ramp.

## The two method failures, both mine

**1. A 20-iteration warmup on a 15 us kernel is 300 us.** The same unchanged code
path measured 20.59, 15.54 and 8.82 us across three runs because it was always
timed first and absorbed the ramp. The benchmark now burns a full second.

**2. Two builds cannot resolve this.** The same unchanged path read 11.30 and
13.88 us across builds, so anything under ~25 %% is drift while the deltas at
stake are 2-5 %%. Implementations must alternate inside one process, which is the
discipline this repo already applies to server measurements and which I failed to
carry over to a kernel microbenchmark.

Both are now written into the benchmark, next to the code they would otherwise
mislead again.

## What stands

The 4.22 ms marginal row is real and comes from server-side four-arm measurements
with residuals. Its cause is now explicitly **unattributed** rather than wrongly
attributed to activation traffic.

Test-only change. `BatchedSmallM` correctness tests still pass.