### PR TITLE
refactor(memory): VramOwned<T>, so a mismatched allocate/free stops compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ there instead of retelling it.
 
 ### Added
 
+- **`VramOwned<T>`: an owning handle for a `VRAMAllocator` allocation.** The
+  allocator says of itself, in its own destructor, that it is "a tracker, not an
+  owner", so ownership lived with the caller as a raw pointer plus a free somewhere
+  else. That spelling is where this week's allocation defects were: four pointers
+  freed through an allocator that had not produced them, and 128 MiB released with
+  the wrong API. The handle carries the allocator that produced it and releases
+  through that one; move-only, and no `release()`, because a raw-pointer escape
+  would make the class writable again. Two callers converted, and the direct-site
+  allowlist shrinks 466 to 464. (`AUDIT.md` R7 records that earlier audits referred
+  to this type before it existed.)
+
 - **The release blocker is now enforced where it is defined.** `GOAL.md` makes a
   hero regressing against a competitor a release blocker, over seven heroes, of
   which gates observed two: Gemma-4 sat 5.3 % down for six weeks and no gate

--- a/src/memory/vram_owned.h
+++ b/src/memory/vram_owned.h
@@ -1,0 +1,97 @@
+#pragma once
+
+// An owning handle for a VRAMAllocator allocation.
+//
+// `VRAMAllocator` says of itself, in its own destructor, that it is "a tracker,
+// not an owner" (vram_allocator.cu). Ownership therefore lives with the caller,
+// spelled as a raw pointer member plus a free somewhere else, and that spelling
+// is what the 2026-08-21 campaign kept finding defects in: four device pointers
+// freed through an allocator that had not produced them (#1505), a 128 MiB
+// cudaMallocAsync block released with cudaFree so it never returned to the async
+// pool, and 469 direct allocation sites outside src/memory/ that
+// tools/check_alloc_pairs.py has to re-derive from source text on every run.
+//
+// A grep-based gate catches those after they are written. This type makes them
+// not compile: the allocation carries the allocator that produced it, and the
+// only way to release it is through that same allocator.
+//
+// `AUDIT.md` R7 records that earlier audits referred to a `VramOwned` type that
+// did not exist. It exists now.
+//
+//   VramOwned<int32_t> buf(vram_alloc_, n, "banned_tokens");
+//   if (!buf) return nullptr;              // allocation failed, nothing leaked
+//   cudaMemcpyAsync(buf.get(), ..., buf.bytes(), ...);
+//   // freed by ~VramOwned, through vram_alloc_, exactly once
+//
+// Move-only on purpose. A copy would be a double free, and there is no sane
+// deep-copy semantic for device memory that this type should be choosing.
+
+#include <cstddef>
+#include <utility>
+
+#include "memory/vram_allocator.h"
+
+namespace imp {
+
+template <typename T>
+class VramOwned {
+public:
+    VramOwned() = default;
+
+    // Allocates `count` elements. On failure the handle is empty and converts
+    // to false; it never throws, because the allocation sites this replaces are
+    // in paths that check and degrade rather than abort.
+    VramOwned(VRAMAllocator& alloc, size_t count, const char* tag, bool bypass_headroom = false)
+        : alloc_(&alloc), count_(count) {
+        if (count_ == 0)
+            return;
+        ptr_ = static_cast<T*>(alloc_->allocate(count_ * sizeof(T), tag, bypass_headroom));
+        if (ptr_ == nullptr)
+            count_ = 0;
+    }
+
+    ~VramOwned() { reset(); }
+
+    VramOwned(const VramOwned&) = delete;
+    VramOwned& operator=(const VramOwned&) = delete;
+
+    VramOwned(VramOwned&& o) noexcept
+        : alloc_(o.alloc_), ptr_(o.ptr_), count_(o.count_) {
+        o.alloc_ = nullptr;
+        o.ptr_ = nullptr;
+        o.count_ = 0;
+    }
+
+    VramOwned& operator=(VramOwned&& o) noexcept {
+        if (this != &o) {
+            reset();
+            alloc_ = o.alloc_;
+            ptr_ = o.ptr_;
+            count_ = o.count_;
+            o.alloc_ = nullptr;
+            o.ptr_ = nullptr;
+            o.count_ = 0;
+        }
+        return *this;
+    }
+
+    // Frees early. Idempotent, and safe on a moved-from handle.
+    void reset() noexcept {
+        if (ptr_ != nullptr && alloc_ != nullptr)
+            alloc_->free(ptr_);
+        ptr_ = nullptr;
+        count_ = 0;
+    }
+
+    T* get() const noexcept { return ptr_; }
+    explicit operator bool() const noexcept { return ptr_ != nullptr; }
+    size_t count() const noexcept { return count_; }
+    size_t bytes() const noexcept { return count_ * sizeof(T); }
+
+private:
+    VRAMAllocator* alloc_ = nullptr;
+    T* ptr_ = nullptr;
+    size_t count_ = 0;
+};
+
+}  // namespace imp

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -123,10 +123,6 @@ Engine::~Engine() {
         IMP_CUDA_CHECK_LOG(cudaFree(async_d_block_tables_swa_));
         async_d_block_tables_swa_ = nullptr;
     }
