### PR TITLE
fix: a knob that did nothing, a branch that answered with stale memory, a dead twin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`[calibration] out_path` now writes a file.** The key was parsed, documented in
+  `config.h` and offered in `imp.conf.example`, and read by nothing: setting it
+  produced no calibration file and no warning, because `imp_calibration_write()`
+  takes the path as an argument and `--calibrate` was the only way in. `--calibrate`
+  still wins when both are given.
+
+- **A decode dispatch branch that logged an error and returned without writing its
+  output** now throws. `gemv_dispatch`'s `CUTLASS_NVFP4` case left the output tensor
+  holding whatever the workspace held before, behind one ERROR line. Unreachable on
+  today's tier assignment, which is exactly where such a path survives unnoticed.
+
+- **A dead FP16 kernel removed from `gdn.cu`.** `vhead_tiled_to_grouped` and its
+  kernel were declared, defined and called nowhere; the one consumer of
+  `gdn.vhead_reorder` has only ever used the FP32 variant.
+
 - **Four device pointers were freed through an allocator that had not produced
   them**, which is invalid CUDA and silent. `mtp_forward.cu` allocated a 4-byte
   token id with `cudaMalloc` and freed it with `cudaFreeAsync` once per MTP draft

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -248,40 +248,13 @@ __global__ void gdn_rmsnorm_gated_silu_kernel(
 }
 
 // ---------------------------------------------------------------------------
-// V-head reorder: tiled → grouped (undo GGUF converter reorder for ssm_out)
+// V-head reorder: tiled -> grouped (undo GGUF converter reorder for ssm_out)
+//
+// FP16 twin removed 2026-08-21: it and its kernel were declared, defined and
+// called nowhere. The only consumer of `gdn.vhead_reorder`
+// (executor_ssm_gdn.cu:421) gathers V out of the FP32 conv1d output, so it has
+// only ever called the _f32 variant below.
 // ---------------------------------------------------------------------------
-__global__ void vhead_tiled_to_grouped_kernel(const half* __restrict__ src, half* __restrict__ dst,
-                                              int n_tokens, int n_heads, int head_dim, int n_groups) {
-    int tid = blockIdx.x * blockDim.x + threadIdx.x;
-    int total = n_tokens * n_heads * head_dim;
-    if (tid >= total)
-        return;
-
-    int d = tid % head_dim;
-    int h_tiled = (tid / head_dim) % n_heads;
-    int t = tid / (n_heads * head_dim);
-
-    int n_v_per_k = n_heads / n_groups;
-    int replica = h_tiled / n_groups;
-    int group = h_tiled % n_groups;
-    int h_grouped = group * n_v_per_k + replica;
-
-    dst[t * n_heads * head_dim + h_grouped * head_dim + d] =
-        src[t * n_heads * head_dim + h_tiled * head_dim + d];
-}
-
-void vhead_tiled_to_grouped(const half* src, half* dst, int n_tokens, int n_heads, int head_dim, int n_groups,
-                            cudaStream_t stream) {
-    if (n_heads == n_groups)
-        return;
-    int total = n_tokens * n_heads * head_dim;
-    int threads = 256;
-    int blocks = (total + threads - 1) / threads;
-    vhead_tiled_to_grouped_kernel<<<blocks, threads, 0, stream>>>(src, dst, n_tokens, n_heads, head_dim,
-                                                                  n_groups);
-    IMP_CUDA_CHECK_LAUNCH();
-}
-
 // FP32 variant for conv1d-SiLU output (= scan V input). Same math as FP16,
 // different element type. Used when the GGUF stored V in tiled layout and the
 // scan kernel reads V[h*HD+d] assuming grouped layout.

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -148,10 +148,6 @@ void gdn_scan_prefill_f32(const float* x, const float* B, const float* C, const 
                           int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
                           cudaStream_t stream, int grouped_layout = 0);
 
