### PR TITLE
constrain: regex and grammar answered '!!!!' because the allow list was uploaded at the wrong width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`response_format: regex` and `grammar` answer the request again instead of
+  `!!!!...` until `max_tokens`.** The allow list was uploaded at the width of the
+  logits row (151936 on Qwen3-8B) into a buffer sized from the tokenizer
+  (151669); the copy failed, the mask killed every token, and greedy argmax fell
+  to id 0. Broken since #1091/#1095, on any checkpoint with a padded `lm_head`.
+
 - **`PrefixCacheE2ETest` asserted bit-equality that the design cannot give.** A
   cache hit chunks differently than a fresh prefill and flips a near-tie: gap
   0.161 between the top two candidates, 0.172 shift between the paths.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,6 +866,7 @@ if(IMP_BUILD_TESTS)
         tests/test_json_constrain.cu
         tests/test_schema_constrain.cu
         tests/test_tool_call_constrain.cu
+        tests/test_grammar_regex_mask.cu
     )
 
     imp_add_test_module(test-e2e WITH_STUB SOURCES

--- a/src/compute/grammar_constrain.cu
+++ b/src/compute/grammar_constrain.cu
@@ -40,7 +40,7 @@ bool GrammarConstrainer::init_grammar_only(const std::string& gbnf) {
     return true;
 }
 
-bool GrammarConstrainer::init(const std::string& gbnf, Tokenizer* tokenizer, int vocab_size) {
+bool GrammarConstrainer::init(const std::string& gbnf, Tokenizer* tokenizer) {
     if (!tokenizer)
         return false;
     if (!init_grammar_only(gbnf))
@@ -52,7 +52,7 @@ bool GrammarConstrainer::init(const std::string& gbnf, Tokenizer* tokenizer, int
         token_texts_[static_cast<size_t>(i)] = tokenizer->decode_token(static_cast<int32_t>(i));
     eos_ids_ = tokenizer->eos_ids();
 
-    if (!dev_.alloc_token_allow("GrammarConstrainer", vocab_size)) {
+    if (!dev_.alloc_token_allow("GrammarConstrainer", vocab_size_)) {
         initialized_ = false;
         return false;
     }
@@ -140,13 +140,18 @@ void GrammarConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_
         return;
 
     const std::vector<uint8_t>& allow = allow_for_current_state(vocab_size);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(vocab_size),
+    // The allow list covers the tokenizer's vocabulary; the logits row can be
+    // wider than that on a checkpoint with a padded lm_head. Upload only what
+    // the buffer holds. The kernel masks everything at or above n_classified
+    // without reading the list, so the padding ids need no entry.
+    const int n_classified = std::min(vocab_size, vocab_size_);
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(n_classified),
                                        cudaMemcpyHostToDevice, stream));
 
     const int threads = 256;
     const int blocks = (vocab_size + threads - 1) / threads;
     grammar_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.token_allow(), vocab_size,
-                                                        std::min(vocab_size, vocab_size_));
+                                                        n_classified);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/grammar_constrain.h
+++ b/src/compute/grammar_constrain.h
@@ -37,7 +37,7 @@ public:
     // Compiles `gbnf` and classifies the tokenizer vocabulary. Returns false on
     // a grammar that does not compile — the caller then declines constrained
     // decoding rather than enforcing something nobody wrote.
-    [[nodiscard]] bool init(const std::string& gbnf, Tokenizer* tokenizer, int vocab_size);
+    [[nodiscard]] bool init(const std::string& gbnf, Tokenizer* tokenizer);
 
     // Grammar-only init for unit tests: no tokenizer, no device buffers. Only
     // update_text/is_done/would_accept work afterwards.

--- a/src/compute/regex_constrain.cu
+++ b/src/compute/regex_constrain.cu
@@ -170,7 +170,7 @@ bool RegexConstrainer::language_non_empty() const {
     return false;
 }
 
-bool RegexConstrainer::init(const std::string& pattern, Tokenizer* tokenizer, int vocab_size) {
+bool RegexConstrainer::init(const std::string& pattern, Tokenizer* tokenizer) {
     if (!tokenizer)
         return false;
     if (!init_pattern_only(pattern))
@@ -182,7 +182,7 @@ bool RegexConstrainer::init(const std::string& pattern, Tokenizer* tokenizer, in
         token_texts_[i] = tokenizer->decode_token(static_cast<int32_t>(i));
     eos_ids_ = tokenizer->eos_ids();
 
-    if (!dev_.alloc_token_allow("RegexConstrainer", vocab_size)) {
+    if (!dev_.alloc_token_allow("RegexConstrainer", vocab_size_)) {
         initialized_ = false;
         return false;
     }
@@ -289,13 +289,17 @@ void RegexConstrainer::apply_mask(float* d_logits, int vocab_size, cudaStream_t 
         return;
 
     const std::vector<uint8_t>& allow = allow_for_current_state(vocab_size);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(vocab_size),
+    // The allow list covers the tokenizer's vocabulary; the logits row can be
+    // wider than that on a checkpoint with a padded lm_head. Upload only what
+    // the buffer holds. The kernel masks everything at or above n_classified
+    // without reading the list, so the padding ids need no entry.
+    const int n_classified = std::min(vocab_size, vocab_size_);
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(dev_.token_allow(), allow.data(), static_cast<size_t>(n_classified),
                                        cudaMemcpyHostToDevice, stream));
 
     const int threads = 256;
     const int blocks = (vocab_size + threads - 1) / threads;
-    regex_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.token_allow(), vocab_size,
-                                                      std::min(vocab_size, vocab_size_));
+    regex_mask_kernel<<<blocks, threads, 0, stream>>>(d_logits, dev_.token_allow(), vocab_size, n_classified);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/regex_constrain.h
+++ b/src/compute/regex_constrain.h
@@ -40,7 +40,7 @@ public:
     // Compiles `pattern` and classifies the tokenizer vocabulary. Returns false
     // on an unsupported/malformed pattern — the caller then declines
     // constrained decoding rather than enforcing a wrong grammar.
-    [[nodiscard]] bool init(const std::string& pattern, Tokenizer* tokenizer, int vocab_size);
+    [[nodiscard]] bool init(const std::string& pattern, Tokenizer* tokenizer);
 
     // Pattern-only init for unit tests: no tokenizer, no device buffers. Only
     // update_text/is_done/would_accept work afterwards.

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -313,7 +313,7 @@ bool ConstraintManager::prepare_regex(const std::string& pattern, Tokenizer* tok
     // vocab_size here is the LOGITS width; the constrainer clamps its own
     // classification to the tokenizer vocab (SafeTensors models pad lm_head
     // past it — indexing to the logits width read out of bounds once).
-    if (!regex_constrainer_->init(pattern, tokenizer, tokenizer->vocab_size())) {
+    if (!regex_constrainer_->init(pattern, tokenizer)) {
         IMP_LOG_WARN("ConstraintManager: regex '%s' rejected — not enforcing it", pattern.c_str());
         return false;
     }
@@ -344,7 +344,7 @@ bool ConstraintManager::prepare_grammar(const std::string& gbnf, Tokenizer* toke
         // vocab_size here is the LOGITS width; the constrainer clamps its own
         // classification to the tokenizer vocab (SafeTensors models pad lm_head
         // past it — indexing to the logits width read out of bounds once).
-        if (!grammar_constrainer_->init(gbnf, tokenizer, tokenizer->vocab_size())) {
+        if (!grammar_constrainer_->init(gbnf, tokenizer)) {
             IMP_LOG_WARN("ConstraintManager: GBNF grammar rejected (%s) — not enforcing it",
                          grammar_constrainer_->error().c_str());
             cached_grammar_string_.clear();

--- a/tests/test_grammar_regex_mask.cu
+++ b/tests/test_grammar_regex_mask.cu
@@ -1,0 +1,110 @@
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include "compute/grammar_constrain.h"
+#include "compute/regex_constrain.h"
+#include "model/tokenizer.h"
+
+#include <cfloat>
+#include <string>
+#include <vector>
+
+#include "test_cuda_skip.h"
+
+namespace imp {
+namespace {
+
+// The allow list is sized from the TOKENIZER vocabulary at init, but apply_mask
+// is handed the width of the logits, which is the MODEL vocabulary. On every
+// checkpoint whose lm_head is padded the second number is larger. Qwen3-8B
+// ships 151936 rows against 151669 tokenizer entries, and the upload of the
+// allow list then wrote past its own buffer.
+//
+// The failure was not visible as a failure: cudaMemcpyAsync returned
+// `invalid argument`, the device allow list kept whatever it held, and the mask
+// kernel masked everything. Greedy argmax over an all -FLT_MAX row picks id 0,
+// so every regex- and grammar-constrained request answered "!!!!..." until it
+// hit max_tokens. JsonConstrainer and SchemaConstrainer size both sides from
+// the tokenizer and were never affected; they are also the only two of the four
+// that had a GPU test.
+//
+// Mirrors JsonConstrainTest.ModelVocabLargerThanTokenizerMasksPadding.
+
+// Builds a tokenizer whose vocabulary is deliberately narrower than the logits
+// row the constrainer will be asked to mask.
+Tokenizer make_tokenizer(std::vector<std::string>& toks) {
+    std::vector<float> scores(toks.size(), 0.0f);
+    Tokenizer tok;
+    tok.load_vocab(toks, scores, /*bos_id=*/1, /*eos_id=*/2);
+    return tok;
+}
+
+TEST(RegexConstrainMaskTest, ModelVocabLargerThanTokenizerMasksPadding) {
+    SKIP_IF_NO_CUDA();
+
+    //                                  0        1      2       3        4       5
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "Paris", "Lyon", "xyz"};
+    Tokenizer tok = make_tokenizer(toks);
+
+    const int tok_vocab = static_cast<int>(toks.size());
+    const int model_vocab = tok_vocab + 9;  // simulated lm_head padding rows
+
+    RegexConstrainer rc;
+    ASSERT_TRUE(rc.init("Paris", &tok));
+
+    std::vector<float> h(model_vocab, 1.0f);
+    float* d = nullptr;
+    ASSERT_EQ(cudaMalloc(&d, model_vocab * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice), cudaSuccess);
+
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "test setup left a CUDA error behind";
+    rc.apply_mask(d, model_vocab, 0);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess)
+        << "apply_mask raised a CUDA error: the allow-list upload is sized from the model "
+           "vocabulary while the buffer is sized from the tokenizer";
+
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost), cudaSuccess);
+    cudaFree(d);
+
+    EXPECT_GT(h[3], -1e30f) << "'Paris' matches the pattern and must survive the mask";
+    EXPECT_FLOAT_EQ(h[4], -FLT_MAX) << "'Lyon' does not match the pattern and must be masked";
+    for (int i = tok_vocab; i < model_vocab; i++)
+        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the regex mask";
+}
+
+TEST(GrammarConstrainMaskTest, ModelVocabLargerThanTokenizerMasksPadding) {
+    SKIP_IF_NO_CUDA();
+
+    //                                  0        1      2       3        4       5
+    std::vector<std::string> toks = {"<unk>", "<s>", "</s>", "Paris", "Lyon", "xyz"};
+    Tokenizer tok = make_tokenizer(toks);
+
+    const int tok_vocab = static_cast<int>(toks.size());
+    const int model_vocab = tok_vocab + 9;
+
+    GrammarConstrainer gc;
+    ASSERT_TRUE(gc.init("root ::= \"Paris\"", &tok));
+
+    std::vector<float> h(model_vocab, 1.0f);
+    float* d = nullptr;
+    ASSERT_EQ(cudaMalloc(&d, model_vocab * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d, h.data(), model_vocab * sizeof(float), cudaMemcpyHostToDevice), cudaSuccess);
+
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess) << "test setup left a CUDA error behind";
+    gc.apply_mask(d, model_vocab, 0);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess)
+        << "apply_mask raised a CUDA error: the allow-list upload is sized from the model "
+           "vocabulary while the buffer is sized from the tokenizer";
+
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(h.data(), d, model_vocab * sizeof(float), cudaMemcpyDeviceToHost), cudaSuccess);
+    cudaFree(d);
+
+    EXPECT_GT(h[3], -1e30f) << "'Paris' is the only production and must survive the mask";
+    EXPECT_FLOAT_EQ(h[4], -FLT_MAX) << "'Lyon' is not in the grammar and must be masked";
+    for (int i = tok_vocab; i < model_vocab; i++)
+        EXPECT_FLOAT_EQ(h[i], -FLT_MAX) << "padding id " << i << " leaked through the grammar mask";
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

`response_format: {"type":"regex"}` and `{"type":"grammar"}` (and their
`guided_regex` / `guided_grammar` aliases) returned `!!!!...` until `max_tokens`
instead of the constrained text. Every non-JSON constrained request on this
engine was affected.

Found while measuring an unrelated claim in `docs/API.md` (that structured
output suppresses thinking). The claim holds; the constrainer underneath it did
not.

## Evidence

Against `imp-server` on `Qwen3-8B-NVFP4-cortecs`, before:

```
grammar single literal   finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
grammar alternation      finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
grammar char class       finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
regex literal            finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
regex char class         finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
regex digits             finish=length   '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
```

after, same server, same requests:

```
grammar single literal   finish=stop     'Paris'
grammar alternation      finish=stop     'Paris'
grammar char class       finish=stop     'apple'
regex literal            finish=stop     'Paris'
regex char class         finish=stop     'apple'
regex digits             finish=stop     '345'
```

The server log named the cause on every step:

```
regex_constrain.cu:292: CUDA error: cudaMemcpyAsync(dev_.token_allow(), allow.data(),
  static_cast<size_t>(vocab_size), ...) — invalid argument
```

## Root cause

The device allow list is allocated from the **tokenizer** vocabulary and
uploaded at the width `apply_mask` is handed, which is the **logits row**
(`executor.cu:112` passes `logits.shape[0]`). On Qwen3-8B those are 151936 and
151669, so the copy overruns its own buffer and fails. The device list keeps
whatever it held, the kernel masks every logit to `-FLT_MAX`, and greedy argmax
over that row picks id 0, which decodes as `!`.

The host-side guard for "nothing continues the pattern, allow EOS"
(`regex_constrain.cu:277`) was already there and names this exact symptom in its
comment. It could not help: it writes into the buffer the failed copy never
delivered.

## Fix

Both sides now read the same number:

- `init()` drops its `vocab_size` parameter and allocates from `vocab_size_`,
  the tokenizer size it derives two lines earlier. Both callers passed exactly
  that value, so no behaviour depended on the parameter.
- `apply_mask` uploads `min(vocab_size, vocab_size_)` bytes. The kernel already
  masked everything at or above that bound *without reading the list*
  (`i >= n_classified || allow[i] == 0`, short-circuit), so the padding ids need
  no entry.

## Why it survived since #1091 / #1095

`JsonConstrainer` and `SchemaConstrainer` size both sides from the tokenizer and
were never affected. They are also **the only two of the four constrainers with
a GPU test** (`test_json_constrain.cu`, `test_schema_constrain.cu`); regex and
grammar had CPU tests over the FSM only, which never reach `apply_mask`. The
two untested ones are the two that were broken.

`JsonConstrainTest.ModelVocabLargerThanTokenizerMasksPadding` covers precisely
this case for JSON. This PR adds its counterpart for the other two.

`#1210` moved the allocation into `ConstrainDeviceBuffers` but did not introduce
the defect: `git show 8302ea3e:src/compute/regex_constrain.cu` has the same
asymmetry at the introducing commit.

## Verification

- New `tests/test_grammar_regex_mask.cu`, 2 tests: red before the fix with
  `cudaGetLastError() == 1` and `'Paris'` masked to `-FLT_MAX`, green after.
  312 ms, no model needed.
- `test-moe-gdn`: 146 tests, 145 passed, 1 skipped (`GDNScanTest.ChunkwiseProtoMicrobench`).
- `make dev-test` (CI lane): 5/5 passed.
- `make verify-fast` on push: OK. decode 281.27 tok/s (-2.06%), prefill 12281.66
  (-1.01%), pp4096 15277.81 (-0.31%), peak VRAM 20718 MiB (+0.01%), graphs 2.45x.
- Regression check on the JSON paths against the fixed server: `json_schema` and
  `json_mode` both well-formed.
