### PR TITLE
fix: ten sites logged at FATAL and then carried on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,12 @@ jobs:
       # decl+def, i.e. two occurrences, and a header-inline definition is one.
       - name: Header-inline definitions with no caller (blocking)
         run: python3 tools/check_dead_inline_accessors.py
+      # IMP_LOG_FATAL only logs; IMP_CHECK is the only thing that aborts. Ten
+      # of twelve sites logged at FATAL and then carried on, three of them
+      # after a comment saying that carrying on hands a host pointer to a
+      # device kernel.
+      - name: FATAL logs that do not stop (blocking)
+        run: python3 tools/check_log_fatal.py --list
 
   # Documentation layer contract (docs/audit/docs-rewrite/). Seven checks, all
   # of which map to a defect this repo actually shipped: a datacenter-Blackwell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Ten sites logged at FATAL and then carried on.** `IMP_LOG_FATAL` only writes a
+  log line; `IMP_CHECK` is the only thing that aborts. One reported
+  `WeightRegistry::handle: id out of range` and indexed out of range on the next
+  line; two returned from a dispatch leaving the output tensor unwritten; three MoE
+  staging sites said in their own comments that continuing hands a host pointer to a
+  device kernel, and then did. Also: the expert-cache parity checker returned `false`
+  into callers that discarded it, so the debug facility detected a host/device
+  divergence and continued. `make check-log-fatal` keeps the count at zero.
+
 - **`[calibration] out_path` now writes a file.** The key was parsed, documented in
   `config.h` and offered in `imp.conf.example`, and read by nothing: setting it
   produced no calibration file and no warning, because `imp_calibration_write()`

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-log-fatal check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that nothing else is using the GPU. Delegates to
 # scripts/require_free_gpu.sh, the same guard the git hooks use, because
@@ -473,6 +473,10 @@ check-test-lanes:
 # Functions defined inline in a header that nothing in the tree mentions.
 check-dead-inline:
 	@python3 tools/check_dead_inline_accessors.py --list
+
+# Sites that log at FATAL and then continue. IMP_LOG_FATAL does not abort.
+check-log-fatal:
+	@python3 tools/check_log_fatal.py --list
 
 format:
 	@$(CLANG_FORMAT_RUN) -i --style=file $(CLANG_FORMAT_FILES)

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -183,6 +183,43 @@ Same shape as item 3: a counter reads clean because the traffic never reaches it
 `vram_alloc` to decline) shows `--mem-report` charging `shared_workspace` the same bytes
 it charges on the non-fallback path.
 
