### PR TITLE
mtp: tell the operator about a head the load is skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **A checkpoint that ships an MTP head now says so when it is not being used.**
+  `speculative.mtp_k` defaults to 0, which also means the head is never loaded,
+  so nothing could mention it: the engine now probes the tensor names (sidecar
+  file, shard index or single-file header, no weight read) and logs the flag,
+  the measured gain (+15 % decode on Qwen3.8-27B-NVFP4, range +8 to +22) and
+  the two prices. The default stays 0.
+
 ### Fixed
 
 - **`scripts/verify.sh` no longer reports OK when no model-backed gate ran.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,9 @@ there instead of retelling it.
 
 ### Added
 
-- **A checkpoint that ships an MTP head now says so when it is not being used.**
-  `speculative.mtp_k` defaults to 0, which also means the head is never loaded,
-  so nothing could mention it: the engine now probes the tensor names (sidecar
-  file, shard index or single-file header, no weight read) and logs the flag,
-  the measured gain (+15 % decode on Qwen3.8-27B-NVFP4, range +8 to +22) and
-  the two prices. The default stays 0.
+- **A checkpoint that ships an MTP head now says so when nothing is using it.**
+  One log line naming `speculative.mtp_k`, the measured gain (+15 % decode on
+  Qwen3.8-27B-NVFP4) and its two prices. The default stays 0.
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,6 +685,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mrope_config.cpp
         tests/test_image_placeholders.cpp
         tests/test_ngram_draft.cpp
