### PR TITLE
mtp: the upload shortfall is one more slab, not a share of the card

### DIFF
--- a/src/model/mtp_head.h
+++ b/src/model/mtp_head.h
@@ -192,28 +192,44 @@ struct MtpHead {
 // second copy of both sets is resident at the peak, and stays resident. See
 // the note on experts_up_stacked.
 //
+// The first slab additionally costs twice its size, because it is the first
+// large request the async pool serves and the pool rounds up when it grows.
+// Probed on Nemotron-3.5, device free after each phase:
+//
+//   start                     12137 MiB
+//   after 270 tensor uploads   9577      2560 used, against 2550 on disk
+//   after slab up              7153      2424 used, for a 1218 MiB slab
+//   after slab down            5937      1216 used, the slab exactly
+//
+// So the term is one extra slab, not a margin: this returns 6204 MiB for that
+// head against 6200 measured. The allocator headroom the caller adds on top is
+// left to cover allocator waste, which is what it is for. Relying on it to
+// cover this would have held only on a large card: it is 5 % of the total, so
+// 1630 MiB on 32 GB but 819 MiB on 16 GB, and only 409 MiB for a process
+// running under an 8 GB --vram-budget.
+//
 // Measured over three runs per arm, comparing device free consumed by the load
 // with speculative.mtp_k at 0 and 1:
 //
 //   Qwen3.6-35B-A3B-NVFP4   packed, 19 tensors    1608 MiB on disk, 1495 used
 //   Nemotron-3.5-Lightning  per-expert, 270       2550 MiB on disk, 6317 used
 //
-// This function returns 1608 and 4987 for those two. The packed number is a
-// slight over-estimate and the per-expert one falls 1330 MiB short of the
-// measurement, which the allocator headroom the caller adds on top covers; the
-// shortfall is async-pool behaviour, not a term that can be derived from the
-// shapes.
+// This returns 1608 for the packed head, a slight over-estimate, and 6204 for
+// the per-expert one.
 inline size_t mtp_upload_peak_bytes(const MtpHead& head) {
     constexpr size_t kFp16Bytes = 2;  // device dtype, independent of CUDA headers
     size_t bytes = head.info.file_bytes;
+    size_t largest_slab = 0;
     for (const std::vector<Tensor>* parts : {&head.experts_up, &head.experts_down}) {
         if (parts->empty() || parts->front().data == nullptr)
             continue;
         const Tensor& t = parts->front();
-        bytes += static_cast<size_t>(t.shape[0]) * static_cast<size_t>(t.shape[1]) * kFp16Bytes *
-                 parts->size();
+        const size_t slab = static_cast<size_t>(t.shape[0]) * static_cast<size_t>(t.shape[1]) * kFp16Bytes *
+                            parts->size();
+        bytes += slab;
+        largest_slab = slab > largest_slab ? slab : largest_slab;
     }
-    return bytes;
+    return bytes + largest_slab;
 }
 
 }  // namespace imp

--- a/tests/test_mtp_upload_budget.cpp
+++ b/tests/test_mtp_upload_budget.cpp
@@ -31,7 +31,7 @@ TEST(MtpUploadBudgetTest, PackedLayoutCostsTheFileSize) {
     EXPECT_EQ(mtp_upload_peak_bytes(head), head.info.file_bytes);
 }
 
