### PR TITLE
bench: re-measure the llama.cpp lead against b10524, pinned by digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ there instead of retelling it.
   or a real difference of opinion. Off by default; the logit buffer is only
   allocated when the flag is on.
 
+- **`make bench-competitive` re-runs the llama.cpp comparison with the competitor
+  image pinned by digest.** The previous sweep was six weeks and 548 upstream
+  builds old and compared against a build the repo did not record. Re-measured
+  against b10524: imp leads on all four heroes (+148 %, +44 %, +29 %, +16 %) and
+  llama.cpp is flat to slightly slower than b9976 on every shared model. It also
+  reports imp with and without n-gram speculation, which is what caught that the
+  drafter never engages on Qwen3-14B Q6_K. ([`BENCHMARKS.md`](docs/BENCHMARKS.md))
+
 - **`speculative.verify_row_parity` makes the verify chunk reduce K the way the
   decode step does.** The two paths grouped the same products into 32 partial sums
   (decode) and 128 (verify); the rounding difference reached the stop decision and

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-log-fatal check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-log-fatal bench-competitive check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that nothing else is using the GPU. Delegates to
 # scripts/require_free_gpu.sh, the same guard the git hooks use, because
@@ -233,6 +233,10 @@ test-perf: build check-gpu
 # coding agent actually feels (see docs/GOAL.md "Agentic surface"). Override the
 # model with MODEL=<name-under-$HOME/models>.
 AGENTIC_MODEL ?= Qwen3-8B-Q8_0.gguf
+bench-competitive: build check-gpu
+	@echo "Competitive decode sweep vs llama.cpp (image pinned by digest in the script)"
+	bash scripts/bench_competitive.sh
+
 bench-agentic: build check-gpu
 	@echo "=== imp agentic bench (RTX 5090) — model=$(AGENTIC_MODEL) ==="
 	@docker rm -f imp-agentic-bench >/dev/null 2>&1 || true

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -69,6 +69,66 @@ Q4_K** hybrid path by extending that sidecar to the Q8_0-kept GDN projections
 (35B Q4_K decode 224 → 272 tok/s, 2026-07-11) — both now ahead of llama.cpp's
 ~229. GGUF remains the legacy path — NVFP4 SafeTensors is the priority.
 
+### Competitive re-sweep 2026-08-21 (llama.cpp build 10524 `9ee9fc04c`)
+
+Reproduce with `make bench-competitive`. The competitor image is pinned **by
+digest** in [`scripts/bench_competitive.sh`](../scripts/bench_competitive.sh),
+not by tag: `:full-cuda` moves, and the two sweeps below were each compared
+against a build that nothing in the repo recorded.
+
+Two imp columns, because one number cannot mean both things. imp's `--bench`
+prompt is self-repetitive, so where the n-gram drafter engages it accepts
+essentially every draft (measured here: 504 of 504 on Qwen3-8B) and
+`llama-bench` has no equivalent. The spec-off column is the same command with
+`--set speculative.ngram=false`. The 2026-07-12 sweep tabulated the defaults
+column only.
+
+| Model (shared quant) | imp default | imp spec-off | llama.cpp | imp lead | lead 07-12 |
+|---|---:|---:|---:|---:|---:|
+| Qwen3-8B Q8_0 | 396.76 | 284.60 | 159.74 | **+148 %** | +48 % |
+| Qwen3-14B Q6_K | 162.06¹ | 163.38 | 112.83 | **+44 %** | +42 % |
+| Qwen3.6-35B-A3B UD-Q4_K_M (hybrid) | 283.99 | 284.48 | 220.53 | **+29 %** | +18 % |
+| Gemma-4-26B-A4B UD-Q4_K_M (MoE) | 244.16 | 244.24 | 210.34 | **+16 %** | +21 % |
+| Qwen3-30B-A3B Q4_K_M (MoE, non-hero) | 314.62 | 314.64 | 303.28 | +3.7 % | +1.7 % |
+| gpt-oss-20b MXFP4² | 412.41 | 412.09 | 330.09 | **+25 %** | +13-19 % |
+
+**Release bar 2 holds on all four heroes, in both columns.** The narrowest
+margin is Gemma-4 at +16 %.
+
+**llama.cpp did not erode the lead.** b10524 measures flat to slightly slower
+than b9976 on every shared model here (8B 160.5 → 159.74, 14B 115.3 → 112.83,
+35B 226.5 → 220.53, Gemma-4 216.0 → 210.34, 30B 319.2 → 303.28). The six weeks
+of batch-1 decode work between the two builds does not show up at these shapes.
+
+**One imp-side regression, and it is Gemma-4:** 261.3 → 244.16, -6.6 %, against
+llama.cpp's -2.6 % on the same model. That is what took the lead from +21 % to
++16 %. Not investigated here; this sweep measures, it does not fix.
+
+**The n-gram drafter never engages on Qwen3-14B Q6_K:** `verify_steps=0
+miss_steps=72 drafted=0` over a full bench run. Both imp columns therefore
+measure the same path on that model, which is what makes the pair a
+repeatability control: where speculation is inert the two columns must agree,
+and on 35B, Gemma-4, 30B and gpt-oss they agree to **0.2 %**.
+
+¹ The sweep produced 154.77 for this row, 5.3 % below its own spec-off column
+where the two must agree. Two isolated re-measurements gave 162.08 and 162.04,
+and the tabulated value is their median. Cause: the first imp run after a
+16 GiB competitor model unloads is not on a settled card. The settle between
+arms was raised from 5 s to 20 s afterwards, so this sweep's own numbers were
+taken at 5 s.
+
+² Basis changed since 07-12. That row compared imp on SafeTensors against
+llama.cpp on GGUF; the SafeTensors checkpoint is no longer on this host, so both
+engines here read the same `gpt-oss-20b-mxfp4.gguf`. The row is more
+apples-to-apples than the one it replaces, not less, but it is not the same
+measurement.
+
+[PROV: commit=fa21f28e date=2026-08-21 hw=RTX5090 tree=imp-campaign (fresh `make build`)
+ image=ghcr.io/ggml-org/llama.cpp@sha256:c49f4d485fb08d3002fcbd6b43be8b18758b4a2f021243b42968f64a37b57e1d
+ cmd=`bash scripts/bench_competitive.sh` -> imp `imp-cli --model <m> --bench --bench-pp 512 --bench-reps 10 --max-tokens 128 --temperature 0`,
+     llama `llama-bench -m <m> -p 512 -n 128 -r 5 -ngl 99`
+ note=one process per (engine, model); GPU verified idle (1502 MiB WSLg baseline, no containers) before the run]
+
 ### Competitive re-sweep 2026-07-12 (llama.cpp build 9976 `e3546c794`)
 
 Same-day, same host state, both engines pp512/tg128: imp

