### PR TITLE
fix(gate): the GPU guard asked one question and answered two with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,19 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The GPU guard asked one question and answered two with it.**
+  `require_free_gpu.sh` refused on `memory.used > 2000 MiB` alone, which misses a
+  tenant that is compute-heavy and VRAM-light (a full Unreal Engine render on this
+  box peaks at 2385 MiB and **71 %** utilisation, so ~700 MiB of its own) and
+  misfires on one that is not there at all: the card idles at **1675 MiB**, seen as
+  low as 1435, so 2000 left ~325 MiB of margin. It refused a commit during a
+  container teardown on 2026-08-21. It now samples five times and splits the two
+  questions: sustained utilisation for "is someone computing", minimum-across-samples
+  memory for "is there room", thresholds derived from this box rather than rounded,
+  and the samples printed on refusal so a flicker is distinguishable from a tenant.
+  An empty `docker ps` now says a Windows-side process would never appear there,
+  instead of printing nothing.
+
 - **`main`'s `File size` gate was red and a PR merged through it.** #1523 added 6
   code lines to `engine_scheduler.cpp` without re-pinning its allowlist ceiling, the
   check failed, and the merge went ahead because ruleset `14716423` requires exactly

--- a/scripts/require_free_gpu.sh
+++ b/scripts/require_free_gpu.sh
@@ -8,8 +8,30 @@
 # itself, and the report points at the diff, which is the wrong place to look.
 # Before this check that cost a Docker build plus the whole suite to find out.
 #
-# The occupied memory is the tell, not the process list: on WSL2 nvidia-smi does
-# not show a container holding the card, so a busy GPU can look idle there.
+# THIS ASKS TWO QUESTIONS AND USED TO ANSWER BOTH WITH ONE NUMBER (2026-08-21).
+# The old rule was `memory.used > 2000 MiB`, and its header argued "the occupied
+# memory is the tell, not the process list". That was true of the tenant it was
+# written against - an imp server holding weights shows up as gigabytes - and
+# false of everything else:
+#
+#   1. "Is someone COMPUTING?" is utilisation, not memory. A tenant that is
+#      compute-heavy and VRAM-light passes a memory-only check while corrupting
+#      every number the gate is protecting. Measured on this box: a full Unreal
+#      Engine render peaks at 2385 MiB and 71 % utilisation, so its own share is
+#      ~700 MiB - invisible to a memory rule, ruinous to a perf measurement.
+#
+#   2. "Is there ROOM for my model?" is free VRAM. Still a real question, with a
+#      different failure and a different message, and it is not contention.
+#
+# And the memory threshold was picked, not derived. This box idles at 1675 MiB
+# (seen as low as 1435), so 2000 left ~325 MiB of margin against a card doing
+# nothing. It misfired on 2026-08-21 during a container teardown and cost a
+# round trip. Worse, the misfire rate is highest exactly when iterating fastest,
+# because back-to-back runs are when a previous container is most likely to be
+# unwinding as the next gate looks.
+#
+# So: SAMPLE, and take the MINIMUM memory rather than one reading. A teardown
+# flicker is not the minimum of five samples; a real tenant is.
 #
 # Silent and successful when there is no GPU at all: that case is the caller's
 # to decide, and the two callers decide it differently.
@@ -18,22 +40,65 @@
 set -uo pipefail
 
 GATE="${1:-gpu gate}"
-THRESHOLD="${IMP_GPU_FREE_MIB:-2000}"
+# Derived from this box, not rounded: idle 1675 (1435 low), plus a ~700 MiB
+# non-imp tenant, is 2400. imp's own models are 8000+ MiB. 4000 separates them
+# with room on both sides.
+THRESHOLD="${IMP_GPU_FREE_MIB:-4000}"
+# Idle here reads 3-8 %. Sustained load above this is somebody computing.
+BUSY_PCT="${IMP_GPU_BUSY_PCT:-25}"
+SAMPLES="${IMP_GPU_SAMPLES:-5}"
 
 command -v nvidia-smi >/dev/null 2>&1 || exit 0
 
-USED=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1)
-USED="${USED// /}"
-case "$USED" in
-    '' | *[!0-9]*) exit 0 ;;  # unreadable: do not block on a parse
-esac
-[ "$USED" -le "$THRESHOLD" ] && exit 0
+MEMS=() UTILS=() LINES=""
+for _ in $(seq 1 "$SAMPLES"); do
+    row=$(nvidia-smi --query-gpu=memory.used,utilization.gpu \
+                     --format=csv,noheader,nounits 2>/dev/null | head -1)
+    m="${row%%,*}"; u="${row##*,}"
+    m="${m// /}"; u="${u// /}"
+    case "$m$u" in '' | *[!0-9]*) exit 0 ;; esac  # unreadable: do not block on a parse
+    MEMS+=("$m"); UTILS+=("$u")
+    LINES="${LINES}${m} MiB/${u}%  "
+    sleep 0.4
+done
 
