### PR TITLE
memory: the weight upload is the first sight of a co-tenant, so stop calling it weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,24 @@ there instead of retelling it.
 
 ### Added
 
+- **`/health` says whether the KV pool can still grow (`kv_pool_growable`).** A
+  fixed pool and a growable one already at its ceiling both report
+  `kv_ceiling_blocks == kv_blocks_total`, and the two want opposite reactions:
+  wait for the card to free, or stop waiting.
+
 - **A checkpoint that ships an MTP head now says so when nothing is using it.**
   One log line naming `speculative.mtp_k`, the measured gain (+15 % decode on
   Qwen3.8-27B-NVFP4) and its two prices. The default stays 0.
 
 ### Fixed
+
+- **The weight-upload log line called a neighbour on the card "weights".** The
+  same 3263 MiB checkpoint consumes 3264 MiB of device free VRAM on an idle card
+  and 8446 MiB beside a process holding 23.4 GiB. The line now names the delta
+  for what it is and warns when it exceeds the checkpoint on disk by a quarter —
+  the first moment a co-tenant is visible at all on WSL2, and the only signal
+  that separates a poisoned start from a healthy one. Why no `/health` field
+  can: [`MEMORY.md`](docs/internals/MEMORY.md) B8.
 
 - **`scripts/verify.sh` no longer reports OK when no model-backed gate ran.**
   `models/` is a gitignored symlink farm that exists only in the main checkout,

