### PR TITLE
fix(gate): main's File size check was red, and the merge went through it anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`main`'s `File size` gate was red and a PR merged through it.** #1523 added 6
+  code lines to `engine_scheduler.cpp` without re-pinning its allowlist ceiling, the
+  check failed, and the merge went ahead because ruleset `14716423` requires exactly
+  one context (`Build`). Re-pinned 1962 to 1968. The enumeration of which checks are
+  required and which are advisory, and what that means for the five gates shipped this
+  week, is [`DEBT_LEDGER`](docs/audit/DEBT_LEDGER_2026_08_21.md) section (j).
+
 - **A failed perplexity run reported `PPL=1.0000`.** "perplexity failed:
   insufficient KV capacity" and `mean_nll=0.0000 PPL=1.0000` on consecutive
   lines, so anyone reading the log takes the failure for a perfect score.

--- a/docs/audit/DEBT_LEDGER_2026_08_21.md
+++ b/docs/audit/DEBT_LEDGER_2026_08_21.md
@@ -697,3 +697,65 @@ the same arm and is neither dense nor GDN, so it looked like a second instance o
 defect. It is not: the trade is genuinely losing for it (+7.4 % decode against +9.0 % PPL).
 The generalisation still stands for the members of that category nobody has measured, but
 it now has one instance where the categorical call was correct.
+
+---
+
+## (j) Every gate this campaign shipped is advisory, and one of them proved it
+
+`main` went red on 2026-08-21 and stayed red: #1523's `File size` check **FAILED and the PR
+merged anyway**.
+
+```
+$ gh pr checks 1523 --json name,state
+FAILURE  File size
+SUCCESS  Build
+SUCCESS  Alloc sites, Docs, Lint, Launch guards, clang-tidy,
+         Mock API contract, Real API contract, Release hygiene, enable-auto-merge
+SKIPPED  Test
+```
+
+Ruleset `14716423` ("Require CI", enforcement active) requires exactly **one** context:
+
+```
+$ gh api repos/kekzl/imp/rulesets/14716423 \
+    --jq '.rules[] | select(.type=="required_status_checks")
+          | .parameters.required_status_checks[].context'
+Build
+```
+
+| check | required | state on #1523 |
+|---|---|---|
+| **Build** | **yes** | SUCCESS |
+| **File size** | no | **FAILURE** |
+| Alloc sites | no | SUCCESS |
+| Docs | no | SUCCESS |
+| Lint | no | SUCCESS |
+| Launch guards | no | SUCCESS |
+| clang-tidy | no | SUCCESS |
+| Mock API contract | no | SUCCESS |
+| Real API contract | no | SUCCESS |
+| Release hygiene | no | SUCCESS |
+| Test | no | SKIPPED |
+| enable-auto-merge | no | SUCCESS |
+
+Eleven of twelve are advisory, and auto-merge squashes on mergeability plus the one required
+context. So `check_alloc_pairs.py` (#1505), `check_test_lanes.py` and
+`check_dead_inline_accessors.py` (#1506), `check_log_fatal.py` (#1511) and
+`check_alloc_interpose.sh` (#1520) are all correct, all red-tested, and **none of them can
+stop a merge.** A step that blocks its own job blocks nothing when the job is not required.
+
+This is the campaign's own defect shape one level up: the property that was verified is
+"does the gate go red", and the property that matters is "does red stop anything". Every one
+of these gates had the first tested and none had the second.
+
+**Deliberately not fixed here.** Adding required contexts changes what can merge for every
+future PR in this repo, which is the repo owner's decision. Until it is made, this entry is
+the honest statement of what these gates are: **documentation with a red light, not
+enforcement.** `.claude/skills/shipping-prs/SKILL.md` already records the same fact from the
+other direction ("every other job can go red and the PR still merges", with the two 2026-08
+`Alloc sites` incidents); what is new here is the enumeration and a case where it happened
+to a gate written the same day.
+
+Query note, because the obvious one is wrong: `gh api repos/kekzl/imp/branches/main/protection`
+returns **404 "Branch not protected"**. That is not the answer. Protection here is configured
+via **rulesets**, which the legacy protection endpoint does not see.

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -86,7 +86,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1068, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 1999, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1962, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1968, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1159, reason = "(c) 59 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
`main` has been red on `check_filesize.py` since #1523 and **two PRs merged over
it** (#1523, #1524).

## The re-pin

#1523 added 6 code lines to `engine_scheduler.cpp` (the `PPL=1.0000` sentinel
fix) without re-pinning its allowlist ceiling. Re-pinned **1962 to 1968**. An
allowlist entry is a ceiling, not an exemption, and the gate's own failure
message asks for exactly this.

## Why it merged: eleven of twelve checks are advisory

```
$ gh api repos/kekzl/imp/rulesets/14716423 \
    --jq '.rules[] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[].context'
Build

$ gh pr checks 1523 --json name,state
FAILURE  File size
SUCCESS  Build
SUCCESS  Alloc sites, Docs, Lint, Launch guards, clang-tidy,
         Mock API contract, Real API contract, Release hygiene, enable-auto-merge
SKIPPED  Test
```

Auto-merge squashes on mergeability plus the single required context. So
`check_alloc_pairs.py` (#1505), `check_test_lanes.py` and
`check_dead_inline_accessors.py` (#1506), `check_log_fatal.py` (#1511) and
`check_alloc_interpose.sh` (#1520) are correct, red-tested, and **none of them
can stop a merge**. A step that blocks its own job blocks nothing when the job is
not required.

That is this campaign's own defect shape one level up: what was verified is
"does the gate go red", and what matters is "does red stop anything". None of
them had the second tested, including by me.

**Deliberately not fixed here.** Making them blocking is its own change and gets
its own PR, so it is reviewable as a wiring decision rather than buried in a
re-pin. Repo settings are untouched either way.

Full enumeration in [`DEBT_LEDGER`](docs/audit/DEBT_LEDGER_2026_08_21.md)
section (j), including a query note: `gh api .../branches/main/protection`
returns **404 "Branch not protected"** on this repo, and that is not the answer.
Protection lives in **rulesets**, which the legacy endpoint does not see.