### PR TITLE
mtp: speculation truncates 2 of 6 answers, and that is the default blocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ there instead of retelling it.
 
 - **MTP speculative decoding pays on Qwen3.8-27B-NVFP4: `speculative.mtp_k=1`
   measures +21.3 % decode** (104.31 against 86.03 tok/s). Only at k=1 — an extra
-  chunk row still costs half a decode step, so k=3 buys 2 %. The default stays 0;
-  measurement and the profile behind it in
-  [`roadmap.md`](docs/roadmap.md).
+  chunk row still costs half a decode step, so k=3 buys 2 %. **The default stays
+  0, and now for a measured reason:** at k=1, 2 of 6 prompts end after ~40 tokens
+  with a re-statement of the question (0 of 6 without speculation). Both in
+  [`LIMITATIONS.md`](docs/LIMITATIONS.md) and [`roadmap.md`](docs/roadmap.md).
 
 - **`/health` says whether the KV pool can still grow (`kv_pool_growable`).** A
   fixed pool and a growable one already at its ceiling both report

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -141,6 +141,52 @@ These have a code path and no gate. They may work; nothing proves it.
   that guarantee from the seed alone if both runs share a long-lived server with
   other traffic between them. Pin `server.recurrent_snapshot_mb=0`, or use a
   fresh process per arm.
+- **MTP speculation truncates answers: 2 of 6 prompts end after ~40 tokens with
+  a re-statement of the question (measured 2026-08-19).** This is the same
+  divergence as the entry below, but it is not the harmless half of it — the
+  answer is not "different but coherent", it is unusable:
+
+  ```
+  # Paged KV Cache in LLM Inference
+  ## The Problem: Traditional KV Cache Wastes Memory
+  In a large language model (LLM) inference engine, and why block size matters.
+  ```
+
+  (164 bytes, `finish_reason: "stop"`. The last clause is the tail of the prompt.)
+
+  Qwen3.8-27B-NVFP4, `speculative.mtp_k=1`, `speculative.ngram=false`,
+  `server.prefix_cache=false`, six prompts, `max_tokens: 400`:
+
+  | arm | degenerate | lengths |
+  |---|---|---|
+  | `mtp_k=1` | **2 / 6** | 164 B, 286 B, and four of 1198-1793 B |
+  | `mtp_k=0` (control) | **0 / 6** | 1146-1784 B |
+
+  **It is deterministic, not noise.** With `runtime.deterministic_gemm=true`
+  four fresh processes produce the same truncated answer byte for byte
+  (**4 / 4**, identical sha). Without it — the default — three of four do
+  (**3 / 4**); the pin does not remove the state, it stabilises it, so the one
+  process in four that escapes is the accident, not the rule.
+
+  **The mechanism, from `diagnostics.spec_trace`:** the final verify reads
+  `p0=114 t0=12482 draft=[13] argmax=[13,248046]` — token 12482 is `" matters"`,
+  13 is `"."`, and **248046 is `<|im_end|>`**. The bonus token that a verify
+  emits after an accepted draft comes from the last chunk row, and that row
+  predicts end-of-turn where the single-token decode path keeps writing. So the
+  structural divergence below is not confined to *which* coherent answer you
+  get; it reaches the stop decision.
+
+  **Consequence: `speculative.mtp_k` stays 0 by default**, despite the +21.3 %
+  it measures on this model ([`roadmap.md`](roadmap.md)). A throughput win that
+  truncates a third of answers is not a win, and this defect is the blocker to
+  clear before that default can be revisited.
+
+  *Caveat this places on that +21.3 %:* the two arms do not generate the same
+  text, and the speculative arm sometimes stops early, so the comparison is
+  between workloads that differ. The token counts ran the other way (2100 at
+  k=1 against 1847 at k=0), so it is not simply "shorter answers decode
+  faster", but the number is not a like-for-like one either.
+
 - **Speculative decoding does not reproduce the non-speculative greedy output
   on a GDN hybrid, and it cannot by construction.** Its contract is that it
   changes speed and not tokens; here it changes tokens. Measured on

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -250,6 +250,21 @@ arm order reversed in the second:
 **MTP pays now.** The k=0 arm reproduces to 0.02 % across rounds, so the +21 %
 is far outside the measurement's own noise.
 
+**It is still not shippable as a default, and the blocker is correctness, not
+speed (2026-08-19).** At `mtp_k=1`, 2 of 6 prompts end after ~40 tokens with a
+re-statement of the question, deterministically (4 of 4 fresh processes
+byte-identical under `deterministic_gemm`), against 0 of 6 for the same prompts
+without speculation. Detail, trace and the exact output in
+[`LIMITATIONS.md`](LIMITATIONS.md). That also puts a caveat on the +21.3 %: the
+arms do not generate the same text.
+
+**Two measurement notes this cost, both worth carrying.** The sweep above sets
+`speculative.ngram=false` to isolate the MTP head — a correct control that also
+*hid* this defect, because the arm that first showed it was the one run at
+defaults. And the degenerate answer is what `deterministic_gemm` pins: the pin
+does not remove the state, it stabilises it, so a run that looks reproducible
+can be reproducibly wrong.
+
 Three things follow, and the first two say what did *not* cause it:
 
 - **Acceptance did not move.** 76.0 % here against the 75.0 % measured before the

