### PR TITLE
tests: a load that cannot fit takes the whole binary down with it, so refuse it first

### DIFF
--- a/tests/test_mtp_forward.cpp
+++ b/tests/test_mtp_forward.cpp
@@ -38,11 +38,38 @@ bool model_available() {
     return fs::exists(std::string(kQwen36ModelDir) + "/model_mtp.safetensors");
 }
 
+// This checkpoint takes ~23.7 GiB of a 32 GiB card, so whether it fits depends
+// on what ran before it in the same process — and running it without the room
+// does not fail cleanly. Measured: the upload OOMs part-way, and from that point
+// NO free works, async or synchronous. 62537 of 62537 cudaFreeAsync calls return
+// "out of memory" with the error state cleared before each one, and a
+// synchronous cudaFree fallback succeeds 0 times out of those 62537. The memory
+// comes back at process exit and not before, so every later test in the binary
+// runs on a full card — 33 of them, in the run that surfaced this.
+//
+// So the guard has to sit BEFORE the load. A checkpoint that cannot fit is a
+// skip with the numbers in it, not a failure: the test says nothing about the
+// code in that state.
+constexpr size_t kNeededMiB = 25000;  // 23.7 GiB upload + headroom for the MTP head
+
+size_t device_free_mib() {
+    size_t free_b = 0, total_b = 0;
+    if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess)
+        return 0;
+    return free_b >> 20;
+}
+
 }  // namespace
 
 TEST(MtpForwardTest, DraftStepProducesValidToken) {
     if (!model_available()) {
         GTEST_SKIP() << "Qwen3.6-NVFP4 with MTP not present at " << kQwen36ModelDir;
+    }
+    const size_t free_mib = device_free_mib();
+    if (free_mib < kNeededMiB) {
+        GTEST_SKIP() << "needs ~" << kNeededMiB << " MiB free, card has " << free_mib
+                     << " MiB — an OOM here leaves the CUDA context unable to free "
+                        "anything, which fails every later test in this binary";
     }
 
     // Load model + upload weights with MTP enabled.


### PR DESCRIPTION
`MtpForwardTest` loads Qwen3.6-35B-A3B-NVFP4 — ~23.7 GiB of a 32 GiB card.
Whether it fits depends on what ran before it *in the same process*, and when it
does not fit the failure is not contained: **33 later tests in `test-e2e` went
down with it.**

## The teardown cannot rescue it, and that is measured

The obvious hypothesis was that the 62537 reported failures are one sticky error
read 62537 times. I instrumented the free loop with the error state cleared
before **every** call:

```
[probe] sticky error before the free loop: out of memory
[probe] async-failed=62537  of which SYNC cudaFree succeeded=0  of 62537
```

**The failures are real**, not an artefact — the hypothesis is wrong. And a
synchronous `cudaFree` fallback does not help either: **zero of 62537**. After
the OOM the context frees nothing at all, and

```
mempool trim: reserved 23968->23968 MiB used 25352->25352 MiB (rc=no error)
```

says the memory stays put. It comes back at process exit and not before
(927 MiB → 851 MiB across the process boundary).

## So the guard sits before the load

A test that cannot run says nothing about the code. It now skips with the
numbers in it:

```
needs ~25000 MiB free, card has 23227 MiB — an OOM here leaves the CUDA context
unable to free anything, which fails every later test in this binary
[  SKIPPED ] MtpForwardTest.DraftStepProducesValidToken (0 ms)
```

and still **runs** when the card is free:

```
[       OK ] MtpForwardTest.DraftStepProducesValidToken (12554 ms)
```

## Result

`test-e2e`, full binary, seven model variables and the repo mounted:

| | ran | passed | skipped | failed |
|---|---:|---:|---:|---:|
| before | 172 | 126 | 12 | **34** |
| after | 172 | 160 | 10 | **2** |

The two that remain are real and reproduce in isolation:
`PrefixCacheE2ETest.FreshVsPrefixHitTokenEqual` and
`.PrefixCacheMatchesNoCacheBaseline`, both reporting that a prefix-cache hit
diverges from a fresh prefill. Separate defect, untouched here.

## What this PR does *not* fix

The goal was "a failed model load gives its GPU memory back". **It cannot**, and
the probe above is the evidence: after the OOM no free succeeds, by either API.
This PR prevents the OOM instead of cleaning up after it.

**The same path runs when a user loads a too-large model**, and there the
process is a server that then holds the memory until restart. A pre-flight check
on the serving path is the product-side answer and is not in this PR.

## Verification

`make verify-fast` → `=== verify fast: OK ===` · `make test-server` →
`PASS — all server batteries green` · full GPU suite green via the pre-commit
gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
