### PR TITLE
fix(memory): four pointers freed by the wrong allocator, plus a gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,6 +460,12 @@ jobs:
         run: python3 tools/check_alloc_sites.py --stats
       - name: I1 allowlist gate (blocking)
         run: python3 tools/check_alloc_sites.py
+      # A pointer freed through the allocator that did not produce it is invalid
+      # CUDA and silent: right pointer width, no driver complaint, program keeps
+      # running. AUDIT B10 recorded one such pair in July and it was still there
+      # in August, two lines further down. Blocking.
+      - name: Allocate/free API pairing gate (blocking)
+        run: python3 tools/check_alloc_pairs.py
 
   # Post-launch error checks after every CUDA kernel launch. Blocking: an
   # unguarded launch turns a launch-time failure (bad config, smem over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Four device pointers were freed through an allocator that had not produced
+  them**, which is invalid CUDA and silent. `mtp_forward.cu` allocated a 4-byte
+  token id with `cudaMalloc` and freed it with `cudaFreeAsync` once per MTP draft
+  step (it is now a persistent workspace slot, so the allocation is gone as well);
+  `chunk_eager_k_`/`_v_` were 128 MiB of `cudaMallocAsync` released with `cudaFree`
+  at executor teardown, which returns success without returning the block to the
+  async pool; the shared-workspace grow branch swapped a `vram_alloc()` buffer for
+  a `cudaMallocAsync` one. See `AUDIT.md` B10.
+
+### Added
+
+- **`make check-alloc-pairs` fails when a pointer is freed by the wrong
+  allocator**, in CI as well. Two passes: within a file, and across files for
+  member variables, because the 128 MiB pair above allocates and frees in
+  different translation units and no per-file check can see it.
+
 ## [0.29.0] - 2026-08-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-alloc-pairs alloc-pairs-list check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that nothing else is using the GPU. Delegates to
 # scripts/require_free_gpu.sh, the same guard the git hooks use, because
@@ -455,6 +455,15 @@ check-alloc-sites:
 # Remaining direct allocation sites, worst files first. Never fails.
 alloc-sites-stats:
 	@python3 tools/check_alloc_sites.py --stats