--- a/tools/analysis/mtp_truncation_check.sh
+++ b/tools/analysis/mtp_truncation_check.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Does MTP speculation truncate answers? Runs six prompts through one process
+# and flags any answer that stops early (finish_reason=stop, well under the
+# budget) -- the signature is a ~40-token answer ending in a re-statement of the
+# question.
+#
+# Usage: bash tools/analysis/mtp_truncation_check.sh 1   # MTP on
+#        bash tools/analysis/mtp_truncation_check.sh 0   # control
+#
+# deterministic_gemm is pinned on purpose: it does not remove the degenerate
+# state, it stabilises it, which is what makes this a repeatable check.
+# Findings: docs/LIMITATIONS.md, "MTP speculation truncates answers".
+set -uo pipefail
+IMG=${IMP_IMAGE:-imp:test}; MODEL=${MTP_MODEL:-/models/Qwen3.8-27B-NVFP4}; PORT=8095; K=$1
+cleanup(){ docker rm -f prproc >/dev/null 2>&1; }
+trap cleanup EXIT
+docker rm -f prproc >/dev/null 2>&1
+docker run -d --name prproc --gpus all -p $PORT:8080 -v /home/kekz/models:/models "$IMG" \
+  imp-server --host 0.0.0.0 --port 8080 --model "$MODEL" --think-budget 0 \
+    --set speculative.mtp_k=$K --set speculative.ngram=false --set server.prefix_cache=false \
+    --set runtime.deterministic_gemm=true >/dev/null
+for _ in $(seq 1 200); do curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+  docker ps --format '{{.Names}}'|grep -q '^prproc$' || break; sleep 3; done
+while IFS= read -r p; do
+  curl -s "http://127.0.0.1:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+    -d "{\"model\":\"$(basename $MODEL)\",\"messages\":[{\"role\":\"user\",\"content\":$(python3 -c 'import json,sys;print(json.dumps(sys.argv[1]))' "$p")}],\"max_tokens\":400,\"temperature\":0,\"top_k\":1}" \
+    | python3 -c "
+import json,sys
+d=json.load(sys.stdin); ch=d['choices'][0]; c=ch['message'].get('content') or ''
+bad = ch.get('finish_reason')=='stop' and len(c)<600
+print(f'  k=$K {\"DEGENERATE\" if bad else \"ok        \"} {len(c):5d}B {ch.get(\"finish_reason\"):6s} {c[-38:]!r}')"
+done <<'PROMPTS'
+Explain how a paged KV cache works in an LLM inference engine, and why block size matters.
+Describe the trade-offs between grouped-query attention and multi-head attention, and when each wins.
+Walk through how a CUDA kernel launch reaches the GPU, and what the driver does in between.
+Explain what makes an LLM inference engine memory-bound at batch size one, and how to tell.
+Summarise the difference between prefill and decode in transformer inference, and why they scale differently.
+What is speculative decoding, and under what conditions does it fail to pay off?
+PROMPTS


### PR DESCRIPTION
I set out to clear the way for an `mtp_k` default after #1481 measured +21.3 %.
**The blocker is correctness, and it is worse than the divergence entry
described.**

## The defect

At `mtp_k=1`, 2 of 6 prompts end after ~40 tokens with a re-statement of the
question. Not "different but coherent" — unusable:

```
# Paged KV Cache in LLM Inference
## The Problem: Traditional KV Cache Wastes Memory
In a large language model (LLM) inference engine, and why block size matters.
```

164 bytes, `finish_reason: "stop"`. The last clause is the tail of the prompt.

| arm | truncated | lengths |
|---|---|---|
| `mtp_k=1` | **2 / 6** | 164 B, 286 B, four of 1198–1793 B |
| `mtp_k=0` (control) | **0 / 6** | 1146–1784 B |

## It is deterministic, not noise

Under `runtime.deterministic_gemm=true`, four fresh processes produce that
answer **byte for byte** (4/4, identical sha). Without it — the default — three
of four do. **The pin does not remove the state, it stabilises it**, so the one
process in four that escapes is the accident, not the rule. A run that looks
reproducible can be reproducibly wrong.

## Mechanism

From `diagnostics.spec_trace`, the final verify:

```
[verify] p0=114 t0=12482 draft=[13] argmax=[13,248046]
```

12482 is `" matters"`, 13 is `"."`, and **248046 is `<|im_end|>`**. The bonus
token a verify emits after an accepted draft comes from the last chunk row —
and that row predicts end-of-turn where the single-token decode path keeps
writing. So the structural divergence documented below it does not only decide
*which* coherent answer you get; **it reaches the stop decision**.

## Two measurement notes this cost

- **#1481's sweep sets `speculative.ngram=false`** to isolate the MTP head. A
  correct control — that also *hid* this, because the first arm that showed it
  was the one run at defaults.
- **The caveat it places on the +21.3 %:** the two arms do not generate the same
  text, so the comparison is between workloads that differ. Token counts ran the
  other way (2100 at k=1 vs 1847 at k=0), so it is not simply "shorter answers
  decode faster" — but it is not like-for-like either, and the entry now says so.

## Consequence

`speculative.mtp_k` stays 0. A throughput win that truncates a third of answers
is not a win. This is the defect to clear before that default can be revisited,
and it now has a one-command reproducer:
`tools/analysis/mtp_truncation_check.sh`.

## Verification

`make verify-fast` via the pre-push hook, `=== verify fast: OK ===`. Full GPU
suite green via pre-commit. `docs_lint` green. Docs + one new script only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
