### PR TITLE
gate(memory): invariant I2 was stated, counted, and unobservable

### DIFF
--- a/.claude/skills/shipping-prs/SKILL.md
+++ b/.claude/skills/shipping-prs/SKILL.md
@@ -53,7 +53,7 @@ git log -1 --stat origin/main                  # confirm your final commit is in
 
 **Don't branch a new topic off `main` while a previous PR's auto-merge is still in flight** — it squashes onto `main` any moment and your new branch misses it (conflict/rework later). Wait for the merge, `git pull --ff-only`, then branch.
 
-### `mergeStateStatus=BLOCKED` — triage before assuming
+### A PR that will not merge: triage before assuming
 
 Don't guess. Dump the real state first:
 
@@ -65,6 +65,22 @@ gh pr view <PR> --json mergeStateStatus,statusCheckRollup,reviewDecision
 - `reviewDecision` not `APPROVED`, or an unresolved review thread → needs review action.
 - Branch out-of-date with `main` → `git pull --no-rebase origin main` (or update via the PR), push.
 - A *different* required status (not `Build`) still pending → wait for it.
+- **`gh pr checks` reports NOTHING at all** → that is not "pending", it is a symptom, and
+  `mergeStateStatus` is the field that answers it. `DIRTY` means the PR conflicts with
+  `main`, and GitHub computes `pull_request` workflows against a merge ref it cannot build
+  when there are conflicts: no CI run, no Auto-merge run, no arming. A conflicted PR
+  therefore looks identical to a queue backlog in every view, and nothing says so.
+  Resolve the conflict (rebase onto `origin/main`; force-push is gated here, so push a
+  fresh branch and reopen) and the checks fire.
+
+  **`UNKNOWN` is not a state.** It means GitHub has not computed mergeability yet and to
+  ask again. Reading it as evidence and building a mechanism on top of it is how #1516 got
+  diagnosed as "GitHub dropped the event" for an hour. Query it twice before believing it.
+
+  The cause is usually upstream of all this: **a PR opened from a base that no longer
+  exists.** #1516 was branched while #1515 was in flight, #1515 merged and touched the same
+  `[Unreleased]` block, and the PR was born conflicted 29 minutes later. That is the rule
+  two sections up, and eleven PRs that followed it merged themselves the same night.
 
 ## Cutting a tagged release (only when explicitly releasing)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ there instead of retelling it.
 
 ### Added
 
+- **Invariant I2 has a gate: `make check-alloc-interpose`.** "Nothing allocates device
+  memory while serving" was stated, counted, and unobservable: the counter only sees what
+  routes through `Backend`, and the `--wrap` interposer that would see the rest compiled in
+  no make target and no CI job. The gate builds it, drives 20 requests at batch 4 with
+  NVFP4 residual KV and an MTP chain, and pins the count. First run: **46 allocations while
+  serving**. 27 were the MTP workspace allocated after the phase flip and are now labelled
+  as the context-setup step they are; the remaining 19 are named by site in
+  [`DEBT_LEDGER`](docs/audit/DEBT_LEDGER_2026_08_21.md) and the pin only ever goes down.
+
 - **`diagnostics.spec_trace` reports the top-2 logit gap per verify chunk row.**
   The trace said which token a row picked and never by how much, which is the
   question that decides whether a disagreement with the decode path is a coin flip

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_ARGS = --build-arg IMP_BUILD_TESTS=ON
 # script — inlining the sed breaks make's $(shell ...) paren matching.
 DEP_ARGS = $(shell scripts/dep_build_args.sh)
 
-.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-log-fatal check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
+.PHONY: check-alloc-pairs alloc-pairs-list check-test-lanes check-dead-inline check-log-fatal check-alloc-interpose check-deps check-deps-online roofline-measure roofline-pin roofline-regress build test-unit test-gpu test-fast test-all test-e2e test-server test-vision test-perf test-golden test-agents test-agents-external test-niah test-rerank bench bench-agentic check-gpu verify verify-fast verify-chunked verify-north-star gen-perf-baseline install-hooks format format-check tidy sanitize asan coverage
 
 # Check that nothing else is using the GPU. Delegates to
 # scripts/require_free_gpu.sh, the same guard the git hooks use, because
