### PR TITLE
prefix-cache: the tests asserted bit-equality the design cannot deliver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`PrefixCacheE2ETest` asserted bit-equality that the design cannot give.** A
+  cache hit chunks differently than a fresh prefill and flips a near-tie: gap
+  0.161 between the top two candidates, 0.172 shift between the paths.
+
 - **`scripts/check-release.sh` now fails when a server battery is red.** It
   deferred only to `make verify-fast`, and `make test-server` is the one place
   `handlers.cpp` and `batching_engine` run end to end. The `json_schema` defect

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -565,5 +565,16 @@ These have a code path and no gate. They may work; nothing proves it.
   as the defect, so neither can point at it. The one signal is the weight-upload
   delta against the checkpoint on disk, which warns at load; measurement and the
   two refuted fields are in [`MEMORY.md`](internals/MEMORY.md) B8.
+- **A prefix-cache hit is not token-identical to a fresh prefill.** The hit skips
+  the cached prefix, so it computes over a different chunk split and accumulates
+  in a different order. Measured on Qwen3-4B-Q8_0 through the C API, at the first
+  position where the two differ: fresh picks token 55486 (logit 38.242889) over
+  279 (38.081467), a gap of 0.161; the cached run returns the same two in the
+  other order (38.253368 against 38.188511). The shift the two paths put on one
+  token is 0.172, larger than the gap between the candidates, so a near-tie
+  flips. Answers stay coherent and agree for many tokens before they part, but
+  greedy plus prefix caching is not bit-reproducible. `tests/test_prefix_cache_e2e.cpp`
+  asserts a common prefix rather than equality for that reason.
+
 - **`kv_cache.swa_snapshot_mb` set below one snapshot silently disables prefix
   caching** — worse than setting it to zero. It warns since #1092.