+    tests/test_mtp_presence.cpp
         tests/test_spec_gates.cpp
         tests/test_suffix_draft.cpp
         tests/test_token_recycle_draft.cpp

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -391,11 +391,25 @@ These have a code path and no gate. They may work; nothing proves it.
        wall time, verify counts from /metrics]
 ```
 
-  - **~1.6 GiB of VRAM** for the draft head, paid whether or not it drafts.
+  - **0.79 GiB of VRAM** for the draft head on this model, paid whether or not
+    it drafts (15 tensors, BF16 to FP16 on upload). The `~1.6 GiB` that
+    `dispatch_policy.h` quotes is not this checkpoint: its head is a dense
+    MLP, and a MoE head costs more.
   - **Output stops being reproducible across processes.** A golden-output test
     has to pin `speculative.mtp_k` or it is testing the drafter's luck; see the
     history-dependence entry above.
   - Measured on one checkpoint. Other MTP-carrying models are untested.
+
+  **The engine says this at load.** A checkpoint that ships an MTP head while
+  `speculative.mtp_k` is 0 gets one INFO line naming the flag, the measured
+  gain and the two prices. It is a name-only probe across all three
+  checkpoint layouts (sidecar file, shard index, single-file header), so it
+  reads no weight and costs nothing on a load that does not want the head. It
+  asks for the fusion projection that the loader's own dispatch keys on, not
+  for any `mtp.*` name, so a group of MTP tensors imp could not actually load
+  does not get advertised. Without it the option is invisible: the head is
+  only loaded when `mtp_k > 0`, so an engine that has not loaded it also cannot
+  mention it.
 
   **Not finished.** A marginal chunk row still costs 4.22 ms, 38 % of a full
   decode step (down from 8.09 ms, 71 %), on a batch-1 memory-bound decode where

--- a/src/core/dispatch_policy.h
+++ b/src/core/dispatch_policy.h
@@ -737,7 +737,11 @@ struct Speculative {
     bool hybrid = true;
     // MTP-head chain-draft length for the verify loop (models shipping a
     // trained MTP head, e.g. Qwen3.6 model_mtp.safetensors). 0 = off.
-    // When >0 the server loads the head (~1.6 GiB VRAM) and enables MTP;
+    // When >0 the server loads the head and enables MTP. Its VRAM cost is
+    // per checkpoint, not a constant: Qwen3.8-27B's dense-MLP head measures
+    // 0.79 GiB (15 tensors, BF16 to FP16 on upload), where the ~1.6 GiB this
+    // line used to quote came from a MoE head. Read the load line rather
+    // than this comment;
     // drafts fill verify steps where the suffix/ngram matcher has no
     // match (draft-poor prose — 78-94% depth-1 accept on Qwen3.6-35B-A3B,
     // PR #804). imp-cli equivalent: --mtp-spec-decode <k>.

--- a/src/model/llm_compressor_loader.cpp
+++ b/src/model/llm_compressor_loader.cpp
@@ -2,6 +2,7 @@
 
 #include "core/logging.h"
 #include "model/json_util.h"
+#include "model/mtp_head.h"
 
 #include <fstream>
 #include <sstream>
@@ -96,7 +97,10 @@ bool name_is_vision(const std::string& in) {
            starts_with(in, "vision_tower.") || starts_with(in, "multi_modal_projector.");
 }
 
-bool name_is_mtp(const std::string& in) { return starts_with(in, "mtp.") || starts_with(in, "model.mtp."); }
+// One rule for the whole loader: this decides the shard drop, load_shard()
+// decides the divert, and probe_mtp_head() decides what the operator is told.
+// #1384 was three sites answering one question and one of them disagreeing.
+bool name_is_mtp(const std::string& in) { return imp::name_is_mtp_tensor(in); }
 
 bool name_is_skipped(const std::string& in, bool keep_vision) {
     if (name_is_vision(in))

--- a/src/model/mtp_head.h
+++ b/src/model/mtp_head.h
@@ -67,9 +67,43 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace imp {
+
+// Is this checkpoint tensor part of an MTP head? Checkpoints write the head
+// either as `mtp.*` or, with the outer prefix kept, as `model.mtp.*`.
+//
+// One rule, two callers: the divert decision in load_shard() and the presence
+// probe that tells the operator about a head it is NOT loading. Two places
+// asking the same question and answering differently is the defect class that
+// produced #1384 and #1443, so both go through here.
+inline bool name_is_mtp_tensor(std::string_view name) {
+    return name.rfind("mtp.", 0) == 0 || name.rfind("model.mtp.", 0) == 0;
+}
+
+// Does this name make an `mtp.*` group a head imp can actually dispatch? It is
+// the projection fusing the embedding with the hidden state, and dispatch_mtp()
+// keys its two checkpoint shapes on exactly these two spellings. A probe that
+// accepted any `mtp.*` name would advertise a head that enabling then rejects,
+// which is a worse failure than saying nothing.
+// The two spellings, as constants, because dispatch_mtp() branches on the same
+// strings. Sharing them is what keeps probe and dispatch from drifting apart:
+// a test could only notice the drift afterwards, a shared constant prevents it.
+inline constexpr const char* kMtpHeadKeyEhProj = "mtp.layers.0.eh_proj.weight";
+inline constexpr const char* kMtpHeadKeyFc = "mtp.fc.weight";
+
+inline bool name_is_mtp_head_key(std::string_view name) {
+    if (name.rfind("model.", 0) == 0)
+        name.remove_prefix(6);
+    return name == kMtpHeadKeyEhProj || name == kMtpHeadKeyFc;
+}
+
+// True when `model_dir` ships an MTP head, decided from tensor NAMES only: the
+// sidecar file, the shard index, or the single-file header. Reads no weight
+// byte, so it is cheap enough to run on a load that does not want the head.
+bool probe_mtp_head(const std::string& model_dir);
 
 // Phase 1.A leftover — kept as part of the new MtpHead struct for compatibility
 // with the existing Model::mtp_info_ field.

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -395,11 +395,10 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             if (translated.action == imp::llm_compressor::NameTranslation::SKIP) {
                 // Embedded MTP head: keep the tensor, but route it to the
                 // separate MTP map under its raw mtp.* name.
-                if (mtp_out != nullptr) {
+                if (mtp_out != nullptr && name_is_mtp_tensor(tensor_name)) {
                     if (tensor_name.rfind("model.mtp.", 0) == 0)
-                        tensor_name = tensor_name.substr(6);  // strip "model."
-                    if (tensor_name.rfind("mtp.", 0) == 0)
-                        divert_to_mtp = true;
+                        tensor_name = tensor_name.substr(6);
+                    divert_to_mtp = true;
                 }
                 if (!divert_to_mtp)
                     continue;
@@ -658,6 +657,67 @@ static bool load_sharded(const std::string& model_dir, std::unordered_map<std::s
 
 // ---- Main SafeTensors loader ----
 
+// Name-only MTP presence check. Three checkpoint layouts carry a head, and a
+// reader that knows only one of them reports "no head" on the other two:
+//   1. sidecar   model_mtp.safetensors
+//   2. sharded   model.safetensors.index.json names it in weight_map
+//   3. single    model.safetensors names it in the header
+// All three answer via name_is_mtp_head_key(), the same tensor dispatch_mtp()
+// keys its shapes on, so a "yes" here means enabling would actually load. Only
+// names are read (the index text, or the 8-byte-prefixed header), never a
+// weight, so this costs nothing on a load that does not want the head.
+bool probe_mtp_head(const std::string& model_dir) {
+    namespace fs = std::filesystem;
+    if (model_dir.empty())
+        return false;
+
+    auto json_has_head = [](const char* data, size_t len) {
+        JsonParser parser(data, len);
+        JValue root = parser.parse();
+        if (!parser.ok() || root.type != JType::OBJECT)
+            return false;
+        // The index nests names under weight_map; a shard header lists them at
+        // the top level.
+        const JValue* map = jobj_find(root, "weight_map");
+        const JValue& obj = (map && map->type == JType::OBJECT) ? *map : root;
+        for (const auto& kv : obj.obj)
+            if (name_is_mtp_head_key(kv.first))
+                return true;
+        return false;
+    };
+
+    // Read a safetensors header without mapping the body.
+    auto header_has_head = [&](const std::string& file) {
+        std::error_code ec;
+        auto total = fs::file_size(file, ec);
+        if (ec || total < 8)
+            return false;
+        std::ifstream f(file, std::ios::binary);
+        if (!f.is_open())
+            return false;
+        uint64_t header_size = 0;
+        if (!f.read(reinterpret_cast<char*>(&header_size), sizeof(header_size)))
+            return false;
+        std::string vh_err;
+        if (!safetensors_internal::validate_header_size(total, header_size, &vh_err))
+            return false;
+        std::string header(static_cast<size_t>(header_size), '\0');
+        if (!f.read(header.data(), static_cast<std::streamsize>(header_size)))
+            return false;
+        return json_has_head(header.data(), header.size());
+    };
+
+    if (header_has_head(model_dir + "/model_mtp.safetensors"))
+        return true;
+
+    std::ifstream idx(model_dir + "/model.safetensors.index.json");
+    if (idx.is_open()) {
+        std::string text((std::istreambuf_iterator<char>(idx)), std::istreambuf_iterator<char>());
+        return json_has_head(text.data(), text.size());
+    }
+    return header_has_head(model_dir + "/model.safetensors");
+}
+
 std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_head) {
     namespace fs = std::filesystem;
 
@@ -775,11 +835,11 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         // says `self_attn`/`mlp`, and per-expert 2-D weights instead of one
         // packed 3-D stack. Detected on a name only this layout has, so the
         // Qwen path below is reached byte-for-byte as before.
-        if (tm.count("mtp.layers.0.eh_proj.weight")) {
+        if (tm.count(kMtpHeadKeyEhProj)) {
             bool nok = true;
             nok &= take("mtp.layers.0.enorm.weight", head.pre_fc_norm_embedding);
             nok &= take("mtp.layers.0.hnorm.weight", head.pre_fc_norm_hidden);
-            nok &= take("mtp.layers.0.eh_proj.weight", head.fc);
+            nok &= take(kMtpHeadKeyEhProj, head.fc);
             nok &= take("mtp.layers.0.norm.weight", head.input_layernorm);
             nok &= take("mtp.layers.0.mixer.q_proj.weight", head.q_proj);
             nok &= take("mtp.layers.0.mixer.k_proj.weight", head.k_proj);
@@ -838,7 +898,7 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         bool ok = true;
         ok &= take("mtp.pre_fc_norm_embedding.weight", head.pre_fc_norm_embedding);
         ok &= take("mtp.pre_fc_norm_hidden.weight", head.pre_fc_norm_hidden);
-        ok &= take("mtp.fc.weight", head.fc);
+        ok &= take(kMtpHeadKeyFc, head.fc);
         ok &= take("mtp.layers.0.input_layernorm.weight", head.input_layernorm);
         ok &= take("mtp.layers.0.post_attention_layernorm.weight", head.post_attention_layernorm);
         ok &= take("mtp.layers.0.self_attn.q_proj.weight", head.q_proj);
@@ -901,10 +961,10 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             // harvest from there.
             if (embedded_mtp_map.empty()) {
                 for (const auto& kv : tensor_map) {
-                    if (kv.first.rfind("mtp.", 0) == 0)
-                        embedded_mtp_map.emplace(kv.first, kv.second);
-                    else if (kv.first.rfind("model.mtp.", 0) == 0)
-                        embedded_mtp_map.emplace(kv.first.substr(6), kv.second);
+                    if (!name_is_mtp_tensor(kv.first))
+                        continue;
+                    const bool prefixed = kv.first.rfind("model.mtp.", 0) == 0;
+                    embedded_mtp_map.emplace(prefixed ? kv.first.substr(6) : kv.first, kv.second);
                 }
             }
             if (!embedded_mtp_map.empty()) {
@@ -914,6 +974,17 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
                 mtp_local = dispatch_mtp(embedded_mtp_map, path + " (embedded mtp.*)", bytes);
             }
         }
+    } else if (probe_mtp_head(model_dir)) {
+        // The caller asked for no head and this checkpoint has one. Say so
+        // once, with the trade, because speculative.mtp_k defaults to 0 and an
+        // option nobody is told about is not a choice the operator gets to
+        // make. Costs a name scan, no weight bytes.
+        IMP_LOG_INFO(
+            "MTP head present in this checkpoint but not loaded (speculative.mtp_k=0). "
+            "Enable with --set speculative.mtp_k=2: measured +15 %% decode on "
+            "Qwen3.8-27B-NVFP4, range +8 to +22 %%, in exchange for the head's VRAM "
+            "(0.79 GiB there) and reproducible output across processes. "
+            "See docs/LIMITATIONS.md");
     }
 
     // Create model

--- a/tests/test_mtp_presence.cpp
+++ b/tests/test_mtp_presence.cpp
@@ -1,0 +1,137 @@
+// The MTP name rule, and the presence probe that reads it.
+//
+// Why this exists: the rule lives in three call sites (the divert in
+// load_shard, the modelopt harvest, and the probe that tells the operator
+// about a head it is not loading). They used to carry three literal copies of
+// the prefixes. A checkpoint whose head one copy sees and another misses is
+// exactly the "two places, same question, different answer" defect that
+// produced #1384 and #1443, so the rule is one function and this pins it.
+#include "model/mtp_head.h"
+#include <filesystem>
+#include <cstdlib>
+#include <fstream>
+#include <gtest/gtest.h>
+
+namespace fs = std::filesystem;
+
+TEST(MtpNameRule, AcceptsBothCheckpointSpellings) {
+    // Sidecar and llm-compressor checkpoints write the bare prefix; modelopt
+    // keeps the outer `model.` on. Both are the same head.
+    EXPECT_TRUE(imp::name_is_mtp_tensor("mtp.layers.0.eh_proj.weight"));
+    EXPECT_TRUE(imp::name_is_mtp_tensor("model.mtp.layers.0.eh_proj.weight"));
+}
+
+TEST(MtpNameRule, RejectsMainModelTensors) {
+    // Must anchor at position 0: a main-model tensor that merely CONTAINS the
+    // substring would otherwise be diverted out of the model and silently lost.
+    EXPECT_FALSE(imp::name_is_mtp_tensor("model.layers.0.mtp.weight"));
+    EXPECT_FALSE(imp::name_is_mtp_tensor("model.embed_tokens.weight"));
+    EXPECT_FALSE(imp::name_is_mtp_tensor("lm_head.weight"));
+    EXPECT_FALSE(imp::name_is_mtp_tensor(""));
+}
+
+TEST(MtpNameRule, HeadKeyAcceptsBothCheckpointShapes) {
+    // dispatch_mtp() branches on the same two constants, so probe and dispatch
+    // cannot drift apart. These cases pin the literal spellings a checkpoint
+    // actually uses, which the shared constants alone do not.
+    EXPECT_TRUE(imp::name_is_mtp_head_key("mtp.fc.weight"));
+    EXPECT_TRUE(imp::name_is_mtp_head_key("model.mtp.fc.weight"));
+    EXPECT_TRUE(imp::name_is_mtp_head_key("mtp.layers.0.eh_proj.weight"));
+    EXPECT_TRUE(imp::name_is_mtp_head_key("model.mtp.layers.0.eh_proj.weight"));
+}
+
+TEST(MtpNameRule, HeadKeyRejectsAnMtpGroupWithoutAFusionProjection) {
+    // `mtp.*` tensors alone are not a usable head: without the fusion
+    // projection dispatch_mtp() warns and disables spec-decode, so the probe
+    // must not advertise one.
+    EXPECT_FALSE(imp::name_is_mtp_head_key("mtp.norm.weight"));
+    EXPECT_FALSE(imp::name_is_mtp_head_key("mtp.layers.0.self_attn.q_proj.weight"));
+    EXPECT_FALSE(imp::name_is_mtp_head_key("lm_head.weight"));
+}
+
+namespace {
+// A checkpoint dir is one of three layouts, and a probe that knows one of them
+// reports "no head" on the other two. Each layout gets its own case.
+struct TempDir {
+    fs::path p;
+    explicit TempDir(const std::string& tag) {
+        p = fs::temp_directory_path() / ("imp_mtp_probe_" + tag);
+        fs::remove_all(p);
+        fs::create_directories(p);
+    }
+    ~TempDir() { fs::remove_all(p); }
+};
+
+void write_single_file(const fs::path& file, const std::string& header_json) {
+    std::ofstream f(file, std::ios::binary);
+    uint64_t n = header_json.size();
+    f.write(reinterpret_cast<const char*>(&n), sizeof(n));
+    f.write(header_json.data(), static_cast<std::streamsize>(n));
+    const char pad[8] = {};  // a body, so header_size validation sees a real file
+    f.write(pad, sizeof(pad));
+}
+}  // namespace
+
+TEST(MtpProbe, FindsSidecarLayout) {
+    TempDir d("sidecar");
+    write_single_file(d.p / "model_mtp.safetensors", R"({"mtp.fc.weight":{"dtype":"BF16"}})");
+    EXPECT_TRUE(imp::probe_mtp_head(d.p.string()));
+}
+
+TEST(MtpProbe, RejectsASidecarThatIsNotAHead) {
+    // A file by that name is not evidence. Before it was read, an empty or
+    // unrelated model_mtp.safetensors advertised a head that enabling would
+    // then fail to dispatch.
+    TempDir d("sidecar_empty");
+    std::ofstream(d.p / "model_mtp.safetensors") << "not empty, not a head";
+    EXPECT_FALSE(imp::probe_mtp_head(d.p.string()));
+}
+
+TEST(MtpProbe, FindsShardedLayoutViaWeightMap) {
+    TempDir d("sharded");
+    std::ofstream(d.p / "model.safetensors.index.json")
+        << R"({"weight_map":{"model.embed_tokens.weight":"a.safetensors",)"
+           R"("mtp.fc.weight":"b.safetensors"}})";
+    EXPECT_TRUE(imp::probe_mtp_head(d.p.string()));
+}
+
+TEST(MtpProbe, FindsSingleFileLayoutViaHeader) {
+    TempDir d("single");
+    write_single_file(d.p / "model.safetensors", R"({"model.mtp.layers.0.eh_proj.weight":{"dtype":"BF16"}})");
+    EXPECT_TRUE(imp::probe_mtp_head(d.p.string()));
+}
+
+TEST(MtpProbe, StaysQuietWithoutAHead) {
+    // The negative case is the one that matters for the hint: a checkpoint
+    // without a head must not advertise one, in any of the three layouts.
+    TempDir d("nohead");
+    std::ofstream(d.p / "model.safetensors.index.json")
+        << R"({"weight_map":{"model.embed_tokens.weight":"a.safetensors"}})";
+    EXPECT_FALSE(imp::probe_mtp_head(d.p.string()));
+
+    TempDir e("nohead_single");
+    write_single_file(e.p / "model.safetensors", R"({"lm_head.weight":{"dtype":"BF16"}})");
+    EXPECT_FALSE(imp::probe_mtp_head(e.p.string()));
+
+    TempDir g("mtp_without_fusion");
+    std::ofstream(g.p / "model.safetensors.index.json")
+        << R"({"weight_map":{"mtp.norm.weight":"a.safetensors",)"
+           R"("mtp.layers.0.self_attn.q_proj.weight":"a.safetensors"}})";
+    EXPECT_FALSE(imp::probe_mtp_head(g.p.string()));
+
+    TempDir f("empty");
+    EXPECT_FALSE(imp::probe_mtp_head(f.p.string()));
+    EXPECT_FALSE(imp::probe_mtp_head(""));
+}
+
+// The synthetic cases above pin the rule; this one pins it against a real
+// checkpoint, because a hand-written weight_map is a statement about what I
+// think checkpoints look like. Reads the index only, no GPU, no weights.
+// Skipped where the model is absent, which includes CI.
+TEST(MtpProbe, FindsTheHeadInARealCheckpoint) {
+    const char* env = std::getenv("IMP_MTP_MODEL");
+    std::string path = env ? env : "/models/Qwen3.8-27B-NVFP4";
+    if (!fs::exists(path))
+        GTEST_SKIP() << "checkpoint not present: " << path;
+    EXPECT_TRUE(imp::probe_mtp_head(path)) << "known to carry mtp.fc.weight (15 tensors)";
+}


### PR DESCRIPTION
## What

A checkpoint that ships a trained MTP head now says so when nothing is using it:

```
MTP head present in this checkpoint but not loaded (speculative.mtp_k=0).
Enable with --set speculative.mtp_k=2: measured +15 % decode on
Qwen3.8-27B-NVFP4, range +8 to +22 %, in exchange for the head's VRAM
(0.79 GiB there) and reproducible output across processes.
See docs/LIMITATIONS.md
```

The default stays 0, which `docs/LIMITATIONS.md` records as a decision rather
than an omission. This changes nothing about it: an option nobody is told about
is not a choice the operator gets to make.

## Why it could not simply be read off the engine

`speculative.mtp_k` decides two things at once. `handlers.cpp:553` passes
`load_mtp_head = mtp_k > 0`, so at the default the head is never read, and an
engine that has not read it cannot mention it. My first attempt put the check
at the end of `Engine::init` and failed in **both** directions: silent at
`mtp_k=0` because the head was absent, and printing at `mtp_k=2` because
`enable_mtp_spec_decode()` runs after `init`. A one-directional test would have
shown neither.

So the answer comes from the tensor names instead. `probe_mtp_head()` handles
all three checkpoint layouts (sidecar file, shard index, single-file header)
and reads no weight byte.

## The part worth reviewing

The rule "is this an MTP tensor" existed in **four** places: the divert in
`load_shard`, the modelopt harvest, the shard drop in
`llm_compressor::name_is_mtp`, and the new probe. That is the shape of #1384,
where three sites answered one question and one disagreed. They are now one
function.

The probe also does not accept just any `mtp.*` name. `dispatch_mtp` refuses a
head without its fusion projection, so a name-only "yes" would have advertised
something that enabling then fails to load. Probe and dispatch branch on the
same two constants, which prevents the drift rather than testing for it
afterwards.

## Also

Corrects the head's VRAM figure in `docs/LIMITATIONS.md` and
`dispatch_policy.h`: 0.79 GiB measured here, against the `~1.6 GiB` the comment
carried over from a MoE head. The cost is per checkpoint, so both now point at
the load line.

## Verification

- 10 cases in `tests/test_mtp_presence.cpp`. Three mutations, each killed by
  its own case: anchor removed from the prefix rule, single-file layout dropped
  from the probe, head key widened to any `mtp.*` name.
- One case runs against the real checkpoint and skips where the model is
  absent, which includes CI.
- End to end on Qwen3.8-27B-NVFP4, both directions: the line appears at
  `mtp_k=0` and is absent at `mtp_k=2`.
- No perf change: the probe runs once per load and only when the head is being
  skipped.

### Gate

`verify-fast` green twice: at commit time on a contended card, and again as the
pre-push hook on a quiet one (peak VRAM 20718 MiB against a 20716 baseline,
+0.01 %; graphs ON 458.73 tok/s, 2.45x; smoke OK). The first run's decode read
284.44 tok/s against 287.19, -0.96 %, with SM clocks at 2430 MHz against a
healthy ~2850 because another process held the card. This change touches the
loader only and cannot move decode either way.

The gated image was confirmed to contain the change rather than assumed to:
`grep -ac "MTP head present in this checkpoint"` returns 1 inside `imp:test`,
with a pre-existing string as the positive control. `verify-fast` does not
rebuild, so that check is what separates a gate that covered this diff from one
that graded an older binary.
