### PR TITLE
mtp: refuse a head that does not fit before uploading any of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The MTP head is refused up front when it does not fit, instead of stranding
+  a partial upload.** It is 272 allocations on a per-expert checkpoint and the
+  allocator decided per allocation, so running out midway left the ones already
+  uploaded resident for the life of the process with spec-decode off anyway. The
+  load line now reports device free consumed (6291 MiB on Nemotron-3.5) next to
+  the 2.49 GiB on disk, which is what the restacking copy actually costs.
+
 - **`response_format: regex` and `grammar` answer the request again instead of
   `!!!!...` until `max_tokens`.** The allow list was uploaded at the width of the
   logits row (151936 on Qwen3-8B) into a buffer sized from the tokenizer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -855,6 +855,7 @@ if(IMP_BUILD_TESTS)
         tests/test_prefix_cache_equiv.cpp
         tests/test_recurrent_snapshot_store.cpp
         tests/test_vram_query.cpp
+        tests/test_mtp_upload_budget.cpp
     )
 
     imp_add_test_module(test-moe-gdn SOURCES

--- a/src/model/mtp_head.h
+++ b/src/model/mtp_head.h
@@ -157,8 +157,13 @@ struct MtpHead {
     // index them from a device-side expert id (gemv_f16_moe_decode) instead of
     // the host reading routing back and issuing one GEMM per chosen expert.
     // That host round trip is what kept the draft out of CUDA graph capture.
-    // Same storage, not a second copy: the per-expert Tensors above are views
-    // into these slabs once packing has run.
+    // The per-expert Tensors above become views into these slabs once packing
+    // has run. The slabs are a second copy in VRAM, not a re-pointing: the
+    // original per-expert allocations stay tracked and are only released at
+    // teardown, so the head costs file_bytes plus both slabs for the life of
+    // the process. Measured on Nemotron-3.5: 6317 MiB of device free for a head
+    // that is 2550 MiB on disk. Uploading straight into the slabs would remove
+    // the second copy and is not done yet.
     Tensor experts_up_stacked;    // [n_experts, d_ff_e, hidden] FP16
     Tensor experts_down_stacked;  // [n_experts, hidden, d_ff_e] FP16
     // DeepSeek-style additive score bias on the router logits. Null when absent.
@@ -178,5 +183,37 @@ struct MtpHead {
     // Status flag set true when ALL of the above tensors are populated.
     bool loaded = false;
 };
+
+// Device VRAM the head's upload needs at its peak, in bytes.
+//
+// The head is BF16 on disk and FP16 on device, so file_bytes is its resident
+// size. A per-expert layout additionally restacks both expert sets into one
+// contiguous slab each while the per-expert allocations are still live, so a
+// second copy of both sets is resident at the peak, and stays resident. See
+// the note on experts_up_stacked.
+//
+// Measured over three runs per arm, comparing device free consumed by the load
+// with speculative.mtp_k at 0 and 1:
+//
+//   Qwen3.6-35B-A3B-NVFP4   packed, 19 tensors    1608 MiB on disk, 1495 used
+//   Nemotron-3.5-Lightning  per-expert, 270       2550 MiB on disk, 6317 used
+//
+// This function returns 1608 and 4987 for those two. The packed number is a
+// slight over-estimate and the per-expert one falls 1330 MiB short of the
+// measurement, which the allocator headroom the caller adds on top covers; the
+// shortfall is async-pool behaviour, not a term that can be derived from the
+// shapes.
+inline size_t mtp_upload_peak_bytes(const MtpHead& head) {
+    constexpr size_t kFp16Bytes = 2;  // device dtype, independent of CUDA headers
+    size_t bytes = head.info.file_bytes;
+    for (const std::vector<Tensor>* parts : {&head.experts_up, &head.experts_down}) {
+        if (parts->empty() || parts->front().data == nullptr)
+            continue;
+        const Tensor& t = parts->front();
+        bytes += static_cast<size_t>(t.shape[0]) * static_cast<size_t>(t.shape[1]) * kFp16Bytes *
+                 parts->size();
+    }
+    return bytes;
+}
 
 }  // namespace imp

--- a/src/model/weight_upload.cu
+++ b/src/model/weight_upload.cu
@@ -986,6 +986,7 @@ static bool upload_embeddings_and_output(Tensor& tok_emb, Tensor& out_norm, Tens
 // producing zero output that locks the LM-head argmax to a deterministic
 // noise token. Pass the offset on norm tensors only.
 // ---------------------------------------------------------------------------
+
 static bool upload_mtp_weights(MtpHead& head, const UploadCtx& ctx) {
     if (!head.loaded) return true;  // nothing to upload
 
@@ -1048,9 +1049,11 @@ static bool upload_mtp_weights(MtpHead& head, const UploadCtx& ctx) {
     // draft has to copy routing D2H and loop on the host, which is exactly what
     // makes the draft path uncapturable.
     //
-    // The per-expert Tensors are then repointed INTO the slab and the originals
-    // freed, so this costs no steady-state VRAM — only a transient second copy
-    // of one expert-set while the slab is filled.
+    // The per-expert Tensors are then repointed INTO the slab. The originals are
+    // NOT freed: they stay in gpu_allocs until teardown, so both copies are
+    // resident for the life of the process. That is why mtp_upload_peak_bytes
+    // counts the slabs on top of the head, and why the load refuses a head it
+    // cannot afford as a whole.
     if (ok && !head.experts_up.empty() && head.experts_up[0].data != nullptr) {
         auto stack = [&](std::vector<Tensor>& parts, Tensor& out, const char* what) -> bool {
             const int64_t ne = static_cast<int64_t>(parts.size());
@@ -2699,12 +2702,37 @@ bool Model::upload_weights_gpu(QType compute_dtype, cudaStream_t stream, size_t 
     // — if the upload fails (no VRAM), we degrade by disabling MTP rather
     // than failing the entire model load.
     if (mtp_.has_value() && mtp_->loaded) {
+        // Refuse a head that does not fit BEFORE uploading any of it. See
+        // mtp_upload_peak_bytes: a per-allocation refusal partway through
+        // strands everything already uploaded for the life of the process.
+        size_t mtp_free = 0, mtp_total = 0;
+        const size_t mtp_need = mtp_upload_peak_bytes(*mtp_);
+        const bool have_reading = vram_budget_mem_get_info(&mtp_free, &mtp_total);
+        const size_t mtp_headroom = vram_allocator_headroom(mtp_total);
+        if (have_reading && mtp_free < mtp_need + mtp_headroom) {
+            IMP_LOG_WARN(
+                "MTP head: needs %zu MiB plus %zu MiB allocator headroom, %zu MiB free. "
+                "Skipping the head, spec-decode disabled.",
+                mtp_need / (1024 * 1024), mtp_headroom / (1024 * 1024), mtp_free / (1024 * 1024));
+            mtp_->loaded = false;
+        }
+    }
+    if (mtp_.has_value() && mtp_->loaded) {
         size_t allocs_before = gpu_allocations_.size();
+        size_t mtp_free_before = 0;
+        vram_budget_mem_get_info(&mtp_free_before, nullptr);
         if (upload_mtp_weights(*mtp_, ctx)) {
-            IMP_LOG_INFO("MTP head: uploaded to GPU (%zu allocations, %.2f GiB BF16→FP16)",
-                         gpu_allocations_.size() - allocs_before,
-                         static_cast<double>(mtp_->info.file_bytes) /
-                             (1024.0 * 1024.0 * 1024.0));
+            // Report what the device actually gave up, not the size on disk:
+            // the restacking copy makes the second number roughly 2.5x the
+            // first, and the file size read like the whole cost.
+            size_t mtp_free_after = 0;
+            vram_budget_mem_get_info(&mtp_free_after, nullptr);
+            const size_t mtp_used = mtp_free_before > mtp_free_after ? mtp_free_before - mtp_free_after : 0;
+            IMP_LOG_INFO(
+                "MTP head: uploaded to GPU (%zu allocations, %zu MiB of device free, "
+                "%.2f GiB on disk)",
+                gpu_allocations_.size() - allocs_before, mtp_used / (1024 * 1024),
+                static_cast<double>(mtp_->info.file_bytes) / (1024.0 * 1024.0 * 1024.0));
         } else {
             IMP_LOG_WARN("MTP head: GPU upload failed — spec-decode disabled");
             mtp_->loaded = false;

--- a/tests/test_mtp_upload_budget.cpp
+++ b/tests/test_mtp_upload_budget.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include "model/mtp_head.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// mtp_upload_peak_bytes decides whether the MTP head is uploaded at all. The
+// upload is 272 allocations on a per-expert checkpoint and the allocator
+// decides per allocation, so running out partway leaves everything already
+// uploaded stranded until the process exits. Under-estimating here is what
+// lets that happen.
+
+// A stand-in expert weight. The estimator reads shape and the non-null data
+// pointer only, so no device memory is involved.
+Tensor fake_expert(int64_t rows, int64_t cols) {
+    static int placeholder = 0;
+    const int64_t shape[4] = {rows, cols, 0, 0};
+    return Tensor(&placeholder, QType::F16, 2, shape, /*on_device=*/true);
+}
+
+TEST(MtpUploadBudgetTest, PackedLayoutCostsTheFileSize) {
+    MtpHead head;
+    head.info.file_bytes = 1608ull * 1024 * 1024;
+
+    // No per-expert tensors: nothing is restacked, so nothing is copied twice.
+    EXPECT_TRUE(head.experts_up.empty());
+    EXPECT_EQ(mtp_upload_peak_bytes(head), head.info.file_bytes);
+}
+
+TEST(MtpUploadBudgetTest, PerExpertLayoutAddsBothSlabs) {
+    // Nemotron-3.5-Lightning-30B: 128 experts, hidden 2688, d_ff_e 1856.
+    constexpr int64_t kExperts = 128, kHidden = 2688, kDffE = 1856;
+    MtpHead head;
+    head.info.file_bytes = 2550ull * 1024 * 1024;
+    for (int64_t e = 0; e < kExperts; e++) {
+        head.experts_up.push_back(fake_expert(kDffE, kHidden));
+        head.experts_down.push_back(fake_expert(kHidden, kDffE));
+    }
+
+    const size_t slab = static_cast<size_t>(kExperts) * kDffE * kHidden * 2;
+    EXPECT_EQ(mtp_upload_peak_bytes(head), head.info.file_bytes + 2 * slab);
+
+    // The point of the function: on this checkpoint the head costs far more
+    // than its file size. The estimate is 4986 MiB against 2550 MiB on disk,
+    // and the load was measured consuming 6317 MiB of device free. The
+    // estimate is deliberately the smaller of the two, because the caller adds
+    // the allocator headroom (1630 MiB on a 32 GiB card) on top of it.
+    EXPECT_GT(mtp_upload_peak_bytes(head), head.info.file_bytes * 19 / 10)
+        << "a per-expert head that estimates near its file size would be waved "
+           "through and then strand its allocations partway";
+}
+
+TEST(MtpUploadBudgetTest, UnuploadedExpertsAreNotCounted) {
+    // Before the upload runs, the per-expert tensors carry host pointers or
+    // none at all. Counting a slab for those would refuse heads that fit.
+    MtpHead head;
+    head.info.file_bytes = 1000;
+    const int64_t shape[4] = {16, 16, 0, 0};
+    head.experts_up.push_back(Tensor(nullptr, QType::F16, 2, shape, /*on_device=*/false));
+    head.experts_down.push_back(Tensor(nullptr, QType::F16, 2, shape, /*on_device=*/false));
+
+    EXPECT_EQ(mtp_upload_peak_bytes(head), 1000u);
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
## What

The MTP head upload is all-or-nothing now. It is checked against free VRAM
before the first allocation, and skipped with a WARN if it does not fit.

## Why the existing degrade path was not enough

`upload_weights_gpu` already disables spec-decode when the upload fails. But the
head is **272 allocations** on a per-expert checkpoint and `checked_cuda_malloc`
decides per allocation. Running out at number 200 leaves 199 of them resident,
disables spec-decode anyway, and never returns that VRAM for the rest of the
process. The refusal has to come before the first one.

## What the head actually costs

Three runs per arm, same binary, same card, comparing device free consumed by
the load with `speculative.mtp_k` at 0 and 1:

| model | layout | on disk | measured | ratio |
|---|---|---|---|---|
| Qwen3.6-35B-A3B-NVFP4 | packed, 19 tensors | 1608 MiB | 1495 MiB | 0.93 |
| Nemotron-3.5-Lightning-30B | per-expert, 270 tensors | 2550 MiB | **6317 MiB** | **2.48** |

```
run=1 mtp_k=0 consumed=18016    run=1 mtp_k=1 consumed=24333
run=2 mtp_k=0 consumed=18016    run=2 mtp_k=1 consumed=24319
run=3 mtp_k=0 consumed=18016    run=3 mtp_k=1 consumed=24340
```

Spread 0.00 % on the k=0 arm, 0.09 % on k=1, and both arms start from an
identical 30153 MiB free.

The difference between the two layouts is the expert restacking, which copies
both expert sets into one contiguous slab each **while the originals are still
live** and leaves the originals in `gpu_allocs` until teardown.

## Two comments said the opposite

- `weight_upload.cu`: *"the originals freed, so this costs no steady-state VRAM
  — only a transient second copy"*
- `mtp_head.h`: *"Same storage, not a second copy"*

Neither holds: the inner comment in the same function already says the
originals *"stay owned by gpu_allocs and are freed at teardown"*, and the 2.48x
above is that second copy. Both corrected against the measurement. Uploading
straight into the slabs would remove the copy entirely and is noted as
follow-up rather than done here.

## The estimator

`mtp_upload_peak_bytes(head)` in `mtp_head.h`, so it is testable without a GPU:
`file_bytes` plus one slab per expert set when the per-expert tensors carry
device pointers. It returns 1608 and 4986 MiB for the two models above. The
per-expert number falls 1330 MiB short of the measurement; that shortfall is
async-pool behaviour, not a term derivable from the shapes, and the caller adds
the allocator headroom (1630 MiB on a 32 GiB card) on top of it, which covers it.

## Verification

Both branches of the gate, on the real server:

```
normal:      MTP head: uploaded to GPU (272 allocations, 6291 MiB of device free,
                                        2.49 GiB on disk)
budget 21000: MTP head: needs 4982 MiB plus 1050 MiB allocator headroom,
                        2210 MiB free. Skipping the head, spec-decode disabled.
```

The refusal leaves the engine in the same state as `speculative.mtp_k=0`. A
control run confirms the refusal is not what breaks a too-small budget:
`mtp_k=0` at `--vram-budget 23000` fails at the identical KV-pool guard, with
MTP never involved.

- New `tests/test_mtp_upload_budget.cpp`, 3 tests, CPU only, in `test-kv`.
  One of them caught a wrong claim in my own first draft (the estimate is 1.96x
  the file size, not over 2x; 2.48x is the measurement, not the estimate).
- `test-kv`: 75 tests, all passed.
- `make dev-test` (CI lane): 5/5.
- `make verify-fast` on push: OK. peak VRAM 20718 MiB (+0.01%), graphs 2.80x,
  smoke prompt green.

## Not in this PR

- Uploading experts directly into the slab, which would drop the head's cost on
  a per-expert checkpoint from 6317 to roughly 3900 MiB.
- MTP is uploaded before the KV pool is sized, so on a tight budget the head can
  take the room the pool needed. The KV guard reports that clearly today; the
  ordering question is #1103's class and belongs in its own change.
