### PR TITLE
docs: speculation is off for six more request features, and logprobs is gated

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -80,7 +80,7 @@ Source: `src/core/qtype.h`.
 | per-request speculative toggle | ✅ | |
 | auth (`--api-key`), `--metrics-require-auth` | ✅ | |
 | embedded web UI at `GET /` | ✅ | |
-| logprobs | 🟡 | in the parameter surface, no dedicated gate |
+| logprobs | ✅ | `tests/test_server_logprobs.py`: at temperature 0 the emitted token IS `top_logprobs[0]` and shares its logprob |
 | C library API, CLI | ✅ | |
 
 ## Engine

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -37,7 +37,6 @@ These have a code path and no gate. They may work; nothing proves it.
 
 - **Llama-4** architecture: loads, no dedicated gate.
 - **FP8 E5M2**: the type exists, nothing exercises it.
-- **logprobs**: present in the parameter surface, no dedicated test.
 
 ## Known-bad and known-limited behaviour
 
@@ -81,13 +80,23 @@ These have a code path and no gate. They may work; nothing proves it.
   since `ea547a53` — `speculative.mtp_k=1` measured +21.3 % — but **only at k=1**:
   an extra chunk row still costs half a decode step, so k=3 buys 2 %. Numbers and
   the profile that localises that cost: [`roadmap.md`](roadmap.md).
-- **Speculation is off for most real requests, by two rules that are easy to
+- **Speculation is off for most real requests, by rules that are easy to
   miss.** It requires greedy sampling (`temperature: 0` or `top_k: 1`), so any
   request with a temperature gets none; and a think budget disables it inside
   the think block, which on a reasoning model is most of the answer. The server
   sets `think_budget` to 0.5 by default, so on such a model speculation never
   runs out of the box. Penalties are **not** a blocker at the default
   `repeat_last_n: 0`: the verify replicates them for the unbounded window.
+
+  **Six further request features disable it outright**, in one condition
+  (`src/runtime/engine_spec_ngram.cpp:295-297`): `logprobs`, `json_mode`,
+  `json_schema`, `regex_pattern`, `grammar` and `tool_constraint_tools`. The
+  verify chunk replicates no FSM masks, so a constrained request stays eager.
+  In practice that means **every tool call and every structured output runs
+  without speculation** — the agentic workload this engine targets, and the
+  constrained-decoding surface it ships. A `logprobs` request is eager too,
+  which also makes logprobs unusable as an instrument for observing what
+  speculation does.
   Other engines have neither rule, because rejection sampling makes a verify
   distribution-preserving at any temperature and none of them force `</think>`.
 - **The same request can produce different output on its second pass through


### PR DESCRIPTION
Two corrections to the release-facing docs, both found while investigating MTP.

## `LIMITATIONS.md` listed two rules that keep speculation off a request. There are eight.

One condition (`engine_spec_ngram.cpp:295-297`) also disqualifies `logprobs`, `json_mode`, `json_schema`, `regex_pattern`, `grammar` and `tool_constraint_tools` — the verify chunk replicates no FSM masks, so a constrained request stays eager.

For this engine that is not a footnote: **every tool call and every structured output runs without speculation.** That is the agentic workload it targets and the constrained-decoding surface it ships.

The `logprobs` entry matters twice over: a `logprobs` request is eager, so **logprobs cannot be used to observe what speculation does**. Measured the hard way — two arms with `logprobs: true` came back bit-identical over 400 tokens, which read like a result and was the flag disabling the thing under test.

## `logprobs` was listed as ungated. It is gated.

`tests/test_server_logprobs.py` exists, hangs in `scripts/test_server.sh:86`, and was green in the `make test-server` run of 2026-08-20. It gates the assurance that matters: at temperature 0 the emitted token IS `top_logprobs[0]` and shares its logprob.

## The two neighbours were checked and left alone

- **Llama-4**: only architecture-name mapping is under test (`test_hf_config_loader.cpp:562`). Not a gate.
- **FP8 E5M2**: the sole assertion is negative — that it is *not* read as E4M3 (`test_quantize_fp8_source.cpp:153`). Does not exercise it.

Both entries stand as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01853oeq1QHE9djDvFS3LH5d