### PR TITLE
release: check-release.sh never asked the server anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`scripts/check-release.sh` now fails when a server battery is red.** It
+  deferred only to `make verify-fast`, and `make test-server` is the one place
+  `handlers.cpp` and `batching_engine` run end to end. The `json_schema` defect
+  fixed above passed this gate every time. `SKIP_VERIFY=1` still exits 0 for the
+  CI job that has no GPU, but the summary no longer says "all gates passed" when
+  no model ran.
+
 - **`response_format: json_schema` could not close a free string value, and
   returned invalid JSON.** A token that carries string content *and* the closing
   quote — `."`, `n"`, `!"`, the usual spelling on a BPE vocabulary — got neither

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -257,6 +257,33 @@ already proven live before you trust the negative — for the sweep above, `code
 write_kv_cache_fp8_fused_kernel` and `… write_kv_cache_nvfp4_kernel` both correctly returned
 `write_kv_cache`, which is what made the two empty answers meaningful.
 
+## D2 — The constrainer's category pre-filter has now been wrong twice
+
+`classify_token` in `src/compute/constrain_common.h` assigns a category, and
+`schema_constrain.cu` / `json_constrain.cu` drop a token whose category misses
+the phase mask **before** `token_legal` is consulted. It exists for cost: the
+simulation deep-copies the frame stack per candidate over the whole vocabulary.
+
+Twice now it has answered a question the FSM was there to answer, and both times
+the symptom was output the FSM would have allowed:
+
+- **#1197 / #1200** — every byte of a multi-byte UTF-8 sequence read as negative
+  through signed `char`, so tokens carrying an umlaut lost `CAT_STRING_CHAR` and
+  were masked out. Constrained output came back transliterated: "Die Bären
+  hören" as "Die Baren horen".
+- **#1489** — `CAT_QUOTE` keyed on `first == '"'`, so a token that carries string
+  content *and* the closing quote (`."`, `n"`, `!"` — the usual spelling on a BPE
+  vocabulary) got category `0x0000` and was dropped. A free string value could
+  then only be closed by a token that *starts* with a quote, which is the
+  exception, so the model closed with a typographic `”` and the value ran to
+  `max_tokens` as invalid JSON.
+
+**The rule, if you touch it again:** the pre-filter may only reject what
+`token_legal` would also reject. When in doubt, let the token through and pay
+the simulation. Both defects above cost correctness to save cycles, and both
+were invisible to the property batteries because those generate documents, not
+the *tokens* a real vocabulary spells them with. A third class is not unlikely.
+
 ## D — Load-bearing; a "cleanup" here is a regression
 
 | # | Thing | Why it must survive |

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -4,7 +4,25 @@
 # Runs the cheap checks that should always pass on a publishable
 # tree: doc links, secrets/path leaks, no accidentally tracked
 # binaries, then defers to `make verify-fast` for build + test
-# + perf + smoke.
+# + perf + smoke and to `make test-server` for the HTTP surface.
+#
+# Both model-backed stages are needed and neither substitutes for the other:
+# verify-fast measures kernels and throughput, test-server is the ONLY place
+# handlers.cpp and batching_engine run end to end (Makefile, test-server).
+# A defect that only shows over HTTP passes verify-fast untouched — one did:
+# `response_format: json_schema` returned invalid JSON for months and this gate
+# reported OK every time, because it never asked the server anything.
+#
+# SKIP_VERIFY=1 skips BOTH of them. The summary then refuses the words "all
+# gates passed" and says what it actually checked, because a run that put no
+# model in front of the GPU is a statement about the tree, not a release
+# verdict — the rule #1474 put into scripts/verify.sh, for the same reason.
+#
+# It still exits 0 in that mode, deliberately: the `Release hygiene` CI job
+# runs exactly this way (ci.yml, SKIP_VERIFY: "1") because the runner has no
+# GPU, and a job that can never be green teaches people to ignore it. The
+# distinction is carried by the summary line, which is what a human reads
+# before tagging — not by an exit code that would only break CI.
 #
 # Exit code 0 if everything passes; non-zero otherwise.
 
@@ -18,6 +36,10 @@ YLW=$(tput setaf 3 || echo)
 RST=$(tput sgr0 || echo)
 
 FAIL=0
+# Model-backed stages that actually put a checkpoint in front of the GPU.
+# SKIP_VERIFY=1 leaves this at zero, and the summary refuses to report success
+# while it is — see the header.
+MODEL_STAGES_RUN=0
 section() { echo; echo "${YLW}== $* ==${RST}"; }
 pass()    { echo "${GRN}PASS${RST} $*"; }
 fail()    { echo "${RED}FAIL${RST} $*"; FAIL=$((FAIL+1)); }
@@ -297,6 +319,7 @@ if [ "${SKIP_VERIFY:-0}" = "1" ]; then
 else
     # A release runs every gate, whatever the shell exported: the pre-push hook
     # sets IMP_VERIFY_SKIP_PERF=1 for diffs outside the measured paths.
