### PR TITLE
docs(goal): Gemma-4's 5.3 % decode drop is a priced trade, not a regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ there instead of retelling it.
 
 ### Changed
 
+- **Gemma-4's 5.3 % decode drop since July is a priced trade, not a regression.**
+  Bisected to `63df2d30` (#982's `gemm.nvfp4_lm_head` auto rule), then named inside
+  that two-change commit by flag rather than by splitting it: `on` buys **+7.4 %
+  decode for +9.0 % PPL** on Gemma-4-26B-A4B UD-Q4_K_M. Losing by the rule's own
+  standard, so the categorical MoE arm made the right call for a model that was
+  never in its calibration set. Priced in `GOAL.md`'s trades list.
+
 - **The `--bench` prompt is not self-repetitive, and six files said it was.**
   `imp-cli --bench` builds it as `tokens[i] = i % vocab_size`, so at
   `--bench-pp 512` it is 512 distinct ids and every 6-gram is unique; with

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -2,7 +2,7 @@
 layer: L1
 audience: operators
 verified: 2026-08-21
-commit: b2a162c0
+commit: d49dfd6d
 -->
 
 # imp — Goal Definition
@@ -167,7 +167,7 @@ A release is shippable when, on RTX 5090:
    - `gemm.nvfp4_lm_head_gdn` default-ON (#483): +2.2% PPL for +11.4% decode on GDN hybrids.
    - `gemm.fp8_ssm_proj` on **GGUF** hybrids default-ON (#962): +1.8% PPL (201-token corpus) for +21% decode on Qwen3.6-35B UD-Q4_K_M — E4M3 stacked on the Q8_0 lattice; the native-NVFP4 branch of the same flag is PPL-flat (#949) and is not a trade.
 
-   - `gemm.nvfp4_lm_head` default **"auto"** (#982, resolved 2026-07-13): the LM-head NVFP4 decode cache follows the measured net rule — ON for native BF16/F16 heads (+8-16% decode, +2.2% PPL, the long-standing accepted trade) and for small dense GGUF heads (d_model ≤ 4096: 4B +6.6% decode/+3.8% PPL, 8B +5.8%/+2.6% — decode win exceeds PPL cost); OFF for larger or MoE GGUF heads where the 2026-07-12 sweep measured the reverse (14B +1.9%/+2.1%, 30B-A3B +3.7%/+5.0%). Cost: north-star (14B Q6_K) −~1.9% decode, accepted for default PPL parity; `"on"`/`"off"` override.
+   - `gemm.nvfp4_lm_head` default **"auto"** (#982, resolved 2026-07-13): the LM-head NVFP4 decode cache follows the measured net rule: ON for native BF16/F16 heads (+8-16% decode, +2.2% PPL, the long-standing accepted trade) and for small dense GGUF heads (d_model ≤ 4096: 4B +6.6% decode/+3.8% PPL, 8B +5.8%/+2.6%, decode win exceeds PPL cost); OFF for larger or MoE GGUF heads where the 2026-07-12 sweep measured the reverse (14B +1.9%/+2.1%, 30B-A3B +3.7%/+5.0%). Cost: north-star (14B Q6_K) −~1.9% decode, accepted for default PPL parity; `"on"`/`"off"` override. **Gemma-4-26B-A4B UD-Q4_K_M, priced 2026-08-21 and it is the largest decode cost this rule carries:** the MoE arm turns the head off categorically (`is_dense=false` short-circuits before `d_model` is read), and that model was not in the calibration set. Measured on one build, alternating arms: `on` buys **+7.4% decode** (245.31 → 263.44 tok/s) for **+9.0% PPL** (251.23 → 273.90, 6465-token corpus). Losing by this rule's own standard, and by a wider margin than the 30B-A3B case it was calibrated on, so the categorical call was correct for a model it had never seen. The decode half is what a competitive sweep sees: Gemma-4 measured 258.96 tok/s before `63df2d30` and 245.24 after, and that −5.3% is this trade, not a regression.
    - `gemm.fp8_attn_proj` default "auto" = full q/k/v/o FP8 decode sidecar on **gpt-oss** (#984, 2026-07-13): +12.1% decode (349.7→392.1 tok/s). Not a teacher-forced-PPL trade by construction — the sidecar is decode-only (M=1 GEMV) and an nsys-verified `--perplexity` run executes zero FP8 kernels; decode-path quality gated via greedy-identity at 100 tokens and coherent 512-token generations across prompts. Opt-out `"off"`, conservative `"qo"` middle mode.
 
    First systematic cross-engine measurement 2026-07-12 (`docs/archive/ppl_parity_2026_07_12.md`): with the LM-head opt-out imp is at parity (−0.8%…+0.2%) with llama.cpp on every comparable GGUF hero.

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -634,3 +634,58 @@ matches the class name anywhere in the line rather than depending on that.
 
 The gate also refuses to judge before it can prove it reached the path it claims to
 exercise: it fails if `residual buffer enabled` is absent from the log.
+
+---
+
+## (h) The release blocker is defined over seven heroes and observed on two
+
+`GOAL.md` says: *"If a hero model regresses against any competitor on the primary
+metric, that is a release blocker."* The hero set has seven entries. Two of them are
+pinned by a gate:
+
+```
+tests/perf_baseline.json             -> Qwen3-8B-Q8_0.gguf
+tests/perf_baseline_north_star.json  -> Qwen3-14B-Q6_K.gguf
+tests/perf_baseline_chunked.json     -> no model pinned
+```
+
+Qwen3-Coder-30B-A3B, Qwen3.6-35B-A3B, **Gemma-4-26B-A4B**, Nemotron-H and gpt-oss-20b are
+measured by nothing. The only instrument that has ever looked at them is the competitive
+sweep, which before 2026-08-21 had last run on 2026-07-12.
+
+This is a coverage gap, not a calibration one, and the distinction decides where the fix
+goes. The 8 % threshold never entered into it: no gate ran on the model, so no threshold
+was applied. Recording it as "5.3 % slipped under 8 %" would send the next reader to argue
+about a number that was never consulted.
+
+`make bench-competitive` (#1518) is the instrument that closes it, wired into
+`scripts/check-release.sh` rather than `verify-fast`, because the blocker is defined at
+release scope and a per-PR cost is not warranted for it.
+
+### Two open shapes recorded here rather than chased
+
+**An unexplained +5 tok/s on Gemma-4 between window index 237 and 476.** The scan that
+located the `63df2d30` trade also mapped the rest of the window, and it is flat to the
+resolution of the instrument for 178 commits and then recovers:
+
+| window index | commit | Gemma-4 tg128 |
+|---|---|---|
+| 0 | `7811658a` | 258.96 |
+| 59 | `c5936db7` | 241.04 |
+| 119 | `5c9f6c07` | 241.37 |
+| 178 | `5408eb5c` | 240.41 |
+| 237 | `9f0322c8` | 240.21 |
+| 476 | `6e503cca` | 245.24 |
+
+Indices 59 through 237 span 1.16 tok/s, 0.48 %, against a within-arm spread of 0.05 to
+0.4 % on this model. Something after index 237 gives back ~5 tok/s and nothing records
+what. Not chased: the question it belonged to ("why is Gemma-4 slow") dissolved when the
+drop turned out to be a priced trade.
+
+**The `is_dense=false` arm has now been checked on a second model and was right there.**
+`pre_dequant_internal.h` records that this arm "silently voided that flag on quantized
+hybrids and cost the hero -5% decode", repaired for GDN hybrids only. Gemma-4 falls through
+the same arm and is neither dense nor GDN, so it looked like a second instance of the same
+defect. It is not: the trade is genuinely losing for it (+7.4 % decode against +9.0 % PPL).
+The generalisation still stands for the members of that category nobody has measured, but
+it now has one instance where the categorical call was correct.


### PR DESCRIPTION
The competitive sweep (#1518) flagged Gemma-4-26B-A4B UD-Q4_K_M as imp's one
regression since 2026-07-12, and the narrowest hero margin in the table. It is
not a regression.

## It reproduces, and the toolkit is not the cause

| arm | runs | median |
|---|---|---:|
| `7811658a` (the 07-12 sweep commit) | 258.12 / 258.96 / 259.07 | **258.96** |
| `6e503cca` (current `main`) | 245.36 / 245.23 / 245.24 | **245.24** |

Same host, same hour, alternating arms, both full `make build` images. The 07-12
pin of 261.3 reproduces today to within 0.9 %, so it was not a good-host-day.
Within-arm spread 0.05 to 0.4 %.

The two endpoints do not share a CUDA pin (13.3.0 against 13.3.1), so that was
isolated first: same code, pin swapped, **+0.03 %**. The toolkit is worth
nothing here and the delta is attributable to imp's 476 commits.

## Mapped, not binary-searched

`git bisect` assumes monotonicity and the first probe disproved it (240.21,
*below* the bad endpoint). Seven evenly spaced points went in instead:

| index | commit | tg128 |
|---|---|---:|
| 0 | `7811658a` | 258.96 |
| 59 | `c5936db7` | 241.04 |
| 119 | `5c9f6c07` | 241.37 |
| 178 | `5408eb5c` | 240.41 |
| 237 | `9f0322c8` | 240.21 |
| 476 | `6e503cca` | 245.24 |

Indices 59 to 237 span **1.16 tok/s over 178 commits**, flat to the resolution
of the instrument. That bounded the event to the first 59 commits and turned an
8-step search into a 5-step one:

```
e283a0ec  258.83  good
4ed3038f  258.46  good
63df2d30  240.93  bad   <- first bad
85a06deb  240.98  bad
d92c7bb5  241.54  bad
f26629c0  241.42  bad
```

Good and bad separated by 17.5 tok/s with nothing between them.

## The commit is not the answer, the change inside it is

`63df2d30` carries #984 and #982, and a bisect structurally cannot say which.
`gemm.nvfp4_lm_head` is a runtime key, so the separation was done from the other
end, on today's `main`, no rebuild:

| arm | decode | PPL (6465 tokens) |
|---|---:|---:|
| default, `auto` to off | 245.33 / 245.29 | 251.23 |
| `--set gemm.nvfp4_lm_head=on` | 263.53 / 263.35 | 273.90 |

**+7.4 % decode for +9.0 % PPL.** The rule's own standard is decode net of PPL:
it turns the head off for 30B-A3B Q4_K_M because +3.7 % cost +5.0 %. Gemma-4 is
losing by the same test and by a wider margin. The categorical `is_dense=false`
arm, which short-circuits before `d_model` is read, made the **correct call for
a model that was never in its calibration set**.

So there is nothing to fix. What was missing is the decode half of the price,
and it is now in `GOAL.md`'s trades list.

## Ledger section (h)

`GOAL.md` says a hero regressing against a competitor is a release blocker. The
hero set has **seven** entries; two are pinned by a gate. Qwen3-Coder-30B-A3B,
Qwen3.6-35B-A3B, Gemma-4-26B-A4B, Nemotron-H and gpt-oss-20b are measured by
nothing but the competitive sweep, which before yesterday had last run on
2026-07-12. That is a coverage gap, not a calibration one: no gate ran on this
model, so the 8 % threshold never entered into it.

Also recorded rather than chased: an unexplained +5 tok/s between window index
237 and 476, with the points that bound it.

Docs only. No code paths touched.