+**NEW, CLOSED - `IMP_LOG_FATAL` does not stop anything, and ten of twelve sites
+assumed it did.**
+
+```
+$ sed -n '58p' src/core/logging.h
+#define IMP_LOG_FATAL(...) ::imp::log_message(::imp::LogLevel::FATAL, __FILE__, __LINE__, __VA_ARGS__)
+$ python3 tools/check_log_fatal.py     # on the pre-fix tree
+log-fatal: 12 IMP_LOG_FATAL site(s), 1 abort, 0 throw, 11 continue (1 allowlisted)
+```
+
+`IMP_CHECK` (`logging.h:68-74`) is the only thing in the tree that reaches
+`std::abort()`, and its own comment says so. So the macro's name promised what
+only its sibling delivered. Census and verdicts:
+
+| site | after the log | verdict |
+|---|---|---|
+| `pre_dequant_phase4_tensor_registry.cu:550` | `std::abort()` | correct |
+| `weight_handle.h:26` | `return self.handles_[id]` | **out-of-bounds read after reporting the id is out of range** |
+| `weight_dispatch.cu:281`, `:392` | `return` | output tensor left holding whatever it held; `:392` is the `default:` |
+| `expert_cache.cu` x4 | falls through / returns the slot | fills a slot it just said does not fit; returns a pointer it just called unusable |
+| 3 MoE staging sites | falls through | each says in its own comment that continuing hands a HOST pointer to a device kernel |
+| `expert_cache.cu` parity check | `return false` | correct in itself, **and both callers discarded the verdict** |
+
+The last row is the one worth keeping: `check_parity()` returning `false` is the
+right contract for a function that reports agreement, but `get_or_load()` called
+it as a bare statement. So the debug facility detected the host/device
+divergence, logged it, returned false into nothing, and carried on - while
+`expert_cache.h:273` documented the behaviour as "aborts on mismatch". Found
+while correcting that comment, not by the census.
+
+Two throw (dispatch failures the API boundary turns into `ImpError`), eight
+abort via `IMP_CHECK` (state corruption or a documented abort contract), one was
+already correct, one is allowlisted with the reason. `tools/check_log_fatal.py`
+keeps it at zero, keyed on the message rather than the line number - the first
+version keyed on lines and rotted immediately when four comment lines moved a
+site by six.
+
 ### (b) Stubs, ignored request fields, dead kernels, tests that assert nothing
 
 ```

--- a/src/compute/weight_dispatch.cu
+++ b/src/compute/weight_dispatch.cu
@@ -277,9 +277,18 @@ void gemm_dispatch(cublasLtHandle_t, const WeightHandle& w, const Tensor& x, Ten
         }
 
         case StorageTier::FP32:
-        case StorageTier::Undefined:
-            IMP_LOG_FATAL("gemm_dispatch: handle in invalid tier %d", std::to_underlying(w.primary_tier));
-            return;
+        case StorageTier::Undefined: {
+            // Was IMP_LOG_FATAL + return, which logs and leaves the output
+            // holding whatever it held. IMP_LOG_FATAL does not abort - only
+            // IMP_CHECK does - so "FATAL" here bought a log line and nothing
+            // else. Throws for the same reason the CUTLASS_NVFP4 case below
+            // does (#1508): no tier accepted is an error, not a degraded
+            // answer (SETTLED.md S-22), and imp_api.cpp turns it into ImpError.
+            char msg[128];
+            snprintf(msg, sizeof(msg), "gemm_dispatch: handle in invalid tier %d",
+                     std::to_underlying(w.primary_tier));
+            throw std::runtime_error(msg);
+        }
     }
 }
 
@@ -388,9 +397,16 @@ void gemv_dispatch(const WeightHandle& w, const Tensor& x, Tensor& y, cudaStream
             return;
         }
 
-        default:
-            IMP_LOG_FATAL("gemv_dispatch: handle in invalid tier %d", std::to_underlying(w.primary_tier));
-            return;
+        default: {
+            // Same class as the branch above, and worse for a structural
+            // reason: this is the `default:`, i.e. the branch that catches a
+            // tier nobody anticipated. That is the case in which continuing
+            // with an unwritten output is least affordable.
+            char msg[128];
+            snprintf(msg, sizeof(msg), "gemv_dispatch: handle in invalid tier %d",
+                     std::to_underlying(w.primary_tier));
+            throw std::runtime_error(msg);
+        }
     }
 }
 

--- a/src/exec/executor_forward_moe_batch.cu
+++ b/src/exec/executor_forward_moe_batch.cu
@@ -112,7 +112,7 @@ bool GraphExecutor::try_run_moe_nvfp4_dequant_batch_prefill_(int layer, cudaStre
     nvfp4_batch_dequant_gemm(*ly.nvfp4_moe_up_ptr, gathered_base, expert_up_base, ctx.d, ctx.eff);
 
     // gpt-oss (#547): per-expert biases on gate/up outputs BEFORE activation.
-    // Rows are expert-sorted (expanded layout) — expert via expert_offsets.
+    // Rows are expert-sorted (expanded layout) - expert via expert_offsets.
     const int32_t* d_offsets = static_cast<const int32_t*>(ctx.routing.expert_offsets.data);
     if (model_->profile().is_gpt_oss) {
         moe_add_expert_bias_sorted(expert_gate_base, ly.expert_gate_bias.data, d_offsets, ctx.ne,
@@ -321,7 +321,7 @@ bool GraphExecutor::try_run_moe_q4k_prefill(int layer, cudaStream_t stream, int 
                             non_gated_experts, expanded, eff, compute_dtype_,
                             cfg.ffn_activation, stream);
 
-    // Step 5+6: Down projection — dp4a, re-quantize activations to Q8_1
+    // Step 5+6: Down projection - dp4a, re-quantize activations to Q8_1
     char* down_act = non_gated_experts ? expert_up_base : expert_swiglu_base;
     QType down_qtype = ly.expert_down_packed.qtype;
     size_t down_stride = expert_stride(ly.expert_down_packed, down_qtype);
@@ -450,8 +450,8 @@ bool GraphExecutor::try_run_moe_fp16_batch_prefill(int layer, cudaStream_t strea
     }
 
     // MoE IMMA prefill (gemm.moe_imma_prefill): Q8_0/Q4_K expert tensors run
-    // the grouped INT8 IMMA kernel — fused dequant, one launch over all
-    // experts — instead of materializing every expert to FP16 (the 63-65%-of-
+    // the grouped INT8 IMMA kernel - fused dequant, one launch over all
+    // experts - instead of materializing every expert to FP16 (the 63-65%-of-
     // window dequant tax, docs/archive/prefill_gap_2026_06_07.md §4.2). Other
     // qtypes (Q6_K down_proj) and FP32-out fall through to the legacy path.
     int max_rows_per_expert = 0;
@@ -585,7 +585,7 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
     // 2 * n syncs (one per token, three GEMVs each) down to ONE sync per
     // layer call. Restores the prefill graph-capture story up to (but not
     // including) the grouped-mmvq kernel work that would eliminate the
-    // remaining sync — see follow-up: replacing this function with a
+    // remaining sync - see follow-up: replacing this function with a
     // device-indexed grouped mmvq lets the whole layer capture cleanly.
     //
     // top_k is bounded by FFN active-expert count (max 32 per kernel
@@ -614,7 +614,7 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
 
         // Per-token expert IDs: read from the pre-fetched host array (no D2H,
         // no sync). Old form: stack `int32_t h_experts[32]` + per-token
-        // cudaMemcpyAsync + cudaStreamSynchronize — M2 batched both above.
+        // cudaMemcpyAsync + cudaStreamSynchronize - M2 batched both above.
         const int32_t* h_experts = h_all_experts.data() + static_cast<size_t>(t) * top_k;
 
         auto do_mmvq = [&](const uint8_t* w, half* out, QType qt, int rows, int cols) {
@@ -690,7 +690,7 @@ bool GraphExecutor::try_run_moe_gemma4_ggml_prefill(int layer, cudaStream_t stre
 }
 
 // Expert-activation histogram (diagnostics.moe_expert_hist). One increment per
-// (token, k) routing decision, bucketed by absolute layer index — non-MoE layers
+// (token, k) routing decision, bucketed by absolute layer index - non-MoE layers
 // of a hybrid simply stay zero. Kept off the hot path by the null check on
 // `hist`; when on, it is one atomicAdd per decision (n * top_k per layer per
 // forward), which is noise next to the expert GEMMs it precedes.
@@ -711,7 +711,7 @@ __global__ void moe_expert_hist_kernel(const int32_t* __restrict__ expert_indice
 
 // Per-token expert trace. One record per (token, layer): [layer, e0..e_{k-1}],
 // appended at an atomically claimed offset so records stay whole even though the
-// claim is concurrent. Capacity is checked before the claim is committed —
+// claim is concurrent. Capacity is checked before the claim is committed -
 // overrunning would corrupt the tail of a trace that is read as evidence.
 __global__ void moe_expert_trace_kernel(const int32_t* __restrict__ expert_indices, int* __restrict__ trace,
                                         unsigned int* __restrict__ cursor, unsigned long long capacity,
@@ -736,7 +736,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     const auto& ly = model_->layer(layer);
 
     auto run_topk = [&](const Tensor& logits_f32) {
-        // gpt-oss (#547): router bias is a true LINEAR bias on the logits —
+        // gpt-oss (#547): router bias is a true LINEAR bias on the logits -
         // added before softmax/top-k it shifts selection AND the renormalized
         // top-k weights (= HF's topk(logits+b) → softmax-over-selected).
         // Distinct from DeepSeek's selection-only score_bias (router_bias_ptr).
@@ -754,7 +754,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     // Fused gate GEMV + topk only profitable when n_experts ≤ warps (8).
     // Higher expert counts (e.g. 128 in Qwen3-Coder) prefer separate
     // gemv_gate_fp32, which puts one warp on each expert row: 128 parallel
-    // WARPS in 16 blocks of 8 (not 128 blocks — kGemvThreads is 256).
+    // WARPS in 16 blocks of 8 (not 128 blocks - kGemvThreads is 256).
     //
     // 16 blocks looks like under-occupancy (16 of this card's 170 SMs, 0.02
     // waves/SM, 205 GB/s = 11.4% of peak) and it is not worth "fixing" by
@@ -764,7 +764,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     // expert models. The work is pinned at 128 warps by one-warp-per-row, so
     // redistributing them only removes each SM's ability to hide DRAM latency
     // across warps. Making this kernel faster needs K split across several
-    // warps per row — an algorithm change, not a launch-config change.
+    // warps per row - an algorithm change, not a launch-config change.
     constexpr int kMaxFusedExperts = 8;
     const std::string& dl = runtime_config().diagnostics.dump_logits_dir;
     bool dump_logits = !dl.empty() && (layer == 29 || dl == "all");
@@ -843,7 +843,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     // Expert-activation histogram. Hooked HERE, at the end of the routing
     // funnel, and not inside run_topk: the fused gate+top-k decode branch above
     // never calls run_topk, so a hook there would silently miss every
-    // single-token decode — which is the case this measurement is about.
+    // single-token decode - which is the case this measurement is about.
     if (!runtime_config().diagnostics.moe_expert_hist.empty()) {
         if (moe_.expert_hist == nullptr) {
             int n_layers = cfg.n_layers;
@@ -860,7 +860,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
                 IMP_LOG_INFO("moe expert histogram: recording %d layers x %d experts -> %s", n_layers, ne,
                              runtime_config().diagnostics.moe_expert_hist.c_str());
             } else {
-                IMP_LOG_WARN("moe expert histogram: allocation failed — not recording");
+                IMP_LOG_WARN("moe expert histogram: allocation failed - not recording");
             }
         }
         // ne can differ per layer in principle; a mismatch would alias buckets,
@@ -879,7 +879,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
     // Per-token expert trace. Decode only: a prefill call routes n tokens at once
     // and would append n*top_k behind a single record header, which the reader
     // cannot split back apart. Prefill decisions are not what a cache is judged
-    // on anyway — the per-token stream is.
+    // on anyway - the per-token stream is.
     if (n == 1 && !runtime_config().diagnostics.moe_expert_trace.empty()) {
         if (moe_.expert_trace == nullptr) {
             // 8M ints ~= 32 MiB: 512 tokens x 48 layers x (1+8) is 221k, so this
@@ -899,7 +899,7 @@ void GraphExecutor::compute_moe_routing(int layer, cudaStream_t stream, int n, i
                 vram_free(vram_alloc_, moe_.trace_cursor);
                 moe_.expert_trace = nullptr;
                 moe_.trace_cursor = nullptr;
-                IMP_LOG_WARN("moe expert trace: allocation failed — not recording");
+                IMP_LOG_WARN("moe expert trace: allocation failed - not recording");
             }
         }
         if (moe_.expert_trace != nullptr && top_k == moe_.trace_top_k) {
@@ -963,7 +963,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
 
     // ---- Host-resident NVFP4 experts: address the LRU cache's slot pool ----
     // Phase 3 builds nvfp4_moe_*_ptr only for device-resident experts, so a
-    // host-resident NVFP4 layer arrives here with none of them — which is how
+    // host-resident NVFP4 layer arrives here with none of them - which is how
     // #1403's placement reached a generic GEMM as raw bytes and answered from
     // the experts that happened to be resident.
     //
@@ -986,7 +986,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
         if (model_->profile().is_gpt_oss) {
             // gpt-oss (#547): per-expert biases on gate/up/down outputs + the
             // clamped GLU. The fused swiglu-down GEMV computes plain SwiGLU
-            // inline — bypassed here in favor of explicit bias→GLU→down→bias.
+            // inline - bypassed here in favor of explicit bias→GLU→down→bias.
             gemv_nvfp4_moe_gate_up_fused(*ly.nvfp4_moe_gate_ptr, *ly.nvfp4_moe_up_ptr, expert_indices,
                                          norm_ptr, gate_buf, up_buf, eff, d, top_k, stream);
             moe_add_expert_bias_indexed(gate_buf, ly.expert_gate_bias.data, expert_indices, top_k, eff,
@@ -1003,7 +1003,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
             gemv_nvfp4_moe_gate_up_fused(*ly.nvfp4_moe_gate_ptr, *ly.nvfp4_moe_up_ptr, expert_indices,
                                          norm_ptr, gate_buf, up_buf, eff, d, top_k, stream);
             // Compute the gated activation (silu(gate)*up) ONCE per element into act_buf,
-            // then a plain bandwidth-bound down GEMV — instead of gemv_nvfp4_moe_swiglu_decode,
+            // then a plain bandwidth-bound down GEMV - instead of gemv_nvfp4_moe_swiglu_decode,
             // which recomputed the silu (exp/div, XU-bound) once per OUTPUT ROW (NR=8x
             // redundant). nsys: the fused swiglu-down kernel was 15.5% of decode wall-clock,
             // XU-bound at 85% occ / 27% peak BW; this matches the gpt-oss + mmvq paths above
@@ -1035,7 +1035,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
     // The fused MoE decode kernels read an expert as `base + idx * stride`.
     // With experts on host the contiguous array is the cache's per-layer slot
     // pool (fixed stride slot_size_), so `idx` is a SLOT index rather than an
-    // expert id — no new kernel, no staging copy. Establishing residency needs
+    // expert id - no new kernel, no staging copy. Establishing residency needs
     // the routing on the host, hence one D2H per layer; that is what the
     // serial fallback this replaces already paid, and CUDA graphs are disabled
     // on this path anyway. Requires the whole working set to fit the layer's
@@ -1102,13 +1102,17 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
             // Unreachable by construction: host_expert_pool_ready() is the same
             // predicate the dispatch used to send us here, and staging can only
             // fail on an out-of-range expert id or layer. Say so loudly rather
-            // than fall through — the fall-through would hand a HOST pointer to
+            // than fall through - the fall-through would hand a HOST pointer to
             // a device kernel.
-            IMP_LOG_FATAL(
-                "MoE decode fast: host-resident experts could not be staged into the LRU pool "
-                "(layer %d, top_k %d, slots/layer %d). The dispatch predicate and this path "
-                "have diverged.",
-                layer, top_k, expert_cache_.slots_per_layer_);
+            // IMP_CHECK, not IMP_LOG_FATAL. The comment above says continuing hands a
+            // HOST pointer to a device kernel, and IMP_LOG_FATAL only LOGS
+            // (logging.h:58) - so it said so and then did it. Abort rather than
+            // throw: this is state corruption, not a request that can be failed.
+            IMP_CHECK(false,
+                      "MoE decode fast: host-resident experts could not be staged into the LRU pool "
+                      "(layer %d, top_k %d, slots/layer %d). The dispatch predicate and this path "
+                      "have diverged.",
+                      layer, top_k, expert_cache_.slots_per_layer_);
         }
     }
 
@@ -1163,7 +1167,7 @@ void GraphExecutor::run_moe_decode_fast(int layer, cudaStream_t stream, int n, i
                                       /*q8_1_stride=*/0, /*d8_stride=*/0, top_k, stream);
         }
     } else {
-        // FP16 dequant fallback — only Q6_K / Q8_0 wired.
+        // FP16 dequant fallback - only Q6_K / Q8_0 wired.
         size_t up_stride_bytes = expert_stride(ly.expert_up_packed, up_qtype);
         if (!non_gated_experts) {
             size_t gate_stride = expert_stride(ly.expert_gate_packed, ly.expert_gate_packed.qtype);

--- a/src/exec/executor_forward_moe_legacy.cu
+++ b/src/exec/executor_forward_moe_legacy.cu
@@ -77,8 +77,8 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
         // Use the LRU cache only when this dispatch's working set fits the
         // layer's slot pool. One dispatch touches kExpertProjCount cells per
         // ACTIVE expert; the pool holds slots_per_layer. Above that the cache
-        // retains nothing across the dispatch — every access misses and
-        // evicts — so it does strictly more work than the single-slot staging
+        // retains nothing across the dispatch - every access misses and
+        // evicts - so it does strictly more work than the single-slot staging
         // buffer for the same H2D bytes.
         //
         // Decode stays on the cache (top_k experts -> 3*top_k cells, well
@@ -103,7 +103,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
         // performance heuristic.
         //
         // Tested 2026-08-11 whether the full-fit rule is too strict at the
-        // margin — a pool at 79% of the working set ought to keep most of the
+        // margin - a pool at 79% of the working set ought to keep most of the
         // reuse. It does not: measured hit rate is 0.0-0.4% at 14 and 19 slots
         // against a 24-cell set, and using the cache there is SLOWER than
         // bypassing it (5.6-6.3 vs 6.8-6.9 tok/s). Below full fit the cache
@@ -160,7 +160,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
 
             const char* src;
             if (!packed.on_device) {
-                // Expert weights offloaded to host — try LRU cache first, then staging
+                // Expert weights offloaded to host - try LRU cache first, then staging
                 // buffer.
                 const char* host_ptr = static_cast<const char*>(packed.data) + offset;
                 if (use_expert_cache) {
@@ -193,7 +193,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
 
         // Helper: try fused quantized GEMV for count=1 decode (dequant+dot in one kernel),
         // else fall back to dequant_expert + cuBLAS gemm.
-        // For host-resident experts: H2D to staging buffer, then fused GEMV on staging —
+        // For host-resident experts: H2D to staging buffer, then fused GEMV on staging -
         // eliminates separate dequant_gpu + cuBLAS gemm overhead.
         auto expert_gemm = [&](const Tensor& a, Tensor& c, const Tensor& packed, QType qtype,
                                const std::vector<Tensor>& fallback,
@@ -258,8 +258,8 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             // Host-resident NVFP4 expert: stage it into the LRU cache's slot
             // pool first, then run the ordinary NVFP4 GEMM against the slot.
             //
-            // Without this the branch below hands `wh.payload.nvfp4.data` —
-            // a HOST pointer for these experts — straight to gemm_nvfp4, which
+            // Without this the branch below hands `wh.payload.nvfp4.data` -
+            // a HOST pointer for these experts - straight to gemm_nvfp4, which
             // dequantises it on the device: an illegal access, and the reason
             // the M>1 fallback died on the 593 MiB expert matrix. #1370 never
             // hit this because its GGUF experts reach dequant_expert's staging
@@ -268,7 +268,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             // WHERE it is staged follows the same working-set rule as the GGUF
             // path above: through the LRU pool when this dispatch fits it,
             // through the single staging buffer when it does not. The bytes
-            // moved are identical either way — what differs is whether the
+            // moved are identical either way - what differs is whether the
             // copies evict anything. A prefill activating every expert asks for
             // 3*n_active cells against slots_per_layer, so using the cache
             // there retains nothing AND throws out the entries decode is about
@@ -280,7 +280,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             // parameter: that one comes from `ly.expert_*_packed`, which stays
             // empty for host-resident NVFP4 layers (Phase 3 only stamps it for
             // device-resident ones). Reading the parameter here would test a
-            // tensor this branch never touches — the same mismatch that made
+            // tensor this branch never touches - the same mismatch that made
             // #1384 and #1403 miss what they were meant to catch.
             if (static_cast<size_t>(eidx) < fallback.size() &&
                 fallback[eidx].qtype == QType::NVFP4) {
@@ -289,7 +289,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                     const auto layout = nvfp4_slot_layout(w.shape[0], w.shape[1] * 2);
 
                     // Whole-layer staging already put this expert on the
-                    // device — read it there and skip the per-expert copies
+                    // device - read it there and skip the per-expert copies
                     // entirely.
                     const StagedProj& sp = staged[std::to_underlying(proj)];
                     if (layer_staged && sp.covers(eidx)) {
@@ -367,12 +367,16 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                         }
                         return;
                     }
-                    IMP_LOG_FATAL(
-                        "MoE legacy fallback: host-resident NVFP4 expert %d on layer %d cannot be "
-                        "staged by either route (needs %zu B; cache slot %zu B, staging buffer "
-                        "%zu B). Continuing would hand a host pointer to a device kernel.",
-                        eidx, layer, layout.slot_bytes(), expert_cache_.slot_size_,
-                        moe_.raw_staging_size);
+                    // IMP_CHECK, not IMP_LOG_FATAL. The comment above says continuing hands a
+                    // HOST pointer to a device kernel, and IMP_LOG_FATAL only LOGS
+                    // (logging.h:58) - so it said so and then did it. Abort rather than
+                    // throw: this is state corruption, not a request that can be failed.
+                    IMP_CHECK(false,
+                              "MoE legacy fallback: host-resident NVFP4 expert %d on layer %d cannot be "
+                              "staged by either route (needs %zu B; cache slot %zu B, staging buffer "
+                              "%zu B). Continuing would hand a host pointer to a device kernel.",
+                              eidx, layer, layout.slot_bytes(), expert_cache_.slot_size_,
+                              moe_.raw_staging_size);
                 }
             }
 
@@ -388,7 +392,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                 nw.packed_data = wh.payload.nvfp4.data;
                 nw.micro_scales = wh.payload.nvfp4.block_scales;
                 // tensor_scale: payload.nvfp4.tensor_scale is a HOST float pointer
-                // (borrowed from wcache_.nvfp4 map entry — stable address). Read directly.
+                // (borrowed from wcache_.nvfp4 map entry - stable address). Read directly.
                 nw.tensor_scale = (wh.payload.nvfp4.tensor_scale != nullptr)
                                       ? *wh.payload.nvfp4.tensor_scale
                                       : 1.0f;
@@ -409,8 +413,8 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                     // loop produces wrong output on Gemma-4 NVFP4 experts even though
                     // it works for Mistral dense decode at the same kernel/dimensions
                     // (see commit message + memory/llm_compressor_phase2_item2…). The
-                    // dense-path mirror — gemm_nvfp4 (NVFP4 → FP16 dequant + cuBLAS
-                    // gemm) — is correct on Gemma-4 and is what Mistral dense prefill
+                    // dense-path mirror - gemm_nvfp4 (NVFP4 → FP16 dequant + cuBLAS
+                    // gemm) - is correct on Gemma-4 and is what Mistral dense prefill
                     // already uses, so route the multi-token expert prefill through
                     // it. Bisected via IMP_EXPERT_NVFP4_DEQUANT_MR=1 on 2026-04-27:
                     // M=1 on gemv_kpar + M>1 on gemm_nvfp4 → "The capital of France
@@ -472,7 +476,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                 // (executor_pre_dequant.cu Phase 0). The legacy fallback below
                 // expects an FP16 weight; calling cuBLAS gemm with qtype=NVFP4
                 // would crash with "unsupported dtype 71". Route through the
-                // native NVFP4 path — same logic as the WeightHandle-driven
+                // native NVFP4 path - same logic as the WeightHandle-driven
                 // has_nvfp4_id branch above.
                 if (b.qtype == QType::NVFP4 && b.scales != nullptr) {
                     NvFP4QuantResult nw;
@@ -539,7 +543,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             size_t expert_raw_sz = static_cast<size_t>(rows) * qtype_row_bytes(qtype, cols);
 
             if (!moe_.batch_dequant_buf || expert_fp16_sz == 0) {
-                // No buffer — serial fallback
+                // No buffer - serial fallback
                 for (int e = 0; e < ne; ++e) {
                     int start = h_offsets[e];
                     int count = h_offsets[e + 1] - start;
@@ -572,7 +576,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
             for (int e = 0; e < ne; ++e)
                 b_ptrs[e] = buf + static_cast<size_t>(e) * expert_fp16_sz;
 
-            // Use cublasGemmGroupedBatchedEx — single call for all experts.
+            // Use cublasGemmGroupedBatchedEx - single call for all experts.
             // We already have h_offsets from D2H sync, so no need for
             // gemm_moe_device_grouped (which does its own D2H sync + 128
             // individual cublasLtMatmul calls).
@@ -593,7 +597,7 @@ void GraphExecutor::run_moe_legacy_fallback_(int layer, cudaStream_t stream, Moe
                                   dequant_gpu_supported(ly.expert_up_packed.qtype));
 
         if (has_precached_up) {
-            // Pre-cached FP16 path — all expert packs in fp16_packed_*_cache
+            // Pre-cached FP16 path - all expert packs in fp16_packed_*_cache
             // ===== PRE-CACHED FP16 BATCHED GEMM PATH =====
             std::vector<const void*> gate_w_ptrs(ne, nullptr);
             std::vector<const void*> up_w_ptrs(ne, nullptr);

--- a/src/exec/executor_forward_moe_nvfp4_host.cu
+++ b/src/exec/executor_forward_moe_nvfp4_host.cu
@@ -6,7 +6,7 @@
 // `idx` becomes a slot index and no kernel changes.
 //
 // NVFP4 experts did not have that path at all. A host-resident placement was
-// loaded and served WRONG — Phase 0 skipped promoting scales onto host weights,
+// loaded and served WRONG - Phase 0 skipped promoting scales onto host weights,
 // the generic GEMM then recognised the scale-less packed weight and returned
 // without multiplying, and the model answered from whichever experts happened
 // to be resident, at exit code 0 (#1403 refused the placement rather than
@@ -15,7 +15,7 @@
 // What is different from the GGUF case, and why it is only different by this
 // much: an NVFP4 expert is TWO byte ranges (packed FP4 weights + FP8 E4M3
 // micro-scales) rather than one. Both are addressed by the same slot index,
-// because the kernels take separate bases and separate strides for them — so a
+// because the kernels take separate bases and separate strides for them - so a
 // slot holding `packed || micro_scales` resolves both at once. The layout
 // arithmetic is in nvfp4_expert_offload.h.
 //
@@ -44,7 +44,7 @@
 
 namespace imp {
 
-// Refuse a placement nothing can serve — the gate #1403 installed, moved to
+// Refuse a placement nothing can serve - the gate #1403 installed, moved to
 // where the answer is actually known.
 //
 // At weight-upload time it was not: whether a host-resident NVFP4 layer can be
@@ -52,7 +52,7 @@ namespace imp {
 // before init_kv_cache). The old gate resolved that by refusing every
 // host-resident NVFP4 placement outright, which was correct while no path
 // existed. Now that one does, re-deriving the cache's sizing at placement time
-// would mean a second copy of that arithmetic — and a copy that drifts is
+// would mean a second copy of that arithmetic - and a copy that drifts is
 // exactly the failure #1384 and #1403 both were.
 //
 // So the check runs here instead, after pre-dequant, against the real tensors
@@ -111,7 +111,7 @@ void GraphExecutor::verify_host_expert_placement() const {
 // Stage one host-resident NVFP4 layer's experts into the device buffer.
 //
 // The per-expert route issues two H2D per expert per projection, ~768 KiB and
-// ~96 KiB — sizes that do not reach PCIe bandwidth. nsys measured 90 759 such
+// ~96 KiB - sizes that do not reach PCIe bandwidth. nsys measured 90 759 such
 // transfers moving 38 GB for one profiling run, with the host inside those
 // calls far longer than the GPU spent transferring. A whole projection at once
 // is the same bytes as ONE transfer of ~110 MiB.
@@ -119,7 +119,7 @@ void GraphExecutor::verify_host_expert_placement() const {
 // That collapse is only possible because the sources are already contiguous:
 // `moe.pin_host_experts` lays a projection's experts into one pinned slab back
 // to back, and a plain mmap usually does the same. Contiguity is CHECKED here
-// rather than assumed — a checkpoint that interleaves its tensors would
+// rather than assumed - a checkpoint that interleaves its tensors would
 // otherwise have its experts silently read from the wrong addresses.
 bool GraphExecutor::stage_nvfp4_layer_(int layer, cudaStream_t stream,
                                        StagedProj out[kExpertProjCount]) {
@@ -227,7 +227,7 @@ bool GraphExecutor::stage_nvfp4_layer_(int layer, cudaStream_t stream,
                                            static_cast<size_t>(ne) * sizeof(float),
                                            cudaMemcpyHostToDevice, stream));
         // The pointer arrays are filled from stack vectors, so this call is
-        // not graph-capturable — which is fine, graphs are already off under
+        // not graph-capturable - which is fine, graphs are already off under
         // host-resident experts.
         out[p].cutlass_ready = true;
     }
@@ -257,7 +257,7 @@ bool GraphExecutor::stage_layer_for_prefill_(int layer, cudaStream_t stream, Moe
 // alpha arrays; this only slices them per projection.
 //
 // Opt-in (moe.staged_cutlass_prefill): the prefill win is large and the decode
-// effect that comes with it is real but unexplained — see dispatch_policy.h.
+// effect that comes with it is real but unexplained - see dispatch_policy.h.
 bool GraphExecutor::build_staged_device_args_(
     const MoeFfnContext& ctx, bool non_gated,
     MoEWorkspace::PerLayerNvfp4DeviceArgsCache& out) const {
@@ -325,7 +325,7 @@ void GraphExecutor::run_moe_decode_nvfp4_host(int layer, cudaStream_t stream, in
     half* down_buf = static_cast<half*>(moe_.expert_down.data);   // [top_k, d]
 
     // Establishing residency needs the routing on the host, so this path pays
-    // one D2H + sync per layer — the same one the GGUF slot path pays, and the
+    // one D2H + sync per layer - the same one the GGUF slot path pays, and the
     // reason CUDA graphs stay disabled under host-resident experts.
     moe_host_args_capture_guard(stream);
     std::vector<int32_t> h_experts(top_k);
@@ -371,10 +371,14 @@ void GraphExecutor::run_moe_decode_nvfp4_host(int layer, cudaStream_t stream, in
         // precondition, and staging can only fail on an out-of-range expert
         // id. Falling through would hand a HOST pointer to a kernel, so say so
         // instead.
-        IMP_LOG_FATAL(
-            "MoE NVFP4 host decode: experts could not be staged into the LRU pool (layer %d, "
-            "top_k %d, slots/layer %d). The dispatch predicate and this path have diverged.",
-            layer, top_k, expert_cache_.slots_per_layer_);
+        // IMP_CHECK, not IMP_LOG_FATAL. The comment above says continuing hands a
+        // HOST pointer to a device kernel, and IMP_LOG_FATAL only LOGS
+        // (logging.h:58) - so it said so and then did it. Abort rather than
+        // throw: this is state corruption, not a request that can be failed.
+        IMP_CHECK(false,
+                  "MoE NVFP4 host decode: experts could not be staged into the LRU pool (layer %d, "
+                  "top_k %d, slots/layer %d). The dispatch predicate and this path have diverged.",
+                  layer, top_k, expert_cache_.slots_per_layer_);
     }
 
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(moe_.d_slot_idx, h_slots.data(),
@@ -405,7 +409,7 @@ void GraphExecutor::run_moe_decode_nvfp4_host(int layer, cudaStream_t stream, in
                       slots_per_layer, eff, d);
         // gate and up sit in DIFFERENT slots, so the one-index fused gate+up
         // kernel cannot express both. Two decodes still collapse 2*top_k
-        // weight launches into 2 — the same trade the GGUF slot path makes.
+        // weight launches into 2 - the same trade the GGUF slot path makes.
         gemv_nvfp4_moe_decode(gate_view, gate_idx, norm_ptr, gate_buf, eff, d, /*x_stride=*/0, top_k,
                               stream);
         gemv_nvfp4_moe_decode(up_view, up_idx, norm_ptr, up_buf, eff, d, /*x_stride=*/0, top_k, stream);

--- a/src/exec/expert_cache.cu
+++ b/src/exec/expert_cache.cu
@@ -50,7 +50,7 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
 
     // The per-slot NVFP4 scale mirror rides at the END of the pool rather than
     // in an allocation of its own. Same lifetime, one acquisition instead of
-    // two — and this file is on the I1 allowlist (tools/alloc_allowlist.txt),
+    // two - and this file is on the I1 allowlist (tools/alloc_allowlist.txt),
     // which only ever shrinks, so a second cudaMalloc/cudaFree pair here would
     // be a regression of that invariant for no benefit.
     const size_t slot_bytes_total = static_cast<size_t>(n_slots_) * slot_size_;
@@ -82,7 +82,7 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         plru.lookup.reserve(slots_per_layer_ * 2);
 
     // Phase 4: per-layer access history ring. Capacity = slots_per_layer ×
-    // kExpertProjCount × 2 — a heuristic giving ~2 tokens worth of memory
+    // kExpertProjCount × 2 - a heuristic giving ~2 tokens worth of memory
     // per layer (each token touches up to top_k experts × 3 projs).
     history_capacity_ = std::max(8, slots_per_layer_ * kExpertProjCount * 2);
     per_layer_history_.assign(n_layers_, PerLayerAccessRing{});
@@ -90,10 +90,10 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         ring.entries.assign(history_capacity_, {-1, -1});
 
     // Prefetch stream + per-layer completion events. Skipped if cudaStream
-    // creation fails — prefetch APIs become no-ops in that case.
+    // creation fails - prefetch APIs become no-ops in that case.
     cudaError_t serr = cudaStreamCreateWithFlags(&prefetch_stream_, cudaStreamNonBlocking);
     if (serr != cudaSuccess) {
-        IMP_LOG_WARN("Expert LRU cache: prefetch_stream alloc failed (%s) — Phase 4 disabled",
+        IMP_LOG_WARN("Expert LRU cache: prefetch_stream alloc failed (%s) - Phase 4 disabled",
                      cudaGetErrorString(serr));
         prefetch_stream_ = nullptr;
     } else {
@@ -120,7 +120,7 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
     // Only built under debug_parity_. NOTHING on the device reads it: the plan
     // was for dispatch kernels to resolve slots from it, but the host-offload
     // decode path (#1370) instead derives the slot from get_or_load's returned
-    // pointer, which leaves the mirror write-only in production — two extra
+    // pointer, which leaves the mirror write-only in production - two extra
     // 4-byte cudaMemcpyAsync per cache miss maintaining a structure with no
     // consumer. Its only reader is check_parity(), which is a debug facility.
     // If a kernel ever does read it, re-enable maintenance in get_or_load and
@@ -131,18 +131,18 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         cudaError_t err = cudaMalloc(reinterpret_cast<void**>(&d_lookup_), bytes);
         if (err != cudaSuccess || !d_lookup_) {
             IMP_LOG_WARN(
-                "Expert LRU cache: device-side mirror alloc failed (%zu bytes, err=%s) — "
+                "Expert LRU cache: device-side mirror alloc failed (%zu bytes, err=%s) - "
                 "disabling mirror, host-side LRU still functional.",
                 bytes, cudaGetErrorString(err));
             d_lookup_ = nullptr;
         } else {
-            // (int32_t)-1 = 0xFFFFFFFF — memset 0xFF gives -1 in every cell.
+            // (int32_t)-1 = 0xFFFFFFFF - memset 0xFF gives -1 in every cell.
             IMP_CUDA_CHECK_LOG(cudaMemset(d_lookup_, 0xFF, bytes));
         }
     }
 
     // Per-slot tensor-scale mirror. Unlike d_lookup_ above this one IS read on
-    // the device — the fused NVFP4 kernels index it with the slot number the
+    // the device - the fused NVFP4 kernels index it with the slot number the
     // dispatch feeds them as `expert_indices`. Zero-init so a slot that is
     // read before it is filled contributes 0 rather than a stale scale; the
     // dispatch cannot produce that ordering, but a zero is a recognisable
@@ -153,16 +153,16 @@ bool ExpertLRUCache::init(size_t max_expert_raw, size_t budget_bytes, VRAMAlloca
         IMP_CUDA_CHECK_LOG(cudaMemset(d_slot_scales_, 0, scale_bytes));
     }
 
-    // Host-side tables — used in production regardless of the mirror above.
+    // Host-side tables - used in production regardless of the mirror above.
     if (n_experts_ > 0) {
         // Host source-pointer table: [layer][proj * n_experts + expert].
-        // Lazy-populated by get_or_load() — the value is stable for the
+        // Lazy-populated by get_or_load() - the value is stable for the
         // model's lifetime once stamped.
         host_expert_addrs_.assign(n_layers_,
                                   std::vector<const void*>(static_cast<size_t>(kExpertProjCount) *
                                                               n_experts_,
                                                           nullptr));
-        // Canonical packed_ptr per (layer, proj) — the prefetcher needs this to
+        // Canonical packed_ptr per (layer, proj) - the prefetcher needs this to
         // rebuild cache keys that match dispatch's get_or_load calls.
         host_packed_ptrs_.assign(static_cast<size_t>(n_layers_) * kExpertProjCount, nullptr);
         // Per-(layer, proj) expert byte size. Avoids overflowing pinned host
@@ -184,7 +184,7 @@ inline int flat_slot(int layer, int slot_in_layer, int slots_per_layer) {
 }
 
 // Write a single int32 cell to the device-side lookup mirror.
-// Async on the supplied stream — Phase 3 mirror is write-only from the
+// Async on the supplied stream - Phase 3 mirror is write-only from the
 // engine's perspective; ordering against subsequent kernels is whatever
 // the stream provides.
 inline void write_lookup_cell(int* d_lookup, int n_experts, int layer, int proj, int expert,
@@ -237,14 +237,14 @@ ExpertLRUCache::Slot* ExpertLRUCache::acquire_slot_(int layer, int proj_idx, Exp
         if (off < table.size())
             table[off] = src_host;
     }
-    // Stamp the canonical packed_ptr per (layer, proj) — Phase 4 needs it
+    // Stamp the canonical packed_ptr per (layer, proj) - Phase 4 needs it
     // to rebuild keys for prefetch_layer.
     if (!host_packed_ptrs_.empty()) {
         size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj_idx;
         if (pp_off < host_packed_ptrs_.size())
             host_packed_ptrs_[pp_off] = key.packed_ptr;
     }
-    // Stamp the per-(layer, proj) expert byte size — prefetch must use this
+    // Stamp the per-(layer, proj) expert byte size - prefetch must use this
     // (not slot_size_) to avoid reading past the pinned host region.
     if (!host_expert_bytes_.empty()) {
         size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj_idx;
@@ -262,13 +262,19 @@ ExpertLRUCache::Slot* ExpertLRUCache::acquire_slot_(int layer, int proj_idx, Exp
             ++ring.filled;
     }
 
-    // Check cache hit — find() handles per-layer LRU front-update. Hits
+    // Check cache hit - find() handles per-layer LRU front-update. Hits
     // don't change which slot holds (layer, proj, expert), so the device
     // mirror cell remains correct.
     void* cached = find(layer, key);
     if (cached) {
+        // IMP_CHECK, not a bare call: both call sites used to DISCARD the
+        // verdict, so the parity checker detected a host/device divergence,
+        // logged it at FATAL (which does not abort - logging.h:58) and
+        // returned false into nothing. A debug facility that finds the
+        // invariant break and then continues is not a facility. The header
+        // documented this as "aborts on mismatch"; now it does.
         if (debug_parity_)
-            check_parity(stream);
+            IMP_CHECK(check_parity(stream), "ExpertLRUCache: parity check failed (cache hit path)");
         *hit = true;
         auto it = plru.lookup.find(key);
         return &slots_[flat_slot(layer, it->second.first, slots_per_layer_)];
@@ -314,7 +320,7 @@ ExpertLRUCache::Slot* ExpertLRUCache::acquire_slot_(int layer, int proj_idx, Exp
         write_lookup_cell(d_lookup_, n_experts_, layer, proj_idx, key.expert_idx, slot_in_layer, stream);
 
     if (debug_parity_)
-        check_parity(stream);
+        IMP_CHECK(check_parity(stream), "ExpertLRUCache: parity check failed (slot fill path)");
 
     return &slot;
 }
@@ -327,11 +333,15 @@ void* ExpertLRUCache::get_or_load(int layer, ExpertProj proj, ExpertCacheKey key
         // it from a single range would leave the scales as whatever the
         // previous occupant left behind, which decodes to fluent nonsense
         // rather than failing. Refuse where the two paths disagree.
-        IMP_LOG_FATAL(
-            "ExpertLRUCache::get_or_load called on an NVFP4 slot pool (layer %d) — "
-            "this pool's slots carry packed weights + micro-scales and must be filled "
-            "via get_or_load_nvfp4().",
-            layer);
+        // IMP_CHECK, not IMP_LOG_FATAL: the latter only LOGS (logging.h:58), so this
+        // reported the wrong-API call and then made it anyway. Abort rather than throw -
+        // expert_cache.h:273 documents this contract as aborting on mismatch, and a
+        // wrong-API call is a programming error, not a request that can be failed.
+        IMP_CHECK(false,
+                  "ExpertLRUCache::get_or_load called on an NVFP4 slot pool (layer %d) - "
+                  "this pool's slots carry packed weights + micro-scales and must be filled "
+                  "via get_or_load_nvfp4().",
+                  layer);
     }
     bool hit = false;
     Slot* slot = acquire_slot_(layer, std::to_underlying(proj), key, src_host, expert_bytes, stream, &hit);
@@ -348,16 +358,19 @@ void* ExpertLRUCache::get_or_load_nvfp4(int layer, ExpertProj proj, ExpertCacheK
                                         const void* src_ms, size_t ms_bytes, size_t ms_off,
                                         float tensor_scale, cudaStream_t stream) {
     if (!nvfp4_slots_ || !d_slot_scales_) {
-        IMP_LOG_FATAL(
-            "ExpertLRUCache::get_or_load_nvfp4 called on a pool that was not initialised for "
-            "NVFP4 slots (layer %d) — there is no per-slot scale mirror to write.",
-            layer);
+        // Same class: reported, then proceeded.
+        IMP_CHECK(false,
+                  "ExpertLRUCache::get_or_load_nvfp4 called on a pool that was not initialised for "
+                  "NVFP4 slots (layer %d) - there is no per-slot scale mirror to write.",
+                  layer);
     }
     if (ms_off + ms_bytes > slot_size_ || packed_bytes > ms_off) {
-        IMP_LOG_FATAL(
-            "ExpertLRUCache::get_or_load_nvfp4: layout does not fit the slot (layer %d, "
-            "packed %zu B, ms_off %zu, ms %zu B, slot %zu B).",
-            layer, packed_bytes, ms_off, ms_bytes, slot_size_);
+        // The sharpest of the four: it declared that the layout does not fit the slot
+        // and then filled the slot anyway.
+        IMP_CHECK(false,
+                  "ExpertLRUCache::get_or_load_nvfp4: layout does not fit the slot (layer %d, "
+                  "packed %zu B, ms_off %zu, ms %zu B, slot %zu B).",
+                  layer, packed_bytes, ms_off, ms_bytes, slot_size_);
     }
     bool hit = false;
     Slot* slot = acquire_slot_(layer, std::to_underlying(proj), key, src_packed, packed_bytes, stream,
@@ -368,13 +381,15 @@ void* ExpertLRUCache::get_or_load_nvfp4(int layer, ExpertProj proj, ExpertCacheK
     if (hit) {
         // The dispatch derives the kernel's micro_scales base from its own copy
         // of the layout. If that ever stops matching what this slot was filled
-        // with, the kernel reads scales from the wrong offset — coherent-looking
+        // with, the kernel reads scales from the wrong offset - coherent-looking
         // and wrong. Assert the agreement instead of assuming it.
         if (slot->ms_off != ms_off) {
-            IMP_LOG_FATAL(
-                "ExpertLRUCache: slot layout disagreement on layer %d expert %d — slot was "
-                "filled with ms_off %zu, dispatch now says %zu.",
-                layer, key.expert_idx, slot->ms_off, ms_off);
+            // Returned slot->gpu_ptr after declaring the slot's layout wrong, i.e. handed
+            // out a pointer it had just said was unusable.
+            IMP_CHECK(false,
+                      "ExpertLRUCache: slot layout disagreement on layer %d expert %d - slot was "
+                      "filled with ms_off %zu, dispatch now says %zu.",
+                      layer, key.expert_idx, slot->ms_off, ms_off);
         }
         return slot->gpu_ptr;
     }
@@ -386,7 +401,7 @@ void* ExpertLRUCache::get_or_load_nvfp4(int layer, ExpertProj proj, ExpertCacheK
         cudaMemcpyAsync(dst + ms_off, src_ms, ms_bytes, cudaMemcpyHostToDevice, stream));
     slot->ms_off = ms_off;
 
-    // The scale mirror is indexed by the layer-relative slot index — the same
+    // The scale mirror is indexed by the layer-relative slot index - the same
     // number the dispatch hands the kernels as `expert_indices`.
     const int slot_in_layer = static_cast<int>(
         (static_cast<char*>(slot->gpu_ptr) - static_cast<char*>(pool_)) / slot_size_) -
@@ -436,7 +451,7 @@ int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes_fal
         considered.push_back({proj, expert});
 
         // Rebuild the cache key from the canonical packed_ptr stamped by
-        // get_or_load — this guarantees prefetched entries are found by
+        // get_or_load - this guarantees prefetched entries are found by
         // subsequent dispatch lookups that use the same packed.data.
         size_t pp_off = static_cast<size_t>(layer) * kExpertProjCount + proj;
         if (pp_off >= host_packed_ptrs_.size())
@@ -487,7 +502,7 @@ int ExpertLRUCache::prefetch_layer(int layer, int top_k, size_t expert_bytes_fal
 
         const int flat = flat_slot(layer, slot_in_layer, slots_per_layer_);
         Slot& slot = slots_[flat];
-        // Prefer the per-(layer, proj) byte size — using slot_size_ as the
+        // Prefer the per-(layer, proj) byte size - using slot_size_ as the
         // fallback overflows for smaller projections and produces a CUDA
         // "invalid argument" on pinned-but-narrower host regions.
         size_t copy_bytes = expert_bytes_fallback;
@@ -540,7 +555,7 @@ bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
     std::vector<int> host(cells, -1);
 
     // Re-derive the expected device-mirror state from the authoritative
-    // host-side slot table — this is what every "+1 every update" path
+    // host-side slot table - this is what every "+1 every update" path
     // should converge to. Cell value is layer-relative slot_idx.
     for (size_t flat = 0; flat < slots_.size(); ++flat) {
         const Slot& slot = slots_[flat];
@@ -577,7 +592,7 @@ bool ExpertLRUCache::check_parity(cudaStream_t stream) const {
             int expert = rest % n_experts_;
             IMP_LOG_FATAL(
                 "ExpertLRUCache parity check failed at (layer=%d, proj=%d, expert=%d): "
-                "host=%d device=%d. The host-side LRU and device-side mirror have diverged — "
+                "host=%d device=%d. The host-side LRU and device-side mirror have diverged - "
                 "Phase 3 invariant broken.",
                 layer, proj, expert, host[i], dev[i]);
             return false;
@@ -604,7 +619,7 @@ void ExpertLRUCache::destroy() {
         cudaFree(d_lookup_);
         d_lookup_ = nullptr;
     }
-    // d_slot_scales_ points into pool_, freed above — nothing of its own.
+    // d_slot_scales_ points into pool_, freed above - nothing of its own.
     d_slot_scales_ = nullptr;
     nvfp4_slots_ = false;
     if (!prefetch_done_.empty()) {

--- a/src/exec/expert_cache.h
+++ b/src/exec/expert_cache.h
@@ -270,7 +270,10 @@ struct ExpertLRUCache {
     // assert every cell matches the host-side LRU state. Returns true on
     // match. When `debug_parity_` is enabled, get_or_load() runs this after
     // every cache mutation and bumps `parity_checks_ok_` on success / aborts
-    // (via IMP_LOG_FATAL) on mismatch. Tests can call it directly.
+    // (via IMP_CHECK) on mismatch. Tests can call it directly.
+    // Said IMP_LOG_FATAL until 2026-08-21, and that was a promise the macro
+    // does not keep: IMP_LOG_FATAL only logs (logging.h:58). The contract
+    // described here is now the one the code implements.
     bool check_parity(cudaStream_t stream) const;
 };
 

--- a/src/exec/weight_handle.h
+++ b/src/exec/weight_handle.h
@@ -22,9 +22,15 @@ public:
     // C++23 deducing this: one overload serves const and non-const callers.
     template <typename Self>
     auto&& handle(this Self&& self, TensorID id) {
-        if (id < 0 || id >= static_cast<TensorID>(self.handles_.size())) {
-            IMP_LOG_FATAL("WeightRegistry::handle: id %d out of range [0, %zu)", id, self.handles_.size());
-        }
+        // IMP_CHECK, not IMP_LOG_FATAL: the latter only LOGS (logging.h:58),
+        // so this used to report "out of range" and then index out of range
+        // anyway. Abort rather than throw, for two reasons specific to this
+        // site: it is a precondition on an accessor called from inside
+        // CUDA-graph capture regions, where unwinding is not a recovery, and
+        // an out-of-range TensorID means the registry and its caller disagree
+        // about identity - there is nothing to return.
+        IMP_CHECK(id >= 0 && id < static_cast<TensorID>(self.handles_.size()),
+                  "WeightRegistry::handle: id %d out of range [0, %zu)", id, self.handles_.size());
         return self.handles_[id];
     }
     size_t size() const { return handles_.size(); }

--- a/tests/test_weight_dispatch.cu
+++ b/tests/test_weight_dispatch.cu
@@ -904,3 +904,80 @@ TEST_F(WeightDispatchTest, MXFP4_GemvMatchesDirect) {
     cudaFree(d_y_direct);
     cudaFree(d_y_disp);
 }
+
+// ===========================================================================
+// The IMP_LOG_FATAL class
+//
+// IMP_LOG_FATAL only LOGS (logging.h:58); IMP_CHECK is the only thing that
+// reaches std::abort(). Of the 12 sites in the tree, ten logged at FATAL and
+// then carried on - three of them after a comment saying that carrying on
+// hands a host pointer to a device kernel. These two are the dispatch pair:
+// they returned leaving the output tensor holding whatever it held before.
+// tools/check_log_fatal.py keeps the count at zero.
+// ===========================================================================
+
+TEST_F(WeightDispatchTest, GemmDispatchRefusesAnInvalidTierInsteadOfReturningQuietly) {
+    const int M = 8, K = 32;
+    half *d_x = nullptr, *d_y = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_x, static_cast<size_t>(K) * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, static_cast<size_t>(M) * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_x, 0, static_cast<size_t>(K) * sizeof(half)), cudaSuccess);
+    // A sentinel the old behaviour would have left in place and called a result.
+    ASSERT_EQ(cudaMemset(d_y, 0xAB, static_cast<size_t>(M) * sizeof(half)), cudaSuccess);
+
+    WeightHandle h;
+    h.kind = TensorKind::WQ;
+    h.primary_tier = StorageTier::FP32;  // no GEMM path serves it
+    h.shape[0] = M;
+    h.shape[1] = K;
+
+    int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_t(d_y, QType::F16, 2, yshape, true);
+
+    EXPECT_THROW(gemm_dispatch(lt_, h, x_t, y_t, 1.0f, 0.0f, workspace_, kWorkspaceBytes, stream_),
+                 std::runtime_error);
+    EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    std::vector<uint16_t> host(M);
+    ASSERT_EQ(cudaMemcpy(host.data(), d_y, host.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    for (int i = 0; i < M; ++i)
+        EXPECT_EQ(host[i], 0xABAB) << "the refusing path wrote to the output";
+
+    cudaFree(d_x);
+    cudaFree(d_y);
+}
+
+TEST_F(WeightDispatchTest, GemvDispatchDefaultRefusesInsteadOfReturningQuietly) {
+    // The `default:` is the branch that catches a tier nobody anticipated,
+    // which is exactly where an unwritten output is least affordable.
+    const int M = 8, K = 32;
+    half *d_x = nullptr, *d_y = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_x, static_cast<size_t>(K) * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, static_cast<size_t>(M) * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_x, 0, static_cast<size_t>(K) * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_y, 0xAB, static_cast<size_t>(M) * sizeof(half)), cudaSuccess);
+
+    WeightHandle h;
+    h.kind = TensorKind::WQ;
+    h.primary_tier = StorageTier::FP32;
+    h.shape[0] = M;
+    h.shape[1] = K;
+
+    int64_t xshape[2] = {1, K}, yshape[2] = {M, 1};
+    Tensor x_t(d_x, QType::F16, 2, xshape, true);
+    Tensor y_t(d_y, QType::F16, 2, yshape, true);
+
+    EXPECT_THROW(gemv_dispatch(h, x_t, y_t, stream_), std::runtime_error);
+    EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    std::vector<uint16_t> host(M);
+    ASSERT_EQ(cudaMemcpy(host.data(), d_y, host.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    for (int i = 0; i < M; ++i)
+        EXPECT_EQ(host[i], 0xABAB) << "the refusing path wrote to the output";
+
+    cudaFree(d_x);
+    cudaFree(d_y);
+}

--- a/tools/check_log_fatal.py
+++ b/tools/check_log_fatal.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Fail when a site logs at FATAL and then carries on as if nothing happened.
+
+WHY THIS EXISTS
+---------------
+`IMP_LOG_FATAL` sounds like it ends the process. It does not. `logging.h:58`
+makes it a plain `log_message(LogLevel::FATAL, ...)` call; `IMP_CHECK`
+(`logging.h:68-74`) is the only thing in the tree that reaches `std::abort()`,
+and its own comment says so. So the macro's name promises what only its sibling
+delivers, and every site that wrote `IMP_LOG_FATAL(...)` expecting the process
+to stop got a log line instead.
+
+Measured 2026-08-21: of 12 sites, **ten continued wrongly**. Three of them said
+so in their own comments first - "Continuing would hand a host pointer to a
+device kernel", "say so loudly rather than fall through" - and then fell
+through. One reported `WeightRegistry::handle: id out of range` and indexed out
+of range on the next line. Two returned from a dispatch leaving the output
+tensor holding whatever it held before, which is the shape #654 removed from
+attention_prefill_dispatch (SETTLED.md S-22).
+
+The failure is not that people wrote the wrong macro. It is that the wrong macro
+is indistinguishable from the right one at the call site, so a reviewer reading
+"FATAL" reads "stops here".
+
+WHAT IT CHECKS
+--------------
+For each `IMP_LOG_FATAL(...)` call outside `logging.h`, what the code does next:
+
+    aborts   -> the statement is followed by std::abort()
+    throws   -> ... by a throw
+    returns  -> ... by a return, which is only correct where the function's
+                contract IS to report a verdict rather than to stop
+    falls    -> nothing: control continues into the operation just declared
+                impossible
+
+`aborts` and `throws` pass. `returns` and `falls` must be justified in
+`tools/log_fatal_allowlist.txt` with a reason, and a stale entry fails too, so
+the list cannot rot in either direction.
+
+Entries are keyed on `path:<first words of the message>`, NOT on a line number.
+The first version used line numbers and immediately rotted: adding four comment
+lines above a site moved it 587 -> 593 and the gate reported both an
+unjustified site and a stale entry for the same unchanged code. A message
+prefix survives edits above it and says at a glance which site is meant.
+
+The check is deliberately syntactic and shallow. It cannot know whether a
+`return` is correct; that is what the allowlist reason is for. What it CAN do is
+make a new one impossible to add silently, which is the whole defect.
+
+Usage:
+    python3 tools/check_log_fatal.py           # gate
+    python3 tools/check_log_fatal.py --list    # every site with its verdict
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+ROOTS = ("src", "tools", "include")
+EXTS = (".cpp", ".cu", ".h", ".cuh", ".hpp")
+ALLOWLIST = ROOT / "tools" / "log_fatal_allowlist.txt"
+
+
+def classify(lines, i):
+    """What happens after the IMP_LOG_FATAL statement starting at line index i."""
+    depth, j, started = 0, i, False
+    while j < len(lines):
+        depth += lines[j].count("(") - lines[j].count(")")
+        if "(" in lines[j]:
+            started = True
+        if started and depth <= 0:
+            break
+        j += 1
+    for k in range(j + 1, min(j + 6, len(lines))):
+        t = lines[k].strip()
+        if not t or t.startswith("//"):
+            continue
+        if t.startswith("std::abort") or t.startswith("abort()"):
+            return "aborts"
+        if t.startswith("throw"):
+            return "throws"
+        if t.startswith("return"):
+            return "returns"
+        if t == "}":
+            continue  # closing the `if` the log sits in; keep looking
+        return "falls"
+    return "falls"
+
+
+def message_key(lines, i):
+    """First few words of the log message: a key that survives edits above it."""
+    depth, j, started, text = 0, i, False, []
+    while j < len(lines):
+        text.append(lines[j])
+        depth += lines[j].count("(") - lines[j].count(")")
+        if "(" in lines[j]:
+            started = True
+        if started and depth <= 0:
+            break
+        j += 1
+    m = re.search(r'"([^"]{4,})"', "\n".join(text))
+    return " ".join(m.group(1).split()[:5]) if m else f"line{i + 1}"
+
+
+def load_allowlist():
+    entries = {}
+    if not ALLOWLIST.exists():
+        return entries
+    for lineno, raw in enumerate(ALLOWLIST.read_text().split("\n"), 1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, reason = line.partition("#")
+        key = key.strip()
+        if not reason.strip():
+            print(f"ERROR {ALLOWLIST.name}:{lineno}: entry {key!r} has no reason", file=sys.stderr)
+            sys.exit(2)
+        entries[key] = reason.strip()
+    return entries
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true")
+    args = ap.parse_args()
+
+    sites = []
+    for r in ROOTS:
+        for p in sorted((ROOT / r).rglob("*")):
+            if p.suffix not in EXTS or "build" in p.parts or p.name == "logging.h":
+                continue
+            lines = p.read_text(errors="ignore").split("\n")
+            for i, l in enumerate(lines):
+                if "IMP_LOG_FATAL(" in l and not l.lstrip().startswith("//"):
+                    sites.append((str(p.relative_to(ROOT)), i + 1, classify(lines, i),
+                                  message_key(lines, i)))
+
+    allow = load_allowlist()
+    bad = [s for s in sites if s[2] in ("returns", "falls") and f"{s[0]}:{s[3]}" not in allow]
+    listed = {f"{s[0]}:{s[3]}" for s in sites if s[2] in ("returns", "falls")}
+    stale = [k for k in allow if k not in listed]
+
+    if args.list:
+        for rel, ln, v, key in sites:
+            print(f"  {v:8s} {rel}:{ln}  key={key!r}")
+
+    print(f"log-fatal: {len(sites)} IMP_LOG_FATAL site(s), "
+          f"{sum(1 for s in sites if s[2] == 'aborts')} abort, "
+          f"{sum(1 for s in sites if s[2] == 'throws')} throw, "
+          f"{len(listed)} continue ({len(allow)} allowlisted)")
+    for rel, ln, v, key in bad:
+        print(f"CONTINUES-WRONGLY {rel}:{ln}  logs at FATAL and then {v}")
+        print(f"                  allowlist key if this is correct: {rel}:{key}")
+    for k in stale:
+        print(f"STALE allowlist entry (the site no longer continues, remove it): {k}")
+    if bad or stale:
+        print("\nIMP_LOG_FATAL only LOGS. Use IMP_CHECK to abort, or throw "
+              "(imp_api.cpp translates to ImpError), or justify the site in "
+              f"{ALLOWLIST.name} with the reason continuing is correct.")
+        return 1
+    print("OK - no site logs at FATAL and then carries on unjustified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -126,7 +126,7 @@ def main():
                     help="expected unlaned macro count (default: read PINNED below)")
     args = ap.parse_args()
 
-    PINNED = 972
+    PINNED = 974
 
     text = CMAKE.read_text()
     mods = module_sources(text)

--- a/tools/log_fatal_allowlist.txt
+++ b/tools/log_fatal_allowlist.txt
@@ -1,0 +1,11 @@
+# Sites that log at FATAL and then continue, where continuing is CORRECT.
+#
+# IMP_LOG_FATAL only logs (logging.h:58); IMP_CHECK is what aborts. So a site
+# that logs and continues is a defect unless the function's contract is to
+# report a verdict rather than to stop. Format: `path:line  # reason`. The
+# reason is mandatory and a stale entry fails the gate, so the list cannot rot
+# in either direction.
+#
+# Line numbers move. When one does, the gate reports the site as unjustified
+# rather than silently accepting it, which is the safe direction.
+src/exec/expert_cache.cu:ExpertLRUCache parity check failed at  # check_parity() RETURNS its verdict, which is correct for a function whose contract is to report agreement: tests call it directly and want the bool. What was NOT correct is that both production callers DISCARDED it - a debug facility that detects the host/device divergence and then continues is not a facility. They now wrap it in IMP_CHECK, so a mismatch aborts as expert_cache.h always claimed.