+
+# Allocate/free API pairing: cudaMalloc<->cudaFree, cudaMallocAsync<->cudaFreeAsync,
+# cudaMallocHost/cudaHostAlloc<->cudaFreeHost. Host-only, no Docker.
+check-alloc-pairs:
+	@python3 tools/check_alloc_pairs.py
+
+# Every pair the checker resolved, matched or not. Never fails.
+alloc-pairs-list:
+	@python3 tools/check_alloc_pairs.py --list
 
 format:
 	@$(CLANG_FORMAT_RUN) -i --style=file $(CLANG_FORMAT_FILES)

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -441,6 +441,7 @@ bool mtp_workspace_allocate(MtpDraftWorkspace& ws, int hidden_dim, int vocab_siz
     ok &= alloc(reinterpret_cast<void**>(&ws.d_topk), kMtpMaxTopW * sizeof(int));
     ok &= alloc(reinterpret_cast<void**>(&ws.d_chain_tokens), kMtpMaxChainK * sizeof(int32_t));
     ok &= alloc(reinterpret_cast<void**>(&ws.d_argmax), sizeof(int));
+    ok &= alloc(reinterpret_cast<void**>(&ws.d_tok), sizeof(int32_t));
 
     ws.hidden_dim   = hidden_dim;
     ws.n_experts    = n_experts;
@@ -525,6 +526,10 @@ void mtp_workspace_free(MtpDraftWorkspace& ws) {
     if (ws.d_topk) { cudaFree(ws.d_topk); ws.d_topk = nullptr; }
     if (ws.d_chain_tokens) { cudaFree(ws.d_chain_tokens); ws.d_chain_tokens = nullptr; }
     if (ws.d_argmax) { cudaFree(ws.d_argmax); ws.d_argmax = nullptr; }
+    if (ws.d_tok) {
+        cudaFree(ws.d_tok);
+        ws.d_tok = nullptr;
+    }
     frfn(ws.d_post_norm);
     frfn(ws.d_expert_gate_up);
     frfn(ws.d_expert_act);
@@ -602,21 +607,20 @@ bool mtp_draft_step(int prev_token_id, const void* d_h_prev,
         imp::embedding_lookup(main_tok_emb, d_prev_token, /*n_tokens=*/1, out_view,
                               main_tok_emb.qtype, stream);
     } else {
-        // Upload prev_token_id to a tiny device buffer so embedding_lookup
-        // can dispatch with the correct signature. (The graph-friendly
-        // _from_device overload also exists if needed.)
-        int32_t  h_tok = static_cast<int32_t>(prev_token_id);
-        int32_t* d_tok = nullptr;
-        if (cudaMalloc(&d_tok, sizeof(int32_t)) != cudaSuccess) {
-            IMP_LOG_ERROR("mtp_draft_step: token-id scratch alloc failed");
+        // Upload prev_token_id to the workspace's persistent token-id slot so
+        // embedding_lookup can dispatch with the correct signature. (The
+        // graph-friendly _from_device overload also exists if needed.)
+        // Persistent rather than per-step: see the ws.d_tok comment in the
+        // header. Allocated once by mtp_workspace_allocate.
+        if (ws.d_tok == nullptr) {
+            IMP_LOG_ERROR("mtp_draft_step: token-id scratch not allocated");
             return false;
         }
-        cudaMemcpyAsync(d_tok, &h_tok, sizeof(int32_t), cudaMemcpyHostToDevice, stream);
+        int32_t h_tok = static_cast<int32_t>(prev_token_id);
+        cudaMemcpyAsync(ws.d_tok, &h_tok, sizeof(int32_t), cudaMemcpyHostToDevice, stream);
         int64_t out_shape[2] = {1, hidden_dim};
         Tensor  out_view(ws.d_fc_in, QType::F16, 2, out_shape, /*on_device=*/true);
-        imp::embedding_lookup(main_tok_emb, d_tok, /*n_tokens=*/1, out_view, main_tok_emb.qtype,
-                              stream);
-        cudaFreeAsync(d_tok, stream);
+        imp::embedding_lookup(main_tok_emb, ws.d_tok, /*n_tokens=*/1, out_view, main_tok_emb.qtype, stream);
     }
 
     // Step 2: emb_norm = RMSNorm(emb, pre_fc_norm_embedding)

--- a/src/compute/mtp_forward.h
+++ b/src/compute/mtp_forward.h
@@ -66,6 +66,13 @@ struct MtpDraftWorkspace {
     // [1] int — persistent argmax scratch for the host-path draft step
     // (replaces a per-draft cudaMallocAsync/cudaFreeAsync pair).
     int*  d_argmax = nullptr;
+    // [1] int32 — persistent token-id scratch for the host-chain draft step,
+    // the input twin of d_argmax above. The host path used to cudaMalloc four
+    // bytes per draft step and free them with cudaFreeAsync (AUDIT B10): the
+    // wrong allocator for that pointer, and a serving-phase allocation on the
+    // one MTP arm every MoE model takes (the device-chain arm needs
+    // n_experts == 0). Persistent here, so it is neither.
+    int32_t* d_tok = nullptr;
 
     // ---- Phase 2.2 MoE scratch ----
     // [hidden_dim] FP16 — post_attention_layernorm(fc_out)

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1580,14 +1580,22 @@ void GraphExecutor::free_buffers() {
     chunk_capture_k_ = nullptr;
     chunk_capture_v_ = nullptr;
     chunk_capture_ctx_ = 0;
+    // cudaFreeAsync, not cudaFree: the grow path in executor_attention_prefill.cu
+    // allocates these with cudaMallocAsync, and this teardown is the only place
+    // that used the sync API on them. Freeing a stream-ordered allocation
+    // synchronously returns success without returning the block to the async
+    // mempool (#834), so the 128 MiB looked reclaimed and was not. Null stream
+    // plus a sync below, matching ~Model.
     if (chunk_eager_k_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(chunk_eager_k_));
+        IMP_CUDA_CHECK_LOG(cudaFreeAsync(chunk_eager_k_, nullptr));
         chunk_eager_k_ = nullptr;
     }
     if (chunk_eager_v_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(chunk_eager_v_));
+        IMP_CUDA_CHECK_LOG(cudaFreeAsync(chunk_eager_v_, nullptr));
         chunk_eager_v_ = nullptr;
     }
+    if (chunk_eager_bytes_ > 0)
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(nullptr));  // retire the frees for the pool
     chunk_eager_bytes_ = 0;
     ws_.free_buffers();  // shared + persistent workspace (Workspace-owned)
     vfree(fp32_accum_buf_);

--- a/src/exec/executor_workspace_config.cu
+++ b/src/exec/executor_workspace_config.cu
@@ -136,9 +136,14 @@ void GraphExecutor::configure_ssm_workspace(int max_tokens) {
 }
 
 bool Workspace::resize_workspace(int new_max_tokens, cudaStream_t stream) {
+    // The grow branch below routes through vram_alloc/vram_free (the owner's
+    // allocator), which is not stream-ordered, so nothing here needs `stream`.
+    // The parameter stays: eight call sites pass it and a stream-ordered
+    // variant is the shape this would take if the branch ever goes live.
+    (void)stream;
     // Resize targets the PREFILL shared arena. While the decode workspace is
     // active (slot 1), shared_workspace_ aliases the fixed-size decode buffer
-    // — growing through that alias cudaFreeAsync's the decode buffer and
+    // — growing through that alias frees the decode buffer and
     // leaves decode_shared_workspace_ dangling; the next use_workspace(1)
     // re-installs the freed pointer and decode kernels write into freed
     // memory (#948: server wedged with an illegal memory access whenever a
@@ -164,16 +169,26 @@ bool Workspace::resize_workspace(int new_max_tokens, cudaStream_t stream) {
 
     if (new_shared > shared_workspace_size_) {
         // Only reallocate when growing — reuse existing buffer if large enough.
-        // This avoids expensive cudaMallocAsync/cudaFreeAsync on every batch size change.
+        //
+        // Through the SAME allocator that owns the buffer. allocate_shared_workspace()
+        // takes it from vram_alloc() (cudaMalloc, or VRAMAllocator when one is
+        // installed) and free_workspace() returns it with vram_free(); this branch
+        // used to cudaFreeAsync that pointer and replace it with a cudaMallocAsync
+        // one, which is the same invalid pair AUDIT B10 recorded in mtp_forward.cu,
+        // plus a buffer whose owner could then no longer account for it. AUDIT's
+        // step-4b/step-5 resolution shows the branch is unreachable today
+        // (new_shared > shared_workspace_size_ cannot hold: allocate_shared_workspace
+        // sizes at max_tokens_, this clamps to it, and every phase term is monotone
+        // in T). Fixed rather than deleted precisely because that reachability
+        // argument is a property of the surrounding code, not of this branch.
         if (shared_workspace_) {
-            IMP_CUDA_CHECK_LOG(cudaFreeAsync(shared_workspace_, stream));
+            vram_free(vram_alloc_, shared_workspace_);
+            shared_workspace_ = nullptr;
         }
         generation_++;  // arena moves — captured verify graphs must invalidate
-        cudaError_t err = cudaMallocAsync(&shared_workspace_, new_shared, stream);
-        if (err != cudaSuccess) {
-            IMP_LOG_ERROR("Failed to resize shared workspace to %zu bytes: %s", new_shared,
-                          cudaGetErrorString(err));
-            shared_workspace_ = nullptr;
+        shared_workspace_ = vram_alloc(vram_alloc_, new_shared, "shared_workspace");
+        if (!shared_workspace_) {
+            IMP_LOG_ERROR("Failed to resize shared workspace to %zu bytes", new_shared);
             shared_workspace_size_ = 0;
             return false;
         }

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -5,7 +5,7 @@
 # be justified in review; the gate fails on any file that allocates and is
 # not listed, and equally on any listed file that no longer allocates.
 #
-# remaining: 68 files, 471 sites
+# remaining: 66 files, 466 sites
 
 src/compute/attention_cublas.cu  # 14
 src/compute/attention_fmha_sm120.cu  # 2
@@ -23,7 +23,7 @@ src/compute/mmq_q4k_imma_tile.cu  # 6
 src/compute/mmq_q8_imma.cu  # 3
 src/compute/mmq_q8_imma_scratch.cu  # 4
 src/compute/moe_routing.cu  # 12
-src/compute/mtp_forward.cu  # 12
+src/compute/mtp_forward.cu  # 11
 src/compute/quantize_fp16_nvfp4_moe_native.cu  # 6
 src/compute/sampling.cu  # 1
 src/compute/sampling_penalties.cu  # 2
@@ -44,7 +44,6 @@ src/exec/executor_perplexity.cu  # 8
 src/exec/executor_ssm_gdn.cu  # 2
 src/exec/executor_workspace.cu  # 7
 src/exec/executor_workspace_buffers.cu  # 15
-src/exec/executor_workspace_config.cu  # 2
 src/exec/expert_cache.cu  # 4
 src/exec/gemm_scratch.cu  # 1
 src/exec/moe_workspace.cu  # 2

--- a/tools/alloc_pairs_allowlist.txt
+++ b/tools/alloc_pairs_allowlist.txt
@@ -1,0 +1,18 @@
+# Justified allocate/free API mismatches, for tools/check_alloc_pairs.py
+#
+# A pointer must go home to the allocator it came from:
+#   cudaMalloc / cudaMallocManaged      <->  cudaFree
+#   cudaMallocAsync                     <->  cudaFreeAsync
+#   cudaMallocHost / cudaHostAlloc      <->  cudaFreeHost
+#
+# An entry belongs here only when the mismatch is apparent rather than real — a
+# pointer that genuinely comes from either API depending on a branch, whose free
+# branch matches. It is NOT a place to park a known-wrong pair: fix those.
+#
+# Format: `path:name  # reason` for an in-file pair, `member:name  # reason` for a
+# member variable paired across translation units. The reason is mandatory (an empty
+# one is rejected) and a stale entry fails the gate too, so the list cannot rot in
+# either direction.
+#
+# Empty on purpose since 2026-08-21: the four mismatches this gate was written to
+# find were fixed rather than listed.

--- a/tools/check_alloc_pairs.py
+++ b/tools/check_alloc_pairs.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Fail when a device pointer is freed through a different allocator than the one
+that produced it.
+
+WHY THIS EXISTS
+---------------
+`cudaFreeAsync` on a pointer from plain `cudaMalloc` (and the reverse) is not valid
+CUDA. It is also invisible: the driver does not have to complain, the pointer is the
+right width, and the program keeps running. `AUDIT.md` B10 recorded exactly one such
+pair in July at `mtp_forward.cu:606/615`; by August the lines had moved to 610/619 and
+the defect had not. A defect that survives its own bug report by moving two lines is a
+defect that needs a gate, not another report.
+
+`tools/check_alloc_sites.py` is the sibling of this file. It counts sites and diffs them
+against an allowlist, which answers "who talks to the driver" (invariant I1). It cannot
+answer "does this pointer come home to the same allocator", because that is a property of
+a *pair*, not of a site.
+
+WHAT IT CHECKS
+--------------
+Three families, each of which must be matched:
+
+    cudaMalloc / cudaMallocManaged        <->  cudaFree
+    cudaMallocAsync                       <->  cudaFreeAsync
+    cudaMallocHost / cudaHostAlloc        <->  cudaFreeHost
+
+Two passes, because the two real defects in this tree had different shapes:
+
+1. **In-file**, keyed on the pointer expression. Catches the `mtp_forward.cu` `d_tok`
+   shape: a local allocated and freed a few lines apart through two allocators.
+2. **Cross-file, member variables only** (names ending in `_`). Catches the
+   `chunk_eager_k_` shape: `cudaMallocAsync` in the grow path in one TU, `cudaFree` in
+   `free_buffers()` in another. An in-file check is structurally blind to it, and that
+   is precisely where a teardown drifts away from its allocator - nobody reads the two
+   files together. Restricted to member-looking names because a bare local called `p`
+   means something different in every function; a trailing underscore is this
+   codebase's member convention and makes the name meaningful tree-wide.
+
+The pointer expression is normalised (casts, `this->`, `[i]` subscripts and whitespace
+stripped) so `cudaFree((void*)m_buf_)` pairs with `cudaMalloc(&m_buf_, n)`.
+
+WHAT IT DELIBERATELY DOES NOT DO
+--------------------------------
+It does not flag a name that is only allocated, or only freed. Half a pair inside one
+file is the normal shape of an owning class whose destructor lives in another TU, and
+flagging it would bury the real finding under hundreds of them. The gate fires only when
+BOTH halves are present in one file and they disagree - which is the case where the
+mismatch is provable from the text alone.
+
+ALLOWLIST
+---------
+`tools/alloc_pairs_allowlist.txt`, one `path:name  # reason` per line (cross-file
+entries use `member:name`). A justified
+mismatch is a pointer that genuinely comes from either API depending on a branch, and
+whose free branch matches. Empty reasons are rejected, and a stale entry (the mismatch is
+gone) fails the gate too, so the list cannot rot in either direction - the same two-way
+ratchet `tools/alloc_allowlist.txt` uses.
+
+Usage:
+    python3 tools/check_alloc_pairs.py            # gate: non-zero on any unlisted mismatch
+    python3 tools/check_alloc_pairs.py --list     # every pair found, matched or not
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ROOTS = ("src", "tools", "include")
+EXTS = (".cpp", ".cu", ".h", ".cuh", ".hpp")
+ALLOWLIST = ROOT / "tools" / "alloc_pairs_allowlist.txt"
+
+# family -> (alloc APIs, free API)
+FAMILIES = {
+    "sync": (("cudaMalloc", "cudaMallocManaged"), "cudaFree"),
+    "async": (("cudaMallocAsync",), "cudaFreeAsync"),
+    "host": (("cudaMallocHost", "cudaHostAlloc"), "cudaFreeHost"),
+}
+ALLOC_FAMILY = {a: f for f, (allocs, _) in FAMILIES.items() for a in allocs}
+FREE_FAMILY = {free: f for f, (_, free) in FAMILIES.items()}
+
+# `cudaMalloc` is a prefix of `cudaMallocAsync`/`cudaMallocHost`/`cudaMallocManaged`, so
+# the alternation must try the longest first and the boundary must be explicit.
+#
+# The regex finds the CALL, not the argument. Reading the first argument with
+# `[^,)]+` looks equivalent and is not: this codebase wraps most calls in
+# IMP_CUDA_CHECK_LOG and clang-format then breaks the line right after the open
+# paren, so `cudaMallocAsync(\n    &d_alpha, ...)` yields an empty first argument
+# and the pointer silently drops out of the census. Three matched MoE pairs
+# disappeared that way on the first run of this tool. `first_arg()` below walks
+# the real parentheses instead, across newlines.
+API_RE = re.compile(
+    r"\b(cudaMallocAsync|cudaMallocManaged|cudaMallocHost|cudaHostAlloc|cudaMalloc"
+    r"|cudaFreeAsync|cudaFreeHost|cudaFree)\s*\(")
+
+CAST_RE = re.compile(r"(?:reinterpret_cast|static_cast|const_cast)\s*<[^>]*>\s*")
+CSTYLE_RE = re.compile(r"\(\s*void\s*\*+\s*\)|\(\s*[A-Za-z_][A-Za-z0-9_:]*\s*\*+\s*\)")
+
+
+def strip_comments(text: str) -> str:
+    """Blank out // and /* */ without touching line numbering."""
+    out, i, n = [], 0, len(text)
+    state = None  # None | 'line' | 'block' | 'str' | 'chr'
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if state is None:
+            if c == "/" and nxt == "/":
+                state = "line"; out.append("  "); i += 2; continue
+            if c == "/" and nxt == "*":
+                state = "block"; out.append("  "); i += 2; continue
+            if c == '"':
+                state = "str"
+            elif c == "'":
+                state = "chr"
+            out.append(c); i += 1; continue
+        if state == "line":
+            if c == "\n":
+                state = None; out.append(c)
+            else:
+                out.append(" ")
+            i += 1; continue
+        if state == "block":
+            if c == "*" and nxt == "/":
+                state = None; out.append("  "); i += 2; continue
+            out.append(c if c == "\n" else " "); i += 1; continue
+        # inside a string/char literal
+        out.append(c)
+        if c == "\\":
+            if i + 1 < n:
+                out.append(text[i + 1]); i += 2; continue
+        elif (state == "str" and c == '"') or (state == "chr" and c == "'"):
+            state = None
+        i += 1
+    return "".join(out)
+
+
+def normalise(expr: str) -> str:
+    """`(void**)&this->buf_[i]` -> `buf_`. Returns "" for anything not a plain name."""
+    e = expr.strip()
+    e = CAST_RE.sub("", e)
+    e = CSTYLE_RE.sub("", e)
+    e = e.strip().lstrip("&").strip()
+    e = re.sub(r"\[[^\]]*\]", "", e)          # drop subscripts
+    e = re.sub(r"^\(+|\)+$", "", e).strip()
+    e = re.sub(r"^this\s*->\s*", "", e)
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*(?:\s*(?:\.|->)\s*[A-Za-z_][A-Za-z0-9_]*)*", e):
+        return ""
+    return re.sub(r"\s+", "", e)
+
+
+def first_arg(text: str, open_paren: int) -> str:
+    """Text of the first argument of the call whose '(' is at `open_paren`.
+
+    Walks real parentheses/brackets so a nested cast or a line break inside the
+    argument list does not truncate it. Returns "" if the parens do not close.
+    """
+    depth, start, i, n = 0, open_paren + 1, open_paren, len(text)
+    while i < n:
+        c = text[i]
+        if c in "([":
+            depth += 1
+        elif c in ")]":
+            depth -= 1
+            if depth == 0:
+                return text[start:i]
+        elif c == "," and depth == 1:
+            return text[start:i]
+        i += 1
+    return ""
+
+
+def scan(path: pathlib.Path):
+    """-> {name: {'alloc': {family: [(line, api)]}, 'free': {family: [(line, api)]}}}"""
+    text = strip_comments(path.read_text(errors="ignore"))
+    starts = [0]
+    for ch in text:
+        starts.append(starts[-1] + (1 if ch == "\n" else 0))
+
+    names = {}
+    for m in API_RE.finditer(text):
+        api = m.group(1)
+        name = normalise(first_arg(text, m.end() - 1))
+        if not name:
+            continue
+        lineno = text.count("\n", 0, m.start()) + 1
+        slot = names.setdefault(name, {"alloc": {}, "free": {}})
+        if api in ALLOC_FAMILY:
+            slot["alloc"].setdefault(ALLOC_FAMILY[api], []).append((lineno, api))
+        else:
+            slot["free"].setdefault(FREE_FAMILY[api], []).append((lineno, api))
+    return names
+
+
+def load_allowlist():
+    entries = {}
+    if not ALLOWLIST.exists():
+        return entries
+    for lineno, raw in enumerate(ALLOWLIST.read_text().split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, reason = line.partition("#")
+        key = key.strip()
+        if not reason.strip():
+            print(f"ERROR {ALLOWLIST.name}:{lineno}: entry {key!r} has no reason", file=sys.stderr)
+            sys.exit(2)
+        entries[key] = reason.strip()
+    return entries
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="print every pair, not just mismatches")
+    args = ap.parse_args()
+
+    files = sorted(p for r in ROOTS for p in (ROOT / r).rglob("*")
+                   if p.suffix in EXTS and "build" not in p.parts)
+    allow = load_allowlist()
+
+    mismatches, pairs, scanned = [], 0, 0
+    # name -> {'alloc'|'free': {family: [(rel, line, api)]}}, members only
+    members = {}
+    for path in files:
+        rel = str(path.relative_to(ROOT))
+        for name, use in scan(path).items():
+            if name.endswith("_") and "." not in name and "->" not in name:
+                slot = members.setdefault(name, {"alloc": {}, "free": {}})
+                for half in ("alloc", "free"):
+                    for fam, hits in use[half].items():
+                        slot[half].setdefault(fam, []).extend(
+                            (rel, ln, api) for ln, api in hits)
+            if not use["alloc"] or not use["free"]:
+                continue
+            pairs += 1
+            afam, ffam = set(use["alloc"]), set(use["free"])
+            if args.list:
+                a = ",".join(f"{ln}:{api}" for f in use["alloc"] for ln, api in use["alloc"][f])
+                fr = ",".join(f"{ln}:{api}" for f in use["free"] for ln, api in use["free"][f])
+                mark = "OK " if afam == ffam else "BAD"
+                print(f"{mark} {rel}:{name}  alloc[{a}]  free[{fr}]")
+            if afam != ffam:
+                mismatches.append((rel, name, use))
+        scanned += 1
+
+    # Pass 2: members whose allocate and free halves disagree ACROSS files. Only
+    # members already reported in pass 1 for a single file are skipped, so the same
+    # defect is never counted twice.
+    seen_in_file = {(rel, name) for rel, name, _ in mismatches}
+    cross = 0
+    for name, use in sorted(members.items()):
+        if not use["alloc"] or not use["free"]:
+            continue
+        cross += 1
+        afam, ffam = set(use["alloc"]), set(use["free"])
+        if afam == ffam:
+            continue
+        files_seen = {r for half in ("alloc", "free") for fam in use[half]
+                      for r, _, _ in use[half][fam]}
+        if len(files_seen) == 1 and (next(iter(files_seen)), name) in seen_in_file:
+            continue  # pass 1 already has it
+        use2 = {half: {fam: [(ln, f"{api} [{r}]") for r, ln, api in hits]
+                       for fam, hits in use[half].items()} for half in ("alloc", "free")}
+        mismatches.append(("member", name, use2))
+
+    unlisted = [m for m in mismatches if f"{m[0]}:{m[1]}" not in allow]
+    listed = {f"{m[0]}:{m[1]}" for m in mismatches}
+    stale = [k for k in allow if k not in listed]
+
+    print(f"alloc-pairs: {scanned} files, {pairs} pointer(s) with both halves in one file, "
+          f"{cross} member(s) with both halves tree-wide, "
+          f"{len(mismatches)} mismatch(es), {len(allow)} allowlisted")
+
+    for rel, name, use in unlisted:
+        pfx = "" if rel == "member" else f"{rel}:"
+        a = ", ".join(f"{pfx}{ln} {api}" for f in use["alloc"] for ln, api in use["alloc"][f])
+        fr = ", ".join(f"{pfx}{ln} {api}" for f in use["free"] for ln, api in use["free"][f])
+        print(f"MISMATCH {name}\n    allocated: {a}\n    freed:     {fr}")
+    for k in stale:
+        print(f"STALE allowlist entry (mismatch is gone, remove it): {k}")
+
+    if unlisted or stale:
+        print("\nA pointer must go home to the allocator it came from: cudaMalloc<->cudaFree, "
+              "cudaMallocAsync<->cudaFreeAsync, cudaMallocHost/cudaHostAlloc<->cudaFreeHost.")
+        return 1
+    print("OK — every in-file allocate/free pair uses one allocator.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_alloc_pairs.py
+++ b/tools/check_alloc_pairs.py
@@ -124,25 +124,46 @@ def strip_comments(text: str) -> str:
             if c == "*" and nxt == "/":
                 state = None; out.append("  "); i += 2; continue
             out.append(c if c == "\n" else " "); i += 1; continue
-        # inside a string/char literal
-        out.append(c)
+        # Inside a string/char literal: blank the CONTENT but keep the quotes and
+        # the line count. `IMP_LOG_ERROR("cudaMalloc(%zu bytes) failed")` is a
+        # message, and counting it as a call site inflates the census with two
+        # entries that can never be attributed to a pointer.
         if c == "\\":
-            if i + 1 < n:
-                out.append(text[i + 1]); i += 2; continue
-        elif (state == "str" and c == '"') or (state == "chr" and c == "'"):
+            out.append("  ")
+            if i + 1 < n and text[i + 1] == "\n":
+                out[-1] = " \n"
+            i += 2; continue
+        if (state == "str" and c == '"') or (state == "chr" and c == "'"):
             state = None
+            out.append(c)
+        else:
+            out.append(c if c == "\n" else " ")
         i += 1
     return "".join(out)
 
 
 def normalise(expr: str) -> str:
-    """`(void**)&this->buf_[i]` -> `buf_`. Returns "" for anything not a plain name."""
+    """`(void**)&this->buf_[i]` -> `buf_`. Returns "" for anything not a plain name.
+
+    Peel casts, parentheses and address-of/deref in a LOOP rather than once each.
+    A single ordered pass looks equivalent and is not: the dominant form in this
+    tree is `reinterpret_cast<void**>(&ws.d_mtp_position)`, where removing the
+    cast leaves `(&...)`, so a `lstrip("&")` that runs before the parens are
+    stripped does nothing and the pointer drops out of the census silently. Five
+    of them did, which is the same shape of blind spot this gate exists to close.
+    """
     e = expr.strip()
-    e = CAST_RE.sub("", e)
-    e = CSTYLE_RE.sub("", e)
-    e = e.strip().lstrip("&").strip()
+    for _ in range(8):  # bounded: each pass strips at least one layer or stops
+        before = e
+        e = CAST_RE.sub("", e)
+        e = CSTYLE_RE.sub("", e)
+        e = e.strip()
+        if e.startswith("(") and e.endswith(")"):
+            e = e[1:-1].strip()
+        e = e.lstrip("&*").strip()
+        if e == before:
+            break
     e = re.sub(r"\[[^\]]*\]", "", e)          # drop subscripts
-    e = re.sub(r"^\(+|\)+$", "", e).strip()
     e = re.sub(r"^this\s*->\s*", "", e)
     if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*(?:\s*(?:\.|->)\s*[A-Za-z_][A-Za-z0-9_]*)*", e):
         return ""


### PR DESCRIPTION
`cudaFreeAsync` on a `cudaMalloc` pointer, and the reverse, is not valid CUDA. It is
also silent: the pointer is the right width, the driver does not have to complain, and
the program keeps running. `AUDIT.md` B10 recorded one such pair in July at
`mtp_forward.cu:606/615`. By August the lines had moved to 610/619 and the defect had
not, which is the argument for a gate rather than another report.

## The four pairs

| pointer | allocated | freed | |
|---|---|---|---|
| `d_tok` | `cudaMalloc` `mtp_forward.cu:610` | `cudaFreeAsync` `:619` | AUDIT B10 |
| `chunk_eager_k_` | `cudaMallocAsync` `executor_attention_prefill.cu:176` | `cudaFree` `executor_workspace_buffers.cu:1584` | new, 64 MiB |
| `chunk_eager_v_` | `cudaMallocAsync` `:177` | `cudaFree` `:1588` | new, 64 MiB |
| `shared_workspace_` | `vram_alloc()` `executor_workspace.cu:632` | `cudaFreeAsync` `executor_workspace_config.cu:169` | new, latent |

**`d_tok`** allocated four bytes per MTP draft step on the host-chain arm, which is the
arm every MoE model takes (the device-chain arm is gated on `n_experts == 0`). So it was
also a serving-phase allocation, and one the phase guard cannot see because the pointer
never goes through `Backend`. It is now a persistent `ws.d_tok` slot next to the existing
`ws.d_argmax`, whose own comment records the identical fix for the output side. The
allocation is gone rather than corrected.

**`chunk_eager_k_` / `_v_`** are the interesting pair: 128 MiB, the reverse direction of
B10, and recorded nowhere. A synchronous free of a stream-ordered allocation returns
success without returning the block to the async mempool (#834), so this memory read as
reclaimed at executor teardown and was not.

**`shared_workspace_`** freed a `vram_alloc()` buffer through `cudaFreeAsync` and
replaced it with a `cudaMallocAsync` one, in the resize grow branch. AUDIT's step-4b/5
resolution shows that branch is unreachable today. Fixed rather than deleted, because the
unreachability is a property of the surrounding code (`allocate_shared_workspace` sizes at
`max_tokens_`, this clamps to it, every phase term is monotone in T) and not of the
branch. It now routes through `vram_alloc`/`vram_free`, the allocator that owns the buffer.

## The gate

`tools/check_alloc_pairs.py`, wired into CI and `make check-alloc-pairs`. Two passes,
because the two real defects had different shapes:

1. **In-file**, keyed on the pointer expression. Catches the `d_tok` shape.
2. **Cross-file, member variables only**. Catches the `chunk_eager` shape, where the
   allocation and the wrong free live in different translation units. An in-file check is
   structurally blind to that, and it is exactly where a teardown drifts away from its
   allocator, because nobody reads the two files together.

Shown red on the unfixed tree and green after, with the same tool version both times
(stash/pop, not two different tools):

```
$ python3 tools/check_alloc_pairs.py     # unfixed
alloc-pairs: 520 files, 201 pointer(s) with both halves in one file, 40 member(s) with both halves tree-wide, 4 mismatch(es), 0 allowlisted
MISMATCH d_tok
    allocated: src/compute/mtp_forward.cu:610 cudaMalloc
    freed:     src/compute/mtp_forward.cu:619 cudaFreeAsync
MISMATCH chunk_eager_k_
    allocated: 176 cudaMallocAsync [src/exec/executor_attention_prefill.cu]
    freed:     173 cudaFreeAsync [...], 180 cudaFreeAsync [...], 1584 cudaFree [src/exec/executor_workspace_buffers.cu]
MISMATCH chunk_eager_v_
    allocated: 177 cudaMallocAsync [src/exec/executor_attention_prefill.cu]
    freed:     174 cudaFreeAsync [...], 181 cudaFreeAsync [...], 1588 cudaFree [src/exec/executor_workspace_buffers.cu]
MISMATCH shared_workspace_
    allocated: 638 cudaMalloc [src/exec/executor_workspace.cu], 172 cudaMallocAsync [src/exec/executor_workspace_config.cu]
    freed:     169 cudaFreeAsync [src/exec/executor_workspace_config.cu]
EXIT=1

$ python3 tools/check_alloc_pairs.py     # fixed
alloc-pairs: 520 files, 199 pointer(s) with both halves in one file, 39 member(s) with both halves tree-wide, 0 mismatch(es), 0 allowlisted
OK — every in-file allocate/free pair uses one allocator.
EXIT=0
```

A note on the checker's own history, because it is the kind of bug it exists to prevent:
the first version read the first argument with `[^,)]+` on one line. This codebase wraps
most calls in `IMP_CUDA_CHECK_LOG` and clang-format then breaks the line after the open
paren, so `cudaMallocAsync(\n    &d_alpha, ...)` produced an empty argument and three
matched MoE pairs silently dropped out of the census. It now walks real parentheses
across newlines. The 197 to 201 jump in the pair count between runs is those three plus one.

## Cross-TU pairs verified by hand

The cross-file pass only covers member variables, so the remaining 30 `cudaFreeAsync`
sites whose allocation is in another TU were traced individually. All correct:
`weight_upload.cu`'s sixteen go through `checked_cuda_malloc` (which is `cudaMallocAsync`
on both of its paths); `weight_snapshot.cpp`'s three go through
`kWarmOps{&checked_cuda_malloc, ...}`; `model.cpp:45` frees `gpu_allocations_`, whose only
two producers are `cudaMallocAsync`; `engine_internal.h`'s four are only ever called on
`engine_scheduler.cpp:696`'s `cudaMallocAsync` buffers; the four `is_base_gpu_allocation`-
guarded frees in `pre_dequant_phase3_moe.cu` / `phase4_tensor_registry.cu` are
`gpu_allocations_` members by construction. `ctx.fp32_down_buf` is correct **because of its
guard**: `!= moe_.fp32_down_buf` is what separates the `cudaMallocAsync` one from the
`vram_alloc` one.

## Also in here

`tools/alloc_allowlist.txt` refreshed in the same commit, because the I1 gate is a two-way
ratchet and both directions fire here: `mtp_forward.cu` drops a site, and
`executor_workspace_config.cu` stops allocating entirely. 67 files / 469 sites becomes
66 / 466.

## One thing found and deliberately not fixed

`executor_workspace.cu:638` falls back to a raw `cudaMalloc` when `vram_alloc()` is
rejected, and `free_workspace()` returns that pointer through `vram_free()`, which calls
`allocator->free()` on a pointer the allocator never handed out. Both ends are the sync
API so it is not this PR's defect class, but the accounting is wrong on that path. Reported,
not touched.

## Gate

`make verify-fast` on this tree, Qwen3-8B-Q8_0 on one RTX 5090, card idle:

```
  perf gate: median of 3 independent runs (spread 0.20%)
  decode  tg128 =  284.95 tok/s  (baseline  287.19, delta -0.78%)
  prefill pp512 = 12517.26 tok/s  (baseline 12406.87, delta 0.89%)
  prefill pp4096 = 15379.40 tok/s  (baseline 15324.70, delta 0.36%, FA2)
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
  graphs ON  tg256 =  456.06 tok/s   (2.23x, threshold 1.3x)
  PASS Qwen3-4B Q8_0 (dense) (distinct=11, contains 'Paris')
=== verify fast: OK ===
```

The pre-push hook ran it a second time independently: decode and VRAM identical, pp4096
15399.30 (+0.49 %), graphs 2.64x. No baseline refresh: nothing here is intended to move perf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