-// V-head reorder: tiled → grouped (FP16 variant, for post-scan y_buf).
-void vhead_tiled_to_grouped(const half* src, half* dst, int n_tokens, int n_heads, int head_dim, int n_groups,
-                            cudaStream_t stream);
-
 // V-head reorder: tiled → grouped (FP32 variant, for conv1d-SiLU output).
 // Asymmetric heads (n_groups != n_heads): the GGUF converter may store V in
 // tiled order (h0_g0, h1_g1, ..., h15_g15, h0_g0_r1, ...) while the scan

--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -9,6 +9,9 @@
 #include "core/logging.h"
 #include "runtime/process_diag.h"
 
+#include <cstdio>
+#include <stdexcept>
+
 #include <cuda_fp16.h>
 #include <cuda_fp8.h>
 #include <vector>
@@ -340,15 +343,26 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y, cudaStream
         //
         // For now: log an error and return (stub behavior for Phase 2).
         case StorageTier::CUTLASS_NVFP4: {
-            // CUTLASS_NVFP4 is a prefill tier (M>1).  Decode falls through
-            // to NVFP4 GEMV in the consumer (executor_kernels.cu line 1951).
-            // gemv_dispatch is only called for decode (M=1); in phase-2 the
-            // consumer still uses the wcache_ NVFP4 entry directly.
-            // Stub: log error and do nothing so tests can verify routing.
-            IMP_LOG_ERROR(
-                "gemv_dispatch CUTLASS_NVFP4: not directly callable for decode "
-                "(no FP8 micro_scales in payload); consumer should use NVFP4 tier");
-            return;
+            // Unreachable today and it must stay an error rather than a silent
+            // return. CUTLASS_NVFP4 is a prefill tier (M>1); decode reaches the
+            // NVFP4 GEMV through the consumer, and `decode_tier` is only ever
+            // assigned `tier`, FP8 or NVFP4 (pre_dequant_phase4_tensor_registry.cu
+            // :90,96,98,100), so no caller can route here.
+            //
+            // Until 2026-08-21 this branch logged and returned WITHOUT WRITING
+            // `y`, i.e. it left the output holding whatever the workspace held
+            // before, behind one ERROR line. That is the shape #654 removed from
+            // attention_prefill_dispatch, and SETTLED.md S-22 records why: "no
+            // tier accepted" is an error, not a degraded answer. An unreachable
+            // branch is exactly where a silent-wrong-output path survives, because
+            // nothing exercises it to prove otherwise.
+            char msg[192];
+            snprintf(msg, sizeof(msg),
+                     "gemv_dispatch: CUTLASS_NVFP4 is not directly callable for decode "
+                     "(no FP8 micro_scales in the payload); the consumer must use the "
+                     "NVFP4 tier. shape=[%lld,%lld]",
+                     static_cast<long long>(w.shape[0]), static_cast<long long>(w.shape[1]));
+            throw std::runtime_error(msg);
         }
 
         // ---- MXFP4 -------------------------------------------------------

--- a/tests/test_server_args.cpp
+++ b/tests/test_server_args.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include "args.h"
+#include "common/args_common.h"
 
 #include <string>
 #include <vector>