--- a/tests/test_prefix_cache_e2e.cpp
+++ b/tests/test_prefix_cache_e2e.cpp
@@ -134,8 +134,41 @@ TEST_F(PrefixCacheE2ETest, ControlNoCacheBackToBackIsDeterministic) {
 // 1. Fresh-prefill vs prefix-cache-HIT must be token-identical.
 //    Same context, prefix caching ON, NO reset between calls: call 1 prefills
 //    fresh and caches its prefix on finish; call 2 hits the cached prefix.
-//    Greedy ⇒ the two outputs must be byte-identical. A mismatch is exactly the
-//    silent-determinism failure that keeps the feature off-by-default.
+//
+//    The two are NOT byte-identical, and asserting that they are was wrong. A
+//    hit skips the cached prefix, so it computes over a different chunk split
+//    than the fresh prefill: measured on this test, "PrefixCache: seq 3 reused
+//    3/4 blocks (48 tokens skippable)". Different split, different accumulation
+//    order, and in FP16 that moves a logit.
+//
+//    Measured at the position where the two first differ, both paths dumping
+//    their raw top-2 (throwaway probe in build_logprob_info, 2026-08-19):
+//
+//      fresh : top1=55486(38.242889)  top2=279(38.081467)   gap 0.161422
+//      cached: top1=  279(38.253368)  top2=55486(38.188511) gap 0.064857
+//
+//    Same two tokens, order flipped. The gap between them is 0.42 % of the
+//    logit, and the shift the two paths produce on the same token is 0.172,
+//    i.e. LARGER than the gap. That is a tie decided by rounding, not a wrong
+//    KV block: a wrong block does not return the same two candidates within
+//    0.4 % of each other.
+//
+//    So the assertion is a common prefix, not equality. The bar comes from a
+//    distribution, not a single run: ten consecutive runs of both tests gave a
+//    common prefix of 103 characters every time, out of 161 and 153. The
+//    divergence point is not itself a coin flip, it is a fixed position where a
+//    fixed near-tie falls the other way, so 103 is a floor and not a sample
+//    mean. kMinCommonChars sits at 64, about 62 % of that.
+//
+//    Counted in CHARACTERS, deliberately: a token-based bar would need a
+//    chars-per-token factor, which is wrong for non-ASCII output and would make
+//    the bar depend on the language of the answer. Bytes are what both strings
+//    are made of.
+//
+//    What the bar has to keep catching is #536: there the hit diverged within
+//    the first tokens and continued differently, i.e. a common prefix near
+//    zero. Rounding diverges at 103. Any bar between those two separates them,
+//    and 64 is far from both.
 TEST_F(PrefixCacheE2ETest, FreshVsPrefixHitTokenEqual) {
     MakeContext(/*prefix_cache=*/true);
 
@@ -143,11 +176,16 @@ TEST_F(PrefixCacheE2ETest, FreshVsPrefixHitTokenEqual) {
     std::string second = gen(kPrompt, kGen);  // hits the cached prefix
 
     ASSERT_FALSE(first.empty()) << "model produced no output";
-    EXPECT_EQ(first, second)
-        << "PREFIX-CACHE HIT DIVERGED FROM FRESH PREFILL (greedy):\n  fresh: " << first
-        << "\n  hit:   " << second
-        << "\nThis is the determinism failure risk #7 names — the cached KV does "
-           "not reproduce the fresh forward pass.";
+    size_t common = 0;
+    while (common < first.size() && common < second.size() && first[common] == second[common])
+        common++;
+    const size_t kMinCommonChars = 64;  // measured floor 103 over ten runs
+    EXPECT_GE(common, kMinCommonChars)
+        << "PREFIX-CACHE HIT DIVERGED FROM FRESH PREFILL TOO EARLY (greedy):\n  fresh: " << first
+        << "\n  hit:   " << second << "\n  common prefix: " << common << " chars, want >= " << kMinCommonChars
+        << "\nLate divergence is the rounding this test tolerates (see the block "
+           "comment). Diverging this early is the failure risk #7 names: the "
+           "cached KV is not the KV a fresh forward would have produced.";
 }
 
 // 2. Cross-context equivalence: prefix-cache-ON output == prefix-cache-OFF
@@ -176,9 +214,19 @@ TEST_F(PrefixCacheE2ETest, PrefixCacheMatchesNoCacheBaseline) {
     std::string cached = gen(kPrompt, kGen);  // prefix-cache hit
 
     ASSERT_FALSE(baseline.empty());
-    EXPECT_EQ(baseline, cached)
-        << "prefix-cache output diverged from the no-cache baseline (greedy):\n"
-        << "  no-cache: " << baseline << "\n  cached:   " << cached;
+    // Same reasoning as test 1, and the comment above already had it for
+    // hybrids: a cache hit skips the cached prefix, so it chunks differently
+    // than the no-cache run and accumulates in a different order. That holds
+    // for a dense model too, it was simply never drawn. Common prefix, with
+    // the bar set the same way.
+    size_t common = 0;
+    while (common < baseline.size() && common < cached.size() && baseline[common] == cached[common])
+        common++;
+    const size_t kMinCommonChars = 64;  // same floor as test 1
+    EXPECT_GE(common, kMinCommonChars)
+        << "prefix-cache output left the no-cache baseline too early (greedy):\n"
+        << "  no-cache: " << baseline << "\n  cached:   " << cached << "\n  common prefix: " << common
+        << " chars, want >= " << kMinCommonChars;
 }
 
 // 3. Shared prefix, different suffix: a cache hit on the common prefix must not


### PR DESCRIPTION
`PrefixCacheE2ETest` asserted that a prefix-cache hit is byte-identical to a
fresh prefill. It is not, and it cannot be.

## Why

A hit skips the cached prefix, so it computes over a different chunk split and
accumulates in a different order:

```
PrefixCache: seq 3 reused 3/4 blocks (48 tokens skippable)
```

## The logits at the first divergence

Both paths dumping their raw top-2 (throwaway probe in `build_logprob_info`):

| | top-1 | top-2 | gap |
|---|---|---|---|
| fresh | 55486 (38.242889) | 279 (38.081467) | **0.161422** |
| cached | 279 (38.253368) | 55486 (38.188511) | 0.064857 |

Same two candidates, order flipped. The gap between them is **0.42 %** of the
logit, and the shift the two paths put on a single token is **0.172**, which is
larger than the gap. That is a tie decided by rounding.

**It is not #536 again.** A wrong KV block does not return the same two
candidates within 0.4 % of each other. That failure diverged within the first
tokens with an entirely different continuation.

## The bar comes from a distribution

Ten consecutive runs of both tests, common prefix each time:

```
[dist] test1 common=103 of first=161 second=153     (x10, identical)
[dist] test2 common=103 of base=161 cached=153      (x10, identical)
```

The divergence point is not itself a coin flip: it is a fixed position where a
fixed near-tie falls the other way. So 103 is a floor, not a sample mean.
`kMinCommonChars` is **64**, about 62 % of it, and far above the near-zero
prefix #536 produced.

Counted in characters on purpose. A token bar would need a chars-per-token
factor, which is wrong for non-ASCII and would tie the threshold to the language
of the answer.

## Verification

| | |
|---|---|
| `PrefixCacheE2ETest` | 4/4 PASSED |
| `test-e2e` alone | 172 ran, **162 passed, 10 skipped, 0 failed** |
| `make verify-fast` | `=== verify fast: OK ===` |
| `make test-server` | `PASS — all server batteries green` |

`docs/LIMITATIONS.md` gains an entry: greedy plus prefix caching is not
bit-reproducible on the C API path, with both logit pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vg4uBk3ob7S9mPeTkNz8Pb
