### PR TITLE
analysis: use MODELS_DIR in the three harnesses I shipped today

### DIFF
--- a/tools/analysis/mtp_k_sweep.sh
+++ b/tools/analysis/mtp_k_sweep.sh
@@ -29,7 +29,7 @@ trap cleanup EXIT
 start_arm(){ # k
   docker rm -f mtpsweep >/dev/null 2>&1
   docker run -d --name mtpsweep --gpus all -p $PORT:8080 \
-    -v /home/kekz/models:/models "$IMG" \
+    -v "${MODELS_DIR:-$HOME/models}":/models "$IMG" \
     imp-server --host 0.0.0.0 --port 8080 --model "$MODEL" --think-budget 0 \
       --set speculative.ngram=false \
       --set speculative.mtp_k=$1 \

--- a/tools/analysis/mtp_truncation_check.sh
+++ b/tools/analysis/mtp_truncation_check.sh
@@ -15,7 +15,7 @@ IMG=${IMP_IMAGE:-imp:test}; MODEL=${MTP_MODEL:-/models/Qwen3.8-27B-NVFP4}; PORT=
 cleanup(){ docker rm -f prproc >/dev/null 2>&1; }
 trap cleanup EXIT
 docker rm -f prproc >/dev/null 2>&1
-docker run -d --name prproc --gpus all -p $PORT:8080 -v /home/kekz/models:/models "$IMG" \
+docker run -d --name prproc --gpus all -p $PORT:8080 -v "${MODELS_DIR:-$HOME/models}":/models "$IMG" \
   imp-server --host 0.0.0.0 --port 8080 --model "$MODEL" --think-budget 0 \
     --set speculative.mtp_k=$K --set speculative.ngram=false --set server.prefix_cache=false \
     --set runtime.deterministic_gemm=true >/dev/null

--- a/tools/analysis/token_recycling_ab.sh
+++ b/tools/analysis/token_recycling_ab.sh
@@ -16,7 +16,7 @@ cleanup(){ docker rm -f recyc >/dev/null 2>&1; }
 trap cleanup EXIT
 start(){ # on|off
   docker rm -f recyc >/dev/null 2>&1
-  docker run -d --name recyc --gpus all -p $PORT:8080 -v /home/kekz/models:/models "$IMG" \
+  docker run -d --name recyc --gpus all -p $PORT:8080 -v "${MODELS_DIR:-$HOME/models}":/models "$IMG" \
     imp-server --host 0.0.0.0 --port 8080 --model "$MODEL" --think-budget 0 \
       --set speculative.token_recycling=$1 --set server.prefix_cache=false >/dev/null
   for _ in $(seq 1 200); do curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && return 0


### PR DESCRIPTION
`Release hygiene` is red on `main`: the three harnesses I shipped today (`mtp_k_sweep.sh`, `token_recycling_ab.sh`, `mtp_truncation_check.sh`) hardcoded `-v /home/kekz/models`, which trips the gate's "personal paths in tracked files" check. The harnesses next to them already use `"\${MODELS_DIR:-\$HOME/models}"`; these now match.

```
SKIP_VERIFY=1 bash scripts/check-release.sh  ->  all gates passed
```

**Twice in two days, same mechanism.** `Release hygiene` is not a required check, so #1481/#1483/#1486/#1487 each merged with it red — exactly what #1480 documented in the `shipping-prs` and `codebase-audit` skills after `Alloc sites` did the same thing. This fix was also written before #1487 merged and still missed it, because auto-merge squashed while the commit was in the pre-commit GPU gate — the auto-merge race those skills describe.

I found it only because a status query prompted me to run `gh pr checks`. The skills now say to check after the merge as well as before; I did not, and that is the second half of why this reached `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb