### PR TITLE
docs: the speculative greedy divergence is structural, five decode-side hypotheses are dead

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -134,18 +134,118 @@ These have a code path and no gate. They may work; nothing proves it.
   that guarantee from the seed alone if both runs share a long-lived server with
   other traffic between them. Pin `server.recurrent_snapshot_mb=0`, or use a
   fresh process per arm.
-- **Speculative decoding does not reproduce the non-speculative greedy output on
-  a GDN hybrid.** Its contract is that it changes speed and not tokens; here it
-  changes tokens. Measured on Qwen3.8-27B-NVFP4 with
-  `runtime.deterministic_gemm=true` on both arms and a stable control (two
-  no-MTP processes, byte-identical): with `mtp_k=2`, two of three prompts
-  diverge from the no-MTP answer, the first at character 79 of 1026 — an early
-  token flip, not a rounding tail. Both answers are coherent and correct, but
-  they are different generations. The verify advances the recurrent state
-  through the chunk kernels while plain decode advances it through the
-  single-token path, and the two do not agree bit for bit. Predates the
-  2026-08-17 verify work: the same two prompts diverge with the older eager
-  replay.
+- **Speculative decoding does not reproduce the non-speculative greedy output
+  on a GDN hybrid, and it cannot by construction.** Its contract is that it
+  changes speed and not tokens; here it changes tokens. Measured on
+  Qwen3.8-27B-NVFP4 with `runtime.deterministic_gemm=true`,
+  `speculative.ngram=false` and `server.prefix_cache=false` on both arms, three
+  prompts at 256 greedy tokens each, against a stable control (two
+  no-speculation processes byte-identical, and that control has held across
+  eight processes): with `mtp_k=2`, **all three prompts** diverge from the
+  no-speculation answer, first at bytes 79 / 332 / 243 (0-indexed). That is an
+  early token flip, not a rounding tail. Both answers are coherent; they are
+  different generations. Predates the 2026-08-17 verify work: the same prompts
+  diverge with the older eager replay.
+
+  **The cause is structural, not a kernel defect.** In a speculative arm every
+  emitted token comes out of the multi-row verify chunk and none out of the
+  single-token decode step: the chunk is built at
+  `src/runtime/engine_spec_ngram.cpp:740,751` and the only emit site in that
+  file is `:988`. Proven by an image whose `n == 1` decode path was broken badly
+  enough to emit pure garbage, and whose speculative arm still produced output
+  byte-identical to the stock speculative arm. Decode and the verify chunk also
+  dispatch different kernels for the same weights, per shape: 10240x5120 and
+  12288x5120 take `gemv_nvfp4_kpar` with its 32-lane `warp_k_loop` partition at
+  decode and `gemm_nvfp4_batched` in the chunk, and the FFN shapes 17408x5120
+  and 5120x17408 never appear on the decode side at all, because the
+  `n == 1`-gated fused NVFP4 kernels serve them there
+  (`src/exec/executor_ffn.cu:98,140`). So "speculation reproduces
+  non-speculative decode" is not a property this design can deliver. It could
+  only hold by kernel coincidence, and it does not.
+
+  **The mechanism this entry used to state is withdrawn.** It read: the verify
+  advances the recurrent state through the chunk kernels while plain decode
+  advances it through the single-token path. `--set gdn.chunkwise_scan=false` is
+  byte-inert on both arms and the divergence survives at the same offsets, so
+  that is not it.
+
+  **Five decode-side hypotheses are dead, each killed by a switch or by a patch
+  that instrumentation proved live. Do not re-run them:**
+
+  1. **GDN chunkwise scan** (`--set gdn.chunkwise_scan=false`): byte-inert on
+     both arms.
+  2. **Fused QK-norm + RoPE** (`--set attention.no_qknorm_fused=true`):
+     byte-inert on both arms.
+  3. **The NVFP4 `use_multirow` K-partition split**
+     (`src/quant/nvfp4_gemv_dense.cu:387`, patched out): byte-inert on both
+     arms. The dispatch log confirms shapes 10240x5120 and 12288x5120 moved from
+     `multirow=1` to `multirow=0` at decode, so the instrument was live.
+  4. **The fused NVFP4 FFN at decode** (two-site patch at
+     `src/exec/executor_ffn.cu:98,140`): decode output byte-identical to stock
+     across 2281 greedy tokens. The log confirms both FFN shapes moved onto
+     `gemv_nvfp4_kpar`, and `gemv_nvfp4_gate_up_fused` never fired.
+  5. **The attention kernel family** (mirror flip at
+     `src/exec/executor_attention.cu:516`, putting the `n == 1` decode step on
+     the chunk's FA2 path): it moves prompts 2 and 3 on the decode side and
+     leaves prompt 1 byte-identical, and prompt 1 is exactly where the
+     speculative divergence sits, at byte 79. With `--set
+     speculative.capture=false` putting both paths on the same eager
+     `FA2_FP16QK` branch, the divergence is still at byte 79.
+
+  **All five are decode-side substitutions, and the direction matters.** This is
+  not "kernel identity is irrelevant". A chunk-side substitution does move the
+  generated text: `--set speculative.verify_nvfp4_gemm=false` moves the first
+  difference to bytes 58 / 130 / 150 on the three prompts, and it still never
+  reaches the non-speculative reference. The standing fact for the chunk side is
+  the weaker one, that no chunk-side kernel choice tried so far closes the gap.
+
+  **What makes the decode-side eliminations hard to argue with is that the
+  invariance is at text level, not at offset level.** Across every decode-side
+  substitution the non-speculative prompt-1 answer is one and the same 1282-byte
+  text in 11 processes (md5 `35e7d9a93d14fe18a604a58fb6456388`), and the
+  `mtp_k=2` prompt-1 answer is one and the same 470-byte text in 8 processes
+  (md5 `c8a63ca87dc1ad95bc185b8c4e97d7b8`). The two differ from byte 79 on.
+  Prompt 2 behaves the same way, so prompts 1 and 2 carry this record.
+  **Prompt 3 does not**: it reads 243 in five pairs and 253 in two, and the 253
+  cannot be separated from the cross-process instability in the entry below.
+  Prompt 3 is evidence that all three prompts diverge, nothing more.
+
+```
+[PROV: commit=e3c48aa2 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens
+       per arm, fresh process per arm, one arm per process
+       cmd=`--set server.prefix_cache=false --set runtime.deterministic_gemm=true
+       --set speculative.ngram=false --set speculative.mtp_k=0|2
+       --set speculative.mtp_econ_min_emit=0`, request `temperature 0,
+       think_budget 0`; divergence offsets from `cmp` over the saved answer
+       bytes, kernel identity from the dispatch log, card idle]
+```
+
+- **A speculative arm is not byte-stable across processes at temperature 0,
+  with identical flags.** At `mtp_k=2`, one of nine processes on identical flags
+  produced a different prompt-3 answer (737 against 733 bytes, first difference
+  at byte 243) while its aggregate speculation counters were identical
+  (476/371/238). At `mtp_k=1` it is larger: two processes on identical flags
+  produced 471 against 1213 bytes on prompt 1, with 326 drafts / 278 accepts
+  against 420 / 345. The no-speculation arm is byte-stable across all eight of
+  its processes, so this is a property of the speculative path and not of the
+  host. It is not localized to one prompt or one chain length. Consequence for
+  callers: a harness that pins temperature 0 to make two runs comparable does
+  not get that from the seed alone while speculation is on. Use
+  `speculative.mtp_k=0` with `speculative.ngram=false` for an arm that has to
+  reproduce, or keep both arms inside one process.
+
+```
+[PROV: commit=e3c48aa2 date=2026-08-18 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=imp-server n=3 prompts x 256 greedy tokens
+       per process, 9 processes at mtp_k=2, 2 at mtp_k=1, 8 at mtp_k=0
+       cmd=`--set server.prefix_cache=false --set runtime.deterministic_gemm=true
+       --set speculative.ngram=false --set speculative.mtp_k=0|1|2
+       --set speculative.mtp_econ_min_emit=0`, request `temperature 0,
+       think_budget 0`; answer bytes compared with `cmp`, drafts and accepts
+       from /metrics deltas, card idle]
+```
+
 - **The MTP head accepts 75.0 % of its first draft, and six explanations for
   the gap to published figures are dead.** Measured on Qwen3.8-27B-NVFP4 over a
   10-prompt mixed corpus (exposition, code, arithmetic, enumeration), n-gram

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -310,6 +310,42 @@ imp's problem and the published 87 % figure describes a regime nobody has pinned
   `engine_scheduler.cpp` that trades it for telemetry coverage is still wrong on
   its own terms, but it is a 1 % wrong.
 
+Added 2026-08-18, on the speculative greedy divergence:
+
+- **The recurrent-state mechanism for it**, i.e. "the verify advances the
+  recurrent state through the chunk kernels while plain decode advances it
+  through the single-token path". Disproven: `--set gdn.chunkwise_scan=false` is
+  byte-inert on both arms and the divergence survives at the same offsets. That
+  sentence stood in [`LIMITATIONS.md`](LIMITATIONS.md) until this measurement
+  and is gone from it now.
+- **Five decode-side kernel hypotheses**: GDN chunkwise scan
+  (`gdn.chunkwise_scan=false`), fused QK-norm + RoPE
+  (`attention.no_qknorm_fused=true`), the NVFP4 `use_multirow` K-partition split
+  (patched out), the fused NVFP4 FFN at decode (two-site patch in
+  `executor_ffn.cu`), the attention kernel family (mirror flip plus
+  `speculative.capture=false`). Each instrument was proven live by its dispatch
+  log before the null result was believed; all five leave the speculative output
+  where it was. They cannot be the cause for a structural reason: in a
+  speculative arm every emitted token comes out of the multi-row verify chunk
+  and none out of the single-token decode step, so no decode-side kernel is on
+  the emitting path at all. Offsets and the per-hypothesis evidence in
+  [`LIMITATIONS.md`](LIMITATIONS.md).
+- **Chunk-side kernel choice as the fix.** Not dead, but not a lever either:
+  `--set speculative.verify_nvfp4_gemm=false` moves the first difference to
+  bytes 58 / 130 / 150 instead of 79 / 332 / 243 and still never reaches the
+  non-speculative reference. No chunk-side kernel choice tried so far closes the
+  gap.
+- **Correction to "Two of three prompts diverge"**, in the *Two findings that
+  are not speed* list further down this file: all three prompts diverge, at
+  bytes 79 / 332 / 243 with `mtp_k=2`. Two of three was the count on the first
+  pass only. The control is unchanged and now holds across eight
+  no-speculation processes.
+- **Cross-process reproducibility of a speculative arm at temperature 0.** It
+  does not hold, and it is not a kernel hypothesis to chase here: 1 of 9
+  processes at `mtp_k=2` produced a different answer on identical flags, and the
+  two processes measured at `mtp_k=1` disagree with each other. Documented for
+  callers in [`LIMITATIONS.md`](LIMITATIONS.md).
+
 ### Withdrawn by their author
 
 - "0.72 forwards per emitted token, so speculation moves fewer bytes": the launch

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -309,7 +309,14 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         // (bucket 3 + the 4-row edge); larger chunks stay on CUTLASS (5+
         // weight sweeps at M=17 would be ~3.5x worse). Same weight + linear
         // micro-scales the M=1 decode GEMV reads (source_data/source_scales),
-        // so verify rows stay in the decode kernel family (argmax parity).
+        // but NOT the same kernel, and there is no argmax parity: decode takes
+        // gemv_nvfp4_kpar (32-lane warp_k_loop K-partition) for shapes
+        // 10240x5120 and 12288x5120 while the verify chunk takes
+        // gemm_nvfp4_batched here, and the FFN shapes 17408x5120 / 5120x17408
+        // never reach this file at decode at all, because the n==1-gated fused
+        // NVFP4 kernels in executor_ffn.cu serve them there. Measured on
+        // Qwen3.8-27B-NVFP4: a speculative arm does not reproduce the
+        // non-speculative greedy output, see docs/LIMITATIONS.md.
         if (ctx.spec_verify_small_m && (ctx.beta == 0.0f || ctx.beta == 1.0f) && M <= 4 &&
             input.qtype == QType::F16 && output.qtype == QType::F16 &&
             h.primary_tier == StorageTier::CUTLASS_NVFP4 && h.source_data != nullptr &&


### PR DESCRIPTION
This is documentation plus one code comment, no behavior change.

## What was wrong

`docs/LIMITATIONS.md` explained the speculative greedy divergence with "the
verify advances the recurrent state through the chunk kernels while plain decode
advances it through the single-token path". `--set gdn.chunkwise_scan=false` is
byte-inert on both arms and the divergence survives at the same offsets, so that
mechanism is out. The entry also said two of three prompts diverge. All three do,
at bytes 79 / 332 / 243 with `mtp_k=2`.

## What replaces it

- **The cause is structural.** In a speculative arm every emitted token comes out
  of the multi-row verify chunk and none out of the single-token decode step
  (`src/runtime/engine_spec_ngram.cpp:740,751`, single emit site at `:988`).
  Proven by an image whose `n == 1` decode path emitted pure garbage while its
  speculative arm stayed byte-identical to the stock speculative arm. So
  "speculation reproduces non-speculative decode" is not a property this design
  can deliver; it could only hold by kernel coincidence.
- **Five decode-side hypotheses are recorded dead**, each with the switch or the
  patch that killed it and the instrumentation that proved the instrument live:
  GDN chunkwise scan, fused QK-norm + RoPE, the NVFP4 `use_multirow` K-partition
  split, the fused NVFP4 FFN at decode, the attention kernel family.
- **The direction is stated**, because the eliminations are decode-side only:
  `--set speculative.verify_nvfp4_gemm=false` on the chunk side does move the
  text (bytes 58 / 130 / 150) and still never reaches the non-speculative
  reference. No chunk-side kernel choice tried so far closes the gap.
- **The invariance is at text level**: the non-speculative prompt-1 answer is the
  same 1282-byte text in 11 processes, the `mtp_k=2` answer the same 470-byte
  text in 8. Prompt 3 is explicitly not claimed as invariant.

## New entry

A speculative arm is not byte-stable across processes at temperature 0. One of
nine `mtp_k=2` processes on identical flags produced a different prompt-3 answer
with identical aggregate counters; at `mtp_k=1` two processes produced 471
against 1213 bytes on prompt 1. The no-speculation arm is byte-stable across all
eight of its processes. Consequence for callers is in the entry.

## The comment

`src/exec/executor_gemm_dispatch.cu:310` claimed verify rows "stay in the decode
kernel family (argmax parity)". Measured false: 10240x5120 and 12288x5120 take
`gemv_nvfp4_kpar` at decode and `gemm_nvfp4_batched` in the chunk, and the FFN
shapes 17408x5120 / 5120x17408 never reach that file at decode because the
`n == 1`-gated fused NVFP4 kernels serve them.

No CHANGELOG entry: nothing user-visible changed, and the CHANGELOG is not a
journal. The dead hypotheses are also buried in `docs/roadmap.md`.

## Gate

```
== perf vs baseline ==
  decode  tg128 =  288.44 tok/s  (baseline  287.19, delta 0.44%)
  prefill pp512 = 12634.50 tok/s  (baseline 12406.87, delta 1.83%)
== peak VRAM vs baseline ==
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
== graphs ON vs OFF decode gate ==
  graphs ON  tg256 =  459.40 tok/s   (2.42x, threshold 1.3x)
== smoke prompts (degeneration check) ==
PASS Qwen3-4B Q8_0 (dense) (distinct=11, contains 'Paris')
=== verify fast: OK ===
```

`make test-gpu` ran as the pre-commit gate on this tree and passed;
`python3 scripts/docs_lint.py` is OK with 11 pre-existing warnings.
