### PR TITLE
audit: a kernel whose only caller was its own test (find-stubs rung 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A kernel whose only caller was its own test.** `fp32_accum_add_fp16_kernel` had
+  a declaration, a definition and a green test, and no production launch site. Every
+  existing dead-code check read it as covered: the decl-only sweeps filter on two
+  mentions, the header-inline gate filters on header definitions, and a caller query
+  finds the test. Removed with its test.
+
 - **Ten sites logged at FATAL and then carried on.** `IMP_LOG_FATAL` only writes a
   log line; `IMP_CHECK` is the only thing that aborts. One reported
   `WeightRegistry::handle: id out of range` and indexed out of range on the next

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -279,6 +279,45 @@ harness-delegating bodies (`run_case(...)`, `run_arch(...)`). 8 `DISABLED_`, all
 stated reason in the file; two of them (`test_determinism_e2e.cpp:177,221`) are deliberately
 the gate for a known limit.
 
+**find-stubs rung 4 ran, 2026-08-21. One finding, and the census is worth less
+than the cross-check.**
+
+```
+$ nm build-dev/imp-server | grep -oP '__device_stub__\S+' | sed 's/.*__device_stub__/_/; s/\.cold//' \
+    | c++filt | sed 's/(.*//; s/<.*//; s/.*:://' | grep '_kernel$' | sort -u
+285 kernels present
+$ <launched, from the four nsys runs of assignments 4 and 4b:
+   dense + MoE x 8k + 32k, prefill and decode>
+61 launched
+249 dark
+```
+
+**249 dark does not mean 249 dead**, and this is the limit of the method as the
+skill describes it: four workloads cover no vision, no constrained decoding, no
+MoE host offload, no KV dtype but FP8, and no speculation. Cross-checking each
+dark kernel against its mentions in `src/` collapses 249 to **7**, and reading
+those 7 collapses it to **1**:
+
+| | |
+|---|---|
+| 6 of 7 | live benchmark/probe kernels that exist only under `tests/bench/` and are launched by their own harnesses |
+| **1 of 7** | `fp32_accum_add_fp16_kernel` - declared in `executor_kernels.h`, defined in `executor_elementwise.cu`, and its **only caller is its own test** |
+
+That last one is the finding, and its shape matters more than its size: **every
+existing check reads it as covered.** The 2026-08-03 decl-only sweeps
+(`SETTLED.md` §C) filtered on decl+def with nothing else, and this has a third
+mention. `check_dead_inline_accessors.py` (#1506) filters on header-inline
+definitions, and this is a `.cu` definition. A code-graph caller query finds a
+caller. A kernel whose only caller is a test is invisible to all three, and it
+is the same class as the `add_fp16_bias_to_fp32_kernel` §C records as "never
+launched at all". Removed, with its test.
+
+The second half of rung 4 - a *live* kernel behind a condition that is never
+true, the `ssm_graph_ban` class - is **not** answered by this. That needs to
+know which condition gates each kernel, which a launch census cannot see, and
+the four workloads here would report such a kernel as merely dark. Stated so the
+next pass does not read this entry as having closed it.
+
 ### (c) Dead code - symbols with no caller
 
 The graph was 76 files stale; `codegraph sync` cost 1.7 s. **`ccg enrich` does not run

--- a/src/exec/executor_elementwise.cu
+++ b/src/exec/executor_elementwise.cu
@@ -71,16 +71,6 @@ __global__ __launch_bounds__(256) void elementwise_add_store_fp16_kernel(const h
     }
 }
 
-// FP32 accumulator += FP16 branch: accum[i] += __half2float(branch[i])
-__global__ __launch_bounds__(256) void fp32_accum_add_fp16_kernel(float* __restrict__ accum,
-                                                                  const half* __restrict__ branch,
-                                                                  int64_t n) {
-    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-    if (idx < n) {
-        accum[idx] += __half2float(branch[idx]);
-    }
-}
-
 // Convert FP32 → FP16 with per-row dynamic scaling.
 // Each row is independently scaled so max_abs maps to ≤65000, preserving
 // the ratio between elements.  Since subsequent operations (RMSNorm) are

--- a/src/exec/executor_kernels.h
+++ b/src/exec/executor_kernels.h
@@ -34,9 +34,6 @@ __global__ __launch_bounds__(256) void elementwise_add_store_fp16_kernel(const h
                                                                          const half* __restrict__ b,
                                                                          half* __restrict__ out, int64_t n);
 
-__global__ __launch_bounds__(256) void fp32_accum_add_fp16_kernel(float* __restrict__ accum,
-                                                                  const half* __restrict__ branch, int64_t n);
-
 __global__ __launch_bounds__(256) void fp32_to_fp16_rowscale_kernel(const float* __restrict__ in,
                                                                     half* __restrict__ out, int rows,
                                                                     int cols);

--- a/tests/test_executor_kernels.cu
+++ b/tests/test_executor_kernels.cu
@@ -261,38 +261,6 @@ TEST(ExecutorKernelsTest, FP16ToFP32Roundtrip) {
 }
 
 // =========================================================================
-// fp32_accum_add_fp16_kernel: accum[i] += half2float(branch[i])
-// =========================================================================
-
-TEST(ExecutorKernelsTest, FP32AccumAddFP16) {
-    const int N = 256;
-    std::vector<float> h_accum(N, 10.0f);
-    std::vector<float> h_branch(N);
-    for (int i = 0; i < N; i++)
-        h_branch[i] = static_cast<float>(i) * 0.1f;
-
-    Tensor accum = make_gpu_fp32(h_accum.data(), {N});
-    Tensor branch = make_gpu_fp16(h_branch.data(), {N});
-
-    int threads = 256;
-    int blocks = (N + threads - 1) / threads;
-    fp32_accum_add_fp16_kernel<<<blocks, threads, 0, nullptr>>>(static_cast<float*>(accum.data),
-                                                                static_cast<const half*>(branch.data), N);
-    cudaDeviceSynchronize();
-
-    auto result = read_fp32(accum);
-    for (int i = 0; i < N; i++) {
-        // branch values lose precision in FP16, so use FP16-rounded value
-        float branch_fp16 = __half2float(__float2half(h_branch[i]));
-        float expected = h_accum[i] + branch_fp16;
-        EXPECT_NEAR(result[i], expected, 1e-5f) << "Mismatch at index " << i;
-    }
-
-    free_tensor(accum);
-    free_tensor(branch);
-}
-
-// =========================================================================
 // Edge case: odd-length elementwise_add (tests the scalar tail path)
 // =========================================================================
 

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -126,7 +126,7 @@ def main():
                     help="expected unlaned macro count (default: read PINNED below)")
     args = ap.parse_args()
 