@@ -103,6 +103,16 @@ dev: dev-image
 # (CI builds the image from a clean tree).
 dev-test: dev
 	$(DEV_RUN) ctest --test-dir $(DEV_DIR) -L unit --output-on-failure
+
+# Invariant I2 has a gate now. -DIMP_ALLOC_INTERPOSE=ON is a measurement build
+# (--wrap on the CUDA allocators), so it gets its own build dir and never
+# stands in for the shipping image - never benchmark it (AUDIT G16).
+INTERPOSE_DIR ?= build-interpose
+check-alloc-interpose: dev-image
+	$(DEV_RUN) bash -c 'cmake -B $(INTERPOSE_DIR) -G Ninja $(DEV_CMAKE_ARGS) \
+	  -DIMP_ALLOC_INTERPOSE=ON >/dev/null \
+	  && cmake --build $(INTERPOSE_DIR) --target imp-server -j$$(nproc)'
+	bash scripts/check_alloc_interpose.sh
 
 dev-clean:
 	docker run --rm -v $(PWD):/src -w /src $(DEV_IMG) rm -rf $(DEV_DIR)

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -21,7 +21,7 @@ because a negative result is what stops the next sweep.
 |---|---|---|---|
 | 1 | Per-decode-step `cudaMallocAsync` whose address is baked into a replayed CUDA graph, with no invalidation | `src/runtime/engine_scheduler.cpp:1695` | Silently wrong KV residual metadata on `residual + batch>1` decode; survives only because the async pool's release threshold is pinned to `UINT64_MAX` |
 | 2 | ~~`cudaMalloc` freed through `cudaFreeAsync`~~ **CLOSED `556f3b8d` (#1505)** | `src/compute/mtp_forward.cu:610` / `:619` | Undefined behaviour per the CUDA API, once per MTP draft step, on every MoE model (the device-chain arm requires `n_experts == 0`) Fixed, and three further pairs this ledger did not have came out with it. |
-| 3 | Invariant I2 has no gate in any shipping build **(still OPEN: #1505's gate is static and does not reach it)** | `CMakeLists.txt:67` | The counter that is supposed to catch items 1 and 2 reads zero in every build anyone runs; 469 direct allocation sites sit outside `src/memory/` where it cannot see them |
+| 3 | ~~Invariant I2 has no gate in any shipping build~~ **CLOSED: `make check-alloc-interpose`, a two-way pin at 19 calls over 5 named sites** | `CMakeLists.txt:67` | The counter that is supposed to catch items 1 and 2 reads zero in every build anyone runs; 469 direct allocation sites sit outside `src/memory/` where it cannot see them First run found **46 device allocations while serving**. 27 were the MTP workspace sitting on the wrong side of the phase flip (fixed). The remaining 19 are enumerated in (g) and the pin only ever goes down. |
 | 4 | ~~829 of 2288 GTest macros run in no CI lane~~ **CLOSED, and corrected to 968** (`tools/check_test_lanes.py`) | `CMakeLists.txt:952-957` | The entire GPU correctness surface reaches `main` on the strength of one human running `make verify-fast`; the required check is `Build`, which runs `ctest -L unit` Pinned now, and it fails when it moves. 829 was an undercount, see (e). |
 | 5 | ~~The file-size allowlist has no ceiling, and 16 of its 29 reasons are numerically stale~~ **CLOSED: every entry carries a measured `code_loc`, drift either way fails** | `tools/filesize_thresholds.toml:60` | An allowlisted file is exempt forever: `engine_scheduler.cpp` went 1074 → **1962** code LOC (+83 %) with the gate green the whole way. The gate is blind exactly where recompile blast radius is worst Reasons re-derived and the LOC figure taken out of the prose, because that is the half that went stale. |
 | 6 | `vram.library_reserve_mb` default is a constant measured to be wrong in both directions | `src/memory/plan.h:100` | On a cold cache the plan charges 3900 MiB where the model needs 0 (Qwen3-4B IQ4_NL) or 7458 (Qwen3-8B Q8_0) - AUDIT B41. Either 3.9 GiB of KV pool set aside for nothing, or a 3.5 GiB under-charge |
@@ -600,3 +600,37 @@ from `grep`, `sed`, `python3 tools/check_filesize.py`, `python3 tools/check_allo
 `codegraph`, or reading the file. Nothing was built and nothing was run on the device, so no
 claim here is a measurement of behaviour - every OPEN item's "proof it is closed" is written
 as the experiment that would settle it, precisely because this pass could not run one.
+
+---
+
+## (g) The 19 serving-phase allocations the I2 gate found
+
+`make check-alloc-interpose` builds `-DIMP_ALLOC_INTERPOSE=ON`, drives 20 requests at
+batch 4 on a config with NVFP4 residual KV and an MTP chain, and reads the interposer's
+report. `scripts/check_alloc_interpose.sh` pins the count at **19** and fails in both
+directions, so this list is a work queue with a gate behind it rather than a note.
+
+| calls | bytes | site | what it would take |
+|---|---|---|---|
+| 15 | ~0 | `Engine::try_launch_async_graph_loop`, `src/runtime/engine_graph_decode.cpp:408-412`, `:434` | `d_bt` / `d_token` / `d_pos` / `d_ctx` / `d_banned` are allocated and torn down **per request**. Making `cpipe_` persistent needs it sized from the KV plan at init and the teardown path reworked with it. This is the real violation of the five, and it is the same family as item 1. |
+| 2 | 128 MiB | `GraphExecutor::run_attention` -> `chunk_eager_k_` / `_v_`, `src/exec/executor_attention_prefill.cu:176-177` | Grow-only gather scratch for the eager chunked prefill path, sized from the live context on first use. Pre-size it from `ctx_capacity` the way its sibling `chunk_capture_k_`/`_v_` already is. |
+| 1 | ~0 | `Engine::banned_tokens_device_`, `src/runtime/engine_graph_decode.cpp:29` | Lazy first-use upload of a list that is known at engine init. The cheapest of the five. |
+| 1 | 0.001 MiB | `imp::VRAMAllocator::allocate` | The engine arena growing after the phase flip. Whether that is a defect or a plan one slab short is its own question. |
+
+Two things the first run got wrong, both worth keeping because both are the campaign's
+recurring shape:
+
+**The violation report was `IMP_LOG_DEBUG`.** Someone who opted into the measurement build
+still saw nothing at default log level. It is `IMP_LOG_WARN` now, and the clean line is
+`IMP_LOG_INFO`, because the gate asserts that **one of the two appears at all**: absent
+both, the binary was built without the flag and a grep for violations passes for the wrong
+reason.
+
+**The gate itself first reported 2 allocations when there were 19.** The report's banner
+and its first class were on the same line (no `\n` after `while serving:`), and the parser
+anchored at the start of a line, so it skipped `cudaMalloc` entirely and summed only the
+async and pinned rows. Both halves are fixed: the format has its newline, and the parser
+matches the class name anywhere in the line rather than depending on that.
+
+The gate also refuses to judge before it can prove it reached the path it claims to
+exercise: it fails if `residual buffer enabled` is absent from the log.

--- a/scripts/check_alloc_interpose.sh
+++ b/scripts/check_alloc_interpose.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Invariant I2 (docs/internals/MEMORY.md): nothing allocates device memory while
+# the engine is serving. `steady_state_allocations()` only ever sees what routes
+# through Backend, so the counter reads zero in every shipping build no matter
+# what the 469 direct allocation sites outside src/memory/ do. The --wrap
+# interposer is what closes that gap, and until this target existed it compiled
+# in no make target and no CI job (DEBT_LEDGER_2026_08_21, item 3).
+#
+# Driven at a config that reaches the known serving-phase allocators:
+#   batch > 1 + NVFP4 residual KV -> engine_scheduler.cpp cudaMallocAsync (B9)
+#   MoE + MTP chain               -> the speculative path's per-step buffers
+#
+# Run via `make check-alloc-interpose`, which builds the binary this needs.
+set -uo pipefail
+
+BIN=${BIN:-build-interpose/imp-server}
+IMG=${DEV_IMG:-imp:toolchain}
+MODEL=${INTERPOSE_MODEL:-/models/Qwen3.8-27B-NVFP4}
+MODELS_DIR=${MODELS_DIR:-$HOME/models}
+PORT=8099
+LOG=$(mktemp /tmp/interpose.XXXXXX.log)
+
+[ -x "$BIN" ] || { echo "FATAL: $BIN not built. Run: make check-alloc-interpose" >&2; exit 1; }
+[ -d "$MODELS_DIR/$(basename "$MODEL")" ] || {
+    echo "FATAL: model not readable: $MODELS_DIR/$(basename "$MODEL")" >&2; exit 1; }
+
+used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits)
+[ "$used" -le 3000 ] || { echo "FATAL: $used MiB already held on the GPU" >&2; exit 1; }
+
+docker rm -f interpose >/dev/null 2>&1
+docker run -d --name interpose --gpus all -p $PORT:8080 \
+    -v "$PWD":/src -w /src -v "$MODELS_DIR":/models "$IMG" \
+    "$BIN" --host 0.0.0.0 --port 8080 --model "$MODEL" --think-budget 0 \
+    --set runtime.max_batch_size=4 \
+    --set kv_cache.dtype=nvfp4 \
+    --set kv_cache.bitdecoding_residual_tokens=128 \
+    --set speculative.mtp_k=1 >/dev/null
+trap 'docker rm -f interpose >/dev/null 2>&1' EXIT
+
+for _ in $(seq 1 200); do
+    curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+    docker ps --format '{{.Names}}' | grep -q '^interpose$' || break
+    sleep 3
+done
+curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 || {
+    echo "FATAL: server never became healthy" >&2; docker logs interpose 2>&1 | tail -20 >&2; exit 1; }
+
+# 18 requests, four at a time: batch > 1 is what reaches the residual allocator.
+for round in 1 2 3 4 5; do
+    for slot in 1 2 3 4; do
+        curl -s "http://127.0.0.1:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+            -d "{\"model\":\"$(basename "$MODEL")\",\"messages\":[{\"role\":\"user\",\"content\":\"Explain topic $round.$slot in two paragraphs.\"}],\"max_tokens\":96,\"temperature\":0}" \
+            >/dev/null &
+    done
+    wait
+done
+
+# Clean shutdown: the report is a static destructor, so SIGKILL loses it.
+docker stop -t 60 interpose >/dev/null 2>&1
+docker logs interpose > "$LOG" 2>&1
+
+# Liveness, before any verdict. This gate claims to exercise the residual KV
+# path at batch > 1; if the pool was declined (wrong kv dtype, a model with
+# non-uniform head_dim) the run measures a config that cannot reach the
+# allocator it is looking for, and a clean result means nothing.
+if ! grep -q 'residual buffer enabled' "$LOG"; then
+    echo "FATAL: the residual KV pool was never enabled, so this run did not"   >&2
+    echo "       exercise the path it claims to. Check kv_cache.dtype=nvfp4 and" >&2
+    echo "       kv_cache.bitdecoding_residual_tokens against this model."       >&2
+    grep -i 'residual' "$LOG" | head -5                                         >&2
+    exit 1
+fi
+
+CLEAN=$(grep -c 'alloc-interpose\] steady state clean' "$LOG")
+VIOL=$(grep -c 'alloc-interpose\] I2 VIOLATIONS' "$LOG")
+
+# Known residue, pinned by CALL COUNT and named by site. This number may only
+# ever go DOWN: the gate fails on a rise (a new serving allocation) and on a
+# fall (someone fixed one and left the pin stale), the same two-way shape as
+# tools/alloc_allowlist.txt. A pin that can be raised is an exemption with
+# extra steps.
+#
+# The five sites behind the 19, from addr2line on a debug-level run. Each is a
+# work item, not a blessing; docs/audit/DEBT_LEDGER_2026_08_21.md tracks them.
+#
+#  15 calls, ~0 MiB   Engine::try_launch_async_graph_loop
+#                     src/runtime/engine_graph_decode.cpp:408-412, :434
+#                     d_bt / d_token / d_pos / d_ctx / d_banned, allocated and
+#                     torn down PER REQUEST. The real violation of the five:
+#                     making cpipe_ persistent needs it sized from the KV plan
+#                     at init, and the teardown path reworked with it.
+#   2 calls, 128 MiB  GraphExecutor::run_attention -> chunk_eager_k_ / _v_
+#                     src/exec/executor_attention_prefill.cu:176-177
+#                     Grow-only gather scratch for the eager chunked prefill
+#                     path, sized from the live context on first use. Fixing it
+#                     means pre-sizing from ctx_capacity the way its sibling
+#                     chunk_capture_k_/_v_ already is.
+#   1 call, ~0 MiB    Engine::banned_tokens_device_
+#                     src/runtime/engine_graph_decode.cpp:29
+#                     Lazy first-use upload of a list known at engine init.
+#                     The cheapest of the five to hoist.
+#   1 call, 0.001 MiB VRAMAllocator::allocate
+#                     The engine arena growing after the phase flip. Whether
+#                     that is a defect or a plan that was one slab short is its
+#                     own question, and it is the smallest of the five.
+#
+PINNED_CALLS=19
+
+if [ "$CLEAN" -eq 0 ] && [ "$VIOL" -eq 0 ]; then
+    echo "FATAL: neither report line appeared. The binary was not built with"        >&2
+    echo "       -DIMP_ALLOC_INTERPOSE=ON, or it did not shut down cleanly."         >&2
+    echo "       Passing here would be passing for the wrong reason."                >&2
+    tail -20 "$LOG" >&2
+    exit 1
+fi
+if [ "$VIOL" -eq 0 ]; then
+    [ "$PINNED_CALLS" -eq 0 ] && { echo "PASS: no device allocation while serving"; exit 0; }
+    echo "FAIL: the pin says $PINNED_CALLS serving allocation(s) and there are none."
+    echo "      Someone fixed them. Set PINNED_CALLS=0 in this script and delete"
+    echo "      the site list above. The pin only ever goes down, so a stale one"
+    echo "      is a gate that would not notice the next regression."
+    exit 1
+fi
+
+# Match on "<class> <n> calls" anywhere in the line, NOT anchored at the start
+# of one. The first class used to be glued to the banner, so an anchored reader
+# skipped it and this gate reported 2 allocations when there were 19. The
+# format is fixed, and this pattern no longer depends on it being fixed.
+# awk, not bc: bc is not installed on this host, and a missing binary would
+# read as "0 allocations" rather than as a broken gate.
+CALLS=$(sed -n '/alloc-interpose\] I2 VIOLATIONS/,/pinned host/p' "$LOG" \
+        | grep -oP '(cudaMalloc|cudaMallocAsync|pinned host)\s+\K[0-9]+(?=\s+calls)' \
+        | awk '{s+=$1} END {print s+0}')
+if [ "${CALLS:-0}" -eq 0 ]; then
+    echo "FATAL: the violation banner is present but no per-class call counts"  >&2
+    echo "       parsed out of it. The report format changed; fix this parser." >&2
+    sed -n '/alloc-interpose\] I2 VIOLATIONS/,/pinned host/p' "$LOG"           >&2
+    exit 1
+fi
+
+if [ "$CALLS" -gt "$PINNED_CALLS" ]; then
+    echo "FAIL: $CALLS device allocations while serving, pin is $PINNED_CALLS (invariant I2)."
+    echo "      A new serving-phase allocation. Find it with:"
+    echo "        --set diagnostics.log_level=debug, then addr2line -e $BIN -f -C <offset>"
+    sed -n '/alloc-interpose\] I2 VIOLATIONS/,/pinned host/p' "$LOG"
+    exit 1
+fi
+if [ "$CALLS" -lt "$PINNED_CALLS" ]; then
+    echo "FAIL: $CALLS device allocations while serving, pin is $PINNED_CALLS."
+    echo "      Fewer than pinned: lower PINNED_CALLS in this script to $CALLS and"
+    echo "      remove the fixed site from the list above."
+    exit 1
+fi
+echo "PASS: $CALLS serving allocation(s), exactly the pinned residue, over 20"
+echo "      requests at batch 4 (NVFP4 residual KV + MTP chain; log: $LOG)"
+exit 0

--- a/src/memory/alloc_interpose.cpp
+++ b/src/memory/alloc_interpose.cpp
@@ -132,13 +132,25 @@ struct Reporter {
         const uint64_t ds = g_dev_sync.calls.load(), da = g_dev_async.calls.load(),
                        hp = g_host_pinned.calls.load();
         if ((ds | da | hp) == 0) {
-            IMP_LOG_DEBUG(
+            // The clean line is INFO for the same reason the violation is WARN:
+            // the gate asserts that one of the two appears at all. Absent both,
+            // the binary was built without -DIMP_ALLOC_INTERPOSE=ON and a grep
+            // for violations passes for the wrong reason.
+            IMP_LOG_INFO(
                 "[alloc-interpose] steady state clean: 0 cudaMalloc, "
                 "0 cudaMallocAsync, 0 pinned-host allocations while serving");
             return;
         }
-        IMP_LOG_DEBUG(
-            "[alloc-interpose] I2 VIOLATIONS while serving:"
+        // WARN, not DEBUG. A detected invariant violation that only appears
+        // when someone remembers to raise the log level is a finding nobody
+        // finds: this is the line `make check-alloc-interpose` fails on.
+        IMP_LOG_WARN(
+            // The newline after the banner is load-bearing: without it the
+            // first class is glued to the banner line, and any reader anchored
+            // at the start of a line silently skips it. That is how
+            // check_alloc_interpose.sh first reported 2 allocations when there
+            // were 19.
+            "[alloc-interpose] I2 VIOLATIONS while serving:\n"
             "    cudaMalloc       %8llu calls  %10.2f MiB\n"
             "    cudaMallocAsync  %8llu calls  %10.2f MiB\n"
             "    pinned host      %8llu calls  %10.2f MiB\n",

--- a/src/runtime/engine_spec_mtp.cpp
+++ b/src/runtime/engine_spec_mtp.cpp
@@ -22,6 +22,7 @@
 // unbinds drafting for the request; the suffix matcher keeps working.
 // =============================================================================
 
+#include "memory/backend.h"
 #include "compute/mtp_forward.h"
 #include "core/logging.h"
 #include "exec/executor.h"
@@ -341,6 +342,16 @@ bool Engine::enable_mtp_spec_decode(int k) {
         mtp_kv_max = kMtpKvCap;
 
     auto* ws = new imp::MtpDraftWorkspace();
+    // 44 cudaMalloc calls, 65.68 MiB, and the phase says Serving for all of
+    // them: `set_alloc_phase(Serving)` fires at the end of engine init
+    // (engine.cpp), while `imp_enable_mtp_spec_decode` is a context-setup step
+    // the API exposes AFTER context creation. The server calls it immediately
+    // after `imp_context_create`, before a single request, so this is init
+    // traffic sitting on the wrong side of the boundary rather than an
+    // invariant breach. Labelled, not exempted: the scope logs its reason at
+    // INFO, so an embedder that calls this mid-serving is visible rather than
+    // masked. Found by `make check-alloc-interpose`.
+    AllocPhaseScope mtp_alloc_phase(AllocPhase::Planning, "mtp workspace");
     if (!imp::mtp_workspace_allocate(*ws, hidden_dim, vocab_size, n_experts, top_k, expert_d_ff, shared_d_ff,
                                      mtp_num_heads, mtp_num_kv_heads, mtp_head_dim, mtp_kv_max)) {
         delete ws;


### PR DESCRIPTION
"Nothing allocates device memory while the engine is serving" had a counter that
could not see the traffic. `steady_state_allocations()` only observes what routes
through `Backend`, and the `--wrap` interposer that would see the rest compiles
under `IMP_ALLOC_INTERPOSE`, which appeared in **no make target and no CI job**.
So the number read zero in every shipping build no matter what the 469 direct
allocation sites outside `src/memory/` did. Ledger item 3.

`make check-alloc-interpose` builds it, starts a server at `max_batch_size=4`
with NVFP4 residual KV and an MTP chain, drives 20 requests four at a time, stops
the container with a 60 s timeout so the static-destructor report actually runs,
and reads the log.

## First run: 46 device allocations while serving

**27 were not a violation.** All of them one function, `mtp_workspace_allocate`.
`set_alloc_phase(Serving)` fires at the end of engine init while
`imp_enable_mtp_spec_decode` is a context-setup step the API exposes *after*
`imp_context_create`, and the server calls it before a single request. Init
traffic on the wrong side of the boundary. Labelled with `AllocPhaseScope`, not
exempted: the scope logs its reason at INFO, so an embedder that calls this
mid-serving is visible rather than masked.

**The remaining 19 are real, and they are five named sites**, not an aggregate:

| calls | bytes | site |
|---|---|---|
| 15 | ~0 | `try_launch_async_graph_loop`, `engine_graph_decode.cpp:408-412`, `:434`, allocated and torn down **per request** |
| 2 | 128 MiB | `run_attention` -> `chunk_eager_k_`/`_v_`, `executor_attention_prefill.cu:176-177` |
| 1 | ~0 | `banned_tokens_device_`, `engine_graph_decode.cpp:29`, lazy upload of a list known at init |
| 1 | 0.001 MiB | `VRAMAllocator::allocate`, the arena growing after the phase flip |

`PINNED_CALLS=19` fails in **both** directions: a rise is a new serving
allocation, a fall means someone fixed one and left the pin stale. Negative
control run at 18 and at 20, both red. Each site is named in the script and in
[`DEBT_LEDGER`](docs/audit/DEBT_LEDGER_2026_08_21.md) section (g), so the pin is
a work queue with addresses rather than a blessing. They are not fixed here:
four of the five are reworks in the decode and prefill launch paths, and each
wants its own measured PR.

## Two defects in the reporting path, and the second was mine

**The violation report was `IMP_LOG_DEBUG`.** Someone who opted into the
measurement build still saw nothing at default log level. It is `WARN` now, the
clean line is `INFO`, and the gate asserts one of the two appears **at all**:
absent both, the binary was built without the flag and a grep for violations
passes for the wrong reason.

**The gate first printed PASS with 19 violations in the log it had just read.**
The report's banner and its first class shared a line (no `\n` after
`while serving:`), and the parser anchored at the start of a line, so it skipped
`cudaMalloc` entirely and summed only the async and pinned rows. Both halves are
fixed: the format has its newline, and the parser matches the class name anywhere
in the line rather than depending on that.

The gate also refuses to judge before it can prove it reached the path it claims
to exercise: absent `residual buffer enabled` in the log, it fails.

## Also

The `shipping-prs` skill gains the #1516 triage lesson: `gh pr checks` reporting
nothing is a symptom, not "pending", and `mergeStateStatus` is the field that
answers it. A conflicted PR gets no workflow run at all and looks identical to a
queue backlog.