-echo "$GATE: the card is not free (${USED} MiB in use, threshold ${THRESHOLD})." >&2
+min_of() { printf '%s\n' "$@" | sort -n | head -1; }
+med_of() { printf '%s\n' "$@" | sort -n | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}'; }
+
+MEM_MIN=$(min_of "${MEMS[@]}")
+UTIL_MED=$(med_of "${UTILS[@]}")
+
+BUSY=0
+[ "$UTIL_MED" -ge "$BUSY_PCT" ] && BUSY=1
+FULL=0
+[ "$MEM_MIN" -gt "$THRESHOLD" ] && FULL=1
+[ "$BUSY" -eq 0 ] && [ "$FULL" -eq 0 ] && exit 0
+
+if [ "$BUSY" -eq 1 ]; then
+    echo "$GATE: something is computing on the card (${UTIL_MED}% median utilisation" >&2
+    echo "         over $SAMPLES samples, threshold ${BUSY_PCT}%)." >&2
+else
+    echo "$GATE: the card is occupied (${MEM_MIN} MiB held across all $SAMPLES samples," >&2
+    echo "         threshold ${THRESHOLD})." >&2
+fi
 echo "         Running it now would report the host rather than the change." >&2
+# The samples themselves, so a reader can tell a flicker from a tenant. A single
+# number invites "raise the threshold" as the fix, which is the wrong fix.
+echo "         samples: ${LINES}" >&2
 # Order matters: >&2 first, so stdout follows the real stderr rather than the
 # /dev/null that 2>/dev/null would have just installed.
-docker ps --format '         running container: {{.Names}} ({{.Image}})' >&2 2>/dev/null
-echo "         Wait for the card and try again. On WSL2 nvidia-smi does not list a" >&2
-echo "         container holding the GPU, so 'docker ps' above is part of the answer." >&2
+HOLDERS=$(docker ps --format '{{.Names}} ({{.Image}})' 2>/dev/null)
+if [ -n "$HOLDERS" ]; then
+    # Line by line, NOT `printf ... $HOLDERS`: unquoted word splitting turned
+    # one container into two lines, "name" and "(image)", which reads as two
+    # tenants where there is one.
+    while IFS= read -r h; do
+        [ -n "$h" ] && echo "         running container: $h" >&2
+    done <<< "$HOLDERS"
+else
+    echo "         No container holds it. On WSL2 that does NOT mean nobody does:" >&2
+    echo "         a Windows-side process (an Unreal Engine run from /mnt/c, a game," >&2
+    echo "         a browser) never appears in 'docker ps' and never will." >&2
+fi
+echo "         Wait for the card and try again." >&2
 exit 1


### PR DESCRIPTION
`require_free_gpu.sh` refused on `memory.used > 2000 MiB` alone. Its own header
argued *"the occupied memory is the tell, not the process list"*, which was true
of the tenant it was written against and false of everything else.

## Two questions, now asked separately

| question | instrument | why the old rule missed it |
|---|---|---|
| **Is someone computing?** | `utilization.gpu`, median of 5 samples | A compute-heavy, VRAM-light tenant passes a memory rule while corrupting every number the gate protects. A full Unreal Engine render on this box peaks at **2385 MiB and 71 %**, so ~700 MiB of its own. |
| **Is there room for my model?** | `memory.used`, **minimum** of 5 samples | Still real, different failure, different message, and not contention. |

## And the threshold was picked, not derived

This box idles at **1675 MiB** (seen as low as 1435). The old 2000 left ~325 MiB
of margin against a card doing nothing, and **it refused a commit here today
during a container teardown**. That misfire rate is highest exactly when
iterating fastest, because back-to-back runs are when a previous container is
most likely to still be unwinding as the next gate looks.

Sampling fixes both: a teardown flicker is not the minimum of five samples, a
real tenant is. Memory threshold **4000** sits above idle plus a ~700 MiB
non-imp tenant and far below imp's own 8000+ MiB models. Utilisation threshold
**25 %** against a measured idle of 3-8 %.

## The refusal now shows its work

```
test gate: the card is occupied (1583 MiB held across all 5 samples, threshold 100).
         Running it now would report the host rather than the change.
         samples: 1583 MiB/5%  1583 MiB/5%  1583 MiB/6%  1583 MiB/4%  1583 MiB/5%
         running container: tactics-dev-run-bd3b97454c19 (tactics-dev)
         running container: guardtest (imp:test)
```

A single number invites "raise the threshold" as the fix, which is the wrong
fix. And an empty `docker ps` no longer prints nothing: on WSL2 a Windows-side
process never appears there, so "no container" is not "no holder", and it says
so rather than leaving the reader with a busy card held by nobody.

## Proof

Both refusal branches negative-controlled: `IMP_GPU_FREE_MIB=100` takes the
memory branch, `IMP_GPU_BUSY_PCT=0` takes the utilisation branch, both exit 1
with their own message; the unmodified guard exits 0 on the idle card. Container
listing verified against two live containers, after fixing a word-splitting bug
that rendered one container as two lines, `name` and `(image)`.