### PR TITLE
constrain: a free string value could not be closed, so json_schema returned invalid JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`response_format: json_schema` could not close a free string value, and
+  returned invalid JSON.** A token that carries string content *and* the closing
+  quote — `."`, `n"`, `!"`, the usual spelling on a BPE vocabulary — got neither
+  `CAT_STRING_CHAR` nor `CAT_QUOTE`, so the category pre-filter dropped it before
+  the FSM (which accepts it) was asked. Measured on Qwen3-8B-NVFP4: unmasked `."`
+  is top-1 at logprob 0.0, masked it is not in the top 5, and the model closed
+  with a typographic `”` instead — legal string content, so the value ran to
+  `max_tokens`. Costs ~5.6 % decode on a constrained request, which is the
+  pre-filter doing less work up front.
+
 - **The weight-upload log line called a neighbour on the card "weights".** The
   same 3263 MiB checkpoint consumes 3264 MiB of device free VRAM on an idle card
   and 8446 MiB beside a process holding 23.4 GiB. The line now names the delta

--- a/src/compute/constrain_common.h
+++ b/src/compute/constrain_common.h
@@ -109,7 +109,18 @@ static inline uint16_t classify_token(const std::string& text) {
             cat |= CAT_COLON;
         if (first == ',')
             cat |= CAT_COMMA;
-        if (first == '"')
+        // CAT_QUOTE follows the PRESENCE of a quote, not its position. A BPE
+        // vocabulary spells the end of a string far more often as `."`, `n"`,
+        // `!"` than as a bare `"`, and those tokens are the only way out of a
+        // free string value. Keying on `first == '"'` gave them neither
+        // CAT_QUOTE (they do not start with one) nor CAT_STRING_CHAR (is_str
+        // clears on any quote, four lines up), so cat came out 0x0000 and the
+        // category pre-filter dropped them before token_legal — which accepts
+        // them — was ever asked. Same shape as #1197 one class over: the mask
+        // decided something the FSM was supposed to decide, and the model
+        // closed the string with a typographic `”` instead, which IS legal
+        // string content, so the value never ended (#1199).
+        if (text.find('"') != std::string::npos)
             cat |= CAT_QUOTE;
 
         if (is_ws)

--- a/tests/test_json_constrain_property.cpp
+++ b/tests/test_json_constrain_property.cpp
@@ -556,6 +556,38 @@ TEST(TokenCategory, NonAsciiCountsAsStringContent) {
     EXPECT_FALSE(classify_token("ab\nc") & CAT_STRING_CHAR) << "embedded newline accepted";
 }
 
+// ---------------------------------------------------------------------------
+// #1199 follow-up: a free string value could not be CLOSED. The end of a string
+// is spelled by a BPE vocabulary far more often as `."`, `n"`, `!"` than as a
+// bare `"`. Those tokens got neither CAT_STRING_CHAR (is_str clears on any
+// quote) nor CAT_QUOTE (it keyed on `first == '"'`), so their category was
+// 0x0000 and the STRING_VALUE pre-filter — CAT_STRING_CHAR | CAT_QUOTE —
+// dropped them before token_legal, which accepts them, was consulted.
+//
+// Measured on Qwen3-8B-NVFP4 at the position after `...rascheln`: unmasked, `."`
+// is top-1 at logprob 0.0 and `.”` sits 13.4 nats behind it; masked, `."` is not
+// in the top 5 at all and `.”` wins. The model then wrote a typographic quote —
+// legal string content — and the value ran to max_tokens as invalid JSON.
+// ---------------------------------------------------------------------------
+TEST(TokenCategory, StringEndingTokensCarryQuote) {
+    const uint16_t string_phase = CAT_STRING_CHAR | CAT_QUOTE;  // schema STRING_VALUE
+    // The forms a vocabulary actually uses to end a string.
+    for (const char* t : {".\"", "n\"", "!\"", "ln\"", ".\")", "\"}", "\"", "e\","}) {
+        EXPECT_TRUE(classify_token(t) & string_phase)
+            << "token " << t << " cannot pass the STRING_VALUE category pre-filter, "
+            << "so a free string can never be closed with it";
+    }
+    // The quote is what earns CAT_QUOTE, wherever it sits in the token.
+    EXPECT_TRUE(classify_token(".\"") & CAT_QUOTE) << "trailing quote not recognised";
+    EXPECT_TRUE(classify_token("\"}") & CAT_QUOTE) << "leading quote not recognised";
+    EXPECT_TRUE(classify_token("a\"b") & CAT_QUOTE) << "embedded quote not recognised";
+    // And a token with no quote must NOT gain it — the pre-filter still has to
+    // separate string content from string end.
+    EXPECT_FALSE(classify_token(".\u201d") & CAT_QUOTE) << "typographic quote counted as a real one";
+    EXPECT_FALSE(classify_token("rascheln") & CAT_QUOTE) << "plain word counted as a quote";
+    EXPECT_TRUE(classify_token(".\u201d") & CAT_STRING_CHAR) << "typographic quote must stay string content";
+}
+
 TEST(JsonConstrainFsm, AcceptsUmlautsInsideStrings) {
     JsonConstrainer fsm;
     fsm.advance_text("{\"k\":\"Die ");


### PR DESCRIPTION
`response_format: json_schema` returned invalid JSON whenever the schema had a
free string field and the prompt did not happen to mention JSON. B5 from the
release audit.

## The defect

`classify_token` gave `CAT_QUOTE` only to tokens that **begin** with a quote
(`constrain_common.h:112`), and `is_str` clears on *any* quote in the token
(`:91`). A token carrying string content **and** the closing quote — `."`, `n"`,
`!"`, which is how a BPE vocabulary usually spells the end of a string — got
category `0x0000`:

```
'."'    cat=0x0000  STRING_CHAR=0 QUOTE=0  -> masked without simulation
'ln"'   cat=0x0000  STRING_CHAR=0 QUOTE=0  -> masked without simulation
'"'     cat=0x0040  STRING_CHAR=0 QUOTE=1  -> passes
'.”'    cat=0x0080  STRING_CHAR=1 QUOTE=0  -> passes
```

The `STRING_VALUE` pre-filter is `CAT_STRING_CHAR | CAT_QUOTE`
(`schema_constrain.cu:396`), so `schema_constrain.cu:513` dropped those tokens
**before** `token_legal` — which accepts every one of them — was consulted.

**A free string could therefore only be closed by a token that starts with a
quote.** On a real vocabulary that is the exception, so the model closed with a
typographic `”` instead. That is legal string content, so the value never ended
and ran to `max_tokens` as invalid JSON.

## The measurement that settled it

At the position after `...rascheln`, same prompt, `logprobs` from the server:

| | token | logprob |
|---|---|---|
| **unmasked** | `."` | **0.0** ← top-1 |
| | `.”` | −13.40 |
| **masked** | `.”` | **−0.0117** ← top-1 |
| | `."` | *not in the top 5* |

13.4 nats is a factor of ~660 000. The model was not preferring typography — the
mask removed the only token it wanted.

## The fix

`CAT_QUOTE` now follows the **presence** of a quote, not its position
(`constrain_common.h:112-122`). `token_legal` decides the rest, which it already
did correctly. Same shape as #1197 one class over: there the pre-filter dropped
non-ASCII before the FSM, here it dropped the string terminator.

## Cost

The pre-filter hands more tokens to the simulation. Constrained decode on a free
string, median of 3: **271.46 → 256.25 tok/s, −5.6 %** — and the output goes from
invalid to valid.

## Verification

| | |
|---|---|
| `TokenCategory.StringEndingTokensCarryQuote` | **red without the fix** (names `."`, `n"`, `!"`, `ln"`), green with it |
| property batteries + `TokenCategory` + `JsonConstrainFsm` | 31/31 |
| `make dev-test` (CI lane) | green |
| `python3 tests/test_server_vision_and_utf8.py` | **PASS**, all cases; `git diff --stat` of the test file empty |
| enum schema | WELL-FORMED 2/2 |
| `json_object` | WELL-FORMED 2/2 |
| `make verify-fast` | `=== verify fast: OK ===` |
| `make test-server` | **PASS — all server batteries green** (8/8) |

## What is not in this PR

A server-side schema injection was built while the cause was still open. With
this fix the battery is green **without** it — measured both ways — so it is
dropped and this PR stays on the constrain fix alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
