### PR TITLE
ci(auto-merge): arm with --delete-branch, or the repo setting does nothing

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,4 +27,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        # --delete-branch is not redundant with the repository's
+        # deleteBranchOnMerge setting. An auto-merge request carries its own
+        # delete preference, and that is what GitHub honours at merge time, so
+        # arming without the flag leaves the head branch behind however the
+        # repository is configured. Measured 2026-08-21: #1531 armed by this
+        # workflow left its branch; #1532, re-armed by hand with the flag in the
+        # same hour, deleted its own. 21 branches had accumulated that way.
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
## What

`auto-merge.yml:30` armed auto-merge without `--delete-branch`. The repository's
`deleteBranchOnMerge` is `true` and did nothing: an auto-merge request carries
its own delete preference, and that is what GitHub honours at merge time.

Result: 21 branches from merged PRs sitting on the remote.

## Measured, same repo, same hour

| PR | armed with | head branch after merge |
|---|---|---|
| #1531 | this workflow, no flag | still there |
| #1532 | re-armed by hand, `--delete-branch` | deleted |
| #1533 | same, `--delete-branch` | deleted |

## Cleanup, done separately

21 branches deleted after checking each tip still equals the head commit its PR
merged, so nothing pushed after a merge was lost. Seven remain, untouched: three
have a closed PR, four never had one.

`ahead_by` is not a safety check here. Every squash-merged branch reads as "N
commits ahead of main", because the squash is a new commit and the branch's own
commits never become ancestors. The check that works is tip == merged head.

## Gate

Workflow YAML only; no source staged, so the pre-commit hook skipped the GPU
tests by its own rule.

Whether this PR deletes its own head branch is **not** the test of the fix: a
`pull_request` run may arm from the base branch's copy of the workflow, in which
case this one is still armed by the old line. The test is the PR after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfzNXKVx6o3kL6ViKQXGaJ
