### PR TITLE
docs(skill): shipping-prs says what a PR body is, not only what a release body is

### DIFF
--- a/.claude/skills/shipping-prs/SKILL.md
+++ b/.claude/skills/shipping-prs/SKILL.md
@@ -37,6 +37,30 @@ gh pr merge --auto --squash                    # re-arm LAST
 git log -1 --stat origin/main                  # after merge: confirm your new commit is in the squash
 ```
 
+## The PR body
+
+A reader opens it to decide whether this can merge. Narrative does not carry
+that decision, and `CHANGELOG.md`'s own rule ("a changelog, not a journal")
+applies here for the same reason.
+
+**Every paragraph carries a number, a file path or a decision.** One that
+carries only reasoning belongs in `docs/`, and the PR links to it.
+
+```
+## <change>        one section per topic, bullets under it
+| | before | after |    a table wherever a count or a timing moved
+## Gate            the measured block, verbatim, nothing wrapped around it
+Not in here:       one line: what a reviewer would look for and not find
+```
+
+Cut on sight: the sentence that sets a finding up before stating it ("that was
+never measured, and it is false"), the retelling of how a bug was found, and any
+instruction on how to read the numbers. State the fact and its evidence
+("the audit's X is false:" + the measurement) and stop.
+
+Measured on #1531: 162 lines to 57, no fact lost. Same rule for commit messages,
+which become squash subjects.
+
 ## Ship sequence
 
 ```bash


### PR DESCRIPTION
## What

`shipping-prs` carried a body skeleton for **releases** and nothing for PRs, so
PR bodies grew narrative. #1531 shipped 162 lines of it; the same content is 57.

Adds one section, `## The PR body`, before `## Ship sequence`:

- every paragraph carries a number, a file path or a decision; one that carries
  only reasoning goes to `docs/` and the PR links to it
- the section skeleton (`## <change>` / before-after table / `## Gate` /
  `Not in here:`)
- three things to cut on sight, with the example that triggered this
- same rule for commit messages, which become squash subjects

`CHANGELOG.md` already states this for changelog entries ("a changelog, not a
journal"). Same rule, one document over.

## Gate

Docs-only, no buildable source staged, so the pre-commit hook skipped the GPU
tests by its own rule. `docs_lint` OK, `sync_docs --check` up to date.

Not in here: the other skills, which were not asked to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfzNXKVx6o3kL6ViKQXGaJ