-TEST(MtpUploadBudgetTest, PerExpertLayoutAddsBothSlabs) {
+TEST(MtpUploadBudgetTest, PerExpertLayoutAddsBothSlabsAndPoolGrowth) {
     // Nemotron-3.5-Lightning-30B: 128 experts, hidden 2688, d_ff_e 1856.
     constexpr int64_t kExperts = 128, kHidden = 2688, kDffE = 1856;
     MtpHead head;
@@ -41,17 +41,22 @@ TEST(MtpUploadBudgetTest, PerExpertLayoutAddsBothSlabs) {
         head.experts_down.push_back(fake_expert(kHidden, kDffE));
     }
 
+    // Both slabs, plus one more for the pool growth the first large request
+    // triggers. Probed phase by phase on this checkpoint: 2424 MiB went for the
+    // first 1218 MiB slab and 1216 MiB for the second.
     const size_t slab = static_cast<size_t>(kExperts) * kDffE * kHidden * 2;
-    EXPECT_EQ(mtp_upload_peak_bytes(head), head.info.file_bytes + 2 * slab);
+    EXPECT_EQ(mtp_upload_peak_bytes(head), head.info.file_bytes + 3 * slab);
 
-    // The point of the function: on this checkpoint the head costs far more
-    // than its file size. The estimate is 4986 MiB against 2550 MiB on disk,
-    // and the load was measured consuming 6317 MiB of device free. The
-    // estimate is deliberately the smaller of the two, because the caller adds
-    // the allocator headroom (1630 MiB on a 32 GiB card) on top of it.
-    EXPECT_GT(mtp_upload_peak_bytes(head), head.info.file_bytes * 19 / 10)
-        << "a per-expert head that estimates near its file size would be waved "
-           "through and then strand its allocations partway";
+    // Which lands within 4 MiB of the 6200 MiB the load was measured taking.
+    const size_t measured = 6200ull * 1024 * 1024;
+    const size_t est = mtp_upload_peak_bytes(head);
+    const size_t off = est > measured ? est - measured : measured - est;
+    EXPECT_LT(off, 16ull * 1024 * 1024)
+        << "estimate " << est / (1024 * 1024) << " MiB against 6200 MiB measured";
+
+    // And it must not be reachable by the file size alone, or a per-expert head
+    // gets waved through and strands its allocations partway.
+    EXPECT_GT(est, 2 * head.info.file_bytes);
 }
 
 TEST(MtpUploadBudgetTest, UnuploadedExpertsAreNotCounted) {


### PR DESCRIPTION
## What

Follow-up to #1494, which merged while this was being measured. The estimator
there leaned on the allocator headroom to cover a 1330 MiB shortfall on a
per-expert head, and a comment said so.

## Why that was wrong

The headroom is `total * 5 / 100` (`vram_query.h:81`). The shortfall is a
property of the head and its layout. They lined up only on this card:

| card / budget | headroom | shortfall | covered |
|---|---|---|---|
| 32 GB | 1630 MiB | 1330 MiB | yes |
| 16 GB | 819 MiB | 1330 MiB | **no** |
| 8 GB `--vram-budget` | 409 MiB | 1330 MiB | **no** |

`vram_budget_mem_get_info` returns the process slice when a budget is
installed, so the third row is a real configuration, not a hypothetical. On any
of those the gate waves the head through and we are back at the OOM it exists
to prevent, with a comment claiming otherwise.

## Where the shortfall actually comes from

I had written that it was async-pool behaviour and not derivable from the
shapes. That was an assumption, so I probed the upload phase by phase. Device
free after each, Nemotron-3.5:

```
start                     12137 MiB
after 270 tensor uploads   9577      2560 used, against 2550 on disk
after slab up              7153      2424 used, for a 1218 MiB slab
after slab down            5937      1216 used, the slab exactly
```

The second slab costs exactly its size. The **first** costs twice: it is the
first large request the async pool serves, and the pool rounds up as it grows.

So the term is one extra slab, and it is derivable after all.

## Result

`mtp_upload_peak_bytes` adds the largest slab once more. It returns 6204 MiB
for that head against 6200 measured, a 4 MiB gap. The test asserts that
agreement (`EXPECT_LT(off, 16 MiB)`) instead of the ratio it asserted before,
so a future change to the term has to stay honest against the measurement
rather than against a rule of thumb.

The headroom stays where it was, covering allocator waste, which is its job.

## Verification

- `test-kv`: 75 tests, all passed, including the 3 budget tests.
- Real load unchanged on this card: `MTP head: uploaded to GPU (272
  allocations, 6168 MiB of device free, 2.49 GiB on disk)`.
- `make verify-fast` on push: OK.