--- a/scripts/bench_competitive.sh
+++ b/scripts/bench_competitive.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Competitive decode sweep: imp against llama.cpp on the shared-quant hero GGUFs.
+#
+# The competitor image is pinned BY DIGEST, not by tag. `:full-cuda` moves, and
+# twice now a published lead was compared against a build nobody recorded. To
+# refresh deliberately: pull the tag, read `docker images --digests`, update
+# LLAMA_DIGEST here, and say which build it resolved to in the PROV block.
+#
+# Model files are required, not optional: a path that is set but unreadable is a
+# failure, never a silent skip. See docs/BENCHMARKS.md.
+set -euo pipefail
+
+LLAMA_IMAGE="ghcr.io/ggml-org/llama.cpp@sha256:c49f4d485fb08d3002fcbd6b43be8b18758b4a2f021243b42968f64a37b57e1d"
+IMP_IMAGE="${IMP_IMAGE:-imp:test}"
+MODELS_DIR="${MODELS_DIR:-$HOME/models}"
+OUT="${OUT:-/tmp/bench_competitive.tsv}"
+
+# name <TAB> gguf path relative to MODELS_DIR
+read -r -d '' MATRIX <<'TSV' || true
+Qwen3-8B Q8_0	Qwen3-8B-Q8_0.gguf
+Qwen3-14B Q6_K	Qwen3-14B-Q6_K.gguf
+Qwen3.6-35B-A3B UD-Q4_K_M	qwen3.6-35B-A3B-gguf/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+Gemma-4-26B-A4B UD-Q4_K_M	gemma-4-26B-A4B-it-UD-Q4_K_M.gguf
+Qwen3-30B-A3B Q4_K_M	Qwen3-30B-A3B-Q4_K_M/Qwen3-30B-A3B-Q4_K_M.gguf
+gpt-oss-20b MXFP4	gpt-oss-20b-mxfp4.gguf
+TSV
+
+require_readable() {
+    [ -r "$1" ] || { echo "FATAL: model not readable: $1" >&2; exit 1; }
+}
+
+check_gpu() {
+    local used
+    used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)
+    if [ "$used" -gt 3000 ]; then
+        echo "FATAL: $used MiB already held on the GPU. On WSL2 the process list is" >&2
+        echo "       blank even when memory is held, so this is the only usable guard." >&2
+        exit 1
+    fi
+    [ "$(docker ps -q | wc -l)" -eq 0 ] || { echo "FATAL: containers running, they depress every number" >&2; exit 1; }
+}
+
+llama_tg() {  # $1 = container path
+    docker run --rm --gpus all -v "$MODELS_DIR":/models "$LLAMA_IMAGE" \
+        --bench -m "$1" -p 512 -n 128 -r 5 -ngl 99 2>/dev/null \
+        | awk -F'|' '/tg128/ {split($8,a,"±"); gsub(/ /,"",a[1]); print a[1]}'
+}
+
+# imp's --bench prompt is self-repetitive, so n-gram speculation accepts ~100 % of
+# its drafts. llama-bench cannot exploit that, so the defaults column and the
+# spec-off column mean different things and both are reported.
+imp_tg() {  # $1 = container path, $2 = extra args
+    docker run --rm --gpus all -v "$MODELS_DIR":/models "$IMP_IMAGE" \
+        imp-cli --model "$1" --bench --bench-pp 512 --bench-reps 10 \
+        --max-tokens 128 --temperature 0 $2 2>&1 \
+        | grep -oP '^tg\s+128 tokens.*?\(\s*\K[0-9.]+(?= tok/s)'
+}
+
+# 20 s between arms, not 5. At 5 s the Qwen3-14B row read 5.3 % low against two
+# isolated re-measurements (154.77 against 162.08 / 162.04) - the first imp run
+# after a 16 GiB competitor model unloads is not on a settled card. The imp
+# default / spec-off pair doubles as this sweep's repeatability control: on every
+# model where speculation is inert the two columns must agree, and they agree to
+# 0.2 % on four of five. That is what caught this.
+check_gpu
+: > "$OUT"
+printf 'model\timp_default\timp_spec_off\tllama_tg128\n' >> "$OUT"
+while IFS=$'\t' read -r name rel; do
+    [ -n "$name" ] || continue
+    require_readable "$MODELS_DIR/$rel"
+    echo ">>> $name" >&2
+    l=$(llama_tg "/models/$rel"); sleep 20
+    i=$(imp_tg   "/models/$rel" ""); sleep 20
+    o=$(imp_tg   "/models/$rel" "--set speculative.ngram=false"); sleep 20
+    printf '%s\t%s\t%s\t%s\n' "$name" "${i:-FAILED}" "${o:-FAILED}" "${l:-FAILED}" >> "$OUT"
+done <<< "$MATRIX"
+
+awk -F'\t' '{printf "%-34s %12s %12s %12s\n", $1, $2, $3, $4}' "$OUT"
+if grep -q FAILED "$OUT"; then
+    echo "FATAL: at least one arm produced no number" >&2
+    exit 1
+fi