-    if (d_banned_tokens_) {
-        IMP_CUDA_CHECK_LOG(cudaFree(d_banned_tokens_));
-        d_banned_tokens_ = nullptr;
-    }
     if (swa_snap_slab_) {
         IMP_CUDA_CHECK_LOG(cudaFree(swa_snap_slab_));
         swa_snap_slab_ = nullptr;

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -1023,7 +1023,7 @@ private:
     int32_t* d_spec_argmax_ = nullptr;  // head of the [argmax | topm] block
     // diagnostics.spec_trace only: the chunk's full logits, so the trace can
     // report the top-2 gap per row rather than just which token won.
-    float* d_spec_logits_ = nullptr;
+    VramOwned<float> d_spec_logits_;
     std::vector<float> h_spec_logits_;
     PinnedBuffer h_spec_argmax_;  // pinned, [argmax | topm] twin (T5b)
     // Token-Recycling top-M harvest (speculative.token_recycling): per-row

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -26,6 +26,7 @@
 #include <span>
 #include "memory/layer_offload.h"
 #include "memory/vram_allocator.h"
+#include "memory/vram_owned.h"
 #include "exec/executor.h"
 #include "core/cuda_raii.h"
 #include <memory>
@@ -642,7 +643,11 @@ private:
     // launch and freed it again (AUDIT B28: part of the per-burst allocation
     // traffic the --wrap interposer named). One engine-owned copy, uploaded
     // once, serves all three.
-    int32_t* d_banned_tokens_ = nullptr;
+    // VramOwned, not a raw pointer plus a cudaFree in engine.cpp: the pairing
+    // used to span two files and tools/check_alloc_pairs.py had to re-derive it
+    // from source text. The handle frees through the allocator that produced it,
+    // once, in its own destructor.
+    VramOwned<int32_t> d_banned_tokens_;
     // Upload d_banned_tokens_ if not already resident. Returns nullptr when
     // the list is empty or the upload failed; callers then simply mask nothing.
     const int32_t* banned_tokens_device_(cudaStream_t stream);

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -23,18 +23,17 @@ const int32_t* Engine::banned_tokens_device_(cudaStream_t stream) {
     if (banned_token_ids_.empty())
         return nullptr;
     if (d_banned_tokens_)
-        return d_banned_tokens_;
-    const size_t bytes = banned_token_ids_.size() * sizeof(int32_t);
-    void* p = nullptr;
-    if (cudaMalloc(&p, bytes) != cudaSuccess) {
-        IMP_LOG_WARN("banned tokens: device upload failed (%zu B) — masking disabled", bytes);
+        return d_banned_tokens_.get();
+    VramOwned<int32_t> buf(vram_alloc_, banned_token_ids_.size(), "banned_tokens");
+    if (!buf) {
+        IMP_LOG_WARN("banned tokens: device upload failed (%zu B), masking disabled", buf.bytes());
         return nullptr;
     }
-    d_banned_tokens_ = static_cast<int32_t*>(p);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_banned_tokens_, banned_token_ids_.data(), bytes,
+    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(buf.get(), banned_token_ids_.data(), buf.bytes(),
                                        cudaMemcpyHostToDevice, stream));
     IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(stream));  // once, at first use
-    return d_banned_tokens_;
+    d_banned_tokens_ = std::move(buf);
+    return d_banned_tokens_.get();
 }
 
 int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -111,14 +111,15 @@ bool Engine::ensure_spec_buffers_(int chunk_cap, int max_blocks) {
     // trace site: a first-use allocation would be a serving-phase allocation
     // (docs/internals/MEMORY.md A3.2, and my own check_alloc_pairs gate would
     // see it). Off by default, so the memory is only taken when asked for.
-    if (runtime_config_.diagnostics.spec_trace && d_spec_logits_ == nullptr) {
+    if (runtime_config_.diagnostics.spec_trace && !d_spec_logits_) {
         const size_t v = static_cast<size_t>(model_->config().vocab_size);
         const size_t bytes = static_cast<size_t>(chunk_cap) * v * sizeof(float);
-        // Through vram_alloc_, like spec_state_snap_ two functions down, rather
-        // than a direct cudaMalloc: invariant I1 keeps the direct-allocation
-        // allowlist shrinking, and a diagnostic is not a reason to grow it.
-        d_spec_logits_ = static_cast<float*>(vram_alloc_.allocate(bytes, "spec_trace_logits"));
-        if (d_spec_logits_ == nullptr) {
+        // VramOwned, not vram_alloc_.allocate() plus a matching free in
+        // free_spec_buffers_(): the handle carries the allocator that produced
+        // it and releases through that one, so the pair cannot be written wrong
+        // and cannot be forgotten. It was correct before; it is now structural.
+        d_spec_logits_ = VramOwned<float>(vram_alloc_, bytes / sizeof(float), "spec_trace_logits");
+        if (!d_spec_logits_) {
             IMP_LOG_WARN(
                 "spec_trace: could not allocate %.1f MiB for the logit dump - the trace "
                 "will report argmax only, without the top-2 gap",
@@ -196,11 +197,10 @@ int Engine::recurrent_slot_for_(int req_id) const {
 }
 
 void Engine::free_spec_buffers_() {
-    // The spec_trace logit dump, freed through the API that allocated it.
-    if (d_spec_logits_) {
-        vram_alloc_.free(d_spec_logits_);
-        d_spec_logits_ = nullptr;
-    }
+    // The spec_trace logit dump releases itself: VramOwned frees through the
+    // allocator it was built from. reset() rather than waiting for ~Engine,
+    // because this function's contract is that the buffers are gone after it.
+    d_spec_logits_.reset();
     h_spec_logits_.clear();
     h_spec_logits_.shrink_to_fit();
     if (spec_state_snap_) {
@@ -978,7 +978,7 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         // Whole block in runtime/spec_trace.cpp: the speculation loop should
         // not carry its own diagnostics, and this one reads full logits.
         spec_trace_emit_verify(p0, t0, mc_on ? &mc[0] : &draft, mc_on ? static_cast<int>(mc.size()) : 0,
-                               h_spec_argmax_.as<int32_t>(), chunk_len, executor_.get(), d_spec_logits_,
+                               h_spec_argmax_.as<int32_t>(), chunk_len, executor_.get(), d_spec_logits_.get(),
                                h_spec_logits_, model_->config().vocab_size, stream);
     }
 

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -5,7 +5,7 @@
 # be justified in review; the gate fails on any file that allocates and is
 # not listed, and equally on any listed file that no longer allocates.
 #
-# remaining: 66 files, 466 sites
+# remaining: 66 files, 464 sites
 
 src/compute/attention_cublas.cu  # 14
 src/compute/attention_fmha_sm120.cu  # 2
@@ -65,8 +65,8 @@ src/quant/nvfp4_gemm.cu  # 3
 src/quant/nvfp4_quant.cu  # 16
 src/runtime/batch.cpp  # 10
 src/runtime/cuda_graph.cu  # 26
-src/runtime/engine.cpp  # 6
-src/runtime/engine_graph_decode.cpp  # 31
+src/runtime/engine.cpp  # 5
+src/runtime/engine_graph_decode.cpp  # 30
 src/runtime/engine_internal.h  # 4
 src/runtime/engine_kv_cache_init.cpp  # 3
 src/runtime/engine_scheduler.cpp  # 24


### PR DESCRIPTION
`VRAMAllocator` says of itself, in its own destructor, that it is **"a tracker,
not an owner"**. So ownership lived with the caller: a raw pointer member plus a
free somewhere else. That spelling is where this week's allocation defects were
- four device pointers freed through an allocator that had not produced them,
and 128 MiB of `cudaMallocAsync` released with `cudaFree` so it never returned to
the async pool (#1505).

A grep-based gate catches those after they are written. This type makes them not
compile: the allocation carries the allocator that produced it, and the only way
to release it is through that same allocator.

`AUDIT.md` R7 records that earlier audits referred to a `VramOwned` type **that
did not exist**. It exists now.

## Design

Move-only, and **no `release()`**. A raw-pointer escape hatch would make the
defect class writable again, which is the whole thing this is for. Failure to
allocate leaves the handle empty and converting to `false`; it never throws,
because the sites it replaces check and degrade rather than abort.

## Two real callers, and the counts move

| member | was | now |
|---|---|---|
| `Engine::d_banned_tokens_` | `cudaMalloc` in `engine_graph_decode.cpp`, `cudaFree` in `engine.cpp` | `VramOwned<int32_t>`, freed once in its own destructor |
| `Engine::d_spec_logits_` | `vram_alloc_.allocate()` with a matching free in `free_spec_buffers_()` | `VramOwned<float>`, `reset()` where the contract says the buffer is gone |

```
I1: 66 files / 464 sites outside src/memory/   (was 466)
tools/alloc_allowlist.txt: engine.cpp 6 -> 5, engine_graph_decode.cpp 31 -> 30
```

Both gates green after the re-pin. The first was a pairing that **spanned two
files**; the second was correct but a convention spanning a class. Neither can
now be written wrong or forgotten.

## Verified working, not merely compiling

`spec_trace` allocates its 19.1 MiB through the allocator and prints its gap
lines:

```
[verify] p0=528 t0=197 draft=[197,26,197] argmax=[197,26,197,197]
         gap=[197>26:6.6018, 26>280:4.3316, 197>298:5.9076, 197>26:7.1303]
```

That output also independently confirms #1521, which was **proved from source
rather than observed**: the prompt is a strictly increasing counting sequence so
it cannot supply a 6-gram match, therefore any draft came from the generation
looping. Here is the loop - the 8B alternates between tokens 197 and 26. A proof
and an observation of the same fact, arrived at from opposite ends.

## Scope

Two callers demonstrate the type; they do not retire the pair gate. The
direction that matters is that the gate should be on a path to being deletable.