### PR TITLE
spec: the economics guard doomed MTP by arithmetic at every chain length

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -255,6 +255,33 @@ These have a code path and no gate. They may work; nothing proves it.
   to describe an unpinned regime. Acceptance was never the problem. Detail in
   the entry above.
 
+  **MTP stays off by default, and that is a decision rather than an omission.**
+  `speculative.mtp_k` remains 0. Enable it with `--set speculative.mtp_k=2`.
+  What you get and what you pay, all measured on Qwen3.8-27B-NVFP4 after the
+  launch fixes:
+
+  - **+15.2 % decode** on the shipped economics guard, two rounds: 109.48 and
+    96.81 tok/s at k=2 against 89.54 and 89.50 without speculation. The two
+    rounds differ by 13 % and ran 342 against 93 verifies on identical
+    settings, so read this as a range of roughly +8 % to +22 %, not a number.
+    The cause of that 3.7x swing in draft opportunity is not understood.
+
+```
+[PROV: commit=6c2c9445 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens,
+       2 alternating rounds, fresh process per arm
+       cmd=`--set speculative.ngram=false --set speculative.mtp_k=0|2
+       --set server.prefix_cache=false`, NO mtp_econ_min_emit override so the
+       shipped guard applies; tok/s from usage.completion_tokens over request
+       wall time, verify counts from /metrics]
+```
+
+  - **~1.6 GiB of VRAM** for the draft head, paid whether or not it drafts.
+  - **Output stops being reproducible across processes.** A golden-output test
+    has to pin `speculative.mtp_k` or it is testing the drafter's luck; see the
+    history-dependence entry above.
+  - Measured on one checkpoint. Other MTP-carrying models are untested.
+
   **Not finished.** A marginal chunk row still costs 4.22 ms, 38 % of a full
   decode step (down from 8.09 ms, 71 %), on a batch-1 memory-bound decode where
   the weights are already streaming and it should be near-free. Remaining

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -759,13 +759,49 @@ struct Speculative {
     // costs change — note a chain of k can emit at most k+1 per verify, so
     // values >= k+1 doom that k unconditionally.
     //
-    // 4.0 came from the #852 measurement, when the verify chunk ran eagerly
-    // and a partial acceptance re-forwarded the accepted prefix through the
-    // whole model. Both are gone: the verify is 26.5 ms against an 11.8 ms
-    // decode step on Qwen3.8-27B, so break-even is 2.25 emitted per verify,
-    // and that model emits 2.72. At 4.0 the guard disabled a configuration
-    // that measures +14.5 % against no MTP at all.
-    float mtp_econ_min_emit = 4.0f;
+    // NEGATIVE (the default) selects a k-aware threshold, 0 disables the
+    // guard, and a positive value is taken as an absolute floor.
+    //
+    // It used to be an absolute 4.0, which doomed MTP at every chain length
+    // this engine can run: a chain of k emits at most k+1 per verify, so 4.0
+    // is unreachable for k=1 (max 2.0), k=2 (max 3.0) and k=3 (max 4.0). The
+    // guard therefore unbound MTP after its 8-verify sample by arithmetic,
+    // whatever the speed, and the 21 % that mtp_k=2 now delivers could not be
+    // received by anyone who did not also override this key. 4.0 came from
+    // #852, when the verify ran eagerly and a partial acceptance re-forwarded
+    // the accepted prefix through the whole model; both are long gone.
+    //
+    // An absolute value cannot be right for every k, because break-even is
+    // chunk_cost(k+1 rows) / decode_cost and that ratio grows with the chain.
+    // Measured on Qwen3.8-27B-NVFP4 after the 2026-08-18 launch fixes, cost
+    // per verify against an 11.21 ms decode step:
+    //
+    //   k=1  15.59 ms -> break-even 1.39, emits 1.721
+    //   k=2  19.65 ms -> break-even 1.75, emits 2.195
+    //   k=3  27.27 ms -> break-even 2.43, emits 2.629
+    //
+    // `1 + 0.5 k` gives 1.5 / 2.0 / 2.5: above each measured break-even, so a
+    // configuration that genuinely loses is still caught, below each measured
+    // emission, and strictly under k+1 for every k, so it can never doom a
+    // chain by arithmetic again. Re-derive it the same way if verify or decode
+    // costs move; the three numbers above are the whole input.
+    //
+    // THE THREE THRESHOLDS ARE NOT EQUALLY SOUND. Margins against break-even
+    // and against measured emission:
+    //
+    //   k=1   +7.9 % above break-even,  12.8 % below emission
+    //   k=2  +14.3 %                     8.9 %
+    //   k=3   +2.9 %                     4.9 %
+    //
+    // Two runs of the identical k=2 configuration differed by 13 % in tok/s and
+    // by 3.7x in verify count, because generations diverge between processes
+    // and different text offers different draft opportunities. Both k=3 margins
+    // are inside that spread, so at k=3 this guard is advisory: on an unlucky
+    // corpus it can unbind a chain that is paying, and on a lucky one it can
+    // miss one that is not. k=1 and k=2 have real headroom. Widening the
+    // coefficient would buy k=3 a margin at the cost of making the guard worse
+    // everywhere else, which is why it is documented rather than fixed.
+    float mtp_econ_min_emit = -1.0f;
     // Graph-captured verify chunk (#847): cache one CUDA graph per
     // draft-length bucket and replay it each verify step — the chunk
     // metadata and KV lengths are read from device buffers, so the graph

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -1154,7 +1154,12 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         // Break-even avg emitted/verify is configurable (0 disables): the
         // right value depends on the chain lm_head cost (NVFP4 vs FP16) and
         // the verify-chunk cost, both of which have moved since #852.
-        const float min_emit = runtime_config_.speculative.mtp_econ_min_emit;
+        // Negative selects the k-aware default; see dispatch_policy.h for the
+        // measurement it comes from and for why an absolute value doomed every
+        // chain length this engine runs.
+        const float cfg_min = runtime_config_.speculative.mtp_econ_min_emit;
+        const float min_emit =
+            cfg_min < 0.0f ? 1.0f + 0.5f * static_cast<float>(mtp_spec_decode_k()) : cfg_min;
         if (min_emit > 0.0f && mtp_econ_verifies_ >= kMtpEconSample &&
             static_cast<float>(mtp_econ_emitted_) <
                 static_cast<float>(mtp_econ_verifies_) * min_emit)

--- a/tests/test_nvfp4_batched_smallm_equiv.cu
+++ b/tests/test_nvfp4_batched_smallm_equiv.cu
@@ -35,6 +35,7 @@
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
+#include <algorithm>
 #include <cmath>
 #include <random>
 #include <vector>
@@ -173,6 +174,87 @@ TEST_F(BatchedSmallM, MatchesDequantisedReference) {
                     << "m=" << m << " row=" << r << " n=" << n;
             }
     }
