### PR TITLE
THROWAWAY: deliberate allowlist drift, to prove a gate finding blocks a merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,15 @@ jobs:
       # Minimal git up front so checkout below pulls real history and the
       # docs-only detection can diff against the PR/push base. (The rest of the
       # build tooling installs later, gated on the detection result.)
-      - name: Install git
+      #
+      # python3 comes with it because the static gates below are python and this
+      # container has neither: `nvidia/cuda:13.3.1-devel-ubuntu26.04` ships no
+      # python3 and no git. Without this the gate step fails "python3: not
+      # found" on every PR, which is a false red on the one required check.
+      - name: Install git and python3
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends git
+          apt-get install -y --no-install-recommends git python3
 
       - uses: actions/checkout@v7
         with:
@@ -96,6 +101,20 @@ jobs:
           fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
           printf 'non-docs changes: code=%s\nchanged files:\n%s\n' "$code" "${files:-<none>}"
+
+      # The blocking static gates, FIRST, before the compile. Ruleset 14716423
+      # requires exactly one context (`Build`), so a gate that runs only as its
+      # own job is advisory: #1523 merged with `File size` FAILED and #1524
+      # merged over the same red gate forty minutes later (DEBT_LEDGER (j)).
+      # Running them here is what makes red stop a merge. They are seconds, they
+      # need no apt and no network, and putting them ahead of the build means a
+      # drifted allowlist fails in ~15 s rather than after a three-minute
+      # compile. The named jobs below still run the same script with a filter,
+      # so `which gate failed` keeps a check name and there is one list, not two.
+      # Runs on docs-only PRs too: the docs and release-hygiene gates are exactly
+      # the ones a docs-only change can break.
+      - name: Static gates (blocking, before the build)
+        run: bash scripts/ci_static_gates.sh
 
       - name: Install build deps
         if: steps.changes.outputs.code == 'true'
@@ -405,25 +424,12 @@ jobs:
           python-version: "3.12"
       - name: File-size smells (advisory, non-blocking)
         run: python3 tools/check_filesize.py --warn-only
-      - name: File-size hard-review gate + allowlist ceilings (blocking)
-        run: python3 tools/check_filesize.py
-      # The size of the hole `No GPU runner in CI` leaves. Reads SOURCES, not a
-      # build directory: a gate that counts by reading build-dev/ inherits that
-      # directory's provenance, and on 2026-08-21 a stray uncommitted file had
-      # been compiled into test-quant and moved the count by 3.
-      - name: Tests that run in no CI lane (blocking)
-        run: python3 tools/check_test_lanes.py --report
-      # Functions defined inline in a header and mentioned nowhere else. The
-      # 2026-08-03 decl-only sweep could not see this class: it filtered on
-      # decl+def, i.e. two occurrences, and a header-inline definition is one.
-      - name: Header-inline definitions with no caller (blocking)
-        run: python3 tools/check_dead_inline_accessors.py
-      # IMP_LOG_FATAL only logs; IMP_CHECK is the only thing that aborts. Ten
-      # of twelve sites logged at FATAL and then carried on, three of them
-      # after a comment saying that carrying on hands a host pointer to a
-      # device kernel.
-      - name: FATAL logs that do not stop (blocking)
-        run: python3 tools/check_log_fatal.py --list
+      # The blocking checks live in scripts/ci_static_gates.sh, which the `Build`
+      # job also runs so a red gate fails the one required context. This job
+      # keeps them a named check: "which gate failed" is worth a check name, and
+      # the filter means there is one list rather than two that drift.
+      - name: File-size gates (blocking)
+        run: bash scripts/ci_static_gates.sh filesize
 
   # Documentation layer contract (docs/audit/docs-rewrite/). Seven checks, all
   # of which map to a defect this repo actually shipped: a datacenter-Blackwell
@@ -438,33 +444,17 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - name: Generated perf blocks match tests/perf_baseline.json
-        run: python3 scripts/sync_docs.py --check
-      - name: Doc lint (layers, provenance, links, budgets)
-        run: python3 scripts/docs_lint.py
+      - name: Doc gates (blocking)
+        run: bash scripts/ci_static_gates.sh docs
 
-  # Publishable-tree hygiene: the cheap half of scripts/check-release.sh (doc
-  # links, maintainer paths, credential-shaped strings, tracked binaries,
-  # LICENSE). SKIP_VERIFY=1 drops the `make verify-fast` step — that one needs a
-  # GPU and the built image, so it stays local. Own ubuntu job, no toolchain,
-  # seconds. The script existed since the first release but was wired into
-  # nothing, so it only ran when someone remembered it: v0.20.0 found two
-  # maintainer paths that had been on main for days. A gate nobody runs is not
-  # a gate.
   hygiene:
     name: Release hygiene
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - name: check-release.sh (without the GPU gate)
-        env:
-          SKIP_VERIFY: "1"
-        run: bash scripts/check-release.sh
+      - name: Release hygiene gate (blocking)
+        run: bash scripts/ci_static_gates.sh hygiene
 
