### PR TITLE
fix(model): four out-of-bounds accesses in the SafeTensors and tokenizer.json parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,21 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Four out-of-bounds accesses in the model-file parsers, all reachable from a
+  checkpoint directory before any inference runs** (#1603, #1604, #1605, #1606).
+  A SafeTensors tensor was validated with one element width and read with
+  another (I16: 2 on disk, 4 in the QType it was mapped to), an unknown dtype
+  skipped the only validator that looks at `offset_start`, the shape product had
+  no overflow or sign guard, and a negative `tokenizer.json` id indexed
+  `vocab_` at `size_t(-1)`. A dtype with no equal-width engine type is now
+  refused instead of re-typed, and token ids are bounded at both ends.
+
+- **`make asan` could not build its own binaries** (#1659). Two test files that
+  use nlohmann sat in the unconditional `test-core` list while nlohmann is only
+  fetched under `IMP_BUILD_SERVER`, which the sanitizer target turns off, so
+  test-core did not compile in any `-DIMP_BUILD_SERVER=OFF` configuration.
+  Now clean: test-core 734, test-text 200, no ASan or UBSan report.
+
 - **imp-quantize read every subnormal value in an F16 `scale_inv` grid up to
   1025x too large** (`0x0001` as 6.1e-05 where the value is 5.96e-08): the
   hand-written widening pasted the subnormal mantissa under a normal exponent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,11 +641,6 @@ if(IMP_BUILD_TESTS)
         # Pre-cudaDeviceReset hook registry (#1207): self-registration replaced a
         # hand-maintained call list, so the new failure mode is an EMPTY registry.
         tests/test_cuda_static_reset.cpp
-        # Generative FSM battery for the schema-less json_object grammar. Lives
-        # in the CPU lane on purpose: the FSM is CUDA-free without init(), and
-        # every past grammar bug escaped CI because its tests need a GPU.
-        tests/test_json_constrain_property.cpp
-        tests/test_schema_constrain_property.cpp
         # GBNF grammar engine (parser + pushdown simulator + UTF-8 assembly).
         # CPU-only by construction — see the file header.
         tests/test_gbnf_grammar.cpp
@@ -748,6 +743,18 @@ if(IMP_BUILD_TESTS)
             tools/imp-server/constraint_validation.cpp
             tests/test_constraint_validation.cpp
             tests/test_server_args.cpp
+            # Generative FSM battery for the schema-less json_object grammar.
+            # Lives in the CPU lane on purpose: the FSM is CUDA-free without
+            # init(), and every past grammar bug escaped CI because its tests
+            # need a GPU. It sits in THIS block rather than the unconditional
+            # list because both files use nlohmann as their oracle, and
+            # nlohmann is only fetched under IMP_BUILD_SERVER (:503). Listed
+            # unconditionally, test-core does not compile in any
+            # -DIMP_BUILD_SERVER=OFF configuration - which is what `make asan`
+            # configures, so the sanitizer target could not build its own
+            # binaries.
+            tests/test_json_constrain_property.cpp
+            tests/test_schema_constrain_property.cpp
             tests/test_base64.cpp)
         target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server
                                                      ${CMAKE_CURRENT_SOURCE_DIR}/tools)

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -21,6 +22,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <string_view>
 #include <algorithm>
 #include <thread>
 #include <mutex>
@@ -86,65 +88,85 @@ bool validate_tensor_offsets(uint64_t offset_start, uint64_t offset_end, uint64_
 
 }  // namespace safetensors_internal
 
-// ---- SafeTensors wire dtype string -> bytes-per-element ----
+// ---- SafeTensors wire dtype: one table for the width AND the QType ----
 //
-// Used by validate_tensor_offsets to compute expected_nbytes from shape ×
-// dtype width. Returns 0 for unknown dtype strings (validation is then
-// skipped for that tensor — the existing safetensors_dtype() WARN covers
-// the unknown-type case).
-static size_t safetensors_wire_dtype_bytes(const std::string& s) {
-    if (s == "F64")
-        return 8;
-    if (s == "F32" || s == "I32" || s == "U32")
-        return 4;
-    if (s == "F16" || s == "BF16" || s == "I16" || s == "U16")
-        return 2;
-    if (s == "F8_E4M3" || s == "F8_E5M2" || s == "I8" || s == "U8" || s == "BOOL")
-        return 1;
-    if (s == "I64" || s == "U64")
-        return 8;
-    return 0;
-}
+// #1604: the width a tensor is validated with and the width its consumer reads
+// it with have to be the same number. They were two private tables, and for
+// I16 they disagreed - 2 bytes on disk against 4 for the QType::INT32 it was
+// mapped to - so a tensor that passed every check was then read 2x past its
+// own window.
+//
+// A dtype whose on-disk width has no equal-width engine type is refused, not
+// re-typed. A "closest proxy" of a different width converts nothing: it
+// reinterprets the bytes at the wrong stride, so element i is read from byte
+// i*4 of a 2-byte-per-element array. Such a tensor was never servable, only
+// silently mapped, and src/model/CLAUDE.md is explicit that a checkpoint this
+// build cannot serve is refused at load rather than served wrong.
+struct SafeTensorsDtype {
+    std::string_view name;
+    size_t wire_bytes;  // bytes per element on disk
+    QType qtype;        // engine type; only meaningful when servable
+    bool servable;
+    const char* once_note;  // logged once, the first time this dtype appears
+};
 