@@ -71,4 +72,29 @@ TEST(ServerArgs, UnrelatedFlagsLeaveLimitsAtDefault) {
     EXPECT_EQ(a.port, 9099);
     EXPECT_EQ(a.max_concurrent, 64);
     EXPECT_EQ(a.max_input_tokens, 0);
+}
+
+// ---------------------------------------------------------------------------
+// resolve_calibration_out - `[calibration] out_path` was parsed, documented in
+// config.h and offered in imp.conf.example, and read by nothing: setting it
+// produced no file and no warning, because imp_calibration_write() takes the
+// path as an argument and imp-cli passed --calibrate straight through.
+// Debt ledger item 7.
+// ---------------------------------------------------------------------------
+
+TEST(CalibrationOutPath, TheFlagWins) {
+    EXPECT_EQ(resolve_calibration_out("/from/flag.json", "/from/conf.json"), "/from/flag.json");
+}
+
+TEST(CalibrationOutPath, TheConfigKeyIsUsedWhenTheFlagCarriesNoPath) {
+    // This is the case that silently did nothing before.
+    EXPECT_EQ(resolve_calibration_out("", "/from/conf.json"), "/from/conf.json");
+}
+
+TEST(CalibrationOutPath, NeitherMeansNoCalibrationRun) { EXPECT_EQ(resolve_calibration_out("", ""), ""); }
+
+TEST(CalibrationOutPath, AnEmptyConfigKeyDoesNotClobberTheFlag) {
+    // imp.conf.example ships `out_path = ""`, so the default value of the key
+    // is the empty string on every run that does not set it.
+    EXPECT_EQ(resolve_calibration_out("/from/flag.json", ""), "/from/flag.json");
 }

--- a/tests/test_weight_dispatch.cu
+++ b/tests/test_weight_dispatch.cu
@@ -10,6 +10,8 @@
 #include "quant/mxfp4_gemm.h"
 
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <stdexcept>
 #include <cuda_runtime.h>
 #include <cublasLt.h>
 #include <cuda_fp16.h>
@@ -665,12 +667,19 @@ TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemmMatchesDirect) {
     cudaFree(d_y_disp);
 }
 
