### PR TITLE
fix(compute): bound and de-desync the request-driven constraint parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,31 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`json_schema`: two shapes desynced the parser and truncated the rest of the
+  schema** (#1564). `additionalProperties` as a schema object and a non-string
+  `enum` member each hit a parse helper that returns a default without consuming
+  input, so every key after them was dropped. With `properties` gone the request
+  silently became `json_object`; `{"enum":[1,2,3]}` constrained the model to the
+  empty string. The object form of `additionalProperties` now parses (its
+  constraint on extra keys is not enforced), a non-string `enum` is a `400`, and
+  trailing or unclosed input fails the parse instead of returning a partial tree.
+
+- **`json_schema`: assertion keywords are refused instead of dropped** (#1567).
+  `minimum`, `maximum`, `multipleOf`, `allOf`, `not`, `uniqueItems` and thirteen
+  more were accepted and ignored, so a caller who bounded a field got an
+  unbounded grammar at HTTP 200. They are a `400` now, per the contract in
+  `docs/API.md`. `const` is implemented. Annotations (`format`, `title`,
+  `description`, `default`) stay ignored. **Behaviour change for clients that
+  send these keywords today.**
+
+- **Three request-driven parsers had no cost bound** (#1608, #1609). Nesting
+  depth mapped 1:1 onto stack frames in the schema, regex and GBNF parsers
+  (`((((` is one frame per byte), and the regex `{n,m}` quantifier cloned its
+  atom `n` times with no cap: `a{2000000000}` ran a two-billion iteration
+  allocating loop on an HTTP worker thread, at admission, before the engine
+  lock. Depth is capped at 64, repeats at 1024 (matching the GBNF parser's
+  existing bound) and one pattern at 100k NFA states.
+
 - **Four out-of-bounds accesses in the model-file parsers, all reachable from a
   checkpoint directory before any inference runs** (#1603, #1604, #1605, #1606).
   A SafeTensors tensor was validated with one element width and read with

--- a/docs/API.md
+++ b/docs/API.md
@@ -67,7 +67,14 @@ post-validation.
 **A constraint imp cannot compile is a `400`, not an unconstrained answer.** That
 changed in v0.23.0 and it is a breaking difference from servers that log the
 rejection and answer anyway. Left recursion, undefined rules and a missing
-`root` are rejected at compile time.
+`root` are rejected at compile time, and since #1567 so are the JSON-Schema
+assertion keywords imp does not enforce. Which ones, and the three shapes that
+are accepted with a weaker guarantee than asked for, are listed in
+[`LIMITATIONS.md`](LIMITATIONS.md#known-bad-and-known-limited-behaviour).
+
+Schema, regex and grammar inputs are bounded: nesting past 64 levels, a `{n,m}`
+repeat above 1024, or a pattern needing more than 100k NFA states is a `400`
+rather than a stack overflow or an allocation storm (#1608, #1609).
 
 Constrained replies parse even when they hit `max_tokens`: the closer-narrowing
 and the no-closer-after-comma rules used to cancel each other out and release the

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -40,6 +40,36 @@ These have a code path and no gate. They may work; nothing proves it.
 
 ## Known-bad and known-limited behaviour
 
+- **JSON Schema: assertion keywords imp cannot enforce are a `400`, not a
+  weaker grammar.** `minimum`, `maximum`, `exclusiveMinimum`,
+  `exclusiveMaximum`, `multipleOf`, `allOf`, `not`, `uniqueItems`,
+  `patternProperties`, `propertyNames`, `prefixItems`, `contains`,
+  `minContains`, `maxContains`, `minProperties`, `maxProperties`,
+  `dependentRequired`, `dependentSchemas`, `if`/`then`/`else` are rejected at
+  admission (#1567). They used to be accepted and dropped, so a request that
+  bounded its output was answered by an unbounded grammar at HTTP 200. Pure
+  annotations (`format`, `title`, `description`, `examples`, `default`,
+  `$schema`) are still ignored, which is what Draft 2020-12 says they do.
+  `const` is enforced, as a one-member enum.
+
+- **JSON Schema: `enum` and `const` members must be strings.** The FSM emits an
+  enum as quoted string content (`schema_constrain.cu:790`), so `{"enum":[1,2]}`
+  has no representation and is a `400`. Before #1564 it constrained the model to
+  the empty string instead.
+
+- **JSON Schema: `additionalProperties` as a schema object is not enforced, it
+  reads as `true`.** The boolean form is enforced. The object form (Pydantic
+  emits it for `Dict[str, T]`) is parsed and its constraint on extra keys is
+  dropped, which is weaker than asked for but not wrong. Before #1564 it
+  truncated the schema at that key: everything after it, `properties` included,
+  was silently discarded and the request downgraded to `json_object`.
+
+- **A `pattern` the regex engine cannot compile is not enforced, and the request
+  still returns 200.** `compile_patterns()` warns and leaves the node
+  unconstrained (`json_schema.cpp:558`), unlike a top-level `regex` constraint,
+  which is refused at admission. Same class as the keyword case above, on the
+  path that has no admission screen in front of it.
+
 - **Calibrated KV-cache scales shipped in a checkpoint are not read.** Six local
   checkpoints carry `*.self_attn.{k_proj.k_scale,v_proj.v_scale}` (96 tensors on
   Qwen3-Coder-30B-A3B-FP4, 12 on NVIDIA-Nemotron-3.5-Lightning-30B, which has 6

--- a/src/compute/gbnf_parser.cpp
+++ b/src/compute/gbnf_parser.cpp
@@ -16,6 +16,11 @@ constexpr uint32_t kMaxCodepoint = 0x10FFFF;
 // A repetition bound larger than this is a grammar bomb, not an intent: {0,100000}
 // would materialise 100k synthetic rules before decoding a single token.
 constexpr int kMaxRepeat = 1024;
+// Nesting depth of `( ... )` groups. Same reasoning as kMaxRepeat, one level
+// up: the parser is recursive descent over a request-supplied string, so
+// `root ::= ((((...` costs one stack frame per byte (#1609). No real grammar
+// nests anywhere near this.
+constexpr int kMaxGroupDepth = 64;
 
 bool is_word_char(char c) {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
@@ -26,6 +31,7 @@ bool is_word_char(char c) {
 struct Parser {
     const std::string& src;
     std::vector<GbnfRule>& rules;
+    int depth = 0;
     std::map<std::string, int32_t> ids;
     std::set<std::string> defined;
     size_t pos = 0;
@@ -387,6 +393,14 @@ struct Parser {
 };
 
 bool Parser::parse_alternates(std::vector<GbnfAlt>& out, bool nested) {
+    if (depth >= kMaxGroupDepth)
+        return fail("group nesting deeper than " + std::to_string(kMaxGroupDepth));
+    depth++;
+    struct Pop {
+        int& d;
+        ~Pop() { d--; }
+    } pop{depth};
+
     GbnfAlt first;
     if (!parse_sequence(first, nested))
         return false;

--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -23,6 +23,14 @@ public:
     std::unique_ptr<SchemaNode> parse() {
         skip_ws();
         auto node = parse_schema_object();
+        // #1564: the object loop breaks on anything that is not ',' and the
+        // closing expect() was discarded, so a desync inside the document
+        // returned a truncated tree that still looked like a parse. Trailing
+        // input is the outermost symptom of that and the cheapest place to
+        // catch a shape nothing else noticed.
+        skip_ws();
+        if (!eof())
+            fail("trailing input after the schema object");
         return node;
     }
 
@@ -34,7 +42,39 @@ public:
     bool ref_error_ = false;
     bool ref_error() const { return ref_error_; }
 
+    // Set when the document is structurally unparseable or uses a keyword this
+    // build cannot enforce. Same contract as ref_error_: the whole parse fails,
+    // and the caller turns that into a 400. Silently dropping the keyword would
+    // answer a bounded request with an unbounded grammar.
+    bool parse_error() const { return parse_error_; }
+    const std::string& error_reason() const { return error_reason_; }
+
 private:
+    bool parse_error_ = false;
+    std::string error_reason_;
+
+    // Recursion depth of parse_schema_object(). A schema is request-supplied
+    // text and the parser is recursive descent, so nesting depth maps 1:1 onto
+    // stack frames (#1609). Real schemas nest a handful deep.
+    int depth_ = 0;
+    static constexpr int kMaxSchemaDepth = 64;
+
+    // Scope-bound depth counter: every early return out of
+    // parse_schema_object() has to decrement, and there are several.
+    struct DepthGuard {
+        int& d;
+        explicit DepthGuard(int& depth) : d(depth) { d++; }
+        ~DepthGuard() { d--; }
+    };
+
+    bool fail(const std::string& why) {
+        if (!parse_error_) {
+            parse_error_ = true;
+            error_reason_ = why;
+        }
+        return false;
+    }
+
     const char* data_;
     size_t len_;
     size_t pos_;
@@ -225,6 +265,41 @@ private:
         return result;
     }
 
+    // Assertion keywords this build parses past but cannot enforce. Split from
+    // annotations on purpose: `format`, `title`, `description`, `examples`,
+    // `default`, `deprecated`, `readOnly`, `writeOnly` change no legal value
+    // and stay silently ignored, which is what the spec says they do.
+    static bool is_unenforceable_keyword(const std::string& k) {
+        static const char* kUnenforceable[] = {
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "multipleOf",
+            "allOf",
+            "not",
+            "uniqueItems",
+            "patternProperties",
+            "propertyNames",
+            "prefixItems",
+            "contains",
+            "minContains",
+            "maxContains",
+            "minProperties",
+            "maxProperties",
+            "dependentRequired",
+            "dependentSchemas",
+            "if",
+            "then",
+            "else",
+        };
+        for (const char* u : kUnenforceable) {
+            if (k == u)
+                return true;
+        }
+        return false;
+    }
+
     static SchemaType type_from_string(const std::string& s) {
         if (s == "string")
             return SchemaType::STRING;
@@ -244,9 +319,19 @@ private:
     }
 
     std::unique_ptr<SchemaNode> parse_schema_object() {
-        skip_ws();
-        if (!expect('{'))
+        // #1609: one frame per nesting level, from an unauthenticated request
+        // body. 10^5 nested "items" objects overflow the worker thread's stack.
+        if (depth_ >= kMaxSchemaDepth) {
+            fail("schema nests deeper than " + std::to_string(kMaxSchemaDepth) + " levels");
             return nullptr;
+        }
+        DepthGuard guard(depth_);
+
+        skip_ws();
+        if (!expect('{')) {
+            fail("expected '{' at the start of a schema object");
+            return nullptr;
+        }
 
         auto node = std::make_unique<SchemaNode>();
         bool has_type = false;
@@ -274,8 +359,10 @@ private:
                     while (!eof() && peek() != '}') {
                         std::string prop_name = parse_string();
                         skip_ws();
-                        if (!expect(':'))
+                        if (!expect(':')) {
+                            fail("expected ':' after a property name");
                             break;
+                        }
                         auto prop_schema = parse_schema_object();
                         if (prop_schema) {
                             node->properties.emplace_back(std::move(prop_name), std::move(prop_schema));
@@ -305,7 +392,23 @@ private:
             } else if (key == "required") {
                 node->required = parse_string_array();
             } else if (key == "additionalProperties") {
-                node->additional_properties = parse_bool();
+                // #1564: parse_bool() returns false WITHOUT consuming when the
+                // value is not true/false, so the schema-object form left pos_
+                // on '{'. The key loop then saw '{' instead of ',', broke, and
+                // every key after this one was dropped - including
+                // `properties`, which downgrades the request to json_object at
+                // constraint_manager.cpp:149. Consume the value either way.
+                skip_ws();
+                if (peek() == 't' || peek() == 'f') {
+                    node->additional_properties = parse_bool();
+                } else {
+                    // The schema form ({"type": "..."}) is legal and common
+                    // (Pydantic emits it for Dict[str, T]). imp does not
+                    // enforce a schema on extra keys, so this reads as the
+                    // permissive `true` - a weaker constraint, not a wrong one.
+                    skip_value();
+                    node->additional_properties = true;
+                }
             } else if (key == "items") {
                 node->items = parse_schema_object();
                 if (!has_type)
@@ -320,10 +423,25 @@ private:
                     node->max_items = static_cast<int>(v);
             } else if (key == "enum") {
                 skip_ws();
-                if (expect('[')) {
+                if (!expect('[')) {
+                    fail("enum is not an array");
+                } else {
                     skip_ws();
                     while (!eof() && peek() != ']') {
-                        // Store enum values as raw strings
+                        // #1564: parse_string() also returns "" without
+                        // consuming. A non-string member therefore produced
+                        // enum_values == {""} and left pos_ on the member, so
+                        // the rest of the schema was dropped AND the only legal
+                        // output became the empty string. The FSM emits an enum
+                        // as quoted string content (schema_constrain.cu:790),
+                        // so a numeric or boolean member has no representation:
+                        // refuse rather than constrain to something else.
+                        if (peek() != '"') {
+                            fail(
+                                "enum members must be strings; a number, boolean or null "
+                                "enum cannot be enforced by this build");
+                            break;
+                        }
                         node->enum_values.push_back(parse_string());
                         skip_ws();
                         if (peek() == ',') {
@@ -333,7 +451,8 @@ private:
                         }
                         break;
                     }
-                    expect(']');
+                    if (!parse_error_ && !expect(']'))
+                        fail("enum array is not closed");
                 }
                 node->type = SchemaType::ENUM;
             } else if (key == "$ref") {
@@ -397,8 +516,31 @@ private:
                     expect(']');
                 }
                 node->type = SchemaType::ANY_OF;
+            } else if (key == "const") {
+                // #1567: const is enum with one member, and the FSM already
+                // has that path. Same string-only limit as enum above.
+                skip_ws();
+                if (peek() != '"') {
+                    fail(
+                        "const must be a string; a number, boolean or null const "
+                        "cannot be enforced by this build");
+                } else {
+                    node->enum_values.push_back(parse_string());
+                    node->type = SchemaType::ENUM;
+                }
+            } else if (is_unenforceable_keyword(key)) {
+                // #1567: these are assertions, not annotations. Dropping one
+                // answers a request that bounded its output with a grammar that
+                // does not - the exact failure #1540/#751 describes, reached by
+                // a caller who did bound the field. docs/API.md: "A constraint
+                // imp cannot compile is a 400, not an unconstrained answer."
+                fail("schema keyword '" + key + "' is not enforceable by this build");
+                skip_value();
             } else {
-                // Skip unknown fields ($schema, title, description, etc.)
+                // Skip unknown fields and pure annotations ($schema, title,
+                // description, examples, default, format - which is an
+                // annotation in Draft 2020-12 unless the format-assertion
+                // vocabulary is in use, and imp does not claim it).
                 skip_value();
             }
 
@@ -410,7 +552,8 @@ private:
             }
             break;
         }
-        expect('}');
+        if (!expect('}'))
+            fail("schema object is not closed; a value before this point was not consumed");
 
         // Enum takes precedence over a co-declared "type". Key order in the
         // object is not significant in JSON, and clients commonly emit
@@ -504,6 +647,10 @@ std::unique_ptr<SchemaNode> parse_json_schema(const std::string& json) {
     }
     if (parser.ref_error()) {
         IMP_LOG_ERROR("Failed to parse JSON schema: unsupported $ref form");
+        return nullptr;
+    }
+    if (parser.parse_error()) {
+        IMP_LOG_ERROR("Failed to parse JSON schema: %s", parser.error_reason().c_str());
         return nullptr;
     }
     // Attach definitions collected anywhere in the document to the root —
@@ -674,6 +821,15 @@ std::unique_ptr<SchemaNode> build_xml_tool_call_schema(
 // ===========================================================================
 
 int RegexNfa::new_state() {
+    // #1608: the {n,m} builder allocates per clone and the nested form
+    // multiplies, so the state count is the resource an attacker actually
+    // spends. Once the budget is gone the parse is an error and every caller
+    // unwinds through the `error_` checks; returning the last valid index keeps
+    // the add_edge()/add_epsilon() calls already in flight in bounds.
+    if (states_.size() >= kMaxStates) {
+        error_ = true;
+        return states_.empty() ? 0 : static_cast<int>(states_.size()) - 1;
+    }
     states_.emplace_back();
     return static_cast<int>(states_.size()) - 1;
 }
@@ -974,7 +1130,11 @@ bool RegexNfa::parse_repeat(Frag& out) {
             long v = 0;
             bool any = false;
             while (pos_ < src_->size() && (*src_)[pos_] >= '0' && (*src_)[pos_] <= '9') {
-                v = v * 10 + ((*src_)[pos_] - '0');
+                // #1608: `v = v*10 + d` over an unbounded digit run is signed
+                // overflow, i.e. UB, before it is ever compared to a limit.
+                // Saturate at the repeat cap; the caller rejects from there.
+                if (v <= kMaxRepeat)
+                    v = v * 10 + ((*src_)[pos_] - '0');
                 pos_++;
                 any = true;
             }
@@ -1000,6 +1160,15 @@ bool RegexNfa::parse_repeat(Frag& out) {
         if (!comma)
             m = n;  // {n}
 
+        // #1608: n is a clone count. `a{2000000000}` ran a two-billion
+        // iteration loop, each iteration re-parsing the atom and allocating
+        // states, on an HTTP worker thread at admission time. The GBNF parser
+        // has had this same bound since it was written.
+        if (n > kMaxRepeat || m > kMaxRepeat) {
+            error_ = true;
+            return false;
+        }
+
         // Build: n mandatory copies, then either unbounded (*) or (m-n) optional.
         int s = new_state();
         int cur = s;
@@ -1018,11 +1187,16 @@ bool RegexNfa::parse_repeat(Frag& out) {
             pos_ = 0;
             error_ = false;
             bool ok = parse_repeat(f);  // atom may itself be a repeat-free atom
-            // restore
+            // The clone's own error has to survive the restore. It did not:
+            // error_ was overwritten with prev_err and THEN read, so `!error_`
+            // reported the state before the clone. That also swallowed the
+            // state-budget signal new_state() raises (#1608), which is what
+            // stops the nested `(((a{100}){100}){100})` form.
+            bool inner_err = error_;
             src_ = prev_src;
             pos_ = prev_pos;
-            error_ = prev_err;
-            return ok && !error_;
+            error_ = prev_err || inner_err;
+            return ok && !inner_err;
         };
 
         // first mandatory copy is the already-built `atom`
@@ -1104,6 +1278,20 @@ bool RegexNfa::parse_concat(Frag& out) {
 
 // alt := concat ('|' concat)*
 bool RegexNfa::parse_alt(Frag& out) {
+    // #1609: parse_atom() recurses back into parse_alt() for a group, so a
+    // pattern of '(' costs one frame per byte - the cheapest stack overflow in
+    // the request surface. parse_alt is the single point that closes the
+    // mutual recursion, so one guard here covers all four functions.
+    if (depth_ >= kMaxDepth) {
+        error_ = true;
+        return false;
+    }
+    depth_++;
+    struct Pop {
+        int& d;
+        ~Pop() { d--; }
+    } pop{depth_};
+
     Frag first{};
     if (!parse_concat(first))
         return false;
@@ -1132,6 +1320,7 @@ bool RegexNfa::compile(const std::string& pattern) {
     states_.clear();
     compiled_ = false;
     error_ = false;
+    depth_ = 0;
     src_ = &pattern;
     pos_ = 0;
 

--- a/src/compute/json_schema.h
+++ b/src/compute/json_schema.h
@@ -65,6 +65,19 @@ public:
     // True if any state in `states` is accepting.
     bool accepts(const std::vector<int>& states) const;
 
+    // Bounds on what one pattern may cost. A pattern is request-supplied text
+    // on an unauthenticated endpoint, and both limits below were unbounded
+    // (#1608, #1609).
+    //
+    // kMaxRepeat mirrors the GBNF parser's own bound (gbnf_parser.cpp:18):
+    // `{n,m}` is built by cloning the atom n times, so n IS an allocation
+    // count. kMaxStates bounds the nested form, which multiplies rather than
+    // adds - `(((a{100}){100}){100}){100}` is 28 bytes and asks for ~10^8
+    // states, each carrying a 256-entry char class.
+    static constexpr long kMaxRepeat = 1024;
+    static constexpr size_t kMaxStates = 100000;
+    static constexpr int kMaxDepth = 64;
+
 private:
     std::vector<NfaState> states_;
     int start_ = -1;
@@ -75,6 +88,7 @@ private:
     const std::string* src_ = nullptr;
     size_t pos_ = 0;
     bool error_ = false;
+    int depth_ = 0;
 
     int new_state();
     void add_epsilon(int from, int to);

--- a/tests/test_gbnf_grammar.cpp
+++ b/tests/test_gbnf_grammar.cpp
@@ -17,6 +17,8 @@
 
 #include "compute/gbnf_grammar.h"
 
+#include <vector>
+
 #include <string>
 
 using imp::GbnfMatcher;
@@ -416,4 +418,26 @@ TEST(GbnfGrammar, ResetReturnsToTheStart) {
     EXPECT_FALSE(m.is_done());
     EXPECT_TRUE(m.would_accept("a"));
     EXPECT_FALSE(m.would_accept("b"));
+}
+
+// #1609: the GBNF parser is recursive descent over a request-supplied string
+// and had a repetition bound but no nesting bound, so `root ::= ((((...` cost
+// one stack frame per byte. A failed parse is already a 400 by design.
+TEST(GbnfDepthCap, DeeplyNestedGroupsAreRefusedInsteadOfOverflowing) {
+    std::string g = "root ::= ";
+    g.append(5000, '(');
+    g += "\"a\"";
+    g.append(5000, ')');
+    std::vector<imp::GbnfRule> rules;
+    int32_t root = -1;
+    std::string err;
+    EXPECT_FALSE(imp::parse_gbnf(g, rules, root, &err));
+    EXPECT_NE(err.find("nesting"), std::string::npos) << err;
+}
+
+TEST(GbnfDepthCap, OrdinaryNestingStillParses) {
+    std::vector<imp::GbnfRule> rules;
+    int32_t root = -1;
+    std::string err;
+    EXPECT_TRUE(imp::parse_gbnf("root ::= ((((\"a\" | \"b\"))))", rules, root, &err)) << err;
 }

--- a/tests/test_regex_constrain.cpp
+++ b/tests/test_regex_constrain.cpp
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 
 #include "compute/regex_constrain.h"
+#include "compute/json_schema.h"  // RegexNfa, the shared engine
 
 #include <memory>
 #include <string>
@@ -211,4 +212,51 @@ TEST(RegexConstrain, ResetReturnsToTheStart) {
     EXPECT_FALSE(rc->is_done());
     EXPECT_TRUE(rc->would_accept("a"));
     EXPECT_FALSE(rc->would_accept("b"));
+}
+
+// =============================================================================
+// Cost bounds on the shared engine (#1608, #1609).
+//
+// A pattern is request-supplied text on an endpoint that is unauthenticated by
+// default, and it is compiled at admission, on the HTTP worker thread, before
+// the engine lock. Both of these were unbounded. Driving RegexNfa directly
+// rather than through the constrainer, because the JSON-Schema `pattern` path
+// calls the compiler with no construct screen in front of it.
+// =============================================================================
+
+TEST(RegexNfaCostBounds, LargeRepeatCountIsRefused) {
+    // {n} is built by cloning the atom n times, so n is an allocation count.
+    imp::RegexNfa nfa;
+    EXPECT_FALSE(nfa.compile("a{2000000000}"));
+    EXPECT_FALSE(nfa.compile("a{0,2000000000}"));
+    // The digit run itself used to overflow `long` before any comparison.
+    EXPECT_FALSE(nfa.compile("a{99999999999999999999999}"));
+}
+
+TEST(RegexNfaCostBounds, NestedRepeatsAreRefused) {
+    // Each level multiplies: ~10^8 states from 28 bytes, each state's edges
+    // carrying a 256-entry char class. The per-level bound alone does not stop
+    // this; the state budget does.
+    imp::RegexNfa nfa;
+    EXPECT_FALSE(nfa.compile("(((a{100}){100}){100}){100}"));
+}
+
+TEST(RegexNfaCostBounds, DeepGroupNestingIsRefused) {
+    // parse_atom -> parse_alt is one stack frame per '(', so this is the
+    // cheapest stack overflow in the request surface: one byte per frame.
+    std::string deep(5000, '(');
+    deep += "a";
+    deep.append(5000, ')');
+    imp::RegexNfa nfa;
+    EXPECT_FALSE(nfa.compile(deep));
+}
+
+TEST(RegexNfaCostBounds, OrdinaryPatternsStillCompile) {
+    // Negative control. The bounds must not cost a pattern anyone writes.
+    imp::RegexNfa nfa;
+    EXPECT_TRUE(nfa.compile("a{3}"));
+    EXPECT_TRUE(nfa.compile("[0-9]{1,64}"));
+    EXPECT_TRUE(nfa.compile("(foo|bar)+baz"));
+    EXPECT_TRUE(nfa.compile(R"(\d{4}-\d{2}-\d{2})"));
+    EXPECT_TRUE(nfa.compile("((((a))))"));
 }

--- a/tests/test_schema_constrain_property.cpp
+++ b/tests/test_schema_constrain_property.cpp
@@ -253,5 +253,137 @@ TEST(SchemaConstrainPropertyTest, NumberGrammarMatchesRfc8259) {
     }
 }
 
+// ===========================================================================
+// Parser-level cases: what the schema parser does with input it cannot handle.
+//
+// Every one of these used to return a non-null tree. The FSM then enforced
+// something the caller did not ask for, at HTTP 200, which is the outcome
+// docs/API.md excludes ("a constraint imp cannot compile is a 400").
+// ===========================================================================
+
+// #1564: parse_bool() returns false WITHOUT consuming when the value is not
+// true/false, so `additionalProperties: {schema}` left pos_ on '{' and every
+// key after it was dropped. With `properties` gone the node is an empty object
+// schema, which constraint_manager.cpp routes to the any-JSON constrainer:
+// the reply is JSON with arbitrary keys and nothing says so.
+TEST(SchemaParserDesync, AdditionalPropertiesAsObjectDoesNotTruncateTheSchema) {
+    const std::string schema = R"({"type":"object","additionalProperties":{"type":"number"},)"
+                               R"("properties":{"a":{"type":"string"}},"required":["a"]})";
+    auto node = parse_json_schema(schema);
+    ASSERT_NE(node, nullptr) << "the object form is legal JSON Schema and must parse";
+    EXPECT_EQ(node->type, SchemaType::OBJECT);
+    ASSERT_EQ(node->properties.size(), 1u)
+        << "keys after additionalProperties were dropped, so the request silently "
+           "downgrades to json_object";
+    EXPECT_EQ(node->properties[0].first, "a");
+    ASSERT_EQ(node->required.size(), 1u);
+    EXPECT_EQ(node->required[0], "a");
+}
+
+TEST(SchemaParserDesync, AdditionalPropertiesFalseStillParses) {
+    // Negative control: the boolean form is the common one and must be untouched.
+    auto node = parse_json_schema(R"({"type":"object","properties":{"v":{"type":"string"}},"required":["v"],)"
+                                  R"("additionalProperties":false})");
+    ASSERT_NE(node, nullptr);
+    EXPECT_FALSE(node->additional_properties);
+    EXPECT_EQ(node->properties.size(), 1u);
+}
+
+// #1564: parse_string() has the same non-consuming default, so {"enum":[1,2,3]}
+// produced enum_values == {""} and constrained the model to the empty string.
+// The FSM emits an enum as quoted string content, so there is no representation
+// for a numeric member: refusing is the only outcome that is not wrong.
+TEST(SchemaParserDesync, NonStringEnumIsRefused) {
+    EXPECT_EQ(parse_json_schema(R"({"type":"integer","enum":[1,2,3]})"), nullptr);
+    EXPECT_EQ(parse_json_schema(R"({"enum":[true,false]})"), nullptr);
+    EXPECT_EQ(parse_json_schema(R"({"enum":[null]})"), nullptr);
+}
+
+TEST(SchemaParserDesync, StringEnumStillParses) {
+    auto node = parse_json_schema(R"({"type":"string","enum":["red","green"]})");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->type, SchemaType::ENUM);
+    ASSERT_EQ(node->enum_values.size(), 2u);
+    EXPECT_EQ(node->enum_values[0], "red");
+}
+
+TEST(SchemaParserDesync, TrailingInputIsAnError) {
+    EXPECT_EQ(parse_json_schema(R"({"type":"string"} {"type":"integer"})"), nullptr);
+}
+
+TEST(SchemaParserDesync, UnclosedObjectIsAnError) {
+    EXPECT_EQ(parse_json_schema(R"({"type":"object","properties":{"a":{"type":"string"})"), nullptr);
+}
+
+// #1567: thirteen standard assertion keywords were accepted and dropped by
+// skip_value(). A caller that bounds its output was answered as if it had not.
+TEST(SchemaUnenforceableKeywords, AssertionKeywordsAreRefused) {
+    const char* refused[] = {
+        R"({"type":"integer","minimum":1,"maximum":5})",
+        R"({"type":"integer","exclusiveMinimum":0})",
+        R"({"type":"number","multipleOf":2})",
+        R"({"allOf":[{"type":"string"}]})",
+        R"({"not":{"type":"string"}})",
+        R"({"type":"array","uniqueItems":true})",
+        R"({"type":"object","patternProperties":{"^a":{"type":"string"}}})",
+        R"({"type":"object","propertyNames":{"pattern":"^a"}})",
+        R"({"type":"array","prefixItems":[{"type":"string"}]})",
+        R"({"type":"object","minProperties":1})",
+    };
+    for (const char* s : refused) {
+        EXPECT_EQ(parse_json_schema(s), nullptr) << "must be refused, not silently dropped: " << s;
+    }
+}
+
+TEST(SchemaUnenforceableKeywords, AnnotationsAreStillIgnored) {
+    // format is an annotation in Draft 2020-12 unless the format-assertion
+    // vocabulary is in use, and these four change no legal value. Refusing them
+    // would break working clients for nothing.
+    auto node = parse_json_schema(R"({"$schema":"https://json-schema.org/draft/2020-12/schema",)"
+                                  R"("title":"T","description":"D","examples":["x"],"default":"x",)"
+                                  R"("type":"string","format":"date-time"})");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->type, SchemaType::STRING);
+}
+
+TEST(SchemaUnenforceableKeywords, ConstIsEnforcedAsASingleValueEnum) {
+    auto node = parse_json_schema(R"({"const":"fixed"})");
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->type, SchemaType::ENUM);
+    ASSERT_EQ(node->enum_values.size(), 1u);
+    EXPECT_EQ(node->enum_values[0], "fixed");
+    // Same string-only limit as enum, and for the same reason.
+    EXPECT_EQ(parse_json_schema(R"({"const":42})"), nullptr);
+}
+
+// #1609: recursive descent over a request body. 10^5 nested "items" objects
+// overflow the worker thread's stack; the cap turns that into a parse error,
+// which the admission path already renders as a 400.
+TEST(SchemaDepthCap, DeeplyNestedSchemaIsRefusedInsteadOfOverflowing) {
+    std::string deep;
+    const int kLevels = 5000;
+    for (int i = 0; i < kLevels; i++)
+        deep += R"({"type":"array","items":)";
+    deep += R"({"type":"string"})";
+    for (int i = 0; i < kLevels; i++)
+        deep += "}";
+    EXPECT_EQ(parse_json_schema(deep), nullptr);
+}
+
+TEST(SchemaDepthCap, ModeratelyNestedSchemaStillParses) {
+    // Negative control: 8 levels is deeper than anything a real generator
+    // emits and must keep working.
+    std::string s;
+    const int kLevels = 8;
+    for (int i = 0; i < kLevels; i++)
+        s += R"({"type":"array","items":)";
+    s += R"({"type":"string"})";
+    for (int i = 0; i < kLevels; i++)
+        s += "}";
+    auto node = parse_json_schema(s);
+    ASSERT_NE(node, nullptr);
+    EXPECT_EQ(node->type, SchemaType::ARRAY);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -71,7 +71,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/gemm_dp4a.cu" = { code_loc = 601, reason = "(c) one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)" }
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = { code_loc = 693, reason = "(c) one small-M grouped-GEMM family (software-ref + prod + smoke variants)" }
 "src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }
-"src/compute/json_schema.cpp" = { code_loc = 1034, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
+"src/compute/json_schema.cpp" = { code_loc = 1147, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
 "src/compute/mtp_forward.cu" = { code_loc = 855, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
 "src/compute/schema_constrain.cu" = { code_loc = 1181, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
 "src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }


### PR DESCRIPTION
Closes #1564. Closes #1567. Closes #1608. Closes #1609.

One surface: schema, regex and GBNF text arrives in a request body, unauthenticated by default, and is compiled at admission on the HTTP worker thread, before the engine lock and before `ensure_model_loaded`. `/v1/messages/count_tokens` reaches it and is exempt from both rate limiting and `--max-concurrent`.

## #1564 — two shapes truncated the schema

`parse_bool()` and `parse_string()` return a default **without consuming** when the value is not of the expected type, and every `expect()` return value in the key loop was discarded.

| input | was | now |
|---|---|---|
| `"additionalProperties":{"type":"number"}` then `"properties"` | `pos_` stays on `{`, loop breaks, `properties` and `required` dropped, empty object schema routed to the any-JSON constrainer (`constraint_manager.cpp:149`): HTTP 200, arbitrary keys | value consumed, read as permissive `true`, rest of the schema parsed |
| `{"enum":[1,2,3]}` | `enum_values == {""}`, the only legal output is the empty string | 400 |
| `{"type":"string"} {"type":"integer"}` | first object returned, trailing input ignored | 400 |
| unclosed object | partial tree returned | 400 |

Non-string `enum`/`const` is a refusal rather than a feature gap: the FSM emits an enum as quoted string content (`schema_constrain.cu:790`), so a numeric member has no representation.

## #1567 — assertion keywords were accepted and dropped

`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `allOf`, `not`, `uniqueItems`, `patternProperties`, `propertyNames`, `prefixItems`, `contains`, `minContains`, `maxContains`, `minProperties`, `maxProperties`, `dependentRequired`, `dependentSchemas`, `if`/`then`/`else` now fail the parse, which the admission path already renders as a 400.

Annotations are kept separate and stay ignored: `format` is annotation-only in Draft 2020-12 unless the format-assertion vocabulary is claimed, and `title`/`description`/`examples`/`default`/`$schema` change no legal value. `const` is implemented as a one-member enum instead of refused.

**Behaviour change.** A client sending `minimum`/`maximum` today gets 200 with the keyword ignored and will get 400. That is the contract in `docs/API.md` ("a constraint imp cannot compile is a 400, not an unconstrained answer"), and the alternative is the unbounded grammar of #1540/#751 reached by a caller who *did* bound the field.

## #1608 — `{n,m}` clones the atom, n was unbounded

| pattern | bytes | was | now |
|---|---|---|---|
| `a{2000000000}` | 13 | 2e9-iteration loop, re-parsing and allocating per iteration | 400 |
| `a{99999999999999999999999}` | 26 | signed overflow in the digit scan before any comparison | 400 |
| `(((a{100}){100}){100}){100}` | 28 | ~1e8 states, each edge a 256-entry char class | 400 |

Caps: 1024 per repeat (the bound `gbnf_parser.cpp:18` has always had) and 100k states per pattern, because the nested form multiplies and a per-level cap alone does not bound it.

Found while wiring the state budget, and required for it to work: `clone_atom()` restored `error_` from its saved value and **then** read it, so a clone's own error was discarded. The budget signal would have been swallowed by that line.

## #1609 — depth caps

One frame per nesting level in all three parsers; `((((` is one frame per byte. Capped at 64 in `SchemaParser::parse_schema_object`, `RegexNfa::parse_alt` (the single point that closes the four-way mutual recursion) and `Parser::parse_alternates`.

## Tests

17 new cases in the unit lane: `test_schema_constrain_property.cpp` (11), `test_regex_constrain.cpp` (4), `test_gbnf_grammar.cpp` (2).

Negative control, by removing every guard and rebuilding:

| | count | cases |
|---|---|---|
| red | 8 | schema desync x4, keyword refusal, schema depth, regex deep group, GBNF depth |
| hang (25 s timeout) | 2 | `a{2000000000}`, `(((a{100}){100}){100}){100}` |
| green, as intended | 7 | six positive controls + `const`, which is new code with no pre-fix behaviour to contradict |

The two that hang are why each case ran under its own timeout rather than in one process.

## Gate

```
perf gate: median of 3 independent runs (spread 0.19%)
decode  tg128 =  284.72 tok/s  (baseline  287.19, delta -0.86%)
prefill pp512 = 12451.84 tok/s  (baseline 12406.87, delta 0.36%)
prefill pp4096 = 15397.22 tok/s (baseline 15324.70, delta 0.47%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  454.05 tok/s   (2.06x, threshold 1.3x)
=== verify fast: OK ===
```

Full GPU suite via the pre-commit hook: 2301 tests, 0 failures, including the GPU-lane constraining batteries (`test_schema_constrain.cu`, `test_tool_call_constrain.cu`, `test_json_constrain.cu`) that the new refusals could have broken.

`filesize_thresholds.toml`: `json_schema.cpp` 1034 -> 1147.

Docs: the refused keywords and the three weaker-than-asked-for shapes are listed in `LIMITATIONS.md`; `API.md` links there and states the new numeric bounds.

Not in here: a `pattern` the regex engine cannot compile is still left unenforced with a WARN and a 200 (`json_schema.cpp:558`), unlike a top-level `regex` constraint. Same class as #1567, on the path with no admission screen. Filed as a limitation rather than changed, because it is a third behaviour change on this surface in one PR.