-// ---- SafeTensors dtype string to QType ----
+static constexpr SafeTensorsDtype kSafeTensorsDtypes[] = {
+    {"F32", 4, QType::F32, true, nullptr},
+    {"F16", 2, QType::F16, true, nullptr},
+    {"BF16", 2, QType::BF16, true, nullptr},
+    {"F8_E4M3", 1, QType::FP8_E4M3, true, nullptr},
+    // Lossy but equal-width, so the stride is right and only the exponent
+    // interpretation is approximate.
+    {"F8_E5M2", 1, QType::FP8_E4M3, true,
+     "SafeTensors F8_E5M2 tensors found; mapping to FP8_E4M3 as a lossy proxy "
+     "(no native E5M2 path). Activation-style tensors may lose precision. (Logged once.)"},
+    {"I8", 1, QType::INT8, true, nullptr},
+    {"U8", 1, QType::INT8, true, nullptr},
+    {"BOOL", 1, QType::INT8, true, nullptr},
+    {"I32", 4, QType::INT32, true, nullptr},
+    {"U32", 4, QType::INT32, true, nullptr},
+    // Not servable: the engine has no 8-byte type and no 16-bit integer type,
+    // so no equal-width mapping exists. These used to be F64/I64 -> INT32
+    // (8 -> 4, wrong stride, garbage values) and I16/U16 -> INT32 or the F32
+    // default (2 -> 4, a 100% over-read running off the end of the mapping for
+    // the last tensor in a shard).
+    {"F64", 8, QType::F32, false, nullptr},
+    {"I64", 8, QType::INT32, false, nullptr},
+    {"U64", 8, QType::INT32, false, nullptr},
+    {"I16", 2, QType::INT32, false, nullptr},
+    {"U16", 2, QType::INT32, false, nullptr},
+};
 
