### PR TITLE
feat(gates): three gates that could not fail, and 28 functions nobody calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,8 +405,19 @@ jobs:
           python-version: "3.12"
       - name: File-size smells (advisory, non-blocking)
         run: python3 tools/check_filesize.py --warn-only
-      - name: File-size hard-review gate (blocking)
+      - name: File-size hard-review gate + allowlist ceilings (blocking)
         run: python3 tools/check_filesize.py
+      # The size of the hole `No GPU runner in CI` leaves. Reads SOURCES, not a
+      # build directory: a gate that counts by reading build-dev/ inherits that
+      # directory's provenance, and on 2026-08-21 a stray uncommitted file had
+      # been compiled into test-quant and moved the count by 3.
+      - name: Tests that run in no CI lane (blocking)
+        run: python3 tools/check_test_lanes.py --report
+      # Functions defined inline in a header and mentioned nowhere else. The
+      # 2026-08-03 decl-only sweep could not see this class: it filtered on
+      # decl+def, i.e. two occurrences, and a header-inline definition is one.
+      - name: Header-inline definitions with no caller (blocking)
+        run: python3 tools/check_dead_inline_accessors.py
 
   # Documentation layer contract (docs/audit/docs-rewrite/). Seven checks, all
   # of which map to a defect this repo actually shipped: a datacenter-Blackwell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ there instead of retelling it.
   message. And 28 functions defined inline in a header with no caller anywhere were
   removed, with a gate to keep the count at zero.
 
+
+- **`make check-alloc-pairs` fails when a pointer is freed by the wrong
+  allocator**, in CI as well. Two passes: within a file, and across files for
+  member variables, because the 128 MiB pair above allocates and frees in
+  different translation units and no per-file check can see it.
+
 ### Fixed
 
 - **Four device pointers were freed through an allocator that had not produced
@@ -31,13 +37,6 @@ there instead of retelling it.
   at executor teardown, which returns success without returning the block to the
   async pool; the shared-workspace grow branch swapped a `vram_alloc()` buffer for
   a `cudaMallocAsync` one. See `AUDIT.md` B10.
-
-### Added
-
-- **`make check-alloc-pairs` fails when a pointer is freed by the wrong
-  allocator**, in CI as well. Two passes: within a file, and across files for
-  member variables, because the 128 MiB pair above allocates and frees in
-  different translation units and no per-file check can see it.
 
 ## [0.29.0] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **Three gates that could not fail now can.** The file-size allowlist gave its 29
+  entries no size limit at all, so `engine_scheduler.cpp` grew 1074 to 1962 code LOC
+  (+83 %) with CI green throughout; each entry now pins a measured `code_loc` and
+  drift either way fails (`--update` re-pins). The number of GTest cases that run in
+  no CI lane is pinned at 968 macros and named as a macro count in its own failure
+  message. And 28 functions defined inline in a header with no caller anywhere were
+  removed, with a gate to keep the count at zero.
+
 ### Fixed
 
 - **Four device pointers were freed through an allocator that had not produced

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: check-alloc-pairs alloc-pairs-list check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that nothing else is using the GPU. Delegates to
 # scripts/require_free_gpu.sh, the same guard the git hooks use, because
@@ -464,6 +464,15 @@ check-alloc-pairs:
 # Every pair the checker resolved, matched or not. Never fails.
 alloc-pairs-list:
 	@python3 tools/check_alloc_pairs.py --list