--- a/docs/API.md
+++ b/docs/API.md
@@ -186,12 +186,15 @@ hold without scraping `/metrics`:
 {"status": "unhealthy", "code": "kv_pool_floored",
  "model_loaded": true, "queue_depth": 0, "suspended": false,
  "kv_blocks_total": 16, "kv_block_size": 32, "kv_capacity_tokens": 512,
- "kv_ceiling_blocks": 16}
+ "kv_ceiling_blocks": 16, "kv_pool_growable": false}
 ```
 
 `kv_ceiling_blocks` is what the pool may still grow to. Equal to
 `kv_blocks_total` means a fixed pool at its final size; greater means it is
-growable and has not got there yet (`kv_cache.growable`). A pool that is small
+growable and has not got there yet (`kv_cache.growable`). `kv_pool_growable`
+resolves the case where that pair cannot: a fixed pool and a growable one that
+has already reached its ceiling both report ceiling == total, and the two want
+opposite reactions — wait for the card to free, or stop waiting. A pool that is small
 **and** can still grow is not reported as unhealthy at all: it heals as the card
 frees, and a client should wait for the total to climb rather than restart the
 server.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -486,5 +486,13 @@ These have a code path and no gate. They may work; nothing proves it.
 - **Free VRAM only ever decreases within a process** on WSL2/WDDM, however
   cleanly CUDA released it. Anything sized from `cudaMemGetInfo` reads a moving
   floor.
+- **No `/health` field separates a server that started beside another process
+  from a healthy one.** It does not fail: it gets a smaller KV pool and reports
+  that pool as sitting at its own ceiling — 23 339 blocks on an idle card
+  against 17 406 beside a neighbour holding 23.4 GiB, both answering `ok`. The
+  plan and the install-time baseline both read `cudaMemGetInfo`, the same source
+  as the defect, so neither can point at it. The one signal is the weight-upload
+  delta against the checkpoint on disk, which warns at load; measurement and the
+  two refuted fields are in [`MEMORY.md`](internals/MEMORY.md) B8.
 - **`kv_cache.swa_snapshot_mb` set below one snapshot silently disables prefix
   caching** — worse than setting it to zero. It warns since #1092.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -100,6 +100,31 @@ The fix is a restart on a free card, not a retry: the pool is sized once, at
 startup. Wait for the old process to release the GPU before starting the new
 one.
 
+## The server came up fine, but its numbers are wrong
+
+The quieter half of the same fault, and the one that costs you a false finding
+rather than a cancelled request. A server started beside another process does
+not fail: it gets a smaller KV pool, and `/health` still reports that pool as
+sitting at its own ceiling, because the ceiling was computed against the same
+occupied card. There is no field in `/health` that separates it from a healthy
+start — both read `ok`.
+
+The load log does say so, since v0.29.0:
+
+```
+WARN  Weight upload consumed 8446 MiB of device free VRAM for a 3263 MiB
+      checkpoint. The excess is not weights: another process is holding the card
+      (on WSL2 it is invisible until this upload), or the upload spilled to host
+      memory.
+```
+
+The weight upload is the first moment a neighbour is visible at all — under
+WSL2/WDDM the driver reports the whole card as free until a process allocates
+against it. Everything sized after that point (KV pool, decode caches) reads the
+same shrunken residual, and the load still reports success, so treat this
+warning as a refusal to measure: free the card and restart before recording any
+number from that process.
+
 ## The server answers 503
 
 Either the model is suspended (`POST /admin/resume`), or the server was started

--- a/docs/internals/MEMORY.md
+++ b/docs/internals/MEMORY.md
@@ -1049,7 +1049,7 @@ rounded up — three of the seven are still open, and one has not moved at all.
 | I1 | Single acquisition point | ✗ — 365 sites / 74 files outside `src/memory/` | **✗ — 499 calls / 74 files (2026-07-31), of which 224 are acquisitions and 275 releases.** The **pinned-host class is CLOSED: 26 → 0** (B58/B60) — every one moved to T5b's `PinnedBuffer`/`HostRegistration`, which is why the total fell 638 → 582 (each migration took its releases with it). What remains is device memory only. Progress since B48's 696/309 came from migrating whole clusters rather than sites (B52–B57); what stalled it before that was migrations keeping their original path as a fallback, which the gate cannot see (B34/B47) | ✓ — `Backend`, allowlist empty, CI gate |
 | I2 | No allocation on the hot path | ✗ — measured +190 MiB/config of steady-state allocation | **✓ — `0 cudaMalloc, 0 cudaMallocAsync, 0 pinned-host allocations while serving`**, 15 requests, dense. Was 414 → 238 → 0 | ✓ — `ScratchStack`, phase guard, counter == 0 |
 | I3 | Stable addresses for graph memory | ~ — true in practice, enforced by comments + a `workspace_generation` hook | **~ — `StableSpan` exists and is passkey-enforced**, so only allocators that can promise stability can mint one; kernel signatures still take raw pointers | ✓ — `StableSpan` in kernel signatures; no conversion from `DeviceSpan` |
-| I4 | Capacity planned, not discovered | ✗ — live `cudaMemGetInfo`, a balloon, six stacked clamps | **~ — `plan_memory()` is pure and runs in shadow**; the live pass now charges the library reserve it always omitted (B37). **The balloon is GONE (2026-07-30, B62)** — the mandatory-cache guarantee is a planned floor instead of a physical hold, which also freed 72x more KV on the config where the hold bound. **The KV block count is now the PLAN's** (B69) — `plan_memory()` decides it, the live pass is the fallback when the plan rejects, and the measured-residual clamp can still only shrink it. What still enters through `cudaMemGetInfo` is the *distributable* figure the plan is handed — **measured 2026-07-31 (B82) and it does not move**: five identical starts produce a byte-identical plan, and a co-tenant holding 31 949 MiB changes neither the plan nor decode throughput (293.4 vs 292.7 tok/s, i.e. no WDDM spill). Replacing it is the invariant's letter, not a fix for anything that fails | ✓ — `plan_memory()` never queries the device; fails at load with a report |
+| I4 | Capacity planned, not discovered | ✗ — live `cudaMemGetInfo`, a balloon, six stacked clamps | **~ — `plan_memory()` is pure and runs in shadow**; the live pass now charges the library reserve it always omitted (B37). **The balloon is GONE (2026-07-30, B62)** — the mandatory-cache guarantee is a planned floor instead of a physical hold, which also freed 72x more KV on the config where the hold bound. **The KV block count is now the PLAN's** (B69) — `plan_memory()` decides it, the live pass is the fallback when the plan rejects, and the measured-residual clamp can still only shrink it. What still enters through `cudaMemGetInfo` is the *distributable* figure the plan is handed — **measured 2026-07-31 (B82) and it does not move**: five identical starts produce a byte-identical plan, and a co-tenant holding 31 949 MiB changes neither the plan nor decode throughput (293.4 vs 292.7 tok/s, i.e. no WDDM spill). Replacing it is the invariant's letter, not a fix for anything that fails. **B82 holds only while the config cap binds before VRAM does** — with a VRAM-bound plan the same co-tenant takes 25 % of the KV pool (B8) | ✓ — `plan_memory()` never queries the device; fails at load with a report |
 | I5 | Unidirectional ownership | ✗ — `VRAMAllocator` is a tracker; raw `void*` cross module boundaries | **~ — KV blocks and the T2/T3 tiers own through move-only RAII** (`Region`, `BlockRef`, `GraphSlotLease`); raw `void*` still crosses boundaries in `exec/` and `compute/` | ✓ — `Owned<T, Tier>`, no cross-tier conversion, no raw device pointers above L1 |
 | I6 | OOM is typed and recoverable | ~ — `RequestStatus::CANCELLED`, plus a warning that fires *after* prefill | **✓ — both halves.** Plan-time: an unservable `--vram-budget` refuses at load with the block arithmetic. Admission-time: `IMP_ERROR_CAPACITY` → HTTP 503 `capacity_error`, distinct from a client cancel (B40) | ✓ — plan-time failure at load; admission-time 429/503 at runtime |
 | I7 | Capacity ≠ occupancy | ✗ — 20–39 % of device memory unattributed | **~ — per-tier reserved *and* live is served** on `/metrics`, plus KV blocks and budget-vs-own. Accounting reaches **98.3 %** once the library reserve is charged at its measured value rather than the 3900 MiB constant (B41/B42); with the constant it is 82.5 % on Qwen3-8B. MoE's **102.0 %** — a negative residual — proves the note double-booking (B32), so that config's gap is the counters, not the attribution | ✓ — per-tier reserved *and* live, library reserve named, ≥95 % accounted |
@@ -1437,6 +1437,67 @@ The I3 mechanism itself is asserted at compile time in
 `StableSpan`, `StableSpan` is not constructible from a raw pointer, and the
 widening direction stays implicit. A refactor that reopens the hole fails to
 compile rather than silently passing.
+
+### B8 — a co-tenant moves the plan, and no `/health` field can say so (2026-08-19)
+
+Same command, same model, same build; only the card differs:
+
+| card at startup | KV blocks | `kv_ceiling_blocks` | what `/health` says |
+|---|---:|---:|---|
+| idle | 23 339 | 23 339 | `ok`, pool at its ceiling |
+| 23.4 GiB in use by a neighbour | 17 406 | 17 406 | `ok`, pool at its ceiling |
+
+A client comparing the total against the ceiling reads "at capacity, healthy" in
+both — at a quarter of the pool. Nothing is faulted and nothing is floored: the
+second server loads, serves, and every number it then produces is a statement
+about a card it shared.
+
+**This bounds B82.** That measurement found a co-tenant holding 31 949 MiB
+changing neither the plan nor decode throughput, and it is correct *in its
+regime*: at `runtime.max_seq_len=8192` this model's plan asks
+`max_seq_len x max_batch / block_size` = 16 384 blocks, the config cap binds
+before VRAM does, and a neighbour is invisible to it. The table above is the
+same box with `max_seq_len=65536`, where the plan is VRAM-bound — and then the
+neighbour takes 25 % of it. "The plan does not move" holds only while something
+other than free VRAM is the binding constraint.
+
+**Two `/health` fields were built for this state and both were measured to
+fail.** Recorded so they are not rebuilt:
+
+1. **The pre-clamp plan beside the total** (`kv_blocks_planned`). The plan is
+   handed `effective_free_vram()`, so it shrinks with the neighbour like
+   everything else. Occupied arm: planned 17 673 against a total of 17 512, a
+   0.9 % gap that reads as a clean bill of health while the pool sits 25 % below
+   an idle-card start. The gap it does expose — the measured residual undercutting
+   the plan — is the ordinary case the `KvResidualSizing::clamped` comment already
+   calls normal.
+2. **Device-used at `vram_budget_install`** (`vram_used_at_install_bytes()`).
+   1679 MiB in **both** arms. Under WSL2/WDDM the driver reports the whole card
+   as free until a process allocates against it, so a snapshot taken before the
+   first allocation cannot see a neighbour at all. Every figure derived from that
+   baseline inherits the blindness, which is why `vram_own_used_bytes()` cannot
+   be made to answer this either.
+
+**What does see it is the process's own upload.** For the same 3263 MiB
+checkpoint, `free_before - free_after` across `upload_weights_gpu` measured
+3264 MiB on the idle card and 8446 MiB beside the neighbour. That is the first
+moment the card's real occupancy is observable at all, and until now the line
+printed the delta as `weights ~8446 MiB` — labelling a co-tenant as this model's
+weights. It now names the delta for what it is and warns when it exceeds the
+checkpoint on disk by more than a quarter (`engine_weight_upload.cpp`).
+One-sided on purpose: consuming *less* than the file is ordinary (host-resident
+experts, dropped sources), consuming a quarter more cannot be weights. Checked
+against a 9.9 GiB NVFP4 checkpoint directory on an idle card, which consumed
+10 080 MiB and stays silent.
+
+```
+[PROV: commit=f39441d0 date=2026-08-19 hw=RTX5090 model=Llama-3.2-3B-Instruct-Q8_0
+       quant=Q8_0 cuda=13.3 path=imp-server n=2 arms x 2 configs
+       cmd=`imp-server --model <m> --set runtime.max_seq_len=65536`, neighbour =
+       a second imp-server pinned to `--set kv_cache.max_blocks=14000`; blocks and
+       ceiling read from GET /health, upload delta from the server log]
+```
+
 
 ---
 

--- a/src/memory/kv_cache.h
+++ b/src/memory/kv_cache.h
@@ -57,6 +57,11 @@ public:
     // How many blocks this pool could grow to. Equals total_blocks() unless it
     // was built growable and has not reached its ceiling.
     int ceiling_blocks() const { return max_blocks_; }
+    // Whether the ceiling can actually be reached. Without this, a client
+    // reading ceiling == total cannot tell a fixed pool from a growable one
+    // sitting at its ceiling, and those want opposite reactions: wait for the
+    // card to free, or stop waiting.
+    bool growable() const { return growable_; }
 
     // Physical memory currently committed by a growable pool, 0 for a fixed
     // one. What the pool actually costs right now, as opposed to the address

--- a/src/memory/vram_query.h
+++ b/src/memory/vram_query.h
@@ -91,6 +91,26 @@ inline size_t vram_reserve_floor(size_t total_bytes, int pct = 10) {
     return share > floor_bytes ? share : floor_bytes;
 }
 
+// Whether a weight upload consumed more device free VRAM than the checkpoint on
+// disk can account for.
+//
+// The upload is the first moment a co-tenant on the card is observable at all:
+// under WSL2/WDDM the driver reports the whole card as free until a process
+// allocates against it, so both `vram_used_at_install_bytes()` and the plan's
+// free-VRAM read are blind to a neighbour, and the KV pool that follows is
+// sized from the same shrunken residual while the load reports success
+// (MEMORY.md B8). Consuming LESS than the file is ordinary — host-resident
+// experts, dropped sources — so this is one-sided by construction; a quarter
+// more than the file holds cannot be weights.
+//
+// `on_disk_bytes == 0` means "could not size the checkpoint", which reads as no
+// reference to check against rather than as a fault.
+inline bool upload_exceeds_checkpoint(size_t consumed_bytes, size_t on_disk_bytes) {
+    if (on_disk_bytes == 0)
+        return false;
+    return consumed_bytes > on_disk_bytes + on_disk_bytes / 4;
+}
+
 // Outcome of sizing the KV pool from the measured post-cache residual.
 struct KvResidualSizing {
     int blocks = 0;         // block count to use

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -18,9 +18,39 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <utility>
 
 namespace imp {
+
+namespace {
+// Bytes of model on disk, for the one comparison that can tell a weight upload
+// from a card someone else is on. A file is its own size; a checkpoint
+// directory is the sum of its weight shards (config/tokenizer JSON is noise at
+// this scale). 0 = could not tell, which reads as "no reference to check
+// against" everywhere below.
+size_t model_source_bytes(const std::string& path) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (path.empty())
+        return 0;
+    if (fs::is_regular_file(path, ec))
+        return static_cast<size_t>(fs::file_size(path, ec));
+    if (!fs::is_directory(path, ec))
+        return 0;
+    size_t total = 0;
+    for (const auto& e : fs::directory_iterator(path, ec)) {
+        if (ec)
+            return 0;
+        if (!e.is_regular_file(ec))
+            continue;
+        const std::string ext = e.path().extension().string();
+        if (ext == ".safetensors" || ext == ".gguf" || ext == ".bin")
+            total += static_cast<size_t>(e.file_size(ec));
+    }
+    return ec ? 0 : total;
+}
+}  // namespace
 
 bool Engine::init_weights() {
     const auto& mcfg = model_->config();
@@ -225,9 +255,35 @@ bool Engine::init_weights() {
 
     size_t free_after = 0, total_after = 0;
     cudaMemGetInfo(&free_after, &total_after);
-    IMP_LOG_INFO("GPU memory after weight upload: %zu MiB free / %zu MiB total (weights ~%zu MiB)",
-                 free_after / (1024UL * 1024), total_after / (1024UL * 1024),
-                 (free_before - free_after) / (1024UL * 1024));
+    // A free-VRAM delta is not a weight size, and this line used to call it one.
+    // The two come apart exactly where it matters: on WSL2 the driver reports
+    // the whole card as free until a process allocates, so a server started
+    // beside a neighbour sees an empty card here and only learns otherwise
+    // THROUGH its own upload. Measured on this box, same 3263 MiB checkpoint:
+    // 3264 MiB consumed on an idle card, 8446 MiB beside a 23.4 GiB neighbour —
+    // and the second one was printed as "weights ~8446 MiB" (MEMORY.md B8).
+    const size_t upload_consumed = free_before - free_after;
+    const size_t on_disk = model_source_bytes(model_->source_path());
+    IMP_LOG_INFO(
+        "GPU memory after weight upload: %zu MiB free / %zu MiB total (upload consumed "
+        "%zu MiB of device free)",
+        free_after / (1024UL * 1024), total_after / (1024UL * 1024), upload_consumed / (1024UL * 1024));
+    // One-sided on purpose. Consuming LESS than the checkpoint is ordinary —
+    // host-resident experts, dropped sources — but consuming a quarter more
+    // than the file holds cannot be weights, and this is the first and only
+    // moment the card's real occupancy is observable. Everything sized after
+    // this point (KV pool, decode caches) reads the same shrunken residual and
+    // the load still reports success, so the operator has to hear it here.
+    if (upload_exceeds_checkpoint(upload_consumed, on_disk)) {
+        IMP_LOG_WARN(
+            "Weight upload consumed %zu MiB of device free VRAM for a %zu MiB checkpoint. The "
+            "excess is not weights: another process is holding the card (on WSL2 it is invisible "
+            "until this upload), or the upload spilled to host memory. This process will still "
+            "load and serve, and every number it produces — pool size, tokens/s — will be a "
+            "statement about the card it shared. Free the card and restart before measuring "
+            "anything here.",
+            upload_consumed / (1024UL * 1024), on_disk / (1024UL * 1024));
+    }
 
     // Check for host-resident expert weights.
     // gpt-oss is exempt: its MXFP4 experts are intentionally kept host-resident

--- a/tests/test_kv_residual_sizing.cpp
+++ b/tests/test_kv_residual_sizing.cpp
@@ -158,5 +158,38 @@ TEST(KvPoolVerdict, UnsetRequirementIsNotAFault) {
     EXPECT_EQ(kv_pool_verdict(s, 2048, 0), KvPoolVerdict::Sufficient);
 }
 
+// ── upload_exceeds_checkpoint ─────────────────────────────────────────────
+//
+// The measured pair this exists for (MEMORY.md B8): the same 3263 MiB
+// checkpoint consumed 3264 MiB of device free VRAM on an idle card and
+// 8446 MiB beside a process holding 23.4 GiB.
+
+TEST(UploadExceedsCheckpoint, TheMeasuredPair) {
+    EXPECT_FALSE(upload_exceeds_checkpoint(3264 * kMiB, 3263 * kMiB));
+    EXPECT_TRUE(upload_exceeds_checkpoint(8446 * kMiB, 3263 * kMiB));
+}
+
+TEST(UploadExceedsCheckpoint, ConsumingLessIsOrdinary) {
+    // Host-resident experts and dropped sources upload less than the file
+    // holds. One-sided on purpose: this direction must never warn, or the
+    // gpt-oss and MoE-offload paths warn on every healthy load.
+    EXPECT_FALSE(upload_exceeds_checkpoint(1 * kMiB, 10000 * kMiB));
+    EXPECT_FALSE(upload_exceeds_checkpoint(0, 10000 * kMiB));
+}
+
+TEST(UploadExceedsCheckpoint, TheQuarterIsInclusiveOfItsBoundary) {
+    // Exactly a quarter over is still silent — the threshold has to absorb the
+    // CUDA context and library growth that the upload phase also pays for.
+    EXPECT_FALSE(upload_exceeds_checkpoint(1250 * kMiB, 1000 * kMiB));
+    EXPECT_TRUE(upload_exceeds_checkpoint(1251 * kMiB, 1000 * kMiB));
+}
+
+TEST(UploadExceedsCheckpoint, UnknownCheckpointSizeIsNotAFault) {
+    // 0 = the checkpoint could not be sized (unreadable path, an unrecognised
+    // layout). There is no reference to compare against, and inventing one
+    // would warn on every load of it.
+    EXPECT_FALSE(upload_exceeds_checkpoint(99999 * kMiB, 0));
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -55,6 +55,7 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
     int kv_blocks = -1;
     int kv_block_size = -1;
     int kv_ceiling = -1;
+    bool kv_growable = false;
     std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
     if (lock.owns_lock()) {
         loaded = state.model_loaded();
@@ -72,6 +73,7 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
                 kv_blocks = kv->total_blocks();
                 kv_block_size = kv->block_size();
                 kv_ceiling = kv->ceiling_blocks();
+                kv_growable = kv->growable();
             }
         }
         lock.unlock();
@@ -98,6 +100,11 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
         // The ceiling a growable pool may still reach. Equal to the total for a
         // fixed pool, so a caller can compare the two rather than test a flag.
         body["kv_ceiling_blocks"] = kv_ceiling;
+        // A fixed pool reports ceiling == total, and so does a growable one
+        // already at its ceiling. Same pair, opposite advice: one heals as the
+        // card frees, the other never will. Say which, rather than leaving the
+        // caller to derive it from a pair that cannot express it.
+        body["kv_pool_growable"] = kv_growable;
     }
     if (!unservable.empty()) {
         // A client has to tell a permanent 503 from a transient one, or it


### PR DESCRIPTION
A server started beside another process on the card does not fail. It gets a
smaller KV pool, reports that pool as sitting at its own ceiling, answers
`/health` with `ok` — and every number it then produces is a statement about a
card it shared. Measured here, same command and same model:

| card at startup | KV blocks | `kv_ceiling_blocks` | `/health` |
|---|---:|---:|---|
| idle | 23 339 | 23 339 | `ok`, at the ceiling |
| 23.4 GiB held by a neighbour | 17 406 | 17 406 | `ok`, at the ceiling |

## Two fields were built for this and both measured blind

Both are recorded in [`MEMORY.md`](docs/internals/MEMORY.md) B8 so they do not
get rebuilt:

1. **The pre-clamp plan beside the total** (`kv_blocks_planned`). The plan is
   handed `effective_free_vram()`, so it shrinks with the neighbour too. In the
   occupied arm it read 17 673 against a total of 17 512 — a 0.9 % gap that
   reads as a clean bill of health while the pool sits 25 % below an idle-card
   start.
2. **Device-used at `vram_budget_install`.** 1679 MiB in **both** arms. Under
   WSL2/WDDM the driver reports the whole card as free until a process
   allocates against it, so a snapshot taken before the first allocation cannot
   see a neighbour at all.

Both read `cudaMemGetInfo` — the same source as the defect, which is why
neither can point at it.

## What does see it

The process's own weight upload. For the same 3263 MiB checkpoint,
`free_before - free_after` across `upload_weights_gpu` measured **3264 MiB on
the idle card and 8446 MiB beside the neighbour**, and that second number was
printed as `weights ~8446 MiB`. The line now names the delta for what it is and
warns when it exceeds the checkpoint on disk by more than a quarter. One-sided
on purpose: consuming *less* than the file is ordinary (host-resident experts,
dropped sources). Checked against a 9.9 GiB NVFP4 checkpoint directory on an
idle card — 10 080 MiB consumed, silent.

`/health` also gains `kv_pool_growable`: a fixed pool and a growable one already
at its ceiling report the same `ceiling == total` pair and want opposite
reactions (wait for the card, or stop waiting).

## Also: a regime boundary on B82

B82 found that a co-tenant moves neither the plan nor decode throughput. That
holds *while the config cap binds*: at `runtime.max_seq_len=8192` this model's
plan asks 16 384 blocks and a neighbour is invisible to it. The table above is
the same box at `max_seq_len=65536`, where the plan is VRAM-bound. The I4 row
now says so.

## Verification

- `make dev-test` (the CI unit lane) green; 4 new cases in
  `tests/test_kv_residual_sizing.cpp` cover the predicate, including the
  measured pair and the one-sided direction.
- Live A/B on this box for both arms of the table, plus the NVFP4 false-positive
  check.
- `python3 scripts/docs_lint.py` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