-  # I1 gate (docs/internals/MEMORY.md): exactly one module talks to the CUDA
-  # driver about memory. Runs against tools/alloc_allowlist.txt, which shrinks
-  # monotonically — the gate fails both on a new direct allocation site and on a
-  # stale allowlist entry, so the list cannot silently stop being accurate.
   alloc-sites:
     name: Alloc sites
     runs-on: ubuntu-24.04
@@ -473,22 +463,9 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - name: Remaining direct allocation sites (progress)
-        run: python3 tools/check_alloc_sites.py --stats
-      - name: I1 allowlist gate (blocking)
-        run: python3 tools/check_alloc_sites.py
-      # A pointer freed through the allocator that did not produce it is invalid
-      # CUDA and silent: right pointer width, no driver complaint, program keeps
-      # running. AUDIT B10 recorded one such pair in July and it was still there
-      # in August, two lines further down. Blocking.
-      - name: Allocate/free API pairing gate (blocking)
-        run: python3 tools/check_alloc_pairs.py
+      - name: Alloc-site gates (blocking)
+        run: bash scripts/ci_static_gates.sh alloc
 
-  # Post-launch error checks after every CUDA kernel launch. Blocking: an
-  # unguarded launch turns a launch-time failure (bad config, smem over the
-  # opt-in, missing kernel image) into silently wrong output instead of an
-  # error. The convention was ~99% adopted and 0% enforced until the 2026-08-02
-  # audit found the whole Qwen3-VL tower at 9 launches / 0 checks.
   launchguards:
     name: Launch guards
     runs-on: ubuntu-24.04
@@ -497,8 +474,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - name: Post-launch check gate (blocking)
-        run: python3 tools/check_launch_guards.py
+      - name: Launch-guard gate (blocking)
+        run: bash scripts/ci_static_gates.sh launchguards
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
       # so `which gate failed` keeps a check name and there is one list, not two.
       # Runs on docs-only PRs too: the docs and release-hygiene gates are exactly
       # the ones a docs-only change can break.