-static QType safetensors_dtype(const std::string& s) {
-    if (s == "F32")
-        return QType::F32;
-    if (s == "F16")
-        return QType::F16;
-    if (s == "BF16")
-        return QType::BF16;
-    if (s == "F64")
-        return QType::F32;  // closest proxy
-    if (s == "I8")
-        return QType::INT8;
-    if (s == "U8")
-        return QType::INT8;  // treat unsigned byte as INT8
-    if (s == "I16")
-        return QType::INT32;  // closest proxy
-    if (s == "I32")
-        return QType::INT32;
-    if (s == "I64")
-        return QType::INT32;  // closest proxy
-    if (s == "BOOL")
-        return QType::INT8;
-    if (s == "F8_E4M3")
-        return QType::FP8_E4M3;
-    if (s == "F8_E5M2") {
-        static bool warned = false;
-        if (!warned) {
-            warned = true;
-            IMP_LOG_WARN(
-                "SafeTensors F8_E5M2 tensors found; mapping to FP8_E4M3 as a "
-                "lossy proxy (no native E5M2 path). Activation-style tensors "
-                "may lose precision. (Logged once.)");
-        }
-        return QType::FP8_E4M3;
+const SafeTensorsDtype* safetensors_dtype_entry(const std::string& s) {
+    for (const auto& e : kSafeTensorsDtypes) {
+        if (e.name == s)
+            return &e;
     }
-    IMP_LOG_WARN("Unknown SafeTensors dtype '%s', defaulting to FP32", s.c_str());
-    return QType::F32;
+    return nullptr;
 }
+
+// Shard loading is multi-threaded, so the once-per-dtype note needs a lock;
+// the previous plain `static bool warned` raced (harmlessly, but it raced).
+static void log_dtype_note_once(const SafeTensorsDtype& dt) {
+    if (!dt.once_note)
+        return;
+    static std::mutex note_mutex;
+    static std::set<std::string> noted;
+    std::lock_guard<std::mutex> lock(note_mutex);
+    if (noted.insert(std::string(dt.name)).second)
+        IMP_LOG_WARN("%s", dt.once_note);
+}
+
+namespace safetensors_internal {
+
+size_t dtype_table_size() { return sizeof(kSafeTensorsDtypes) / sizeof(kSafeTensorsDtypes[0]); }
+
+DtypeTableRow dtype_table_row(size_t i) {
+    const auto& e = kSafeTensorsDtypes[i];
+    return DtypeTableRow{std::string(e.name), e.wire_bytes, e.qtype, e.servable};
+}
+
+}  // namespace safetensors_internal
 
 // ---- Architecture detection from weight names ----
 
@@ -375,6 +397,8 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
     int n_dropped_too_many_dims = 0;
     int n_dropped_no_offsets = 0;
     int n_dropped_offset_validation = 0;
+    int n_dropped_dtype_unsupported = 0;
+    int n_dropped_bad_shape = 0;
     auto warn_drop = [&](const char* tensor_name, const char* reason) {
         IMP_LOG_WARN("SafeTensors %s: dropping tensor '%s' — %s", path.c_str(), tensor_name, reason);
     };
@@ -413,7 +437,20 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             warn_drop(tensor_name.c_str(), "missing or non-string 'dtype' field");
             continue;
         }
-        QType dtype = safetensors_dtype(dtype_val->str_val);
+        // #1603/#1604: the dtype decides both the QType and the width the
+        // offsets are validated with, so an unknown or unservable one is a
+        // drop here and never reaches a lenient validation branch below.
+        const SafeTensorsDtype* dt = safetensors_dtype_entry(dtype_val->str_val);
+        if (!dt || !dt->servable) {
+            n_dropped_dtype_unsupported++;
+            std::string reason = dt ? ("dtype '" + dtype_val->str_val +
+                                       "' has no equal-width engine type, refusing to re-type it")
+                                    : ("unknown SafeTensors dtype '" + dtype_val->str_val + "'");
+            warn_drop(tensor_name.c_str(), reason.c_str());
+            continue;
+        }
+        log_dtype_note_once(*dt);
+        QType dtype = dt->qtype;
 
         const JValue* shape_val = jobj_find(tensor_meta, "shape");
         if (!shape_val || shape_val->type != JType::ARRAY) {
@@ -424,6 +461,36 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
 
         int ndim = static_cast<int>(shape_val->arr.size());
         int64_t shape[kMaxDims] = {};
+
+        // #1605: every dim arrives as a JSON double narrowed to int64, so the
+        // sign and the running product have to be checked BEFORE any
+        // multiplication - a wrapped product yields a small expected_nbytes
+        // that then passes the offset check. gguf_tensor_byte_size()
+        // (src/model/gguf_parse.cpp) has had exactly this guard since it was
+        // written; this is the same computation without it.
+        uint64_t nelem = 1;
+        bool bad_shape = false;
+        for (int d = 0; d < ndim; d++) {
+            int64_t dim = shape_val->arr[d].as_int();
+            if (dim < 0) {
+                bad_shape = true;
+                break;
+            }
+            uint64_t udim = static_cast<uint64_t>(dim);
+            if (udim != 0 && nelem > UINT64_MAX / udim) {
+                bad_shape = true;
+                break;
+            }
+            nelem *= udim;
+        }
+        // Tensor::numel() redoes this product in int64_t, so a value above
+        // INT64_MAX would be signed overflow there even though it fits here.
+        if (bad_shape || nelem > static_cast<uint64_t>(INT64_MAX)) {
+            n_dropped_bad_shape++;
+            warn_drop(tensor_name.c_str(), "negative or overflowing shape dimension");
+            continue;
+        }
+
         if (ndim > kMaxDims) {
             // Was: drop with a WARN. That loses a weight and only says so in a
             // log line — Qwen3-VL's patch embed is [1024, 3, 2, 16, 16] and
@@ -442,11 +509,26 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
             // structure here — but it was being DROPPED before, so nothing can
             // regress, and the INFO line makes the reinterpretation visible
             // rather than silent.
-            int64_t tail = 1;
-            for (int d = 1; d < ndim; d++)
-                tail *= shape_val->arr[d].as_int();
+            // Dims are non-negative here, but shape[0] == 0 makes the total
+            // product 0 while the tail alone can still overflow, so the tail
+            // gets its own saturating guard.
+            uint64_t tail = 1;
+            bool tail_overflow = false;
+            for (int d = 1; d < ndim; d++) {
+                uint64_t udim = static_cast<uint64_t>(shape_val->arr[d].as_int());
+                if (udim != 0 && tail > static_cast<uint64_t>(INT64_MAX) / udim) {
+                    tail_overflow = true;
+                    break;
+                }
+                tail *= udim;
+            }
+            if (tail_overflow) {
+                n_dropped_bad_shape++;
+                warn_drop(tensor_name.c_str(), "trailing shape dims overflow when flattened");
+                continue;
+            }
             shape[0] = shape_val->arr[0].as_int();
-            shape[1] = tail;
+            shape[1] = static_cast<int64_t>(tail);
             IMP_LOG_WARN("SafeTensors %s: tensor '%s' has %d dims; flattening trailing dims to [%lld, %lld]",
                          path.c_str(), tensor_name.c_str(), ndim, static_cast<long long>(shape[0]),
                          static_cast<long long>(shape[1]));
@@ -468,29 +550,27 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
         uint64_t offset_end = static_cast<uint64_t>(offsets_val->arr[1].as_int());
 
         // Per-tensor offset/size validation (F4): reject swap, OOB end, and
-        // shape-vs-byte-count mismatch. expected_nbytes = nelem × wire_dtype_bytes.
-        size_t wire_bytes = safetensors_wire_dtype_bytes(dtype_val->str_val);
-        if (wire_bytes == 0) {
-            // Unknown wire dtype — skip strict validation but keep the soft
-            // OOB check below. safetensors_dtype()'s WARN already fires for
-            // unknown wire types when the tensor is actually emitted.
-            if (tensor_data_offset + offset_end > file_size) {
-                n_dropped_offset_validation++;
-                warn_drop(tensor_name.c_str(), "offset_end past EOF (unknown wire dtype, lenient check)");
-                continue;
-            }
-        } else {
-            int64_t nelem = 1;
-            for (int d = 0; d < ndim; d++)
-                nelem *= shape[d];
-            uint64_t expected_nbytes = static_cast<uint64_t>(nelem) * static_cast<uint64_t>(wire_bytes);
-            std::string vt_err;
-            if (!safetensors_internal::validate_tensor_offsets(offset_start, offset_end, expected_nbytes,
-                                                               tensor_data_offset, file_size, &vt_err)) {
-                n_dropped_offset_validation++;
-                warn_drop(tensor_name.c_str(), vt_err.c_str());
-                continue;
-            }
+        // shape-vs-byte-count mismatch. expected_nbytes = nelem * wire_bytes.
+        //
+        // #1603: there is no lenient branch any more. The old one ran for every
+        // unknown dtype and never looked at offset_start at all - the only
+        // checker of offset_start is validate_tensor_offsets - so the raw
+        // pointer below was `mmap_base + tensor_data_offset + <unbounded>`. Its
+        // one check also added two file-controlled uint64s, which wraps for
+        // offset_end >= 2^64 - tensor_data_offset; validate_header_size at the
+        // top of this file rejects exactly that pattern and says why.
+        if (nelem != 0 && dt->wire_bytes > UINT64_MAX / nelem) {
+            n_dropped_bad_shape++;
+            warn_drop(tensor_name.c_str(), "shape times dtype width overflows");
+            continue;
+        }
+        uint64_t expected_nbytes = nelem * static_cast<uint64_t>(dt->wire_bytes);
+        std::string vt_err;
+        if (!safetensors_internal::validate_tensor_offsets(offset_start, offset_end, expected_nbytes,
+                                                           tensor_data_offset, file_size, &vt_err)) {
+            n_dropped_offset_validation++;
+            warn_drop(tensor_name.c_str(), vt_err.c_str());
+            continue;
         }
 
         void* tensor_ptr = tensor_data_base + offset_start;
@@ -505,13 +585,15 @@ static bool load_shard(const std::string& path, std::unordered_map<std::string, 
     }
 
     int n_total_dropped = n_dropped_no_dtype + n_dropped_no_shape + n_dropped_too_many_dims +
-                          n_dropped_no_offsets + n_dropped_offset_validation;
+                          n_dropped_no_offsets + n_dropped_offset_validation + n_dropped_dtype_unsupported +
+                          n_dropped_bad_shape;
     if (n_total_dropped > 0) {
         IMP_LOG_WARN(
             "SafeTensors %s: dropped %d malformed tensors (no_dtype=%d no_shape=%d "
-            "too_many_dims=%d no_offsets=%d offset_validation=%d)",
+            "too_many_dims=%d no_offsets=%d offset_validation=%d dtype_unsupported=%d bad_shape=%d)",
             path.c_str(), n_total_dropped, n_dropped_no_dtype, n_dropped_no_shape, n_dropped_too_many_dims,
-            n_dropped_no_offsets, n_dropped_offset_validation);
+            n_dropped_no_offsets, n_dropped_offset_validation, n_dropped_dtype_unsupported,
+            n_dropped_bad_shape);
     }
 
     return true;

--- a/src/model/safetensors_loader.h
+++ b/src/model/safetensors_loader.h
@@ -58,6 +58,22 @@ bool validate_tensor_offsets(uint64_t offset_start, uint64_t offset_end,
                              uint64_t expected_nbytes, uint64_t tensor_data_offset,
                              uint64_t file_size, std::string* err);
 
+// One row of the SafeTensors wire-dtype table (#1604). `wire_bytes` is the
+// on-disk element width and `qtype` is what the tensor is mapped to; for a
+// servable row those two widths MUST agree, otherwise the loader validates a
+// tensor with one width and its consumer reads it with another. Exposed so a
+// test can assert that equality over the whole table and fail when a new
+// proxy mapping is added.
+struct DtypeTableRow {
+    std::string name;
+    size_t wire_bytes;
+    QType qtype;
+    bool servable;
+};
+
+size_t dtype_table_size();
+DtypeTableRow dtype_table_row(size_t i);
+
 }  // namespace safetensors_internal
 
 }  // namespace imp

--- a/src/model/tokenizer.cpp
+++ b/src/model/tokenizer.cpp
@@ -835,28 +835,49 @@ bool Tokenizer::load(const std::string& path) {
     // Extract vocabulary from model.vocab
     const JValue* vocab = jobj_find(*model, "vocab");
     if (vocab && vocab->type == JType::OBJECT) {
-        // Find max id to size the vocab vector
-        int max_id = 0;
+        // Find max id to size the vocab vector.
+        //
+        // #1606: an id arrives as a JSON double and is narrowed to int, so it
+        // can be negative or absurd. max_id only ever grew, so a negative id
+        // never widened the vector and `vocab_[id]` below indexed at size_t(-1)
+        // - a heap write before any inference runs, on any checkpoint
+        // directory the operator points at. The decode side of this same file
+        // has always range-checked (decode_spm_token); the load side did not.
+        // The upper bound matters too: max_id + 1 in `int` wraps to INT_MIN at
+        // INT_MAX, and an id of 2^31-1 alone asks for a 2.1-billion-element
+        // vector<string>.
+        int64_t max_id = -1;
+        size_t n_dropped_id = 0;
         for (const auto& [token, val] : vocab->obj) {
             if (val.type == JType::NUMBER) {
-                int id = static_cast<int>(val.num_val);
+                int64_t id = static_cast<int64_t>(val.num_val);
+                if (id < 0 || id > kMaxTokenId) {
+                    n_dropped_id++;
+                    continue;
+                }
                 if (id > max_id)
                     max_id = id;
             }
         }
-        vocab_.resize(max_id + 1);
-        scores_.resize(max_id + 1, 0.0f);
+        vocab_.resize(static_cast<size_t>(max_id + 1));
+        scores_.resize(static_cast<size_t>(max_id + 1), 0.0f);
 
         token_to_id_.clear();
         token_to_id_.reserve(vocab->obj.size());
         for (const auto& [token, val] : vocab->obj) {
             if (val.type != JType::NUMBER)
                 continue;
-            int id = static_cast<int>(val.num_val);
-            vocab_[id] = token;
-            token_to_id_[token] = id;
+            int64_t id = static_cast<int64_t>(val.num_val);
+            if (id < 0 || id > max_id)
+                continue;
+            vocab_[static_cast<size_t>(id)] = token;
+            token_to_id_[token] = static_cast<int>(id);
         }
 
+        if (n_dropped_id > 0) {
+            IMP_LOG_WARN("tokenizer.json: dropped %zu vocab entries with an out-of-range id (< 0 or > %lld)",
+                         n_dropped_id, static_cast<long long>(kMaxTokenId));
+        }
         IMP_LOG_INFO("tokenizer.json: loaded %zu vocab entries (type=%s)", vocab->obj.size(),
                      model_type.c_str());
     }
@@ -896,7 +917,18 @@ bool Tokenizer::load(const std::string& path) {
                 continue;
             if (id_v->type != JType::NUMBER || content_v->type != JType::STRING)
                 continue;
-            int id = static_cast<int>(id_v->num_val);
+            // #1606: same unchecked narrowing as the vocab loop above. The
+            // "ensure vectors are large enough" guard below is a `>=` test,
+            // which a negative id passes without resizing, so it lands as a
+            // write at a negative index - including a vector<bool> proxy write
+            // into added_token_ids_.
+            int64_t id64 = static_cast<int64_t>(id_v->num_val);
+            if (id64 < 0 || id64 > kMaxTokenId) {
+                IMP_LOG_WARN("tokenizer.json: added_token with out-of-range id %lld dropped",
+                             static_cast<long long>(id64));
+                continue;
+            }
+            int id = static_cast<int>(id64);
             const std::string& content = content_v->str_val;
             bool is_special = special_v && special_v->type == JType::NUMBER && special_v->num_val != 0.0;
             // HF semantics: an added token with `normalized=false` is matched

--- a/src/model/tokenizer.h
+++ b/src/model/tokenizer.h
@@ -8,6 +8,13 @@
 
 namespace imp {
 
+// Largest token id a tokenizer.json may declare (#1606). Ids come out of the
+// file as JSON doubles and index vocab_/scores_/token_types_ directly, so they
+// need both a lower and an upper bound: below zero is an out-of-bounds write,
+// and near INT_MAX the `max_id + 1` sizing wraps. 4M is roughly 16x the largest
+// vocabulary any shipped checkpoint uses (Gemma, ~256k).
+constexpr int64_t kMaxTokenId = 4 * 1024 * 1024;
+
 class Tokenizer {
 public:
     Tokenizer() = default;

--- a/tests/test_safetensors_loader.cpp
+++ b/tests/test_safetensors_loader.cpp
@@ -3,6 +3,7 @@
 // synthetic blob bytes — no Model construction, no GPU.
 
 #include "model/safetensors_loader.h"
+#include "core/qtype.h"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -240,6 +241,175 @@ TEST(SafeTensorsHighDimTensors, FlattenedInsteadOfDropped) {
     // The old behaviour must be gone: nothing dropped for dimensionality.
     EXPECT_EQ(captured.find("ndim exceeds"), std::string::npos)
         << "High-dim tensors must no longer be dropped. Captured: " << captured;
+}
+
+// INFO goes to stdout and WARN/ERROR to stderr (src/core/logging.cpp:71), so
+// a test that only captures stderr cannot see "Parsed N tensors" - which is the
+// line that says whether the tensor actually survived. Capture both.
+static std::string load_and_capture(const std::string& path) {
+    testing::internal::CaptureStdout();
+    testing::internal::CaptureStderr();
+    auto model = load_safetensors(path);
+    (void)model;
+    std::string out = testing::internal::GetCapturedStdout();
+    std::string err = testing::internal::GetCapturedStderr();
+    return out + err;
+}
+
+// ---- #1604: the validated width and the consumed width are one number ----
+//
+// The loader used to keep two private dtype tables: one for the byte count it
+// validated a tensor with, one for the QType its consumer reads it with. For
+// I16 they were 2 and 4. A file that passed every check was then read at twice
+// its own size. This test fails the moment a row is added whose two widths
+// disagree, which is how that defect would come back.
+TEST(SafeTensorsDtypeTable, ServableRowsHaveMatchingWidths) {
+    const size_t n = safetensors_internal::dtype_table_size();
+    ASSERT_GT(n, 0u);
+    size_t n_servable = 0;
+    for (size_t i = 0; i < n; i++) {
+        auto row = safetensors_internal::dtype_table_row(i);
+        if (!row.servable)
+            continue;
+        n_servable++;
+        EXPECT_EQ(qtype_elem_bytes(row.qtype), row.wire_bytes)
+            << "dtype '" << row.name << "' is served as a QType " << qtype_elem_bytes(row.qtype)
+            << " bytes wide but is " << row.wire_bytes
+            << " bytes wide on disk. Either map it to an equal-width QType or mark it unservable.";
+    }
+    EXPECT_GT(n_servable, 0u);
+}
+
+TEST(SafeTensorsDtypeTable, WidthMismatchedWireTypesAreRefused) {
+    // The five that have no equal-width engine type. Pinning them by name so a
+    // future "closest proxy" re-typing has to argue with a test.
+    const char* refused[] = {"F64", "I64", "U64", "I16", "U16"};
+    for (const char* name : refused) {
+        bool found = false;
+        for (size_t i = 0; i < safetensors_internal::dtype_table_size(); i++) {
+            auto row = safetensors_internal::dtype_table_row(i);
+            if (row.name == name) {
+                found = true;
+                EXPECT_FALSE(row.servable) << name << " must not be re-typed to a different width";
+            }
+        }
+        EXPECT_TRUE(found) << name << " missing from the wire dtype table";
+    }
+}
+
+TEST(SafeTensorsHostileHeader, I16TensorIsDroppedNotRetyped) {
+    // Internally consistent file: 4 elements x 2 bytes = 8 bytes, exactly the
+    // declared window. Nothing here is malformed - the defect was that the
+    // consumer then read 16 bytes, running off the end of the mapping.
+    const std::string header = "{\"w\": {\"dtype\": \"I16\", \"shape\": [4], \"data_offsets\": [0, 8]}}";
+    std::string path = write_temp_blob(header, 8);
+    ASSERT_FALSE(path.empty());
+
+    std::string captured = load_and_capture(path);
+    std::remove(path.c_str());
+
+    EXPECT_NE(captured.find("equal-width"), std::string::npos)
+        << "Expected an I16 tensor to be refused, not mapped to a 4-byte QType. Captured: " << captured;
+    EXPECT_NE(captured.find("dtype_unsupported=1"), std::string::npos) << captured;
+    EXPECT_EQ(captured.find("Parsed 1 tensors"), std::string::npos)
+        << "The tensor must not survive into the map. Captured: " << captured;
+}
+
+// ---- #1603: no lenient branch for an unknown dtype ----
+
+TEST(SafeTensorsHostileHeader, UnknownDtypeWithUnboundedOffsetStartIsDropped) {
+    // The reachable half of #1603. offset_start was never validated on the
+    // unknown-dtype branch - validate_tensor_offsets is its only checker and
+    // that branch skipped it - while the branch's own check looked at
+    // offset_end alone. So offset_start went straight into
+    // `mmap_base + tensor_data_offset + offset_start` and the tensor was
+    // emitted, with the pointer 2^63 bytes outside a 16-byte mapping.
+    const std::string header =
+        "{\"w\": {\"dtype\": \"F8_E8M0\", \"shape\": [4, 4], "
+        "\"data_offsets\": [18446744073709551000, 0]}}";
+    std::string path = write_temp_blob(header, 64);
+    ASSERT_FALSE(path.empty());
+
+    std::string captured = load_and_capture(path);
+    std::remove(path.c_str());
+
+    EXPECT_NE(captured.find("dtype_unsupported=1"), std::string::npos) << captured;
+    // The old lenient path emitted this text; it must be gone entirely.
+    EXPECT_EQ(captured.find("lenient check"), std::string::npos)
+        << "The lenient unknown-dtype branch must not exist. Captured: " << captured;
+    EXPECT_EQ(captured.find("Parsed 1 tensors"), std::string::npos)
+        << "The tensor must not survive into the map. Captured: " << captured;
+}
+
+TEST(SafeTensorsHostileHeader, HugeOffsetEndIsRejected) {
+    // NOT a wrap test. data_offsets values are read through JsonValue::as_int(),
+    // which narrows a double to int64_t, so anything above 2^63 lands on
+    // exactly INT64_MIN and reads back as 2^63 - measured, not assumed:
+    //   static_cast<int64_t>(18446744073709551608.0) == INT64_MIN.
+    // tensor_data_offset + offset_end therefore cannot reach 2^64 from this
+    // path, and the wrapping addition the old lenient branch used was never
+    // defeatable through the header. What IS reachable is an offset far past
+    // the file, and that has to be refused on every dtype.
+    for (const char* dtype : {"F32", "F8_E8M0"}) {
+        const std::string header = std::string("{\"w\": {\"dtype\": \"") + dtype +
+                                   "\", \"shape\": [4], "
+                                   "\"data_offsets\": [0, 9223372036854775807]}}";
+        std::string path = write_temp_blob(header, 16);
+        ASSERT_FALSE(path.empty());
+        std::string captured = load_and_capture(path);
+        std::remove(path.c_str());
+        EXPECT_EQ(captured.find("Parsed 1 tensors"), std::string::npos)
+            << "dtype " << dtype << " must not produce a tensor. Captured: " << captured;
+    }
+}
+
+TEST(SafeTensorsHostileHeader, NegativeShapeDimIsDropped) {
+    const std::string header = "{\"w\": {\"dtype\": \"F32\", \"shape\": [-4], \"data_offsets\": [0, 16]}}";
+    std::string path = write_temp_blob(header, 16);
+    ASSERT_FALSE(path.empty());
+
+    std::string captured = load_and_capture(path);
+    std::remove(path.c_str());
+
+    EXPECT_NE(captured.find("bad_shape=1"), std::string::npos)
+        << "A negative dim must be dropped, not multiplied into nelem. Captured: " << captured;
+    EXPECT_EQ(captured.find("Parsed 1 tensors"), std::string::npos)
+        << "The tensor must not survive into the map. Captured: " << captured;
+}
+
+TEST(SafeTensorsHostileHeader, OverflowingShapeProductIsDropped) {
+    // 2^32 x 2^32 x 4 bytes wraps int64 to 0, which would make expected_nbytes
+    // 0 and let a zero-length window pass the size check for a tensor whose
+    // numel() the consumer recomputes as something else entirely.
+    const std::string header =
+        "{\"w\": {\"dtype\": \"F32\", \"shape\": [4294967296, 4294967296], "
+        "\"data_offsets\": [0, 0]}}";
+    std::string path = write_temp_blob(header, 16);
+    ASSERT_FALSE(path.empty());
+
+    std::string captured = load_and_capture(path);
+    std::remove(path.c_str());
+
+    EXPECT_NE(captured.find("bad_shape=1"), std::string::npos)
+        << "An overflowing shape product must be dropped. Captured: " << captured;
+    EXPECT_EQ(captured.find("Parsed 1 tensors"), std::string::npos)
+        << "The tensor must not survive into the map. Captured: " << captured;
+}
+
+TEST(SafeTensorsHostileHeader, WellFormedF32TensorStillLoads) {
+    // Negative control: the hardening above must not reject a valid tensor.
+    // Nothing is dropped, so no drop summary is emitted at all.
+    const std::string header = "{\"w\": {\"dtype\": \"F32\", \"shape\": [2, 2], \"data_offsets\": [0, 16]}}";
+    std::string path = write_temp_blob(header, 16);
+    ASSERT_FALSE(path.empty());
+
+    std::string captured = load_and_capture(path);
+    std::remove(path.c_str());
+
+    EXPECT_EQ(captured.find("dropped"), std::string::npos)
+        << "A well-formed F32 tensor must survive the hardening. Captured: " << captured;
+    EXPECT_NE(captured.find("Parsed 1 tensors"), std::string::npos)
+        << "The tensor must reach the map. Captured: " << captured;
 }
 
 }  // namespace

--- a/tests/test_tokenizer_robustness.cpp
+++ b/tests/test_tokenizer_robustness.cpp
@@ -20,7 +20,10 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdio>
+#include <fstream>
 #include <string>
+#include <unistd.h>
 #include <vector>
 
 namespace imp {
@@ -320,6 +323,114 @@ TEST(TokenizerRobustness, SpmByteFallbackNoCrashOnArbitraryBytes) {
     ASSERT_FALSE(ids.empty());
     std::string back = tok.decode(ids);
     EXPECT_EQ(back, s) << "SPM byte fallback must reconstruct raw bytes";
+}
+
+// ---- #1606: tokenizer.json ids are bounded on the load path ----
+//
+// Ids arrive as JSON doubles, are narrowed to int, and index vocab_/scores_/
+// token_types_/added_token_ids_ directly. `max_id` only ever grew from 0, so a
+// negative id never widened the vector and the write landed at size_t(-1) - a
+// heap write during load, before any inference. The decode side of the same
+// file has always range-checked; the load side did not.
+
+static std::string write_temp_tokenizer_json(const std::string& body) {
+    char tmpl[] = "/tmp/imp_test_tok_XXXXXX";
+    int fd = ::mkstemp(tmpl);
+    if (fd < 0)
+        return "";
+    std::string path = tmpl;
+    ::close(fd);
+    std::string final_path = path + ".json";
+    ::rename(path.c_str(), final_path.c_str());
+    std::ofstream out(final_path, std::ios::binary);
+    if (!out)
+        return "";
+    out << body;
+    out.close();
+    return final_path;
+}
+
+TEST(TokenizerJsonHostileIds, NegativeVocabIdIsDroppedNotWritten) {
+    // "a" claims id -1. Before the bound check this was vocab_.data()[-1] = "a".
+    const std::string body = R"({"model":{"type":"BPE","vocab":{"a":-1,"b":0,"c":1},"merges":[]}})";
+    std::string path = write_temp_tokenizer_json(body);
+    ASSERT_FALSE(path.empty());
+
+    testing::internal::CaptureStderr();
+    Tokenizer tok;
+    bool ok = tok.load(path);
+    std::string captured = testing::internal::GetCapturedStderr();
+    std::remove(path.c_str());
+
+    EXPECT_TRUE(ok);
+    // The drop has to be reported. Without the bound check the entry is not
+    // dropped at all - it is written at vocab_.data()[-1] and this line is
+    // absent, which is what makes this assertion the detector outside ASan.
+    // find_token("a") cannot tell the two apart: the corrupt path stores -1 in
+    // token_to_id_, which reads back exactly like "not found".
+    EXPECT_NE(captured.find("out-of-range id"), std::string::npos) << captured;
+    // Only b(0) and c(1) survive; the vector is sized for those two.
+    EXPECT_EQ(tok.vocab_size(), 2);
+    EXPECT_EQ(tok.find_token("a"), -1) << "an out-of-range id must not enter token_to_id_";
+    EXPECT_EQ(tok.find_token("b"), 0);
+    EXPECT_EQ(tok.find_token("c"), 1);
+}
+
+TEST(TokenizerJsonHostileIds, HugeVocabIdDoesNotSizeTheVocabulary) {
+    // max_id + 1 in `int` wraps to INT_MIN at INT_MAX; one id below that asks
+    // for a 2.1-billion-element vector<string>. Neither may happen.
+    const std::string body = R"({"model":{"type":"BPE","vocab":{"a":0,"huge":2147483647},"merges":[]}})";
+    std::string path = write_temp_tokenizer_json(body);
+    ASSERT_FALSE(path.empty());
+
+    Tokenizer tok;
+    bool ok = tok.load(path);
+    std::remove(path.c_str());
+
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(tok.vocab_size(), 1) << "the out-of-range id must not size the vocabulary";
+    EXPECT_EQ(tok.find_token("huge"), -1);
+}
+
+TEST(TokenizerJsonHostileIds, NegativeAddedTokenIdIsDropped) {
+    // The added_tokens path has its own copy of the same narrowing, and its
+    // "ensure vectors are large enough" guard is a >= test that a negative id
+    // passes without resizing. added_token_ids_[id] = true is a vector<bool>
+    // proxy write at a negative bit index.
+    const std::string body = R"({"model":{"type":"BPE","vocab":{"a":0},"merges":[]},)"
+                             R"("added_tokens":[{"id":-5,"content":"<bad>","special":1},)"
+                             R"({"id":1,"content":"<good>","special":1}]})";
+    std::string path = write_temp_tokenizer_json(body);
+    ASSERT_FALSE(path.empty());
+
+    testing::internal::CaptureStderr();
+    Tokenizer tok;
+    bool ok = tok.load(path);
+    std::string captured = testing::internal::GetCapturedStderr();
+    std::remove(path.c_str());
+
+    EXPECT_TRUE(ok);
+    EXPECT_NE(captured.find("out-of-range id -5"), std::string::npos) << captured;
+    EXPECT_EQ(tok.find_token("<bad>"), -1);
+    EXPECT_EQ(tok.find_token("<good>"), 1);
+    EXPECT_TRUE(tok.is_added_token(1));
+}
+
+TEST(TokenizerJsonHostileIds, WellFormedVocabStillLoads) {
+    // Negative control: bounding the ids must not change a normal load.
+    const std::string body = R"({"model":{"type":"BPE","vocab":{"a":0,"b":1,"c":2},"merges":[]},)"
+                             R"("added_tokens":[{"id":3,"content":"<eos>","special":1}]})";
+    std::string path = write_temp_tokenizer_json(body);
+    ASSERT_FALSE(path.empty());
+
+    Tokenizer tok;
+    bool ok = tok.load(path);
+    std::remove(path.c_str());
+
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(tok.vocab_size(), 4);
+    EXPECT_EQ(tok.find_token("<eos>"), 3);
+    EXPECT_TRUE(tok.is_added_token(3));
 }
 
 }  // namespace

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -81,8 +81,8 @@ roots = ["src", "tools", "tests"]
 "src/model/gguf_loader.cpp" = { code_loc = 812, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
 "src/model/jinja.cpp" = { code_loc = 2294, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
-"src/model/safetensors_loader.cpp" = { code_loc = 1088, reason = "(c) one loader: header validation + tensor assign + arch inference" }
-"src/model/tokenizer.cpp" = { code_loc = 1801, reason = "(c) one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)" }
+"src/model/safetensors_loader.cpp" = { code_loc = 1128, reason = "(c) one loader: header validation + tensor assign + arch inference" }
+"src/model/tokenizer.cpp" = { code_loc = 1818, reason = "(c) one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)" }
 "src/model/weight_map.cpp" = { code_loc = 1068, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 1995, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }


### PR DESCRIPTION
Closes #1603, #1604, #1605, #1606, #1659.

All four are reachable from a checkpoint directory, before any inference runs, on every path that resolves a model: `--model`, `--models-dir` auto-load, and a HuggingFace repo id through `hf_hub.cpp`. GGUF is unaffected: its equivalents saturate (`gguf_parse.cpp:436-459`) and its tokenizer path is index-based.

## #1604 — two widths for one tensor

The loader validated with a private wire-width table and the consumer read with `qtype_elem_bytes`. Both tables are now one, and a dtype with no equal-width engine type is refused rather than re-typed: a proxy of a different width reads element i from byte i*4 of a 2-byte-per-element array, so those tensors were never servable.

| dtype | on disk | mapped to | was | now |
|---|---|---|---|---|
| I16 | 2 | INT32 (4) | 100% over-read | refused |
| U16 | 2 | F32 default (4) | 100% over-read | refused |
| F64 | 8 | F32 (4) | wrong stride | refused |
| I64 / U64 | 8 | INT32 / F32 (4) | wrong stride | refused |
| U32 | 4 | F32 default (4) | width ok, read as float | explicit INT32 row |

`SafeTensorsDtypeTable.ServableRowsHaveMatchingWidths` fails the moment a row is added whose two widths disagree.

## #1603 — the lenient branch is gone

An unknown dtype string skipped `validate_tensor_offsets`, the only checker of `offset_start`, so the tensor pointer became `mmap_base + tensor_data_offset + <unvalidated>` and the tensor was emitted. Every tensor now takes the strict path.

The wrapping `tensor_data_offset + offset_end` in the issue's second impact bullet is **not** reachable through the header, measured in the toolchain container: `data_offsets` goes through `JsonValue::as_int()` (`json_util.h:29`), which narrows a double, and `static_cast<int64_t>(18446744073709551608.0) == INT64_MIN`, i.e. 2^63 read back as unsigned. The issue owner has withdrawn that bullet. The test for the case says what it pins instead of claiming a wrap it cannot produce.

## #1605 — shape product

`nelem *= shape[d]` had neither an overflow nor a sign guard, while `gguf_tensor_byte_size` does the same computation with both. Same saturating form now, plus the trailing-dims product in the flatten branch, which overflows on its own when dim 0 is zero.

## #1606 — token ids

Ids are narrowed from a JSON double to `int` and index `vocab_`/`scores_`/`token_types_`/`added_token_ids_` directly. `max_id` only ever grew from 0, so a negative id never widened the vector and `vocab_[id]` wrote at `size_t(-1)`. The `added_tokens` path repeats it and its "large enough" guard is a `>=` test a negative id passes without resizing. Both ends bounded at `kMaxTokenId = 4M` (~16x Gemma's 256k), sizing done in int64 so `max_id + 1` cannot wrap.

## #1659 — `make asan` did not build

`tests/test_json_constrain_property.cpp` and `test_schema_constrain_property.cpp` sat in the unconditional `test-core` list while nlohmann is only fetched (`CMakeLists.txt:503`) and linked (`:754`) under `IMP_BUILD_SERVER`, which `make asan` turns off (`Makefile:445`). test-core therefore did not compile in any `-DIMP_BUILD_SERVER=OFF` configuration, which made the ASan acceptance criterion on the four issues above unreachable. The two files moved into the block that provides their dependency. `check_test_lanes.py` unchanged at 1339 tests in the CI lane.

## Tests

13 new cases, all in the `unit` lane: 9 in `test_safetensors_loader.cpp` (test-core), 4 in `test_tokenizer_robustness.cpp` (test-text).

Negative control, by restoring the pre-fix loader behaviour and rebuilding: 6 of the 9 go red. The 3 that stay green are the positive control and two regression pins the old code also satisfied, and they are labelled as such in the file. That pass is also what caught two assertions of mine that could not fail: a stderr-only capture cannot see `Parsed N tensors` (INFO goes to stdout, `logging.cpp:71`), and `find_token()` returns -1 both when an id is dropped and when the corrupt path stores -1.

## Gate

```
perf gate: median of 3 independent runs (spread 0.25%)
decode  tg128 =  285.36 tok/s  (baseline  287.19, delta -0.64%)
prefill pp512 = 12418.99 tok/s  (baseline 12406.87, delta 0.10%)
prefill pp4096 = 15410.91 tok/s (baseline 15324.70, delta 0.56%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  456.10 tok/s   (2.65x, threshold 1.3x)
GPU during bench: sm=2895MHz(med) mem=13801MHz(med) power=497W(max) n=14
=== verify fast: OK ===
```

Full GPU suite via the pre-commit hook: 2284 tests, 0 failures.
`make asan`: test-core 734, test-text 200, no ASan or UBSan report.

`filesize_thresholds.toml` re-pinned upward: `safetensors_loader.cpp` 1088 -> 1128, `tokenizer.cpp` 1801 -> 1818, from the guards and the single dtype table.

Not in here: no crafted-file corpus and no fuzz target (#1620 stays open), and the four remaining request-side S0 (#1607, #1608, #1609, #1610) are a separate PR since they live in `src/compute/` and `tools/imp-server/`.