+    MODEL_STAGES_RUN=$((MODEL_STAGES_RUN+1))
     if IMP_VERIFY_SKIP_PERF=0 IMP_VERIFY_SKIP_VRAM=0 IMP_VERIFY_SKIP_GRAPHS=0 \
        make verify-fast >/tmp/imp_check_release_verify.log 2>&1; then
         pass "make verify-fast"
@@ -307,8 +330,37 @@ else
     fi
 fi
 
+# ----------------------------------------------- 7. defer to make test-server
+# The HTTP surface, which verify-fast never touches. Its batteries are the only
+# thing in this repository that drives handlers.cpp and batching_engine against
+# a live model, so a release that skips it ships whatever the wire protocol has
+# broken since the last manual run.
+section "make test-server"
+if [ "${SKIP_VERIFY:-0}" = "1" ]; then
+    echo "  (skipped via SKIP_VERIFY=1)"
+else
+    MODEL_STAGES_RUN=$((MODEL_STAGES_RUN+1))
+    if make test-server >/tmp/imp_check_release_server.log 2>&1; then
+        pass "make test-server"
+    else
+        echo "  log: /tmp/imp_check_release_server.log"
+        # The per-battery verdicts are what names the culprit; the tail alone is
+        # usually the make error and says nothing.
+        grep -E '^   -> |^test-server:' /tmp/imp_check_release_server.log | sed 's/^/  /' || true
+        fail "make test-server"
+    fi
+fi
+
 # --------------------------------------------------------------------- end
 echo
+if [ "$FAIL" -eq 0 ] && [ "$MODEL_STAGES_RUN" -eq 0 ]; then
+    # Exit 0 on purpose — see the header. The wording is the gate here: nobody
+    # should be able to read this line as a release verdict.
+    echo "${YLW}check-release: cheap checks passed — NOT a release verdict${RST}"
+    echo "         SKIP_VERIFY=1 skipped verify-fast and test-server, so no model ran."
+    echo "         Re-run without it before tagging."
+    exit 0
+fi
 if [ "$FAIL" -eq 0 ]; then
     echo "${GRN}check-release: all gates passed${RST}"
     exit 0


### PR DESCRIPTION
`check-release.sh` deferred to `make verify-fast` and stopped there.
`make test-server` is the only place `handlers.cpp` and `batching_engine` run
end to end (`Makefile:120-121`), so every defect that lives on the wire passed
this gate untouched.

**One did.** The `json_schema` defect fixed in #1489 returned invalid JSON for
months, and `check-release.sh` reported OK every time it ran.

## Proof that the new section bites

Measured on `main` **before** #1489 landed — a genuinely red battery, no
manipulation needed:

```
$ bash scripts/check-release.sh ; echo "EXIT=$?"
== make test-server ==
  log: /tmp/imp_check_release_server.log
     -> PASS (endpoints smoke)
     -> PASS (robustness (#712))
     -> PASS (logprobs)
     -> PASS (messages stream)
     -> PASS (thinking toggle)
     -> FAIL (vision refusal + utf8 (#1197/#1198))
     -> PASS (embed/chat interleave)
     -> PASS (0-token battery (#710))
  test-server: FAIL — 1 batterie(s) regressed: vision refusal + utf8 (#1197/#1198)
FAIL make test-server

check-release: 1 gate(s) failed
EXIT=1
```

And on current `main` (with #1489):

```
$ bash scripts/check-release.sh ; echo "EXIT=$?"
== make verify-fast ==
PASS make verify-fast

== make test-server ==
PASS make test-server

check-release: all gates passed
EXIT=0
```

## `SKIP_VERIFY` semantics, and why it still exits 0

`SKIP_VERIFY=1` skips **both** model-backed stages, and the summary refuses the
words "all gates passed":

```
$ SKIP_VERIFY=1 bash scripts/check-release.sh ; echo "EXIT=$?"
check-release: cheap checks passed — NOT a release verdict
         SKIP_VERIFY=1 skipped verify-fast and test-server, so no model ran.
         Re-run without it before tagging.
EXIT=0
```

**Exit 0 is deliberate.** The `Release hygiene` CI job runs exactly this way
(`ci.yml:444`) because the runner has no GPU. Failing there would make a job
that can *never* be green, which teaches people to ignore it — the opposite of
what this PR is for. The distinction is carried by the summary line, which is
what a human reads before tagging, not by an exit code that would only break CI.

(My first draft did exit 1 here. Checking `ci.yml` before shipping it is the
only reason this PR does not break the `Release hygiene` job.)

## Runtime

| | |
|---|---|
| before | **37 s** |
| after | **336 s** |

That is `test-server` booting a real server against a live model. It is the
price of the gate meaning something.

## Also

`docs/audit/SETTLED.md` D2 records the pattern behind #1489: the constrainer's
category pre-filter has now decided twice what the FSM was there to decide
(#1197 non-ASCII, #1489 the string terminator), with the rule for whoever
touches it next. Both were invisible to the property batteries, because those
generate *documents*, not the *tokens* a real vocabulary spells them with.

## Ordering

This PR must land **after** #1489 (merged). On a tree without that fix the new
section is red — which is exactly the proof above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