### PR DESCRIPTION
`IMP_LOG_FATAL` sounds like it ends the process. It does not. `logging.h:58` makes it a plain `log_message(LogLevel::FATAL, ...)` call; `IMP_CHECK` (`logging.h:68-74`) is the only thing in the tree that reaches `std::abort()`, and its own comment says so.

The failure is not that people wrote the wrong macro. It is that **the wrong macro is indistinguishable from the right one at the call site**, so a reviewer reading "FATAL" reads "stops here".

## Census: all 12 sites, and what each did next

| site | after the log | |
|---|---|---|
| `pre_dequant_phase4_tensor_registry.cu:550` | `std::abort()` | correct |
| `weight_handle.h:26` | `return self.handles_[id]` | **reported the id is out of range, then indexed out of range** |
| `weight_dispatch.cu:281` | `return` | output tensor left holding whatever it held |
| `weight_dispatch.cu:392` | `return` | same, and it is the `default:` - the branch that catches a tier nobody anticipated |
| `expert_cache.cu:330,351,357` | falls through | `:357` said the layout does not fit the slot, then filled the slot |
| `expert_cache.cu:374` | `return slot->gpu_ptr` | returned a pointer it had just called unusable |
| `expert_cache.cu:578` | `return false` | correct in itself - **see below** |
| `executor_forward_moe_batch.cu:1107` | falls through | its own comment: *"the fall-through would hand a HOST pointer to a device kernel"* |
| `executor_forward_moe_legacy.cu:370` | falls through | *"Continuing would hand a host pointer to a device kernel"* |
| `executor_forward_moe_nvfp4_host.cu:374` | falls through | *"Falling through would hand a HOST pointer to a kernel, so say so instead"* |

