### PR TITLE
mtp: the +21.3% comes from the kernel that truncates, so there is no fast+correct setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ there instead of retelling it.
   measures +21.3 % decode** (104.31 against 86.03 tok/s). Only at k=1 — an extra
   chunk row still costs half a decode step, so k=3 buys 2 %. **The default stays
   0, and now for a measured reason:** at k=1, 2 of 6 prompts end after ~40 tokens
-  with a re-statement of the question (0 of 6 without speculation). Both in
-  [`LIMITATIONS.md`](docs/LIMITATIONS.md) and [`roadmap.md`](docs/roadmap.md).
+  with a re-statement of the question (0 of 6 without speculation), and the one
+  switch that fixes that (`speculative.verify_nvfp4_gemm=false`) turns the
+  +21.3 % into -11.2 %. Both in [`LIMITATIONS.md`](docs/LIMITATIONS.md) and
+  [`roadmap.md`](docs/roadmap.md).
 
 - **`/health` says whether the KV pool can still grow (`kv_pool_growable`).** A
   fixed pool and a growable one already at its ceiling both report

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -176,10 +176,28 @@ These have a code path and no gate. They may work; nothing proves it.
   structural divergence below is not confined to *which* coherent answer you
   get; it reaches the stop decision.
 
+  **A switch fixes it, and it costs the entire win.**
+  `speculative.verify_nvfp4_gemm=false` routes the verify chunk off the batched
+  NVFP4 GEMV: truncation drops to **0 of 6** on the same prompts, both offenders
+  included, with acceptance unchanged (72-80 %). Throughput goes with it:
+
+  | arm | tok/s (r1, r2) | vs k=0 |
+  |---|---|---:|
+  | k=0 | 88.97, 88.93 | — |
+  | k=1, `verify_nvfp4_gemm=false` | 80.50, 77.43 | **-11.2 %** |
+  | k=1, default (truncates) | see roadmap | +21.3 % |
+
+  So **the +21.3 % comes from precisely the kernel that causes the truncation.**
+  Both accumulate in `float` — the difference is summation order, not precision,
+  and it is enough to flip the stop decision on a third of prompts. No setting
+  of this pair is both fast and correct.
+
   **Consequence: `speculative.mtp_k` stays 0 by default**, despite the +21.3 %
   it measures on this model ([`roadmap.md`](roadmap.md)). A throughput win that
-  truncates a third of answers is not a win, and this defect is the blocker to
-  clear before that default can be revisited.
+  truncates a third of answers is not a win, and the cheap escape does not
+  exist: MTP is either fast and wrong, or correct and slower than no speculation
+  at all. Closing this needs the chunk path to agree with decode numerically,
+  which is a kernel change, not a flag.
 
   *Caveat this places on that +21.3 %:* the two arms do not generate the same
   text, and the speculative arm sometimes stops early, so the comparison is

--- a/tools/analysis/mtp_k_sweep.sh
+++ b/tools/analysis/mtp_k_sweep.sh
@@ -34,7 +34,7 @@ start_arm(){ # k
       --set speculative.ngram=false \
       --set speculative.mtp_k=$1 \
       --set speculative.mtp_econ_min_emit=0 \
-      --set server.prefix_cache=false >/dev/null
+      --set server.prefix_cache=false ${EXTRA:-} >/dev/null
   for _ in $(seq 1 200); do
     curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && return 0
     docker ps --format '{{.Names}}' | grep -q '^mtpsweep$' || { echo "DIED k=$1"; docker logs mtpsweep 2>&1|tail -20; return 1; }


### PR DESCRIPTION
Continuing #1486, which found MTP truncating 2 of 6 answers. **There is exactly
one switch that turns that off, and it costs more than the feature is worth.**

`speculative.verify_nvfp4_gemm=false` routes the verify chunk off the batched
NVFP4 GEMV:

| arm | truncated | tok/s (r1, r2) | vs k=0 |
|---|---|---|---:|
| k=0 | 0 / 6 | 88.97, 88.93 | — |
| k=1, `verify_nvfp4_gemm=false` | **0 / 6** | 80.50, 77.43 | **−11.2 %** |
| k=1, default | 2 / 6 | see #1481 | +21.3 % |

Acceptance is unchanged at 72–80 %, so the drafter is not what moved — only the
kernel the chunk runs on.

## What that settles

**The +21.3 % comes from precisely the kernel that causes the truncation.** Both
paths accumulate in `float`; the difference is summation order, not precision,
and it is enough to flip the stop decision on a third of prompts.

So MTP is **either fast and wrong, or correct and slower than no speculation at
all**. The cheap escape does not exist. Closing this needs the chunk path to
agree with decode numerically — a kernel change, not a flag.

This is the answer to "can `speculative.mtp_k` ship as a default": not as
things stand, and now for a reason with a number attached rather than a hunch
about reproducibility.

## Verification

`make verify-fast` via the pre-push hook, `=== verify fast: OK ===`, full GPU
suite green via pre-commit, `docs_lint` green. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