+      # git refuses this checkout on ownership inside the container: the
+      # Actions runner owns /__w/imp/imp and the job's user does not. Without
+      # this, any gate that shells out to git dies - check-release.sh:55 got an
+      # empty `git rev-parse` and cd'd to nothing, which failed the required
+      # check for a reason that had nothing to do with the tree.
+      - name: Trust the checkout (container UID differs from the runner's)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Static gates (blocking, before the build)
         run: bash scripts/ci_static_gates.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ there instead of retelling it.
 
 ### Changed
 
+- **A red gate now blocks the merge.** Ruleset `Require CI` requires exactly one
+  context, `Build`, so every other check was advisory and two PRs merged over a red
+  `File size` in forty minutes. `scripts/ci_static_gates.sh` is one list run from two
+  places: the first step of `Build`, where a failure makes the required context red,
+  and the named jobs with a filter, so which gate failed still has a check name. Ahead
+  of the compile, so a drifted allowlist fails in ~15 s rather than after three
+  minutes. `Lint`, `Mock API contract`, `clang-tidy` and `Real API contract` stay
+  advisory for stated reasons; repo settings are untouched.
+
 - **Why a verify chunk costs 8.4x a decode step on Q6_K is recorded as open, with
   three refuted explanations.** It is what makes n-gram speculation net-negative on
   short requests on the north-star checkpoint. The chunk being a different, unfused

--- a/scripts/ci_static_gates.sh
+++ b/scripts/ci_static_gates.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# The blocking static gates, in one list, run from two places.
+#
+# WHY THIS FILE EXISTS. Until 2026-08-21 these ran only as their own CI jobs,
+# and branch ruleset 14716423 requires exactly one context: `Build`. Every other
+# job is advisory. #1523 merged with `File size` FAILED, #1524 merged over the
+# same red gate forty minutes later, and `main` stayed red. A step that blocks
+# its own job blocks nothing when the job is not required
+# (docs/audit/DEBT_LEDGER_2026_08_21.md section (j)).
+#
+# So the same list runs as the FIRST step of the `Build` job, where a failure
+# makes the one required context red and the PR unmergeable. The named jobs stay
+# as they are, because "which gate failed" is worth a check name; they call this
+# script with a filter so there is exactly one list rather than two that drift.
+#
+# WHY NOT `needs:`. Making `Build` depend on the gate jobs would keep the names
+# and add no wall time, but it rests on an unverified claim: that a required
+# check SKIPPED because its dependency failed blocks a merge rather than being
+# treated as satisfied. GitHub's behaviour differs between `needs`-skips and
+# path-filter skips, and this campaign's rule is not to build on a claim nobody
+# checked. Running inside `Build` needs no such assumption.
+#
+# WHAT IS DELIBERATELY NOT HERE, and it is a decision rather than an oversight:
+#   Lint            apt-installs clang-format and hits the network for upstream
+#                   dependency tags. Adding an apt install and a network call to
+#                   the one required check trades enforcement for flakiness.
+#   Mock API        `pip install -r tests/api/requirements.txt` then pytest. Same
+#                   objection as Lint: a network install inside the required
+#                   check. It is cheap in CPU and not hermetic, which is the axis
+#                   that matters here.
+#   clang-tidy      ~1m30, and it is advisory by its own step name.
+#   Real API        ~1m50, needs the build artifact, so it cannot run before the
+#                   compile it would gate.
+#   alloc-interpose costs ~15 minutes and a GPU. It belongs in check-release.sh,
+#                   where it already is (stage 9's sibling), not in CI at all.
+# Those four stay advisory. Everything in this file is cheap, hermetic and
+# deterministic: no apt, no network, no build directory, seconds in total.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+FAIL=0
+run() {  # run <label> <cmd...>
+    local label="$1"; shift
+    if "$@"; then
+        printf '  ok    %s\n' "$label"
+    else
+        printf '  FAIL  %s\n' "$label"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+want() {  # no filter = everything
+    [ "$#" -eq 0 ] && return 0
+    [ "$SELECT_ALL" = "1" ] && return 0
+    case " $SELECTED " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+SELECTED="$*"
+SELECT_ALL=0
+[ -z "$SELECTED" ] && SELECT_ALL=1
+
+if want filesize; then
+    echo "== File size =="
+    run "hard-review gate + allowlist ceilings" python3 tools/check_filesize.py
+    run "tests that run in no CI lane"          python3 tools/check_test_lanes.py --report
+    run "header-inline definitions with no caller" python3 tools/check_dead_inline_accessors.py
+    run "FATAL logs that do not stop"           python3 tools/check_log_fatal.py --list
+fi
+
+if want alloc; then
+    echo "== Alloc sites =="
+    run "I1 allowlist gate"                     python3 tools/check_alloc_sites.py
+    run "allocate/free API pairing"             python3 tools/check_alloc_pairs.py
+fi
+
+if want launchguards; then
+    echo "== Launch guards =="
+    run "post-launch check gate"                python3 tools/check_launch_guards.py
+fi
+
+if want docs; then
+    echo "== Docs =="
+    run "generated perf blocks match baseline"  python3 scripts/sync_docs.py --check
+    run "doc lint (layers, provenance, links)"  python3 scripts/docs_lint.py
+fi
+
+if want hygiene; then
+    echo "== Release hygiene =="
+    run "check-release.sh without the GPU gate" env SKIP_VERIFY=1 bash scripts/check-release.sh
+fi
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+    echo "ci-static-gates: $FAIL gate(s) failed"
+    exit 1
+fi
+echo "ci-static-gates: all selected gates passed"

--- a/scripts/ci_static_gates.sh
+++ b/scripts/ci_static_gates.sh
@@ -37,7 +37,11 @@
 # deterministic: no apt, no network, no build directory, seconds in total.
 set -uo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# Repo root from this script's own location, not from git. The GitHub Actions
+# container runs as a different user than owns the checkout, so `git rev-parse`
+# there dies with "detected dubious ownership in repository at /__w/imp/imp" and
+# takes the whole required check with it. This needs no git and no safe.directory.
+cd "$(dirname "$(readlink -f "$0")")/.."
 FAIL=0
 run() {  # run <label> <cmd...>
     local label="$1"; shift

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -2977,3 +2977,18 @@ void Engine::abandon_decode_pipeline() {
     bd_pipe_.n = 0;
 }
 }  // namespace imp
+
+// THROWAWAY: deliberate allowlist drift to prove the File size gate blocks a
+// merge. This branch is never merged; see the PR that opens it.
+namespace imp {
+namespace prove_the_gate_blocks {
+int a1() { return 1; }
+int a2() { return 2; }
+int a3() { return 3; }
+int a4() { return 4; }
+int a5() { return 5; }
+int a6() { return 6; }
+int a7() { return 7; }
+int a8() { return 8; }
+}  // namespace prove_the_gate_blocks
+}  // namespace imp


### PR DESCRIPTION
**Do not merge. This PR is an instrument and will be closed.**

It carries #1527's gate wiring plus a deliberate 12-code-LOC drift in an
allowlisted file: `src/runtime/engine_scheduler.cpp` pinned at 1968, actual
1980. Eight unused functions in a throwaway namespace, nothing else.

## What it is here to show

#1527 already demonstrated that a **broken** gate step blocks: its own `Build`
went red on a git-ownership failure and the PR could not merge. That proves the
chain, not the claim. Same exit code, different statement.

This one asks whether a **legitimate gate finding** propagates the whole way:
`check_filesize.py` notices a real drift, `ci_static_gates.sh` exits 1, the
`Build` job fails, the one required context goes red, and the PR becomes
unmergeable. That is the claim this campaign has been making since #1506 about
every gate it shipped, and until now none of them had it tested.

Locally: `python3 tools/check_filesize.py` exits 1, `bash
scripts/ci_static_gates.sh` exits 1.

The result, either way, goes in the assignment 11 report. **If it merges anyway,
that is the finding** and it is worth more than a wiring we believe in.