**Ten continued wrongly.** Three of them say what the danger is, in their own comments, immediately before doing it.

## Fixed per site, because a dispatch failure and a cache invariant are not the same call

**Throw (2)** - the dispatch pair. Request-level: `imp_api.cpp` translates to `ImpError` and the server answers instead of dying. Also matches what #1508 did to the `CUTLASS_NVFP4` case in the same function, so `gemv_dispatch` is now internally consistent rather than half-throwing.

**Abort via `IMP_CHECK` (8)**:
- `weight_handle.h` - a precondition on an accessor called from inside CUDA-graph capture regions, where unwinding is not a recovery, and an out-of-range `TensorID` means the registry and its caller disagree about identity. There is nothing to return.
- `expert_cache` x4 - `expert_cache.h:273` already documented this contract as *"aborts on mismatch"*.
- MoE x3 - state corruption, not a request that can be failed cleanly.

## The one I found by correcting a comment, not by the census

`check_parity()` returning `false` is the **right** contract: it exists to report whether the host LRU and the device mirror agree, and tests call it directly for that bool.

What was not right is that **both production callers invoked it as a bare statement and discarded the verdict**. So with `moe.expert_cache_debug_parity` on, the facility detected the divergence, logged it at FATAL, returned `false` into nothing, and carried on - while the header said it aborts. Both callers now wrap it in `IMP_CHECK`.

