### PR TITLE
weightmap: the MTP sidecar is not an unrecognised weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,6 @@ there instead of retelling it.
   again.** A token carrying string content *and* the closing quote got neither
   category, so the pre-filter dropped it before the FSM. Costs ~5.6 % decode.
 
-- **A checkpoint's MTP tensors are no longer reported as unrecognised weights.**
-  They have their own loader; 270 false WARN lines on Nemotron-3.5 were hiding
-  12 real ones (`k_scale`/`v_scale`, which imp does not read).
-
 - **`response_format: regex` and `grammar` answer the request instead of
   `!!!!...` until `max_tokens`.** The allow list was uploaded at the width of the
   logits row into a tokenizer-sized buffer. Broken since #1091/#1095.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ there instead of retelling it.
   again.** A token carrying string content *and* the closing quote got neither
   category, so the pre-filter dropped it before the FSM. Costs ~5.6 % decode.
 
+- **A checkpoint's MTP tensors are no longer reported as unrecognised weights.**
+  They have their own loader; 270 false WARN lines on Nemotron-3.5 were hiding
+  12 real ones (`k_scale`/`v_scale`, which imp does not read).
+
 - **`response_format: regex` and `grammar` answer the request instead of
   `!!!!...` until `max_tokens`.** The allow list was uploaded at the width of the
   logits row into a tokenizer-sized buffer. Broken since #1091/#1095.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -41,6 +41,14 @@ These have a code path and no gate. They may work; nothing proves it.
 
 ## Known-bad and known-limited behaviour
 
+- **Calibrated KV-cache scales shipped in a checkpoint are not read.** Six local
+  checkpoints carry `*.self_attn.{k_proj.k_scale,v_proj.v_scale}` (96 tensors on
+  Qwen3-Coder-30B-A3B-FP4, 12 on NVIDIA-Nemotron-3.5-Lightning-30B, which has 6
+  attention layers of 52); no consumer for them exists in the tree, and the FP8
+  KV path derives its own. Whether adopting them changes output quality is
+  unmeasured. They were invisible until #1497, counted among 270 false
+  "unrecognised weight name" warnings for the MTP sidecar.
+
 - **INT4 KV cache produces empty output on gpt-oss.** Its sink term is correct
   and is unit-tested against a sink-aware reference; 4 bits per value on a
   64-wide head is simply not enough. It falls back to FP16 rather than pretending.

--- a/src/model/weight_map.cpp
+++ b/src/model/weight_map.cpp
@@ -331,6 +331,7 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
 
     int assigned = 0;
     int skipped = 0;
+    int mtp_sidecar = 0;  // read by the MTP loader, not a miss here
 
     const bool is_gemma4 = (arch_ == ModelArch::GEMMA4);
     const bool is_gemma4_moe = is_gemma4 && (model.config_.n_experts > 0);
@@ -513,6 +514,18 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
         // -----------------------------------------------------------------
         // Layer weights: model.layers.{i}.<rest>
         // -----------------------------------------------------------------
+        // The MTP head is a sidecar with its own loader and its own naming
+        // (`mtp.layers.N.*`). It is not a weight of the main model, so it is
+        // not a finding here. Reported as unrecognised it produced 270 WARN
+        // lines on Nemotron-3.5-Lightning for a head that loaded correctly,
+        // which is worse than silence: "unrecognised weight name" is the string
+        // you grep for after a first load to catch a checkpoint whose tensors
+        // this map does not read, and 270 false ones make it useless.
+        if (!parts.empty() && parts[0] == "mtp") {
+            IMP_LOG_DEBUG("  MTP head tensor, read by the MTP loader: %s", name.c_str());
+            ++mtp_sidecar;
+            continue;
+        }
         if (parts.size() < 4 || parts[0] != "model" || parts[1] != "layers") {
             IMP_LOG_WARN("WeightMap: unrecognised weight name: %s", name.c_str());
             ++skipped;
@@ -1317,10 +1330,17 @@ bool WeightMap::apply_weights(Model& model, const std::unordered_map<std::string
         }
     }
 
-    IMP_LOG_INFO(
-        "WeightMap (%s): assigned %d tensors, skipped %d, "
-        "layers=%d, experts=%d",
-        model_arch_name(arch_), assigned, skipped, model.config_.n_layers, model.config_.n_experts);
+    if (mtp_sidecar > 0)
+        IMP_LOG_INFO(
+            "WeightMap (%s): assigned %d tensors, skipped %d, %d MTP sidecar (own loader), "
+            "layers=%d, experts=%d",
+            model_arch_name(arch_), assigned, skipped, mtp_sidecar, model.config_.n_layers,
+            model.config_.n_experts);
+    else
+        IMP_LOG_INFO(
+            "WeightMap (%s): assigned %d tensors, skipped %d, "
+            "layers=%d, experts=%d",
+            model_arch_name(arch_), assigned, skipped, model.config_.n_layers, model.config_.n_experts);
 
     // Vision tower, when the config loader recognised one. Its weights ride in
     // the same shard map as the LM's — that is why Model owns it — but they are


### PR DESCRIPTION
## What

`WeightMap: unrecognised weight name` fired **270 times** on
Nemotron-3.5-Lightning for an MTP head that loads correctly. The head is a
sidecar with its own loader and its own naming (`mtp.layers.N.*`); it is not a
weight of the main model, so it is not a finding here.

## Why it matters more than log volume

That string is what you grep for after a first load, to catch a checkpoint whose
tensors this map cannot read. It is the check that found the 869 silently
skipped tensors in a community NVFP4 export. 270 false positives make it useless
exactly where it is needed.

The 270 were also counted as `skipped`, and that count is printed inside the
"not one expert tensor was recognised" error.

## What it uncovered

With the sidecar classified, the summary line reads:

```
WeightMap (nemotron_h_moe): assigned 18205 tensors, skipped 12,
                            270 MTP sidecar (own loader), layers=52, experts=128
```

and those **12 are a finding that was invisible before**:

```
model.layers.{5,12,19,26,33,42}.self_attn.k_proj.k_scale
model.layers.{5,12,19,26,33,42}.self_attn.v_proj.v_scale
```

`k_scale` / `v_scale` for exactly the 6 attention layers this hybrid has. They
are KV-cache quantisation scales the checkpoint ships and imp never reads
(`grep -rn "k_scale" src/` finds no consumer; the FP8 path computes its own).
Whether adopting them changes output quality is unmeasured and not touched here.
It is now visible, which it was not while it sat behind 270 false warnings.

## Verification

On the model, before and after: **270 warnings to 0**, head still loading its
270 tensors (`MTP head loaded: ... (270 tensors, Nemotron layout ...)`).

No unit test. The only observable here is a log level, and a test asserting that
`"mtp.x"` starts with `"mtp."` would assert nothing, which is the failure mode
the `find-stubs` skill calls the most dangerous kind of unfinished. The
behaviour is pinned by the model run above instead.