+}
+
+
+// DISABLED by default: a measurement, not an assertion. Run it with
+//   ./build-dev/test-quant --gtest_also_run_disabled_tests \\
+//       --gtest_filter='*MarginalRowCost*'
+//
+// TWO METHOD REQUIREMENTS ARE BAKED IN HERE BECAUSE GETTING EITHER WRONG
+// PRODUCED CONFIDENT NONSENSE (2026-08-18):
+//
+//  1. Warm up past the clock ramp. With a 20-iteration warmup the SAME
+//     unchanged code path measured 20.59, 15.54 and 8.82 us across three runs,
+//     purely because it was always timed first. Burn a full second.
+//  2. Compare implementations PAIRED AND ALTERNATING INSIDE ONE PROCESS. Across
+//     two builds the same unchanged path read 11.30 and 13.88 us, so any
+//     difference under ~25 % is drift, and a 2-5 us delta on a 10 us kernel is
+//     not resolvable that way.
+//
+// An N-tiled variant of this kernel (one activation read shared across several
+// output rows) was built and measured this way: +0.55, +0.23 and -0.20 us at
+// MR = 2, 3, 4. A wash, so it was not kept. The per-verify marginal row cost of
+// 4.22 ms is real and comes from server measurements, but its cause is NOT the
+// activation re-read, and it remains unattributed.
+TEST_F(BatchedSmallM, DISABLED_MarginalRowCost) {
+    std::mt19937 rng(5);
+    std::normal_distribution<float> dist(0.0f, 1.0f);
+    std::vector<half> x(static_cast<size_t>(4) * kK);
+    for (auto& h : x) h = __float2half(dist(rng));
+
+    // A real GDN projection shape: at the fixture's N=512 only 512 blocks reach
+    // a 170-SM card and the kernel is latency-bound, which is not the regime a
+    // verify chunk runs in.
+    constexpr int kBenchN = 5120;
+    imp::NvFP4QuantResult bw{};
+    {
+        std::vector<half> hw(static_cast<size_t>(kBenchN) * kK);
+        std::normal_distribution<float> wd(0.0f, 0.05f);
+        for (auto& h : hw) h = __float2half(wd(rng));
+        void* d_bw = nullptr;
+        ASSERT_EQ(cudaMalloc(&d_bw, hw.size() * sizeof(half)), cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(d_bw, hw.data(), hw.size() * sizeof(half), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        int64_t sh[2] = {kBenchN, kK};
+        imp::Tensor wt(d_bw, imp::QType::F16, 2, sh, true);
+        imp::quantize_fp16_to_nvfp4(wt, bw, nullptr);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        cudaFree(d_bw);
+    }
+
+    half *d_x = nullptr, *d_y = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_x, x.size() * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, static_cast<size_t>(4) * kBenchN * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_x, x.data(), x.size() * sizeof(half), cudaMemcpyHostToDevice), cudaSuccess);
+
+    cudaEvent_t a, b;
+    cudaEventCreate(&a); cudaEventCreate(&b);
+    for (int i = 0; i < 80000; ++i)  // > 1 s, see requirement 1 above
+        imp::gemm_nvfp4_batched(bw, d_x, d_y, kBenchN, kK, 2, nullptr);
+    cudaDeviceSynchronize();
+
+    printf("\n  N=%d K=%d  (weight ~%.2f MB)\n", kBenchN, kK, kBenchN * kK * 0.5 / 1e6);
+    float prev = 0.0f;
+    for (int m = 1; m <= 4; ++m) {
+        float best = 1e9f;
+        for (int rep = 0; rep < 5; ++rep) {
+            constexpr int kIter = 300;
+            cudaEventRecord(a);
+            for (int i = 0; i < kIter; ++i)
+                imp::gemm_nvfp4_batched(bw, d_x, d_y, kBenchN, kK, m, nullptr);
+            cudaEventRecord(b);
+            cudaEventSynchronize(b);
+            float ms = 0.0f; cudaEventElapsedTime(&ms, a, b);
+            best = std::min(best, ms * 1000.0f / kIter);
+        }
+        printf("  MR=%d  %8.2f us  marginal %+7.2f us  %.0f GB/s of weight\n",
+               m, best, m == 1 ? 0.0f : best - prev, (kBenchN * kK * 0.5) / (best * 1e3));
+        prev = best;
+    }
+    cudaEventDestroy(a); cudaEventDestroy(b);
+    cudaFree(d_x); cudaFree(d_y);
+    imp::free_nvfp4_result(bw);
 }
 
 }  // namespace