+
+# How many GTest macros run in no CI lane (docs/DESIGN_DECISIONS.md "No GPU
+# runner in CI"). Source-derived, no build needed, no Docker.
+check-test-lanes:
+	@python3 tools/check_test_lanes.py --report
+
+# Functions defined inline in a header that nothing in the tree mentions.
+check-dead-inline:
+	@python3 tools/check_dead_inline_accessors.py --list
 
 format:
 	@$(CLANG_FORMAT_RUN) -i --style=file $(CLANG_FORMAT_FILES)

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -1,0 +1,526 @@
+# Debt ledger - 2026-08-21
+
+What is actually open in imp today, measured against the tree at `d40cd394` (v0.29.0,
+clean), not against a doc. Every OPEN item carries a `path:line` verified on this date, the
+failure mode it produces, and the command that would prove it closed.
+
+Read with [`SETTLED.md`](SETTLED.md), [`../LIMITATIONS.md`](../LIMITATIONS.md),
+[`../DESIGN_DECISIONS.md`](../DESIGN_DECISIONS.md), [`../../AUDIT.md`](../../AUDIT.md) and
+[`../roadmap.md`](../roadmap.md). Section 3 lists what those already killed, so the next
+pass does not re-chase it.
+
+Convention: **OPEN** = verified against the code today. **CLOSED** = the doc said open, the
+code says otherwise, with the evidence. **NOT A FINDING** = swept, nothing there - recorded
+because a negative result is what stops the next sweep.
+
+---
+
+## 1. Top 10, ranked by cost if ignored
+
+| # | Item | Where | Cost if ignored |
+|---|---|---|---|
+| 1 | Per-decode-step `cudaMallocAsync` whose address is baked into a replayed CUDA graph, with no invalidation | `src/runtime/engine_scheduler.cpp:1695` | Silently wrong KV residual metadata on `residual + batch>1` decode; survives only because the async pool's release threshold is pinned to `UINT64_MAX` |
+| 2 | ~~`cudaMalloc` freed through `cudaFreeAsync`~~ **CLOSED `556f3b8d` (#1505)** | `src/compute/mtp_forward.cu:610` / `:619` | Undefined behaviour per the CUDA API, once per MTP draft step, on every MoE model (the device-chain arm requires `n_experts == 0`) Fixed, and three further pairs this ledger did not have came out with it. |
+| 3 | Invariant I2 has no gate in any shipping build **(still OPEN: #1505's gate is static and does not reach it)** | `CMakeLists.txt:67` | The counter that is supposed to catch items 1 and 2 reads zero in every build anyone runs; 469 direct allocation sites sit outside `src/memory/` where it cannot see them |
+| 4 | ~~829 of 2288 GTest macros run in no CI lane~~ **CLOSED, and corrected to 968** (`tools/check_test_lanes.py`) | `CMakeLists.txt:952-957` | The entire GPU correctness surface reaches `main` on the strength of one human running `make verify-fast`; the required check is `Build`, which runs `ctest -L unit` Pinned now, and it fails when it moves. 829 was an undercount, see (e). |
+| 5 | ~~The file-size allowlist has no ceiling, and 16 of its 29 reasons are numerically stale~~ **CLOSED: every entry carries a measured `code_loc`, drift either way fails** | `tools/filesize_thresholds.toml:60` | An allowlisted file is exempt forever: `engine_scheduler.cpp` went 1074 → **1962** code LOC (+83 %) with the gate green the whole way. The gate is blind exactly where recompile blast radius is worst Reasons re-derived and the LOC figure taken out of the prose, because that is the half that went stale. |
+| 6 | `vram.library_reserve_mb` default is a constant measured to be wrong in both directions | `src/memory/plan.h:100` | On a cold cache the plan charges 3900 MiB where the model needs 0 (Qwen3-4B IQ4_NL) or 7458 (Qwen3-8B Q8_0) - AUDIT B41. Either 3.9 GiB of KV pool set aside for nothing, or a 3.5 GiB under-charge |
+| 7 | `calibration.out_path` is parsed, documented, and never read | `src/runtime/config.h:362` | An operator who sets it in `imp.conf` gets no file and no warning; the real path comes from `--calibrate-out` |
+| 8 | A dispatch case that logs an error and returns **without writing its output tensor** | `src/compute/weight_dispatch.cu:342` | Unreachable today, and the shape of the failure is a whole projection emitting stale device memory with one ERROR line. Its comment still describes a "phase-2 shim" whose phase 3 landed elsewhere |
+| 9 | Dead FP16 twin of a live FP32 kernel | `src/compute/gdn.cu:273` + `src/compute/gdn.h:152` | ~35 LOC and a `__global__` in a `.cu` already 44 code LOC over its warn threshold; only `vhead_tiled_to_grouped_f32` runs |
+| 10 | ~~20 header-inline accessors with no caller anywhere~~ **CLOSED: 28 removed, `tools/check_dead_inline_accessors.py` added** | `src/exec/executor.h:187` and 19 others | Weak on its own. It is here because it is the *class the 2026-08-03 decl-only sweep could not see*: that sweep filtered on decl+def (2 occurrences); a header-inline definition is 1 20 was an undercount and the sweep cascaded, see (c). |
+
+Item 10 is the only one on this list whose justification is maintenance surface rather than a
+failure mode or a blind gate. It is ranked last for that reason, and it is stated rather than
+dressed up.
+
+---
+
+## 2. The six categories
+
+### (a) Memory / allocation invariants I1-I7 - `AUDIT.md` B8, B9, B10, O1
+
+```
+$ grep -rn "set_alloc_phase" src/ include/ tools/ | wc -l
+8
+$ python3 tools/check_alloc_sites.py
+I1: 67 files / 469 sites outside src/memory/ (allowlist: 67 files / 469 sites)
+OK — no new direct allocation sites.
+$ python3 tools/check_alloc_sites.py --stats | sed -n 2p
+  acquisitions 210  (device 210, pinned-host 0)   releases 279
+```
+
+**B8 - CLOSED.** The entry's headline ("`set_alloc_phase()` appears only in `tests/`; the
+allocation-phase guard was never armed - acceptance criterion 3 is currently vacuous") is
+false against the tree. `src/runtime/engine.cpp:789` sets `Planning` before the sub-phases,
+`:818` sets `Serving` after `prewarm_spec_scratch_()`, `:75` resets to `Loading` in the
+destructor and logs the count. The CUDA-side watermarks are armed at the same transition
+(`engine.cpp:822`). B35 records the measured result: `steady state clean: 0 cudaMalloc,
+0 cudaMallocAsync, 0 pinned-host allocations while serving`.
+
+**B8's second half - OPEN, and it is item 3 above.** `note_serving_allocation()`
+(`src/memory/backend.cpp:100`) is called from `Backend::acquire()` and from the `--wrap`
+interposer. The interposer compiles only under `IMP_ALLOC_INTERPOSE`, which is `OFF`
+(`CMakeLists.txt:67`) and appears in **no make target and no CI job**:
+
+```
+$ grep -rn "IMP_ALLOC_INTERPOSE" Makefile .github/workflows/ scripts/ | wc -l
+0
+```
+
+So in every build that ships, `steady_state_allocations()` sees only what routes through
+`Backend` - which is the arena at init - while 469 direct sites sit outside `src/memory/`.
+B9 and B10 below both allocate while serving and both read as zero.
+*Proof it is closed:* a `make` target that builds `-DIMP_ALLOC_INTERPOSE=ON`, drives ≥15
+requests on a config that exercises residual+batch>1 and an MoE MTP chain, and fails on a
+non-zero `[alloc-interpose] steady state` line.
+
+**B9 - OPEN, structurally unchanged, line numbers moved 1511 → 1695 and 1873 → 2057.**
+
+```
+$ sed -n '1695p' src/runtime/engine_scheduler.cpp
+            if (cudaMallocAsync(&residual_meta_d_buf_, meta_bytes, dec_stream) == cudaSuccess) {
+$ sed -n '1703,1705p' src/runtime/engine_scheduler.cpp
+                state.d_residual_seq_slots = base + static_cast<ptrdiff_t>(0) * N;
+                state.d_residual_counts = base + static_cast<ptrdiff_t>(1) * N;
+                state.d_residual_write_idxes = base + static_cast<ptrdiff_t>(2) * N;
+$ sed -n '2023p' src/runtime/engine_scheduler.cpp
+        graph_runner.execute(dec_stream);
+$ sed -n '2056,2058p' src/runtime/engine_scheduler.cpp
+    if (residual_meta_d_buf_ != nullptr) {
+        IMP_CUDA_CHECK_LOG(cudaFreeAsync(residual_meta_d_buf_, dec_stream));
+        residual_meta_d_buf_ = nullptr;
+```
+
+The three invalidation triggers around `graph_runner.execute()` are `bucketed_max_blocks`
+(`:1981`), `bucketed_max_ctx` (`:2002`) and the recurrent state slot (`:2015`). None of them
+observes `residual_meta_d_buf_`. **Failure mode:** the captured `forward_logits` replays with
+the previous step's device address baked in as a kernel parameter; if the stream-ordered
+allocator ever hands back a different address, the residual metadata read is a stale pointer.
+**Nothing tests it** - `grep -rn "TEST.*[Rr]esidual" tests/` returns 17 tests, all of them
+kernel-level or sizing-level; `test_attention_paged_nvfp4_tc_residual.cu:242
+MultiSeqBatchArrayForm_HD64` is the closest and it never captures a graph.
+*Proof it is closed:* token-for-token equality between `use_cuda_graphs=false` and the default,
+on a run with `kv_cache.bitdecoding_residual_tokens>0`, `kv_cache_dtype=NVFP4` and `batch>1`,
+over ≥200 tokens.
+
+**B10 - CLOSED `556f3b8d` (#1505).** The allocation is gone rather than re-typed: `ws.d_tok`
+is a persistent workspace slot beside the existing `ws.d_argmax`, whose comment already
+recorded the same fix for the output side of the same function. Three further mismatched
+pairs came out of that sweep and were **not** in this ledger: `chunk_eager_k_`/`_v_`
+(128 MiB, `cudaMallocAsync` at `executor_attention_prefill.cu:176`/`:177` against `cudaFree`
+at `executor_workspace_buffers.cu:1584`/`:1588` - the reverse direction of B10, recorded
+nowhere) and `shared_workspace_`'s resize grow branch. `tools/check_alloc_pairs.py` gates
+the class.
+
+**What #1505 did NOT reach**, stated so "an allocation gate landed" is not read as "I2 is
+gated": the pairing gate is a *static* check over source text. Item 3 - that no shipping
+build can observe a serving-phase allocation - is untouched by it. A future per-request
+`cudaMallocAsync`/`cudaFreeAsync` pair is correctly paired *and* an I2 violation, and
+nothing in the tree would say so.
+
+The entry as it read before the fix:
+
+**B10 - was OPEN, lines moved 606 → 610 and 615 → 619.**
+
+```
+$ sed -n '609,610p;619p' src/compute/mtp_forward.cu
+        int32_t* d_tok = nullptr;
+        if (cudaMalloc(&d_tok, sizeof(int32_t)) != cudaSuccess) {
+        cudaFreeAsync(d_tok, stream);
+```
+
+Reachability, which the entry did not state: the arm runs when `d_prev_token == nullptr`,
+which is the default of `mtp_draft_step` (`src/compute/mtp_forward.h:212`). Four call sites
+take it - `engine_spec_mtp.cpp:94`, `:143`, `engine_scheduler.cpp:2199`, `:2232` - and the
+device-chain arm that avoids it is gated on `ws->n_experts == 0`
+(`src/runtime/engine_spec_mtp.cpp:80`), so **every MoE model takes the host arm on every
+draft step**. *Proof it is closed:* the allocation is gone (arena or workspace slot), and
+`check_alloc_sites.py --stats` shows `src/compute/mtp_forward.cu` one acquisition lighter.
+
+**O1 - CLOSED, and the answer is bigger than the question.** "What claims the ~3.9 GiB" was
+answered by AUDIT B41: it is the cuBLAS/CUTLASS reserve claimed on the two warmup forward
+passes, it is not a constant, and it was measured at 0 / 4182 / 7458 MiB across three
+checkpoints. B42/B43 shipped the measurement and a warning; the auto-persist follow-up B42
+called for now exists as `src/memory/library_reserve_cache.h` and is wired at
+`src/runtime/engine_kv_cache_init.cpp:196-227`.
+
+**What is still open from O1 (item 6):** the cold path.
+
+```
+$ sed -n '98,100p' src/memory/plan.h
+// Re-measure after a driver or CUDA bump; imp.conf `vram.library_reserve_mb`
+// overrides it per host.
+constexpr size_t kMeasuredLibraryReserveBytes = 3900ull * 1024 * 1024;
+$ sed -n '195,196p' src/runtime/engine_kv_cache_init.cpp
+    // vram.library_reserve_mb always wins; a miss leaves the constant in place.
+    if (config_.library_reserve_mb < 0 && runtime_config_.vram.library_reserve_cache != "off") {
+```
+
+A first run on any new model/quant charges 3900 by construction. *Proof it is closed:* a
+first-run boot on a model whose measured reserve is 0 (Qwen3-4B IQ4_NL) plans a KV pool
+within 1 % of the same model's second run.
+
+**NEW, OPEN - the shared-workspace fallback loses its bytes from the accounting.**
+
+```
+$ sed -n '638p;666p' src/exec/executor_workspace.cu
+        cudaError_t err = cudaMalloc(&shared_workspace_, max_shared);
+        vram_free(vram_alloc_, shared_workspace_);
+$ sed -n '99p' src/memory/vram_allocator.cu
+    IMP_CUDA_CHECK_LOG(cudaFree(ptr));
+```
+
+`allocate_shared_workspace` falls back to a raw `cudaMalloc` when `VRAMAllocator` rejects
+the request (the Nemotron-30B case its own comment names), and `free_workspace` returns
+that pointer through `vram_free` -> `allocator->free()`, which never handed it out.
+**Memory-safe**: `VRAMAllocator::free` misses the map, skips the bookkeeping and still
+calls `cudaFree`. **Not accounted for**: the `allocated_` counter and the `MemAccount`
+pool note are both skipped, so the largest single workspace allocation in the process is
+invisible to the accounting exactly on the configurations where it was hardest to get.
+Same shape as item 3: a counter reads clean because the traffic never reaches it.
+*Proof it is closed:* a run that forces the fallback (a budget tight enough for
+`vram_alloc` to decline) shows `--mem-report` charging `shared_workspace` the same bytes
+it charges on the non-fallback path.
+
+### (b) Stubs, ignored request fields, dead kernels, tests that assert nothing
+
+```
+$ rg -n -i --glob '!build*' -e '\b(STUB|NOT[_ ]?IMPLEMENTED|UNIMPLEMENTED)\b' src include tools | wc -l
+8
+$ grep -rn "TODO\|XXX\|FIXME\|HACK" src/ include/ tools/ --include=*.cpp --include=*.h --include=*.cu --include=*.cuh | wc -l
+6
+$ rg -n 'DISABLED_' tests | wc -l
+8
+$ awk -f .claude/skills/find-stubs/tests_without_assertions.awk $(find tests -name '*.cpp' -o -name '*.cu') | wc -l
+44
+```
+
+Rung 1 is **8, down from the skill's stated baseline of 12** - `gemm_grouped_dispatch`, the
+2026-08-19 find, is gone from the tree. Of the 8: three are the `mmq_q4k_hmma` "Phase 0 stub"
+header/comment set, live behind `gemm.q4k_hmma_enabled` (default `false`, dispatched at
+`src/exec/executor_gemm_dispatch.cu:340`); one (`src/compute/gdn.cu:393`) is a comment
+*describing a fixed defect*, not a stub; one is a tokenizer note; two are the item-8 branch.
+
+**OPEN - `src/compute/weight_dispatch.cu:342`, item 8.**
+
+```
+$ sed -n '342,353p' src/compute/weight_dispatch.cu
+        case StorageTier::CUTLASS_NVFP4: {
+            // CUTLASS_NVFP4 is a prefill tier (M>1).  Decode falls through
+            // to NVFP4 GEMV in the consumer (executor_kernels.cu line 1951).
+            // gemv_dispatch is only called for decode (M=1); in phase-2 the
+            // consumer still uses the wcache_ NVFP4 entry directly.
+            // Stub: log error and do nothing so tests can verify routing.
+            IMP_LOG_ERROR(
+                "gemv_dispatch CUTLASS_NVFP4: not directly callable for decode "
+                "(no FP8 micro_scales in payload); consumer should use NVFP4 tier");
+            return;
+        }
+```
+
+`gemv_dispatch` switches on `w.primary_tier`; its four callers
+(`src/exec/executor_gemm_dispatch.cu:235,263,266`) switch on `decode_tier`. Traced:
+`decode_tier` is assigned in exactly one place - `src/exec/pre_dequant_phase4_tensor_registry.cu:90,96,98,100` -
+to `tier`, `FP8` or `NVFP4` and nothing else, so `primary_tier == CUTLASS_NVFP4` with a
+`decode_tier` that routes here is not producible today. It is reported because the branch
+returns **without writing `y`**: reached, it emits a projection of stale device memory behind
+one ERROR line. *Proof it is closed:* the branch either writes a correct result or throws
+(the `#654` precedent, `SETTLED.md` S-22).
+
+**NOT A FINDING - accepted-but-ignored request fields.** Rung 5 reproduces the recorded
+baseline exactly: 53 fields, 10 candidates, no name with 0 uses, no new name in the list.
+
+```
+SUSPECT cache_prompt (2)  enable_thinking_requested (2)  image_error (2)  include_usage (1)
+SUSPECT json_schema_str (2)  max_stop_len (1)  rep_pen_explicit (1)  requested_model (1)
+SUSPECT top_k_explicit (1)  top_p_explicit (1)
+```
+
+**NOT A FINDING - tests that assert nothing.** 44, the recorded baseline, dominated by
+harness-delegating bodies (`run_case(...)`, `run_arch(...)`). 8 `DISABLED_`, all with a
+stated reason in the file; two of them (`test_determinism_e2e.cpp:177,221`) are deliberately
+the gate for a known limit.
+
+### (c) Dead code - symbols with no caller
+
+The graph was 76 files stale; `codegraph sync` cost 1.7 s. **`ccg enrich` does not run
+against this DB** - it aborts on `sqlite3.IntegrityError: UNIQUE constraint failed:
+index 'idx_edges_identity'` after reporting `already in graph: 225`, so there are no
+`launches` edges and every `__global__` kernel appears uncalled. The sweep was therefore run
+graph-first and filtered by the mandatory grep, per `code-graph` trap 2.
+
+```
+$ codegraph sync
+Synced 76 changed files — Added: 4, Modified: 72 — 1,895 nodes in 817ms
+$ <sql: functions/methods in src|tools with no incoming calls edge>
+581
+$ <filter: ≤2 textual occurrences across src tools tests include>
+110 candidates, of which 33 are Python (dynamic dispatch, false positives)
+```
+
+Verified against the code, the 77 C++ candidates resolve to:
+
+- **False-positive family, refuted:** 10 `*_reset_static_cuda_state` functions, every one
+  bound by `IMP_REGISTER_CUDA_STATIC_RESET` on the line after its definition. This is
+  `SETTLED.md` §C's R-11 mechanism, which says it "looks deadest of all". Not dead.
+- **False-positive family, refuted:** every `__global__` kernel checked
+  (`paged_attention_decode_kernel`, `paged_attention_splitk_pipeline_kernel`,
+  `paged_attention_splitk_fp8_pipeline_kernel`, `paged_attention_splitk_int4_kernel`,
+  `paged_attention_decode_int8_kernel`, `gguf_q*_kernel`, `q4k_imma_kernel`) has its launch
+  or registration in the same file, invisible to the graph without launch edges.
+- **OPEN, one genuine dead function (item 9):**
+
+```
+$ grep -rwn "vhead_tiled_to_grouped" src tools tests include
+src/compute/gdn.cu:273:void vhead_tiled_to_grouped(const half* src, half* dst, ...
+src/compute/gdn.h:152:void vhead_tiled_to_grouped(const half* src, half* dst, ...
+$ grep -rwn "vhead_tiled_to_grouped_f32" src tools tests include
+src/compute/gdn.h:160:void vhead_tiled_to_grouped_f32(...
+src/compute/gdn.cu:308:void vhead_tiled_to_grouped_f32(...
+src/exec/executor_ssm_gdn.cu:438:        vhead_tiled_to_grouped_f32(v_scratch_tiled, v_scratch_grouped, ...
+```
+
+  The single consumer of `gdn.vhead_reorder` (`src/exec/executor_ssm_gdn.cu:421-422`) calls
+  only the FP32 variant. The FP16 twin plus `vhead_tiled_to_grouped_kernel` is dead.
+  *Proof it is closed:* both symbols removed, `make dev-test` green, `check_filesize.py`
+  shows `src/compute/gdn.cu` below its 544 code LOC.
+
+- **OPEN, item 10 - 20 header-inline accessors with exactly one occurrence in the tree**
+  (their own definition):
+
+```
+src/exec/executor.h:187 sample_slots          src/exec/executor.h:200 sample_parity
+src/exec/executor.h:390 streaming_n_sinks     src/memory/kv_cache_manager.h:147 pin_budget_blocks
+src/memory/kv_cache_manager.h:282 residual_n_kv_heads
+src/memory/kv_cache_manager.h:283 residual_head_dim
+src/core/weight_handle.h:77 is_populated      src/core/qtype.h:51 is_block_quant
+src/core/qtype.h:59 is_compute_dtype          src/core/buffer.h:32 is_device
+src/compute/json_schema.h:68 empty_set_dead   src/compute/json_constrain.h:94 closing_tokens_needed
+src/runtime/engine.h:182 lora_active          src/vision/vision_pipeline.h:64 boi_id
+src/vision/vision_pipeline.h:65 eoi_id        src/exec/activation_calibrator.h:53 skipped_non_fp16
+src/memory/graph_slots.h:176 host_bytes       src/lora/lora_adapter.h:59 set_name
+src/memory/weight_snapshot.h:145 builder_set_identity
+src/model/loader_assign.h:22 assign_quant_with_scales
+```
+
+  **CORRECTION, 2026-08-21: 20 was an undercount and the true figure is 28.** Two reasons,
+  both mine rather than the tree's. (1) I counted `hidden_state` as having two occurrences;
+  the second is inside a *comment* in `src/model/mtp_head.h:19`, and the purpose-built gate
+  strips comments before counting. (2) Four device `__forceinline__` helpers
+  (`cp_async_cg_8` in `attention_paged_common.cuh`, three `tq_fp4_*` in `turboquant_fp4.cuh`)
+  were in my candidate list and I did not carry them into the written list, because I was
+  selecting accessor-shaped names by eye - a filter applied after the measurement and never
+  stated. (3) The remaining three appeared only when the first 25 were removed: deleting
+  `tq_fp4_pack_pair`/`_unpack_lo`/`_unpack_hi` orphaned `tq_fp4_quantize_signed` and
+  `tq_fp4_dequant_nibble`, and removing those orphaned one more. Dead code hiding dead code,
+  so the sweep has to run to a fixpoint (three rounds: 25, 2, 1).
+  `turboquant_fp4.cuh` goes from ~100 lines to 44. `attention_paged_common.cuh` is included
+  by 10 TUs, so `cp_async_cg_8` is the one with real recompile fan-out.
+
+  Why they survived the sweep `SETTLED.md` §C calls "fully resolved": that sweep filtered on
+  the decl+def signature, i.e. **2** occurrences. A header-inline definition has **1**. Dated
+  with `git log -S`, all six sampled predate 2026-08-03, so this is an uncovered class, not a
+  re-run. *Proof it is closed:* the list is empty under the same query, and the query becomes
+  a gate.
+
+### (d) `[allow]` entries in `tools/filesize_thresholds.toml` whose reason no longer holds
+
+```
+$ python3 tools/check_filesize.py | tail -1
+scanned 739 files in src, tools, tests | warn=38 allowlisted=29 violations=0
+```
+
+The gate is green and the allowlist is the reason. Every entry states a code-LOC figure as
+its justification; **16 of 29 files are now larger than the figure that justified them**, and
+the gate has no mechanism to notice:
+
+| file | reason says | measured today | drift |
+|---|---|---|---|
+| `src/runtime/engine_scheduler.cpp` | 1074 | **1962** | +83 % |
+| `src/compute/attention_fmha_mxfp4_sm120.cu` | 810 | **1520** | +88 % |
+| `src/exec/executor_workspace_buffers.cu` | 906 | **1346** | +49 % |
+| `src/memory/kv_cache_manager.cpp` | 852 | **1200** | +41 % |
+| `src/model/weight_upload.cu` | 1658 | **1999** | +21 % |
+| `src/compute/mtp_forward.cu` | 651 | **853** | +31 % |
+| `src/runtime/cuda_graph.cu` | 863 | **1046** | +21 % |
+| `src/exec/executor_forward_moe_batch.cu` | 872 | **1061** | +22 % |
+| `src/compute/gemm.cu` | 613 | **727** | +19 % |
+| `src/model/weight_map.cpp` | 966 | **1068** | +11 % |
+| `src/model/hf_config_loader.cpp` | 810 | **943** | +16 % |
+| `src/compute/attention_paged.cu` | 1134 | **1196** | +5 % |
+| `src/compute/attention_fmha_sm120.cu` | 1436 | **1480** | +3 % |
+| `tests/test_paged_attention.cu` | 982, "14 tests" | **1202**, **26 tests** | +22 % / +86 % |
+| `tests/test_kv_cache.cpp` | 951, "56 tests" | **1159**, **59 tests** | +22 % |
+| `tests/test_gdn.cu` | 942, "11 tests" | **1026**, **12 tests** | +9 % |
+
+Two entries shrank below their stated figure (`src/compute/json_schema.cpp` 1158 → 1034,
+`src/model/safetensors_loader.cpp` 1147 → 1088) and one is exact
+(`src/model/gguf_loader.cpp` 812). Test counts from
+`grep -cE '^\s*(TEST|TEST_F|TEST_P)\(' <file>`.
+
+**Failure mode (item 5):** `SETTLED.md` S-26 blesses this allowlist as "manages file size
+instead of silencing it", and it does - for the *decision*. It does not manage the *number*.
+An allowlisted file has no ceiling at all, so the metric the gate exists to control
+(recompile blast radius, one `.cu` = one `ptxas` TU) grows unobserved; `engine_scheduler.cpp`
+nearly doubled. One reason is additionally wrong in substance rather than arithmetic:
+`schema_constrain.cu` says "split candidate if a third grammar lands", and it now carries
+`init_grammar_for_test` plus two body grammars around one `sim_advance` - the condition it
+names is at its boundary, not past it.
+*Proof it is closed:* each `[allow]` entry carries a measured `code_loc` the gate compares
+against, failing on growth in either direction - the same two-way ratchet
+`tools/alloc_allowlist.txt` already has (`SETTLED.md` S-27).
+
+### (e) Untested paths - `docs/FEATURES.md` 🟡, and gates reachable from no target
+
+```
+$ grep -c "🟡" docs/FEATURES.md
+4
+```
+
+One of the four is the legend line. The three real ones - Llama-4 (`:43`), FP8 E5M2 (`:61`),
+MoE host offload for NVFP4 experts (`:102`) - are each recorded in `LIMITATIONS.md` at
+`:38`, `:39` and `:54`. **The contract FEATURES.md states about itself holds.** NOT A FINDING.
+
+**No orphan test file.** Every `tests/*.cpp|cu` is a source of one of the eight
+`imp_add_test_module` targets:
+
+```
+$ comm -23 <(ls tests/*.{cpp,cu} | sed 's|tests/||' | sort) \
+           <(sed -n '580,930p' CMakeLists.txt | grep -oE '[A-Za-z0-9_]+\.(cpp|cu)' | sort -u)
+(empty)
+```
+
+(A case-sensitive first pass wrongly flagged `test_gemm_grouped_nvfp4_smallM.cu`; it is at
+`CMakeLists.txt:828`.)
+
+**OPEN - item 4. The gap is the lane, not the file.**
+
+| binary | files | `TEST*()` macros | ctest lane |
+|---|---|---|---|
+| test-core | 59 + 13 via `target_sources` (`CMakeLists.txt:734-749`) | 1086 | `unit` |
+| test-text | 6 | 197 | `unit` |
+| test-e2e | 28 | 176 | `unit` (6-pattern filter) + `gpu` (its complement) |
+| test-compute | 23 | 200 | `gpu` only |
+| test-attention | 13 | 210 | `gpu` only |
+| test-quant | 34 | 196 | `gpu` only |
+| test-kv | 11 | 75 | `gpu` only |
+| test-moe-gdn | 9 | 148 | `gpu` only |
+| **total** | **195** | **2288** | |
+
+Macro counts, not instantiations: a `TEST_P` counts once here and runs once per value. The
+13 `target_sources` files are the trap in this table - an `imp_add_test_module`-only parse
+misses them and undercounts test-core by 271.
+
+CI's required check is the job named `Build` (`.github/workflows/ci.yml:42`), whose test step
+is `cd build && ctest -L unit` (`:189`). **829 macros in the five GPU-only binaries run in no
+CI lane at all**, plus test-e2e's complement. The `perf` lane covers compute/attention/quant/e2e
+and omits `test-kv` and `test-moe-gdn` (`CMakeLists.txt:962-967`) - harmless, since the `gpu`
+lane runs those binaries unfiltered, but it means `*Perf*`/`*Bench*` there are never run in
+isolation.
+
+**CORRECTION, 2026-08-21: the figure above is a macro count and it is also incomplete.**
+829 counts `TEST`/`TEST_F`/`TEST_P` macros in the five GPU-only binaries and omits
+`test-e2e`'s GPU half. Three numbers, all honest, all reconciled:
+
+| quantity | value | how |
+|---|---|---|
+| macros, five GPU-only binaries | 829 | what this ledger first said |
+| macros, + `test-e2e`'s GPU half (139) | **968** | what `tools/check_test_lanes.py` pins |
+| listed tests, same set | 995 | `--gtest_list_tests` on a clean build |
+
+968 -> 995 is 27 `TEST_P` value rows (compute +9, attention +7, quant +6, e2e +5). The gate
+pins the **macro** count because that is the one derivable from sources, and it says so in
+its own failure message so the two can never be silently compared. Both were re-derived from
+two independent states after a stray uncommitted file in the shared working tree was found
+compiled into `test-quant`, moving the listed count from 202 to 205 and the total from 995
+to 998. A gate whose first-ever value is its own pin has nothing to disagree with, which is
+why it is derived twice here.
+
+This is downstream of a recorded decision (`DESIGN_DECISIONS.md:72`, "No GPU runner in CI"),
+so the decision is not the finding. The finding is that nothing in the repo *states the
+number*, and `make verify-fast` is the single point of failure for all 829.
+*Proof it is closed:* the count is asserted somewhere that fails when it grows - the same
+shape as `guard_e2e_lane_split` and `guard_det_suite_filter`, which already guard the two
+filters that could silently shift a test into the wrong lane.
+
+### (f) `RuntimeConfig` knobs parsed but never read, read but never acted on, documented and absent
+
+```
+$ grep -cE '^\s*[BIFS]\("' src/runtime/config.cpp
+184
+$ <per-leaf read count outside config.{h,cpp}, sorted ascending, head -1>
+0 calibration.out_path out_path
+$ comm -23 <(imp.conf.example leaf keys) <(config.cpp leaf keys)
+0 auto cublas_fp16_acc deterministic dp4a hd
+```
+
+**Documented and absent: none.** The five names the diff surfaces are false positives -
+`cublas_fp16_acc` and `deterministic` are parsed by the special-case branches at
+`config.cpp:229` and `:103` rather than the `B/I/F/S(...)` ladder; `auto`, `dp4a`, `hd` and
+`0` come from prose in comment lines. NOT A FINDING.
+
+**Parsed but never read: one (item 7).**
+
+```
+$ sed -n '358,363p' src/runtime/config.h
+    struct Calibration {
+        bool enabled = false;
+        // Where imp_calibration_write() puts the file. Empty means the caller
+        // supplies the path.
+        std::string out_path;
+    } calibration;
+$ grep -rn "out_path" src/ tools/ --include=*.cpp --include=*.cu --include=*.h | grep -v "config.cpp\|config.h"
+(no output)
+$ sed -n '377,378p' tools/imp-cli/main.cpp
+        if (!args.calibrate_out.empty()) {
+            ImpError ce = imp_calibration_write(ctx, args.calibrate_out.c_str());
+```
+
+`imp_calibration_write` (`src/api/imp_api.cpp:821`) takes the path as its argument. The
+sibling `calibration.enabled` *is* live (`src/runtime/engine_weight_upload.cpp:87`), which is
+what makes the dead one look wired. *Proof it is closed:* either the key is removed, or a run
+with `calibration.out_path` set and `--calibrate-out` unset writes that file.
+
+**Read but never acted on: none found.** Six leaves whose only textual consumer is
+`src/runtime/process_diag.cpp` were checked one by one; five reach a real decision through a
+`process_diag_*` accessor (`attention_paged_fp8.cu:619`, `attention_paged.cu:1487`,
+`weight_upload.cu:1725`, `nvfp4_gemv_moe.cu:185`). The sixth, `attention.fp8_qk_scaled`,
+**looked** dead under a name-symmetric grep and is live at
+`src/compute/attention_fmha_sm120.cu:1980` - the accessor is `process_diag_fp8_qk_scaled()`,
+not `process_diag_attention_fp8_qk_scaled()`. Recording the near-miss: this is the G1 shape,
+and the naming asymmetry is what would make the next sweep report it.
+
+---
+
+## 3. Already dead - do not re-chase
+
+| Considered | Killed where |
+|---|---|
+| "Architecture dispatch / quant dispatch / loader mapping / KV cache / execution paths / layer primitives / sampling are duplicated" | `SETTLED.md` S-1…S-7, all REFUTED 2026-07-29 |
+| "The legacy cuBLAS prefill is a vestige" | `SETTLED.md` S-8 - 0.0 % on hd=128/256; Gemma-4 hd=512 takes it by design |
+| "NVFP4 grouped-GEMM has two competing paths" | `SETTLED.md` S-11 - a designed 4-tier ladder, `src/exec/moe_prefill_decision.h` |
+| `#if 0` blocks, `_v2`/`_new`/`_old` pairs, stale `wgmma`/`tcgen05`/`sm_100` code, a `VramOwned` type | `SETTLED.md` §C - hunted, absent |
+| The `executor_kernels.h` decl-only kernel sweep; the non-kernel decl+def sweep (27 candidates) | `SETTLED.md` §C - fully resolved 2026-08-03, explicitly "do not re-open" |
+| `*_reset_static_cuda_state` as dead code | `SETTLED.md` §C R-11 - macro-bound self-registration |
+| "Engine teardowns leak ~15 GiB" | `AUDIT.md` B5 → B36 - WSL2/WDDM never returns peak commitment; not imp's to fix |
+| `cudaDeviceGraphMemTrim` | `AUDIT.md` B27 - dead, already recorded |
+| The six grow-on-demand statics that freed a live graph parameter (B13) | `AUDIT.md` B13 - CLOSED 2026-07-31 by #1139/#1140 |
+| `runtime.cuda_graphs=never` inert on dense models | `AUDIT.md` G1 - FIXED 2026-08-20 (#1502) |
+| `--vram-budget` overrun; the peak-VRAM gate that was declared and never implemented | `AUDIT.md` B37/B38/B39 - measured and shipped |
+| "Device sync per layer in `attention_cublas.cu`"; F-17; F-4's count | `SETTLED.md` §E - the findings were themselves wrong |
+| MTP: six drafter-accuracy hypotheses, MoE draft head, unfused verify chunk, the repair forward, the async conditional-graph loop | `roadmap.md` "Buried, so they are not re-run" (`:407-461`) |
+| Launch-count framing; the 22.3 % CUTLASS share | `roadmap.md` "Withdrawn by their author" (`:462`) |
+| Draft-model speculation, FFN contextual sparsity, BitDecoding, NVFP4 GEMV tuning, FMHA rewrites, cuTile, CompileIQ ptxas tuning | `roadmap.md` "Investigated and shelved" (`:923`) |
+| "No GPU runner in CI is debt" | `DESIGN_DECISIONS.md:72` - a decision with a stated cost, not debt. Item 4 is about the *unstated count*, not the decision |
+| Splitting a file because it is large | `codebase-audit` skill - split on conflation, and only with a concrete recompile cost |
+
+---
+
+## 4. Provenance
+
+Tree `d40cd394`, working copy clean, 2026-08-21. No GPU was used: every number here comes
+from `grep`, `sed`, `python3 tools/check_filesize.py`, `python3 tools/check_alloc_sites.py`,
+`codegraph`, or reading the file. Nothing was built and nothing was run on the device, so no
+claim here is a measurement of behaviour - every OPEN item's "proof it is closed" is written
+as the experiment that would settle it, precisely because this pass could not run one.

--- a/src/compute/attention_paged_common.cuh
+++ b/src/compute/attention_paged_common.cuh
@@ -34,13 +34,6 @@ __device__ __forceinline__ void cp_async_ca_16(void* smem, const void* glob) {
     asm volatile("cp.async.ca.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(glob));
 }
 
-// Streaming variant: cache at global level only (skip L1), evict-first from L2.
-// Used for KV cache loads that have no intra-step reuse across kernels.
-__device__ __forceinline__ void cp_async_cg_8(void* smem, const void* glob) {
-    uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
-    asm volatile("cp.async.cg.shared.global [%0], [%1], 8;\n" ::"r"(s), "l"(glob));
-}
-
 __device__ __forceinline__ void cp_async_cg_16(void* smem, const void* glob) {
     uint32_t s = static_cast<uint32_t>(__cvta_generic_to_shared(smem));
     asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" ::"r"(s), "l"(glob));

--- a/src/compute/json_constrain.h
+++ b/src/compute/json_constrain.h
@@ -90,9 +90,6 @@ public:
     // Check if initialized
     bool is_initialized() const { return initialized_; }
 
-    // Get max tokens to finish (force-close open structures near limit)
-    int closing_tokens_needed() const { return static_cast<int>(state_stack_.size()); }
-
     // Strict-simulate `text` from the current state without mutating it —
     // true iff every char is a legal grammar continuation. Public for the
     // FSM unit tests; apply_mask uses it for whole-token validation.

--- a/src/compute/json_schema.h
+++ b/src/compute/json_schema.h
@@ -65,8 +65,6 @@ public:
     // True if any state in `states` is accepting.
     bool accepts(const std::vector<int>& states) const;
 
-    static bool empty_set_dead(const std::vector<int>& states) { return states.empty(); }
-
 private:
     std::vector<NfaState> states_;
     int start_ = -1;

--- a/src/core/buffer.h
+++ b/src/core/buffer.h
@@ -29,7 +29,6 @@ public:
     // Accessors
     void* ptr() const { return data_; }
     size_t size() const { return size_; }
-    bool is_device() const { return on_device_; }
     explicit operator bool() const { return data_ != nullptr; }
 
     template <typename T>

--- a/src/core/qtype.h
+++ b/src/core/qtype.h
@@ -46,33 +46,6 @@ enum class QType : uint16_t {
     // (2026-05-17); the C-API aliases followed 2026-07-07.
 };
 
-// True for block-quantised disk formats (Q*_K, Q*_0, Q*_1, IQ4_*, MXFP4, NVFP4).
-// These types require a Sidecar scales tensor for reconstruction.
-constexpr bool is_block_quant(QType q) {
-    auto v = static_cast<uint16_t>(q);
-    return (v >= 2 && v <= 15) || q == QType::IQ4_NL || q == QType::IQ4_XS || q == QType::MXFP4 ||
-           q == QType::NVFP4;
-}
-
-// True for compute-side dtypes that map directly to a hardware FP/INT type.
-// These tensors store raw values; no Sidecar scales needed.
-constexpr bool is_compute_dtype(QType q) {
-    switch (q) {
-        case QType::F32:
-        case QType::F16:
-        case QType::BF16:
-        case QType::FP8_E4M3:
-        case QType::FP8_E5M2:
-        case QType::INT8:
-        case QType::INT4:
-        case QType::INT32:
-        case QType::FP4_E2M1:
-            return true;
-        default:
-            return false;
-    }
-}
-
 // Does this source qtype benefit from an NVFP4 decode-cache conversion?
 // (> 4.5 bits/elem, or no fast native decode kernel.) Single source of truth
 // for the pre-dequant phases AND the VRAM-budget heuristic — keep any policy

--- a/src/core/weight_handle.h
+++ b/src/core/weight_handle.h
@@ -74,8 +74,6 @@ struct WeightHandle {
         } mxfp4;
     } payload{};
 
-    bool is_populated() const { return primary_tier != StorageTier::Undefined; }
-
     // Phase 5 PR #1 Commit 5.1.4.a: can the original GGUF source bytes
     // (source_data, owned by Model::gpu_allocations_) be safely freed once
     // this handle is populated?

--- a/src/exec/activation_calibrator.h
+++ b/src/exec/activation_calibrator.h
@@ -50,7 +50,6 @@ public:
     CalibrationStats snapshot(const std::string& model_id) const;
 
     bool empty() const { return entries_.empty(); }
-    size_t skipped_non_fp16() const { return skipped_non_fp16_; }
 
 private:
     struct Entry {

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -184,7 +184,6 @@ public:
     bool sample_single_from_logits_async(const Tensor& logits, const InferenceState& state, int slot_idx,
                                          cudaStream_t stream = nullptr);
     const int32_t* collect_sampled_tokens(int n_slots, cudaStream_t stream = nullptr);
-    int sample_slots() const { return sample_slots_; }
 
     // Parity-buffered sampling for the pipelined batched decode (one step in
     // flight): the slot region, pinned gather buffer, and top-k row-args
@@ -197,7 +196,6 @@ public:
     // thread never waits on work enqueued after the gather.
     // All non-pipelined callers run at parity 0 (identical to the old layout).
     void set_sample_parity(int parity) { sample_parity_ = parity & 1; }
-    int sample_parity() const { return sample_parity_; }
     bool gather_sampled_tokens_async(int n_slots, cudaStream_t stream = nullptr);
     const int32_t* wait_gathered_tokens(int parity);
     // Device pointer of slot 0 of the given parity set (the chain-advance
@@ -387,7 +385,6 @@ public:
         streaming_n_sinks_ = (n_sinks > 0) ? n_sinks : 0;
         streaming_window_ = (window > 0) ? window : 0;
     }
-    int streaming_n_sinks() const { return streaming_n_sinks_; }
     int streaming_window() const { return streaming_window_; }
 
     // LoRA runtime delta (issue #522): activation-path low-rank deltas, no
@@ -396,10 +393,6 @@ public:
     // captured graph holds the adapter's kernel launches/pointers.
     void set_lora(const LoraAdapter* adapter);
     const LoraAdapter* lora() const { return lora_; }
-
-    // Access the hidden state buffer after forward_logits().
-    // Returns [max_tokens, d_model] FP16 on device. Use view_tokens() to get [n, d_model].
-    const Tensor& hidden_state() const { return hidden_; }
 
     // Public view_tokens wrapper for external callers.
     Tensor view_hidden(int n_tokens) const { return view_tokens(hidden_, n_tokens); }

--- a/src/lora/lora_adapter.h
+++ b/src/lora/lora_adapter.h
@@ -56,7 +56,6 @@ public:
     float scale() const { return scale_; }
     int max_rank() const { return max_rank_; }
     const std::string& name() const { return name_; }
-    void set_name(const std::string& n) { name_ = n; }
 
 private:
     struct LayerSlots {

--- a/src/memory/graph_slots.h
+++ b/src/memory/graph_slots.h
@@ -173,7 +173,6 @@ public:
     uint64_t declines_too_small() const;
 
     size_t device_bytes() const { return device_bytes_; }
-    size_t host_bytes() const { return host_bytes_; }
 
 private:
     friend class GraphSlotLease;

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -144,7 +144,6 @@ public:
 
     // Cap on unique pin_prefix-pinned blocks. 0 = unlimited (default).
     void set_pin_budget_blocks(int blocks) { pin_budget_blocks_ = blocks; }
-    int pin_budget_blocks() const { return pin_budget_blocks_; }
 
     // Cached (unreferenced) blocks that are actually reclaimable, i.e.
     // excluding pinned blocks. O(1).
@@ -278,9 +277,6 @@ public:
 
     bool residual_enabled() const { return residual_pool_ != nullptr; }
     int residual_n_tokens() const { return residual_n_tokens_; }
-    int residual_max_seqs() const { return residual_max_seqs_; }
-    int residual_n_kv_heads() const { return residual_n_kv_heads_; }
-    int residual_head_dim() const { return residual_head_dim_; }
 
     // Per-(seq, layer) K/V pointer into the residual pool. Returns nullptr if
     // residual is not enabled, seq_id has no allocated slot, or layer is out

--- a/src/memory/weight_snapshot.h
+++ b/src/memory/weight_snapshot.h
@@ -140,12 +140,6 @@ public:
     // resume — proves warm and cold uploads mix byte-safely.
     bool drop_key(const std::string& key) { return blobs_.erase(key) > 0; }
 
-    // Builder API for the on-disk warm cache (memory/weight_cache_file.cpp):
-    // assembles a snapshot from deserialized records instead of a live capture.
-    void builder_set_identity(int arch_id, int n_layers) {
-        arch_id_ = arch_id;
-        n_layers_ = n_layers;
-    }
     // Zero-copy variant: blob bytes are VIEWS into an mmap the snapshot takes
     // ownership of via builder_set_mmap (munmapped in the destructor).
     void builder_add_views(WeightUploadRecord rec, std::vector<const uint8_t*> views) {

--- a/src/quant/turboquant_fp4.cuh
+++ b/src/quant/turboquant_fp4.cuh
@@ -14,41 +14,6 @@ static constexpr int kTQFP4GroupSize = 32;
 // Values: {0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0}
 static __constant__ float kTQFP4DequantLUT[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
 
-// Quantize float magnitude → FP4 E2M1 3-bit code (round-to-nearest)
-// Branchless version: sum of comparisons against midpoint thresholds.
-// Thresholds between adjacent E2M1 values: 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0
-// The code equals the count of thresholds the value exceeds.
-__device__ __forceinline__ uint8_t tq_fp4_quantize_abs(float abs_val) {
-    uint8_t code = (abs_val >= 0.25f) + (abs_val >= 0.75f) + (abs_val >= 1.25f) + (abs_val >= 1.75f) +
-                   (abs_val >= 2.5f) + (abs_val >= 3.5f) + (abs_val >= 5.0f);
-    return code;  // 0..7 maps directly to E2M1 magnitude codes
-}
-
-// Quantize a float (signed) to packed 4-bit FP4 E2M1 nibble [sign:1 | code:3]
-__device__ __forceinline__ uint8_t tq_fp4_quantize_signed(float val) {
-    uint8_t sign = (val < 0.0f) ? 1u : 0u;
-    uint8_t code = tq_fp4_quantize_abs(fabsf(val));
-    return (sign << 3) | code;
-}
-
-// Pack two signed FP4 nibbles into one byte (lo=even, hi=odd).
-// Uses HW cvt.rn.satfinite.e2m1x2.f32 on sm_120+ (single PTX instruction,
-// IEEE RNE rounding, saturates to ±6). SW fallback for older archs.
-__device__ __forceinline__ uint8_t tq_fp4_pack_pair(float v0, float v1) {
-#if __CUDA_ARCH__ >= 1200
-    uint32_t out;
-    asm volatile(
-        "{ .reg .b8 b;\n"
-        "  cvt.rn.satfinite.e2m1x2.f32 b, %2, %1;\n"
-        "  cvt.u32.u8 %0, b; }\n"
-        : "=r"(out)
-        : "f"(v0), "f"(v1));
-    return static_cast<uint8_t>(out);
-#else
-    return tq_fp4_quantize_signed(v0) | (tq_fp4_quantize_signed(v1) << 4);
-#endif
-}
-
 // Float → UE8M0 (pure-exponent, value = 2^(bits-127), rounds up to next pow2)
 __device__ __forceinline__ uint8_t tq_fp4_float_to_ue8m0(float val) {
     if (val <= 0.0f)
@@ -71,24 +36,6 @@ __device__ __forceinline__ float tq_fp4_ue8m0_to_float(uint8_t bits) {
         return 0.0f;
     uint32_t fp32 = static_cast<uint32_t>(bits) << 23;
     return __uint_as_float(fp32);
-}
-
-// Dequant one FP4 E2M1 nibble (4 bits: sign[3] | code[2:0]) → float
-__device__ __forceinline__ float tq_fp4_dequant_nibble(uint8_t nibble) {
-    uint8_t sign = (nibble >> 3) & 1;
-    uint8_t code = nibble & 0x7;
-    float val = kTQFP4DequantLUT[code];
-    return sign ? -val : val;
-}
-
-// Unpack + dequant low nibble (bits [3:0]) of a packed byte
-__device__ __forceinline__ float tq_fp4_unpack_lo(uint8_t packed) {
-    return tq_fp4_dequant_nibble(packed & 0xF);
-}
-
-// Unpack + dequant high nibble (bits [7:4]) of a packed byte
-__device__ __forceinline__ float tq_fp4_unpack_hi(uint8_t packed) {
-    return tq_fp4_dequant_nibble((packed >> 4) & 0xF);
 }
 
 // Reciprocal of INT4 symmetric range max (7) for dequantization: val / 7.0

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -179,7 +179,6 @@ public:
     // Returns adapter id >= 1, or 0 on failure. id 0 = base model.
     int lora_load(const std::string& path);
     bool lora_set(int id);  // 0 deactivates
-    int lora_active() const { return active_lora_; }
 
     // Reset batch pool upload cache (call on context_reset to prevent
     // stale block table pointers when KV blocks are reused)

--- a/src/vision/vision_pipeline.h
+++ b/src/vision/vision_pipeline.h
@@ -61,8 +61,6 @@ public:
     half* embeddings() const noexcept { return d_embeddings_; }
     int num_image_tokens() const noexcept { return model_ ? model_->config.num_image_tokens : 0; }
     int32_t soft_token_id() const noexcept { return soft_token_id_; }
-    int32_t boi_id() const noexcept { return boi_id_; }
-    int32_t eoi_id() const noexcept { return eoi_id_; }
     const VisionModel* vision_model() const noexcept { return model_.get(); }
 
 private:

--- a/tools/check_alloc_pairs.py
+++ b/tools/check_alloc_pairs.py
@@ -304,7 +304,7 @@ def main():
         print("\nA pointer must go home to the allocator it came from: cudaMalloc<->cudaFree, "
               "cudaMallocAsync<->cudaFreeAsync, cudaMallocHost/cudaHostAlloc<->cudaFreeHost.")
         return 1
-    print("OK — every in-file allocate/free pair uses one allocator.")
+    print("OK - every in-file allocate/free pair uses one allocator.")
     return 0
 
 

--- a/tools/check_dead_inline_accessors.py
+++ b/tools/check_dead_inline_accessors.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Fail on a function defined inline in a header that nothing anywhere calls.
+
+WHY THIS EXISTS
+---------------
+`docs/audit/SETTLED.md` §C records two decl-only sweeps from 2026-08-03 that
+removed thirteen never-called functions and closed the class. It did not close
+this one, and the reason is a detail of the filter rather than of the tree: that
+sweep matched the decl+def signature, i.e. a name occurring exactly TWICE (once
+in a header, once in a .cpp). A function DEFINED in the header occurs once, so it
+scored as "already unique" and fell out of the candidate set. Twenty of them
+survived, all predating that sweep.
+
+Nothing here is a runtime defect: an uncalled `constexpr` accessor costs nothing
+at execution. What it costs is the reading of the header - an accessor is an
+assertion that some caller needs this value, and twenty untrue assertions is a
+header that describes an API nobody uses. This gate keeps the count at zero so
+the next reader can trust the ones that remain.
+
+WHAT IT CHECKS
+--------------
+For every function DEFINED inline in a header under `src/` (the body opens on
+the same line as the signature), count word-boundary occurrences of its name
+across `src tools tests include`. Exactly one occurrence means the definition is
+the only mention: no call, no address taken, no test.
+
+`include/` is deliberately out of scope: it is the public C API, whose consumers
+are outside this repo, and "no caller in the tree" says nothing there.
+
+KNOWN LIMITS, stated rather than papered over
+---------------------------------------------
+This is a text scan, not a compiler. It cannot see a name produced by token
+pasting, so a macro-generated caller reads as no caller. It skips constructors,
+destructors and `operator`s (a constructor's name is its class, so the count is
+never 1). If a legitimate entry ever appears, put it in the allowlist with a
+reason - do not widen the regex until it stops finding things.
+
+Usage:
+    python3 tools/check_dead_inline_accessors.py           # gate
+    python3 tools/check_dead_inline_accessors.py --list    # candidates + counts
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+HEADER_ROOTS = ("src",)
+SEARCH_ROOTS = ("src", "tools", "tests", "include")
+HEADER_EXTS = (".h", ".hpp", ".cuh")
+SEARCH_EXTS = (".cpp", ".cu", ".h", ".hpp", ".cuh")
+ALLOWLIST = ROOT / "tools" / "dead_inline_allowlist.txt"
+
+# An inline definition: optional specifiers, a return type, a name, an argument
+# list, optional trailing const/noexcept/override, then `{` on the SAME line.
+# Requiring the brace on the line is what separates a definition from a
+# declaration, and it is why this finds a class the decl+def sweep could not.
+DEF_RE = re.compile(
+    r"^[ \t]*"
+    r"(?:\[\[nodiscard\]\][ \t]*)?"
+    r"(?:(?:static|constexpr|inline|virtual|explicit|friend)[ \t]+)*"
+    r"(?:[A-Za-z_][\w:]*(?:[ \t]*<[^;{}]*>)?(?:[ \t]*(?:const|\*|&))*[ \t]+)+"
+    r"([A-Za-z_]\w*)[ \t]*\("
+    r"[^;{}]*\)[ \t]*"
+    r"(?:const[ \t]*)?(?:noexcept[ \t]*)?(?:override[ \t]*)?(?:const[ \t]*)?"
+    r"\{")
+
+SKIP_NAMES = {"if", "for", "while", "switch", "return", "catch", "sizeof", "operator"}
+
+
+def strip_comments(text):
+    out, i, n, state = [], 0, len(text), None
+    while i < n:
+        c, nxt = text[i], text[i + 1] if i + 1 < n else ""
+        if state is None:
+            if c == "/" and nxt == "/":
+                state = "line"; out.append("  "); i += 2; continue
+            if c == "/" and nxt == "*":
+                state = "block"; out.append("  "); i += 2; continue
+            if c == '"': state = "str"
+            elif c == "'": state = "chr"
+            out.append(c); i += 1; continue
+        if state == "line":
+            if c == "\n": state = None; out.append(c)
+            else: out.append(" ")
+            i += 1; continue
+        if state == "block":
+            if c == "*" and nxt == "/": state = None; out.append("  "); i += 2; continue
+            out.append(c if c == "\n" else " "); i += 1; continue
+        out.append(c)
+        if c == "\\":
+            if i + 1 < n: out.append(text[i + 1]); i += 2; continue
+        elif (state == "str" and c == '"') or (state == "chr" and c == "'"):
+            state = None
+        i += 1
+    return "".join(out)
+
+
+def load_allowlist():
+    entries = {}
+    if not ALLOWLIST.exists():
+        return entries
+    for lineno, raw in enumerate(ALLOWLIST.read_text().split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, reason = line.partition("#")
+        key = key.strip()
+        if not reason.strip():
+            print(f"ERROR {ALLOWLIST.name}:{lineno}: entry {key!r} has no reason", file=sys.stderr)
+            sys.exit(2)
+        entries[key] = reason.strip()
+    return entries
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true")
+    args = ap.parse_args()
+
+    # One pass over the corpus, so the occurrence count is a dict lookup rather
+    # than a grep per candidate (which was ~90 s on this tree).
+    corpus = []
+    for r in SEARCH_ROOTS:
+        for p in (ROOT / r).rglob("*"):
+            if p.suffix in SEARCH_EXTS and "build" not in p.parts:
+                corpus.append((p, strip_comments(p.read_text(errors="ignore"))))
+
+    counts = {}
+    for _, text in corpus:
+        for tok in re.findall(r"[A-Za-z_]\w*", text):
+            counts[tok] = counts.get(tok, 0) + 1
+
+    candidates = []
+    for p, text in corpus:
+        rel = str(p.relative_to(ROOT))
+        if p.suffix not in HEADER_EXTS or not any(rel.startswith(r + "/") for r in HEADER_ROOTS):
+            continue
+        # Class name in scope, so a constructor is not mistaken for a function.
+        classes = set(re.findall(r"\b(?:class|struct)\s+([A-Za-z_]\w*)", text))
+        for lineno, line in enumerate(text.split("\n"), 1):
+            m = DEF_RE.match(line)
+            if not m:
+                continue
+            name = m.group(1)
+            if name in SKIP_NAMES or name in classes or name.startswith("operator"):
+                continue
+            if counts.get(name, 0) == 1:
+                candidates.append((rel, lineno, name))
+
+    allow = load_allowlist()
+    unlisted = [c for c in candidates if f"{c[0]}:{c[2]}" not in allow]
+    listed = {f"{c[0]}:{c[2]}" for c in candidates}
+    stale = [k for k in allow if k not in listed]
+
+    if args.list:
+        for rel, lineno, name in candidates:
+            print(f"{rel}:{lineno}  {name}  (occurrences: {counts.get(name, 0)})")
+
+    print(f"dead-inline: {len(corpus)} files scanned, {len(candidates)} header-inline "
+          f"definition(s) with no other mention, {len(allow)} allowlisted")
+    for rel, lineno, name in unlisted:
+        print(f"DEAD {rel}:{lineno}  {name}()  - defined here and mentioned nowhere else")
+    for k in stale:
+        print(f"STALE allowlist entry (no longer dead, remove it): {k}")
+    if unlisted or stale:
+        print("\nAn accessor nobody calls is a claim that some caller needs the value. "
+              "Delete it, or allowlist it with the reason it must stay.")
+        return 1
+    print("OK - every header-inline definition under src/ is mentioned somewhere else.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_filesize.py
+++ b/tools/check_filesize.py
@@ -16,10 +16,24 @@ Usage:
   python3 tools/check_filesize.py                 # blocking hard gate
   python3 tools/check_filesize.py --warn-only     # advisory, never fails
   python3 tools/check_filesize.py --config X.toml  # alternate config (tests)
+  python3 tools/check_filesize.py --update         # re-pin [allow] code_loc values
+
+THE ALLOWLIST IS A CEILING, NOT AN EXEMPTION
+--------------------------------------------
+An entry in [allow] used to remove the file from the gate entirely, which meant
+the 29 allowlisted files were the only ones in the tree with no size limit at
+all — exactly the files where recompile blast radius is worst. Measured
+2026-08-21: sixteen of them had grown past the code-LOC figure their own reason
+cited, `engine_scheduler.cpp` by 83 % (1074 -> 1962), and every CI run was green
+throughout. So each entry now carries a measured `code_loc` and the gate fails
+when the file drifts from it in EITHER direction, the same two-way ratchet
+`tools/alloc_allowlist.txt` uses. Growing an allowlisted file is still allowed;
+growing it silently is not. `--update` re-pins, and the diff is the record.
   python3 tools/check_filesize.py --root src/compute  # restrict scan roots
 """
 import argparse
 import os
+import re
 import sys
 
 try:
@@ -138,16 +152,27 @@ def main():
     ap.add_argument("--config", default=DEFAULT_CONFIG)
     ap.add_argument("--warn-only", action="store_true", help="print smells but always exit 0")
     ap.add_argument("--root", action="append", help="override scan roots (repeatable)")
+    ap.add_argument("--update", action="store_true",
+                    help="re-pin every [allow] code_loc to the measured value")
     args = ap.parse_args()
 
     cfg = load_config(args.config)
     th = cfg["thresholds"]
     allow = cfg.get("allow", {})
 
-    # Validate allowlist: every entry needs a non-empty reason (anti-cheat).
-    bad = [p for p, reason in allow.items() if not str(reason).strip()]
+    # Validate allowlist: every entry is a table with a measured code_loc and a
+    # non-empty reason. The reason is the anti-cheat; the code_loc is the ceiling.
+    legacy = [p for p, v in allow.items() if not isinstance(v, dict)]
+    if legacy:
+        print("ERROR: allowlist entries are `{ code_loc = N, reason = \"...\" }` tables now,")
+        print("       not bare strings. Run --update after adding code_loc. Offenders:")
+        for p in legacy:
+            print(f"  {p}")
+        return 2
+    bad = [p for p, v in allow.items()
+           if not str(v.get("reason", "")).strip() or not isinstance(v.get("code_loc"), int)]
     if bad:
-        print("ERROR: allowlist entries without a reason:")
+        print("ERROR: allowlist entries missing a reason or an integer code_loc:")
         for p in bad:
             print(f"  {p}")
         return 2
@@ -194,6 +219,41 @@ def main():
               f"(safe to remove from [allow]):")
         for p in sorted(stale):
             print(f"  {p}")
+
+    # The ceiling half of the allowlist: a listed file must still measure what its
+    # entry says it measures. Drift in either direction fails, because a stale
+    # number is what let engine_scheduler.cpp grow 83 % with the gate green.
+    drift = []
+    measured = {r["path"]: r["code"] for r in rows}
+    for path, entry in sorted(allow.items()):
+        actual = measured.get(path)
+        if actual is None:
+            continue  # file gone; the stale-entry note above already covers it
+        if actual != entry["code_loc"]:
+            drift.append((path, entry["code_loc"], actual))
+
+    if args.update:
+        text = open(args.config, encoding="utf-8").read()
+        for path, _, actual in drift:
+            pat = re.compile(r'(^"' + re.escape(path) + r'"\s*=\s*\{\s*code_loc\s*=\s*)\d+',
+                             re.M)
+            text, n = pat.subn(lambda m: m.group(1) + str(actual), text)
+            if n != 1:
+                print(f"ERROR: --update could not re-pin {path} (matched {n} lines)")
+                return 2
+        open(args.config, "w", encoding="utf-8").write(text)
+        print(f"\nallowlist re-pinned: {len(drift)} entr(y/ies) updated")
+        return 0
+
+    if drift and not args.warn_only:
+        print(f"\nFAIL: {len(drift)} allowlisted file(s) drifted from their pinned code_loc.")
+        print(f"  {'pinned':>7} {'actual':>7} {'+/-':>6}  file")
+        for path, pinned, actual in drift:
+            print(f"  {pinned:>7} {actual:>7} {actual - pinned:>+6}  {path}")
+        print("\nAn allowlist entry is a ceiling, not an exemption. Re-pin with")
+        print("  python3 tools/check_filesize.py --update")
+        print("and say in the PR body which way it moved and why.")
+        return 1
 
     if hards and not args.warn_only:
         print("\nFAIL: hard-review threshold exceeded. Split the file, or — if it is "

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Pin the number of GTest cases that no CI lane runs, and fail when it moves.
+
+WHY THIS EXISTS
+---------------
+`docs/DESIGN_DECISIONS.md` "No GPU runner in CI" is a decision with a stated
+reason, and this file does not argue with it. What was missing is that the
+decision's cost was never a number anywhere in the repo. The required check is
+the job named `Build`, whose test step is `ctest -L unit`; five whole binaries
+(test-compute, test-attention, test-quant, test-kv, test-moe-gdn) and the
+complement of the e2e unit filter carry the label `gpu` and execute only when a
+human runs `make verify-fast` or `make test-gpu` on a real card.
+
+So this asserts the size of that hole. Growing it stays allowed. Growing it
+without anyone noticing does not.
+
+WHY IT READS SOURCES AND NOT A BUILD DIRECTORY
+----------------------------------------------
+The obvious implementation counts `--gtest_list_tests` on the built binaries.
+That was the first implementation and it was wrong, for a reason worth writing
+down: a gate that counts by reading `build-dev/` inherits that directory's
+provenance, and a build directory is exactly the artefact whose provenance
+nobody checks. Measured 2026-08-21: an uncommitted file belonging to another
+session, registered in `CMakeLists.txt` but never committed, had been compiled
+into `test-quant`, and the count read 998 where the clean tree gives 995. Pinning
+998 would have baked a stranger's local diagnostic into a gate on `main`, where
+it would then fail on every clean checkout with a message pointing at the
+contributor's tests rather than at the bad pin.
+
+Reading sources removes the failure mode rather than mitigating it. A stray file
+that was never registered cannot move the number; a stray file that WAS
+registered shows up as a `CMakeLists.txt` diff in review, which is where it
+belongs.
+
+WHAT IT COUNTS, EXACTLY
+-----------------------
+**`TEST` / `TEST_F` / `TEST_P` macros in the test sources of each module**, which
+is not the same quantity as `--gtest_list_tests`. A `TEST_P` is one macro and
+runs once per instantiated value row, so the listed-test figure is larger: 995
+listed against 829 macros for the unlaned set on 2026-08-21. Both are honest
+readings of "tests no CI lane runs". This file pins the macro count because it is
+the one derivable from sources, and it says so in its own failure message so the
+two can never be read against each other by accident. The listed-test figure is
+recorded beside it in `docs/audit/DEBT_LEDGER_2026_08_21.md`.
+
+Usage:
+    python3 tools/check_test_lanes.py           # gate
+    python3 tools/check_test_lanes.py --report  # the full per-module breakdown
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CMAKE = ROOT / "CMakeLists.txt"
+
+# Binaries whose every test carries the ctest label `gpu` (CMakeLists.txt
+# add_test/set_tests_properties). test-e2e is split by a filter and handled
+# separately below.
+GPU_ONLY = ("test-compute", "test-attention", "test-quant", "test-kv", "test-moe-gdn")
+UNIT_ONLY = ("test-core", "test-text")
+
+TEST_RE = re.compile(r"^\s*(TEST|TEST_F|TEST_P)\(\s*([A-Za-z_]\w*)\s*,\s*([A-Za-z_]\w*)\s*\)", re.M)
+
+
+def module_sources(text):
+    """-> {module: [tests/<file>, ...]}, from both registration forms.
+
+    `imp_add_test_module(<name> ... SOURCES ...)` is the common one, and
+    `target_sources(<name> PRIVATE ...)` is the one that is easy to miss: it adds
+    13 files to test-core, 271 macros' worth. A parse that only handles the first
+    form undercounts test-core and silently inflates the unlaned share.
+    """
+    mods = {}
+    for m in re.finditer(r"imp_add_test_module\(\s*(test-[a-z0-9-]+)", text):
+        name = m.group(1)
+        depth, i = 1, m.end()
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        mods.setdefault(name, []).extend(re.findall(r"tests/([A-Za-z0-9_]+\.(?:cpp|cu))", text[m.end():i]))
+    for m in re.finditer(r"target_sources\(\s*(test-[a-z0-9-]+)", text):
+        name = m.group(1)
+        depth, i = 1, m.end()
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        mods.setdefault(name, []).extend(re.findall(r"tests/([A-Za-z0-9_]+\.(?:cpp|cu))", text[m.end():i]))
+    return {k: sorted(set(v)) for k, v in mods.items()}
+
+
+def unit_filter(text):
+    m = re.search(r'set\(_unit_e2e_filter\s+"([^"]+)"\)', text)
+    if not m:
+        print("ERROR: could not find _unit_e2e_filter in CMakeLists.txt", file=sys.stderr)
+        sys.exit(2)
+    return m.group(1).split(":")
+
+
+def matches(patterns, fixture, name):
+    full = f"{fixture}.{name}"
+    for p in patterns:
+        if p.endswith(".*"):
+            if fixture == p[:-2]:
+                return True
+        elif p == full:
+            return True
+    return False
+
+
+def macros(path):
+    return TEST_RE.findall(path.read_text(errors="ignore"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--report", action="store_true")
+    ap.add_argument("--pin", type=int, default=None,
+                    help="expected unlaned macro count (default: read PINNED below)")
+    args = ap.parse_args()
+
+    PINNED = 968
+
+    text = CMAKE.read_text()
+    mods = module_sources(text)
+    patterns = unit_filter(text)
+
+    counts, unlaned, laned = {}, 0, 0
+    for mod, files in sorted(mods.items()):
+        n = 0
+        for f in files:
+            p = ROOT / "tests" / f
+            if p.exists():
+                n += len(macros(p))
+        counts[mod] = n
+        if mod in GPU_ONLY:
+            unlaned += n
+        elif mod in UNIT_ONLY:
+            laned += n
+
+    e2e_unit = e2e_gpu = 0
+    for f in mods.get("test-e2e", []):
+        p = ROOT / "tests" / f
+        if not p.exists():
+            continue
+        for _, fixture, name in macros(p):
+            if matches(patterns, fixture, name):
+                e2e_unit += 1
+            else:
+                e2e_gpu += 1
+    unlaned += e2e_gpu
+    laned += e2e_unit
+
+    if args.report:
+        print(f"{'module':<16} {'macros':>7}  lane")
+        for mod, n in counts.items():
+            lane = "gpu only" if mod in GPU_ONLY else ("unit" if mod in UNIT_ONLY else "split")
+            print(f"{mod:<16} {n:>7}  {lane}")
+        print(f"{'  test-e2e unit':<16} {e2e_unit:>7}  unit (filter)")
+        print(f"{'  test-e2e gpu':<16} {e2e_gpu:>7}  gpu only")
+        print(f"\n{'in a CI lane':<16} {laned:>7}")
+        print(f"{'in no CI lane':<16} {unlaned:>7}")
+        print(f"{'total':<16} {laned + unlaned:>7}")
+
+    pin = args.pin if args.pin is not None else PINNED
+    print(f"test-lanes: {unlaned} GTest macro(s) run in no CI lane (pinned {pin}); "
+          f"{laned} run in `ctest -L unit`")
+    if unlaned != pin:
+        print(f"\nFAIL: the unlaned GTest MACRO count is {unlaned}, pinned at {pin}.")
+        print("This counts TEST/TEST_F/TEST_P macros in sources. It is NOT the")
+        print("`--gtest_list_tests` figure, which is larger because a TEST_P runs")
+        print("once per instantiated value row. Do not compare the two.")
+        print("\nNot automatically a regression: it is the number of tests whose only")
+        print("execution is a human running `make verify-fast` / `make test-gpu` on a")
+        print("real card. If you added GPU tests, re-pin PINNED in this file and say")
+        print("so in the PR. If it DROPPED, a test moved into the CPU lane -- re-pin")
+        print("and say that too, because that is the direction worth celebrating.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dead_inline_allowlist.txt
+++ b/tools/dead_inline_allowlist.txt
@@ -1,0 +1,13 @@
+# Justified header-inline definitions with no other mention in the tree,
+# for tools/check_dead_inline_accessors.py
+#
+# Format: `path:name  # reason`. The reason is mandatory (an empty one is rejected)
+# and a stale entry fails the gate too, so the list cannot rot in either direction.
+#
+# An entry belongs here only when the call really exists and the scan cannot see it:
+# a name produced by token pasting, or a definition kept deliberately for a consumer
+# outside this repository. It is NOT a place to park an accessor nobody calls -
+# delete those.
+#
+# Empty on purpose since 2026-08-21: all 25 the gate found on its first run were
+# deleted rather than listed.

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -46,40 +46,49 @@ header_ext = [".cuh", ".hpp", ".h"]
 # Directory roots scanned by the audit + the gate.
 roots = ["src", "tools", "tests"]
 
-# Allowlist: files that EXCEED their hard-review threshold today and are accepted
-# into the baseline so CI is green WITHOUT splitting anything in this change.
-# Every entry MUST carry a non-empty reason (the gate rejects an empty value).
-# Classification letter: (a) bundles multiple independent concepts → split candidate;
-# (b) explicit template instantiations/specializations inline; (c) legitimately
-# monolithic (one cohesive unit / one test target). "split candidate" marks the
-# (a) entries that should eventually be broken up — they are allowlisted, not blessed.
 [allow]
-"src/compute/attention_fmha_sm120.cu" = "(c) 1436 code LOC — single FA2 attention family (base/fp8/fa2 variants) sharing one smem layout"
-"src/compute/attention_paged.cu" = "(c) 1134 code LOC — one paged-attention family: gqa-prefill, decode, splitk, reduce, cluster — shared block/KV layout"
-"src/compute/attention_paged_nvfp4_tc.cu" = "(c) 845 code LOC — NVFP4 tensor-core paged-attn family (decode/splitk/reduce) — shared TC path"
-"src/compute/attention_fmha_mxfp4_sm120.cu" = "(c) 810 code LOC — single MXFP4 FA2 attention kernel family"
-"src/compute/gemm.cu" = "(c) 613 code LOC — one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)"
-"src/compute/gemm_dp4a.cu" = "(c) 601 code LOC — one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)"
-"src/compute/gemm_grouped_nvfp4_smallM.cu" = "(c) 718 code LOC — one small-M grouped-GEMM family (software-ref + prod + smoke variants)"
-"src/compute/schema_constrain.cu" = "(c) 1146 code LOC — schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands"
-"src/compute/mtp_forward.cu" = "(c) 651 code LOC — MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature"
-"src/exec/executor_workspace_buffers.cu" = "(c) 906 code LOC — one concern: executor scratch/workspace sizing+allocation (host-only)"
-"src/exec/executor_forward_moe_batch.cu" = "(c) 872 code LOC — one path: batched-MoE forward dispatch (host-only)"
-"src/exec/executor_forward.cu" = "(c) 712 code LOC — executor forward orchestration (one dense forward path + 2 scale helpers)"
-"src/model/jinja.cpp" = "(c) 2295 code LOC — one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator"
-"src/model/tokenizer.cpp" = "(c) 1800 code LOC — one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)"
-"src/model/weight_upload.cu" = "(c) 1658 code LOC — one upload pipeline: pinned staging + checked malloc + tensor load orchestration"
-"src/compute/json_schema.cpp" = "(c) 1158 code LOC — one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode"
-"src/model/safetensors_loader.cpp" = "(c) 1147 code LOC — one loader: header validation + tensor assign + arch inference"
-"src/runtime/engine_scheduler.cpp" = "(c) 1074 code LOC — one scheduler: prefill/decode scheduling + chunked exec + perplexity capture"
-"src/model/weight_map.cpp" = "(c) 966 code LOC — one mapping module: weight-name parse + layer-index + arch inference"
-"src/model/hf_config_loader.cpp" = "(tu) 810 code LOC — central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow"
-"src/model/gguf_loader.cpp" = "(a->c) 812 code LOC — the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check."
-"src/runtime/cuda_graph.cu" = "(c) 863 code LOC — one module: graph capture/mode-resolve + PDL edges + barrier insert + replay"
-"src/memory/kv_cache_manager.cpp" = "(c) 852 code LOC — one manager: block alloc + residual pool + prefix cache + eviction"
-"tests/test_quant_integration.cu" = "(c) 1442 code LOC — 24 tests, all exercising the quant_gemm/dequant unit — one test target"
-"tests/test_gemm_kernel_registry.cu" = "(c) 1214 code LOC — 40 tests of the gemm_kernel_registry dispatch contract — one test target"
-"tests/test_paged_attention.cu" = "(c) 982 code LOC — 14 tests of the paged-attention kernel — one test target"
-"tests/test_kv_cache.cpp" = "(c) 951 code LOC — 56 tests across KV allocator/cache/manager — one test target"
-"tests/test_gdn.cu" = "(c) 942 code LOC — 11 tests of the GDN state-recurrent module — one test target"
-"src/compute/gemv_dp4a_traits.cuh" = "(b) 1295 code LOC — trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header — wide include blast radius)"
+# Allowlist: files that EXCEED their hard-review threshold today and are accepted
+# into the baseline. An entry is a CEILING, not an exemption: `code_loc` is the
+# measured code LOC at the time of pinning and the gate fails when the file drifts
+# from it in either direction. Re-pin with `python3 tools/check_filesize.py --update`
+# and say in the PR body which way it moved.
+#
+# Why the ceiling exists: before 2026-08-21 an [allow] entry removed the file from
+# the gate entirely, so the 29 allowlisted files were the only ones in the tree with
+# no size limit at all - exactly the files where recompile blast radius is worst.
+# Sixteen had grown past the code-LOC figure their own reason cited, `engine_scheduler.cpp`
+# by 83 % (1074 -> 1962), with every CI run green throughout.
+#
+# `reason` is mandatory (an empty one is rejected) and no longer carries the LOC
+# figure, because that is the part that went stale. Classification letter:
+# (a) bundles independent concepts -> split candidate; (b) explicit template
+# instantiations inline; (c) legitimately monolithic (one cohesive unit / test target).
+"src/compute/attention_fmha_mxfp4_sm120.cu" = { code_loc = 1520, reason = "(c) single MXFP4 FA2 attention kernel family" }
+"src/compute/attention_fmha_sm120.cu" = { code_loc = 1480, reason = "(c) single FA2 attention family (base/fp8/fa2 variants) sharing one smem layout" }
+"src/compute/attention_paged.cu" = { code_loc = 1196, reason = "(c) one paged-attention family: gqa-prefill, decode, splitk, reduce, cluster - shared block/KV layout" }
+"src/compute/attention_paged_nvfp4_tc.cu" = { code_loc = 848, reason = "(c) NVFP4 tensor-core paged-attn family (decode/splitk/reduce) - shared TC path" }
+"src/compute/gemm.cu" = { code_loc = 727, reason = "(c) one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)" }
+"src/compute/gemm_dp4a.cu" = { code_loc = 601, reason = "(c) one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)" }
+"src/compute/gemm_grouped_nvfp4_smallM.cu" = { code_loc = 693, reason = "(c) one small-M grouped-GEMM family (software-ref + prod + smoke variants)" }
+"src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }
+"src/compute/json_schema.cpp" = { code_loc = 1034, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
+"src/compute/mtp_forward.cu" = { code_loc = 855, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
+"src/compute/schema_constrain.cu" = { code_loc = 1181, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
+"src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
+"src/exec/executor_forward_moe_batch.cu" = { code_loc = 1061, reason = "(c) one path: batched-MoE forward dispatch (host-only)" }
+"src/exec/executor_workspace_buffers.cu" = { code_loc = 1348, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
+"src/memory/kv_cache_manager.cpp" = { code_loc = 1200, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
+"src/model/gguf_loader.cpp" = { code_loc = 812, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
+"src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
+"src/model/jinja.cpp" = { code_loc = 2294, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
+"src/model/safetensors_loader.cpp" = { code_loc = 1088, reason = "(c) one loader: header validation + tensor assign + arch inference" }
+"src/model/tokenizer.cpp" = { code_loc = 1801, reason = "(c) one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)" }
+"src/model/weight_map.cpp" = { code_loc = 1068, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
+"src/model/weight_upload.cu" = { code_loc = 1999, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
+"src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1962, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
+"tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
+"tests/test_kv_cache.cpp" = { code_loc = 1159, reason = "(c) 59 tests across KV allocator/cache/manager - one test target" }
+"tests/test_paged_attention.cu" = { code_loc = 1202, reason = "(c) 26 tests of the paged-attention kernel - one test target" }
+"tests/test_quant_integration.cu" = { code_loc = 1470, reason = "(c) 25 tests, all exercising the quant_gemm/dequant unit - one test target" }


### PR DESCRIPTION
Three gates in this repo were green for a reason unrelated to the property they claim to
check. This makes each of them able to fail, and removes 28 functions the fourth one could
not see.

## 1. The file-size allowlist was an exemption, not a ceiling

An `[allow]` entry removed the file from the gate entirely. So the 29 allowlisted files were
the only ones in the tree with **no size limit at all** - exactly the files where recompile
blast radius is worst, which is the cost `check_filesize.py` exists to control. Sixteen had
grown past the code-LOC figure their own reason cited:

| file | reason said | measured | |
|---|---|---|---|
| `src/runtime/engine_scheduler.cpp` | 1074 | **1962** | +83 % |
| `src/compute/attention_fmha_mxfp4_sm120.cu` | 810 | **1520** | +88 % |
| `src/exec/executor_workspace_buffers.cu` | 906 | **1346** | +49 % |
| `src/memory/kv_cache_manager.cpp` | 852 | **1200** | +41 % |
| `src/compute/mtp_forward.cu` | 651 | **855** | +31 % |
| ... | | | 16 total |

Each entry is now `{ code_loc = N, reason = "..." }` and the gate fails on drift **in either
direction**, the same two-way ratchet `tools/alloc_allowlist.txt` uses (`SETTLED.md` S-27).
`--update` re-pins, so the number moving is a diff line in review rather than nothing at all.

The LOC figure is out of the `reason` prose, because that is the half that went stale. Five
test-target reasons also quoted stale test counts - `test_paged_attention.cu` said "14 tests"
and has 26 - and those are corrected from `grep -cE '^\s*(TEST|TEST_F|TEST_P)\('`.

## 2. "No GPU runner in CI" is a decision; its cost was never a number

`docs/DESIGN_DECISIONS.md:72` records the decision and this PR does not argue with it. What
was missing is that nothing in the repo said how large the hole is.
`tools/check_test_lanes.py` pins it: **968 GTest macros run in no CI lane**, against 1320 in
`ctest -L unit`.

**It reads sources, not a build directory, and that is the load-bearing choice.** The first
implementation counted `--gtest_list_tests` on the built binaries. A gate that counts by
reading `build-dev/` inherits that directory's provenance, and a build directory is precisely
the artefact whose provenance nobody checks. Measured while writing this: an uncommitted file
belonging to another session, registered in `CMakeLists.txt` but never committed, had been
compiled into `test-quant`; the count read 998 where a clean tree gives 995. Pinning 998
would have baked a stranger's local diagnostic into a gate on `main`, failing every clean
checkout with a message pointing at the contributor's tests rather than at the bad pin.

**The failure message names its own metric.** 968 macros and 995 listed tests are both honest
readings of the same set; they differ by 27 `TEST_P` value rows. A gate that does not say
which one it pins invites the next reader to compare the two and see a drift that never
happened. The ledger records both, side by side.

## 3. Twenty-eight functions defined inline in a header and called nowhere

`SETTLED.md` §C records two decl-only sweeps from 2026-08-03 that removed thirteen
never-called functions and closed the class. They could not see this shape: that filter
matched the decl+def signature, i.e. a name occurring **twice**. A function defined in the
header occurs **once**, so it scored as already-unique and fell out of the candidate set. All
28 predate that sweep.

**The sweep has to run to a fixpoint, because dead code hides dead code.** Removing
`tq_fp4_pack_pair` / `_unpack_lo` / `_unpack_hi` orphaned `tq_fp4_quantize_signed` and
`tq_fp4_dequant_nibble`; removing those orphaned one more. Three rounds: 25, 2, 1.
`src/quant/turboquant_fp4.cuh` goes from ~100 lines to 44, keeping only the two helpers that
have real callers. `src/compute/attention_paged_common.cuh` is included by 10 TUs, so
`cp_async_cg_8` is the one with actual recompile fan-out.

Nothing here is a runtime defect - an uncalled `constexpr` accessor costs nothing at
execution. What it costs is the reading of the header: an accessor is an assertion that some
caller needs this value, and 28 untrue assertions is a header describing an API nobody uses.

## All three shown red before green

For gates whose whole defect was that they could not fail, this is the deliverable:

```
$ python3 tools/check_filesize.py          # engine_scheduler.cpp pinned back at its stale 1074
FAIL: 2 allowlisted file(s) drifted from their pinned code_loc.
   pinned  actual    +/-  file
     1800    1801     +1  src/model/tokenizer.cpp
     1074    1962   +888  src/runtime/engine_scheduler.cpp
EXIT=1
$ python3 tools/check_filesize.py --update && python3 tools/check_filesize.py
allowlist re-pinned: 2 entr(y/ies) updated
OK                                                                       EXIT=0

$ python3 tools/check_test_lanes.py        # pinned at the ledger's 829
FAIL: the unlaned GTest MACRO count is 968, pinned at 829.
This counts TEST/TEST_F/TEST_P macros in sources. It is NOT the
`--gtest_list_tests` figure, which is larger because a TEST_P runs
once per instantiated value row. Do not compare the two.
EXIT=1
                                        (restored to 968)                EXIT=0

$ git stash push -- src/core/qtype.h && python3 tools/check_dead_inline_accessors.py
dead-inline: 743 files scanned, 2 header-inline definition(s) with no other mention
DEAD src/core/qtype.h:51  is_block_quant()  - defined here and mentioned nowhere else
DEAD src/core/qtype.h:59  is_compute_dtype()  - defined here and mentioned nowhere else
EXIT=1
                                        (restored)                       EXIT=0
```

## The ledger, with three corrections to my own figures

`docs/audit/DEBT_LEDGER_2026_08_21.md` lands here. Corrections are written into it rather
than applied silently:

- **item 4's 829 was a macro count missing `test-e2e`'s GPU half.** 968 is the macro figure,
  995 the listed one, reconciled by 27 `TEST_P` rows and re-derived from two independent
  tree states.
- **item 10's 20 was an undercount, and I can say why it was mine and not the tree's.** I
  read `hidden_state` as having two occurrences because the second is inside a *comment*; and
  I dropped four device `__forceinline__` helpers from the written list because I was
  selecting accessor-shaped names by eye, a filter applied after the measurement and never
  stated. Plus three the cascade exposed.
- **a new OPEN item.** `src/exec/executor_workspace.cu:638` falls back to a raw `cudaMalloc`
  when `VRAMAllocator` declines, and `free_workspace` returns that pointer through
  `vram_free` to `allocator->free()`, which never handed it out. Memory-safe
  (`vram_allocator.cu:99` still calls `cudaFree`), but `allocated_` and the `MemAccount` note
  are both skipped, so the largest single workspace allocation is invisible to the accounting
  on exactly the configurations where it was hardest to get. Same shape as ledger item 3: a
  counter reads clean because the traffic never reaches it. Not fixed here; not this PR's class.

Items 2, 4, 5 and 10 are struck in the ledger with what closed them. **Item 3 is annotated as
still open**, so "an allocation gate landed" is not read as "I2 is gated" - #1505's pairing
gate is a static check over source text and does not reach it.

## Gate

`make verify-fast` on this tree, Qwen3-8B-Q8_0 on one RTX 5090, card idle, clocks warm:

```
  perf gate: median of 3 independent runs (spread 0.63%)
  decode  tg128 =  285.20 tok/s  (baseline  287.19, delta -0.69%)
  prefill pp512 = 12477.47 tok/s  (baseline 12406.87, delta 0.57%)
  prefill pp4096 = 15416.00 tok/s  (baseline 15324.70, delta 0.60%, FA2)
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
  graphs ON  tg256 =  456.74 tok/s   (2.40x, threshold 1.3x)
  PASS Qwen3-4B Q8_0 (dense) (distinct=11, contains 'Paris')
=== verify fast: OK ===
```

`make dev-test` 5/5. No baseline refresh: nothing here is intended to move perf, and the
header removals are all uncalled definitions.

Timings in this PR are not comparable to those in #1505: that work moved to a fresh worktree
in between and lost its `build-dev/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