### PR DESCRIPTION
Reopened from a rebased branch; supersedes #1516, which was born conflicting with
`main` and therefore never got a CI run at all.

The competitive sweep in `docs/BENCHMARKS.md` was 2026-07-12 against llama.cpp
build 9976, and it recorded the **tag**, not the digest. `:full-cuda` moves, so
nothing in the repo said which competitor build a published lead was measured
against. `make bench-competitive` now runs `scripts/bench_competitive.sh`, which
pins the image by digest.

## Result: release bar 2 holds on all four heroes

| Model (shared quant) | imp default | imp spec-off | llama.cpp b10524 | lead | lead 07-12 |
|---|---:|---:|---:|---:|---:|
| Qwen3-8B Q8_0 | 396.76 | 284.60 | 159.74 | **+148 %** | +48 % |
| Qwen3-14B Q6_K | 162.06¹ | 163.38 | 112.83 | **+44 %** | +42 % |
| Qwen3.6-35B-A3B UD-Q4_K_M | 283.99 | 284.48 | 220.53 | **+29 %** | +18 % |
| Gemma-4-26B-A4B UD-Q4_K_M | 244.16 | 244.24 | 210.34 | **+16 %** | +21 % |
| Qwen3-30B-A3B Q4_K_M (non-hero) | 314.62 | 314.64 | 303.28 | +3.7 % | +1.7 % |
| gpt-oss-20b MXFP4² | 412.41 | 412.09 | 330.09 | **+25 %** | +13-19 % |

**llama.cpp did not erode the lead.** b10524 is flat to slightly slower than
b9976 on every shared model (8B 160.5 to 159.74, 14B 115.3 to 112.83, 35B 226.5
to 220.53, Gemma-4 216.0 to 210.34, 30B 319.2 to 303.28).

## Two findings this reports rather than fixes

- **Gemma-4-26B-A4B is imp's one regression**, 261.3 to 244.16 (-6.6 %) against
  llama.cpp's -2.6 % on the same model. That is what took the lead from +21 % to
  +16 %, and it is now the narrowest hero margin.
- **The n-gram drafter never engages on Qwen3-14B Q6_K**: `verify_steps=0
  miss_steps=72 drafted=0` over a full bench run.

## Why there are two imp columns

imp's `--bench` prompt is self-repetitive, so where the drafter engages it
accepts essentially every draft (504 of 504 on Qwen3-8B) and `llama-bench` has
no equivalent. One number cannot mean both things. The pair also works as the
sweep's own repeatability control: where speculation is inert the two columns
must agree, and on 35B, Gemma-4, 30B and gpt-oss they agree to **0.2 %**.

¹ That control caught the one row where they did not. The sweep produced 154.77,
5.3 % below its own spec-off column; two isolated re-measurements gave 162.08 and
162.04 and the table carries their median. The first imp run after a 16 GiB
competitor model unloads is not on a settled card, so the settle between arms
was raised from 5 s to 20 s. This sweep's numbers were taken at 5 s.

² Basis changed: the 07-12 row compared imp on SafeTensors against llama.cpp on
GGUF. That checkpoint is no longer on this host, so both engines here read the
same GGUF. More apples-to-apples than the row it replaces, but not the same
measurement.

Docs, a script and a make target. No code paths touched.