I would have allowlisted this site as correct if I had not gone to fix the comment that names the wrong macro.

## The gate, red then green

```
$ python3 tools/check_log_fatal.py          # pre-fix tree
log-fatal: 12 IMP_LOG_FATAL site(s), 1 abort, 0 throw, 11 continue (1 allowlisted)
CONTINUES-WRONGLY src/compute/weight_dispatch.cu:281  logs at FATAL and then returns
CONTINUES-WRONGLY src/compute/weight_dispatch.cu:392  logs at FATAL and then returns
CONTINUES-WRONGLY src/exec/executor_forward_moe_batch.cu:1107  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/executor_forward_moe_legacy.cu:370  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/executor_forward_moe_nvfp4_host.cu:374  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/expert_cache.cu:330  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/expert_cache.cu:351  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/expert_cache.cu:357  logs at FATAL and then falls
CONTINUES-WRONGLY src/exec/expert_cache.cu:374  logs at FATAL and then returns
CONTINUES-WRONGLY src/exec/expert_cache.cu:578  logs at FATAL and then returns
CONTINUES-WRONGLY src/exec/weight_handle.h:26  logs at FATAL and then returns
EXIT=1

$ python3 tools/check_log_fatal.py          # after
log-fatal: 2 IMP_LOG_FATAL site(s), 1 abort, 0 throw, 1 continue (1 allowlisted)
OK - no site logs at FATAL and then carries on unjustified.
EXIT=0
```