### PR DESCRIPTION
Tonight's 21 %% could not be received by anyone. `mtp_econ_min_emit` shipped as
an absolute **4.0**, and a chain of k emits at most **k+1** tokens per verify:

| k | max possible emitted/verify | guard demands | outcome |
|---|---:|---:|---|
| 1 | 2.0 | 4.0 | doomed |
| 2 | 3.0 | 4.0 | doomed |
| 3 | 4.0 | 4.0 | doomed |

So the guard unbound MTP after its 8-verify sample at every chain length this
engine runs, regardless of speed. With `mtp_k` also defaulting to 0, a user had
to override two keys to get anything.

The comment above the constant already said it was wrong: *"At 4.0 the guard
disabled a configuration that measures +14.5 %% against no MTP at all."* It was
written and the 4.0 was left in place, by me, earlier the same night, because an
A/B did not justify lowering it. That A/B ran on the build before the two launch
fixes and I did not go back to it.

## Why not just a smaller number

Break-even is `chunk_cost(k+1 rows) / decode_cost`, and that ratio grows with the
chain, so an absolute value is wrong at every k and only differently wrong.
Measured after the launch fixes against an 11.21 ms decode step:

| k | ms/verify | break-even | emits |
|---|---:|---:|---:|
| 1 | 15.59 | 1.39 | 1.721 |
| 2 | 19.65 | 1.75 | 2.195 |
| 3 | 27.27 | 2.43 | 2.629 |

The default is now **negative, selecting `1 + 0.5k`**: 1.5 / 2.0 / 2.5. Above each
measured break-even so a genuinely losing configuration is still caught, below
each measured emission, and **strictly under k+1 for every k**, so the arithmetic
doom is structurally impossible rather than merely avoided. `0` still disables and
a positive value is still an absolute floor, so explicit settings are unaffected.

**The three thresholds are not equally sound, and the comment says so.** k=3 sits
+2.9 %% above break-even and 4.9 %% below measured emission, both inside the
run-to-run spread documented below, so the guard is advisory there. Widening the
coefficient would buy k=3 a margin by making the guard worse everywhere else.

## Verified with no override

The shipped default has to carry it, so nothing was overridden:

| arm | round 1 | round 2 | verifies | `uneconomic` unbinds |
|---|---:|---:|---:|---:|
| k=0 | 89.54 | 89.50 | 0 | n/a |
| k=2 | **109.48** | **96.81** | 342 / 93 | **0** |

MTP survives its own guard. The two k=2 rounds differ by 13 %% in tok/s and 3.7x
in verify count on identical settings, generations having diverged between
processes, so **+15.2 %% is the mean of a roughly +8 to +22 %% range**, not a
number. That swing is recorded as not understood rather than averaged away.

## And a decision, not an omission

`mtp_k` stays 0. That was put to the maintainer with the numbers attached and
declined, so LIMITATIONS.md now states the opt-in and its full price: the range
above, ~1.6 GiB of VRAM for the draft head whether or not it drafts, output that
stops being reproducible across processes, and one checkpoint measured.