-    PINNED = 974
+    PINNED = 973
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
Rung 4 of skill `find-stubs` is the reachability sweep: kernels present in the binary against kernels actually launched. Ran against the four nsys profiles from assignments 4 and 4b (dense + MoE, 8k + 32k, prefill and decode), so it cost no new card time.

```
285 kernels present
 61 launched in those four workloads
249 dark
```

## 249 dark does not mean 249 dead

That is the honest limit of the census, and it is why the number alone would be a bad finding: four workloads cover no vision, no constrained decoding, no MoE host offload, no KV dtype but FP8, and no speculation.

Cross-checking each dark kernel against its mentions in `src/` collapses 249 to **7**. Reading those 7 collapses it to **1**.

| | |
|---|---|
| 6 of 7 | benchmark and probe kernels living entirely under `tests/bench/`, launched by their own harnesses. Correct as they are. |
| **1 of 7** | `fp32_accum_add_fp16_kernel` |

## The finding, and why its shape matters more than its size

`fp32_accum_add_fp16_kernel` is declared in `executor_kernels.h`, defined in `executor_elementwise.cu`, and its only caller anywhere is its own test.

**Every existing check reads it as covered:**

- the 2026-08-03 decl-only sweeps (`SETTLED.md` §C) filtered on decl+def and nothing else - this has a third mention
- `check_dead_inline_accessors.py` (#1506) filters on header-inline definitions - this is a `.cu` definition
- a code-graph caller query finds a caller, because there is one

A kernel whose only caller is a test is invisible to all three. Same class as the `add_fp16_bias_to_fp32_kernel` that §C records as *"never launched at all"*. Removed, with its test.

## The gate moved the good way for the first time

`check_test_lanes` re-pinned **974 -> 973**. Its own failure message says a drop means a test left the GPU-only set and to *"say that too, because that is the direction worth celebrating"*. This is the first time it has fired that way.

## Not answered by this

The second half of rung 4 - a **live** kernel behind a condition that is never true, the `ssm_graph_ban` class that cost 3x decode - is untouched. That needs to know which condition gates each kernel, which a launch census structurally cannot see, and these four workloads would report such a kernel as merely dark. Written into the ledger so the next pass does not read this entry as having closed it.

## Gate

`make verify-fast` green, `make dev-test` 5/5, all five source gates green, `docs_lint` and `check-release.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