**Keyed on the log message, not on a line number.** The first version keyed on lines and rotted inside the same session: adding four comment lines above a site moved it 587 -> 593, and the gate then reported both an unjustified site *and* a stale allowlist entry for code that had not changed. A message prefix survives edits above it and says at a glance which site is meant.

## Tests

Same shape #1508 established - sentinel in the output, assert the throw, assert the sentinel survives, so a caller that swallows the exception still cannot read the buffer as a result:

```
[ OK ] WeightDispatchTest.GemmDispatchRefusesAnInvalidTierInsteadOfReturningQuietly
[ OK ] WeightDispatchTest.GemvDispatchDefaultRefusesInsteadOfReturningQuietly
```

**The eight abort sites are not covered by tests**, and I am stating that rather than implying coverage: they are `IMP_CHECK`, so exercising one ends the process, and reaching them needs a corrupted dispatch predicate a test would have to fabricate. The gate is what holds them.

## Gate

`make verify-fast` green: own peak VRAM 20718 MiB (+0.01 %), graphs ON 2.37x, smoke prompt coherent, perf within threshold. `make dev-test` 5/5. All five source gates green. `check_test_lanes` re-pinned 972 -> 974 for the two new GPU-lane tests, deliberately and in this commit.

Ledger updated with the census as a closed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)