-// gemv_dispatch CUTLASS_NVFP4 (M=1): CUTLASS_NVFP4 is a prefill-only tier.
-// The consumer decode path uses the NVFP4 tier directly; the CUTLASS_NVFP4
-// gemv_dispatch stub logs an error and returns without crashing.
-TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemvIsStub) {
-    // This tests that calling gemv_dispatch on a CUTLASS_NVFP4 handle does
-    // not crash (logs an error but returns cleanly).
+// gemv_dispatch CUTLASS_NVFP4 (M=1): CUTLASS_NVFP4 is a prefill-only tier and
+// the consumer decode path uses the NVFP4 tier directly, so reaching this case
+// is a routing bug in the caller.
+//
+// This test used to assert the opposite. It was named `CUTLASS_NVFP4_GemvIsStub`
+// and asserted EXPECT_NO_THROW with the comment "output buffer is unchanged
+// (stub returns early)" - i.e. it pinned a branch that answered with whatever
+// the output buffer already held, behind one ERROR line, and it pinned it as
+// the expected behaviour. That is the shape #654 removed from
+// attention_prefill_dispatch: "no tier accepted" is an error, not a degraded
+// answer (SETTLED.md S-22). The routing check the test was written for is kept;
+// what changed is what counts as correct routing behaviour.
+TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemvRefusesInsteadOfAnsweringWithStaleMemory) {
     const int M = 8, K = 32;
 
     void* dummy_data;
@@ -699,9 +708,18 @@ TEST_F(WeightDispatchTest, CUTLASS_NVFP4_GemvIsStub) {
     Tensor x_t(d_x, QType::F16, 2, xshape, true);
     Tensor y_t(d_y, QType::F16, 2, yshape, true);
 
-    // Must not crash; output buffer is unchanged (stub returns early)
-    EXPECT_NO_THROW(gemv_dispatch(h, x_t, y_t, stream_));
+    // A sentinel the old behaviour would have left in place and called an answer.
+    EXPECT_EQ(cudaMemset(d_y, 0xAB, M * sizeof(half)), cudaSuccess);
+
+    EXPECT_THROW(gemv_dispatch(h, x_t, y_t, stream_), std::runtime_error);
     EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    // And it refuses without touching the output, so a caller that ignores the
+    // exception still cannot mistake the buffer for a result.
+    std::vector<uint16_t> host(M);
+    EXPECT_EQ(cudaMemcpy(host.data(), d_y, M * sizeof(half), cudaMemcpyDeviceToHost), cudaSuccess);
+    for (int i = 0; i < M; ++i)
+        EXPECT_EQ(host[i], 0xABAB) << "output was written by a path that refused";
 
     cudaFree(dummy_data);
     cudaFree(dummy_sf);

--- a/tools/common/args_common.cpp
+++ b/tools/common/args_common.cpp
@@ -64,3 +64,9 @@ bool parse_common_flag(CommonArgs& args, int argc, char** argv, int& i) {
     }
     return true;
 }
+
+std::string resolve_calibration_out(const std::string& flag_value, const std::string& config_value) {
+    if (!flag_value.empty())
+        return flag_value;
+    return config_value;
+}

--- a/tools/common/args_common.h
+++ b/tools/common/args_common.h
@@ -69,3 +69,22 @@ struct CommonArgs {
 // must not be able to shadow a shared flag with a divergent local handler,
 // which is the failure this consolidation exists to prevent.
 bool parse_common_flag(CommonArgs& args, int argc, char** argv, int& i);
+
+// Where a calibration run writes its statistics.
+//
+// `imp_calibration_write()` takes the path as an argument, so imp-cli passed
+// `--calibrate <out>` straight through and NOTHING ever read
+// `[calibration] out_path`. The key was parsed (config.cpp), documented in
+// config.h ("Where imp_calibration_write() puts the file") and offered in
+// imp.conf.example - a promise to the operator that nothing kept: setting it
+// produced no file and no warning.
+//
+// Resolution order, flag first, because a flag is the more specific intent:
+//   1. `--calibrate <path>` if given
+//   2. `[calibration] out_path` from imp.conf
+//   3. empty, meaning no calibration run was asked for
+//
+// Pure and here rather than inline in main.cpp so it has a test: an unwired
+// knob is what this fixes, and wiring it untested would be the same defect one
+// step along.
+std::string resolve_calibration_out(const std::string& flag_value, const std::string& config_value);

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -107,6 +107,11 @@ int main(int argc, char** argv) {
         if (!pc_set)
             runtime_cfg.server.prefix_cache = false;
     }
+    // `[calibration] out_path` is the fallback when --calibrate carries no path.
+    // The key was parsed and documented and read by nothing, so an operator who
+    // set it in imp.conf got no file and no warning (debt ledger item 7).
+    args.calibrate_out = resolve_calibration_out(args.calibrate_out, runtime_cfg.calibration.out_path);
+
     // --calibrate is only meaningful alongside a corpus pass: the statistics
     // are what a forward pass saw, and --perplexity is the pass that walks a
     // whole corpus without sampling.


### PR DESCRIPTION
Three items from `docs/audit/DEBT_LEDGER_2026_08_21.md` (7, 8, 9), each simply wrong rather than merely untidy.

## 1. `[calibration] out_path` was parsed, documented and read by nothing

`config.cpp` parses the key, `config.h:360` says *"Where imp_calibration_write() puts the file"*, `imp.conf.example:734` offers it. Nothing read it: `imp_calibration_write()` takes the path as an argument and imp-cli passed `--calibrate` straight through, so an operator who set it in `imp.conf` got **no file and no warning**.

**Honoured, not removed.** The promise is user-facing, and `SETTLED.md` §C has the precedent: `log_set_level` had no caller and no config key, and *"removing it would have cemented the gap and taken away the hook"* - it was fixed by wiring. Resolution order is flag, then config key, then nothing; `--calibrate` still wins.

`resolve_calibration_out` is a pure function in `tools/common/args_common.cpp` rather than three inline lines in `main.cpp`, so it has a test. Wiring an unwired knob without one would be the same defect a step along.

**Verified end to end, because a green CPU test cannot catch a wire that goes nowhere:**

```
config key only, no flag -> "Calibration written: /out/from_config.json (196 entries)", 1152290 bytes
both set                 -> only from_flag.json exists, the flag wins
neither                  -> no file, no crash, perplexity still printed
```

The first run doubles as the negative control, by accident: I ran it first against `imp:test`, which comes from `make build` and therefore did **not** contain this change, and it wrote nothing. Same command against the build that has the fix writes the file.

## 2. `gemv_dispatch`'s CUTLASS_NVFP4 case returned without writing `y`

It logged one ERROR line and returned, leaving the output tensor holding whatever the workspace held before. #654 removed exactly this shape from `attention_prefill_dispatch`; `SETTLED.md` S-22 records why: *"no tier accepted" is an error, not a degraded answer.* It now throws.

**Note what this does NOT do.** I planned to follow the file's own idiom, which is `IMP_LOG_FATAL(...); return;` at `:278` and `:378` - then checked, and **`IMP_LOG_FATAL` only logs.** `IMP_CHECK` is what aborts. So those two siblings carry the identical defect and following the local idiom would have reproduced it. Reported here, deliberately untouched: same class, one follow-up, not a partial fix.

**And a correction to my own ledger entry.** I wrote *"unreachable today, nothing exercises it"*. Unreachable from production is right (`decode_tier` is only ever `tier`, FP8 or NVFP4 - `pre_dequant_phase4_tensor_registry.cu:90,96,98,100`). *"Nothing exercises it"* was wrong, and **the pre-commit hook is what told me**: `WeightDispatchTest.CUTLASS_NVFP4_GemvIsStub` went red.

That test is the more interesting half of this item. It asserted `EXPECT_NO_THROW` with the comment *"output buffer is unchanged (stub returns early)"* - **a test that pinned a silent-wrong-answer path as the expected behaviour**, which is a large part of why this branch survived a decl-only sweep, a file-size audit and two allocation audits untouched. It looked covered.

Rewritten to the contract the fix establishes and renamed `CUTLASS_NVFP4_GemvRefusesInsteadOfAnsweringWithStaleMemory`. It fills the output with a `0xAB` sentinel first and asserts both that the call throws **and** that the sentinel survives, so a caller that swallows the exception still cannot read the buffer as a result. The routing check the test was written for is unchanged.

```
[ RUN      ] WeightDispatchTest.CUTLASS_NVFP4_GemvRefusesInsteadOfAnsweringWithStaleMemory
[       OK ] WeightDispatchTest.CUTLASS_NVFP4_GemvRefusesInsteadOfAnsweringWithStaleMemory (6 ms)
```

## 3. `vhead_tiled_to_grouped` (FP16) and its kernel, dead

Declared in `gdn.h`, defined in `gdn.cu`, called nowhere. The single consumer of `gdn.vhead_reorder` (`executor_ssm_gdn.cu:421`) gathers V out of the FP32 conv1d output and has only ever called the `_f32` variant. 35 lines out of a `.cu` that was 44 code LOC over its warn threshold.

## Gates

`make verify-fast` green: own peak VRAM 20718 MiB (+0.01 %), graphs ON 2.54x, smoke prompt coherent, perf within threshold. `make dev-test` 5/5. All four source gates green (`check_alloc_pairs`, `check_test_lanes` at 968, `check_dead_inline_accessors`, `check_filesize`).

`check_test_lanes` stays at 968 because the rewritten test is a rename, not an addition, and the four new `resolve_calibration_out` tests land in `test-core`, which is in the CPU lane.

## Reported, not fixed

- `weight_dispatch.cu:278` and `:378` - `IMP_LOG_FATAL(...); return;` on the FP32/Undefined tiers. Same defect as item 2, and `IMP_LOG_FATAL` does not abort.
- `executor_workspace.cu:638` (already an OPEN item in the ledger) - the raw-`cudaMalloc` fallback returned through `vram_free`, so the largest single workspace allocation is memory-safe but invisible to the accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)