### PR TITLE
fix(vram): act on any planner-vs-heuristic divergence, not only a 2x one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,18 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`imp-server` did not start at shipped defaults on the repo's own
+  perf-baseline model** (#1631). `imp-server --model Qwen3-8B-Q8_0.gguf` on an
+  idle 32 GB card ended in 537 CUDA out-of-memory lines and exit 1: the planner
+  cross-checks its NVFP4 heuristic against the storage planner's projection but
+  only acted on a 2x divergence, and this model diverges 1.35x (6100 vs 4511
+  MiB), so the KV pool took the difference and the first cuBLASLt call had
+  nothing left. Any divergence now raises the reserve. The pool is smaller
+  (11390 to 7079 blocks, 105136 tokens of capacity) and the server answers in
+  3 s. `scripts/test_server_default_start.sh` gates it, wired into
+  `make test-server`, because every other server battery boots with capacity
+  flags and the default configuration was covered by none of them.
+
 - **`json_schema`: two shapes desynced the parser and truncated the rest of the
   schema** (#1564). `additionalProperties` as a schema object and a non-string
   `enum` member each hit a parse helper that returns a default without consuming

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -40,6 +40,22 @@ These have a code path and no gate. They may work; nothing proves it.
 
 ## Known-bad and known-limited behaviour
 
+- **The VRAM planner's weight-cache reserve is an estimate with a floor, not a
+  measurement, and there is no retry if it is wrong.** A start that overcommits
+  still ends in `imp_context_create` aborting rather than degrading to a smaller
+  KV pool. #1631 fixed the case that made `imp-server` unstartable at defaults
+  on `Qwen3-8B-Q8_0` by raising the reserve to the planner's own projection plus
+  the reserve floor, and the margin matters: the projection alone plans 9977 KV
+  blocks and still OOMs, while the arm that works plans 7079. That is a 500 MiB
+  edge, so a model whose demand sits inside it can still fail to start. The
+  robust form is a retry at a smaller pool; it is not implemented.
+
+- **The measured library reserve is only remembered if the cache path outlives
+  the process.** `vram.library_reserve_cache` defaults inside the container, so
+  a `docker run --rm` server re-measures every start and plans with the 3900 MiB
+  constant, which is wrong in both directions (measured: 0 MiB on Qwen3-4B
+  IQ4_NL, 7460 MiB on Qwen3-8B-Q8_0). Mount that path to keep it.
+
 - **JSON Schema: assertion keywords imp cannot enforce are a `400`, not a
   weaker grammar.** `minimum`, `maximum`, `exclusiveMinimum`,
   `exclusiveMaximum`, `multipleOf`, `allOf`, `not`, `uniqueItems`,

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -49,6 +49,16 @@ fi
 cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
 
+# Stage 3a: does the server start with NO capacity flags at all? Every battery
+# below runs against a server booted with four of them, so the configuration a
+# first-time reader runs was the one nothing covered (#1631). Its own script,
+# because it needs its own container with different arguments.
+echo "== default-start gate (#1631) =="
+if ! bash scripts/test_server_default_start.sh; then
+    echo "test-server: FAIL - imp-server does not start on shipped defaults"
+    exit 1
+fi
+
 echo "== launch imp-server ($MODEL) =="
 docker rm -f "$CTR" >/dev/null 2>&1 || true
 docker run -d --name "$CTR" --gpus all -v "$MODELS_DIR":/models -p "$PORT":"$PORT" "$IMG" \

--- a/scripts/test_server_default_start.sh
+++ b/scripts/test_server_default_start.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Does imp-server start on SHIPPED DEFAULTS? (#1631)
+#
+# Every other server battery passes flags: scripts/test_server.sh boots with
+# --max-concurrent / --rate-limit / --max-input-tokens, and the audit's own
+# runtime pass used --set runtime.max_seq_len=8192 --max-batch 4 because the
+# defaults did not start. So the one configuration a first-time reader actually
+# runs was the one nothing exercised, and it exited 1 with 537 CUDA OOM lines on
+# the repo's own perf-baseline model, on an idle 32 GB card.
+#
+# The gate is deliberately narrow: `imp-server --model <path>` and nothing else,
+# then /health, then one generation. A start that reaches /health but cannot
+# answer is not a pass.
+#
+# Usage:   bash scripts/test_server_default_start.sh
+# Env:     IMP_DEFAULT_START_MODEL  file name under the models dir
+#                                   (default: the perf-baseline model)
+#          IMP_MODELS_DIR           host dir mounted at /models (default $HOME/models)
+#          IMP_SRV_PORT             (default 8080)
+#          IMP_TEST_IMG             (default imp:test)
+set -uo pipefail
+
+MODEL="${IMP_DEFAULT_START_MODEL:-Qwen3-8B-Q8_0.gguf}"
+MODELS_DIR="${IMP_MODELS_DIR:-$HOME/models}"
+PORT="${IMP_SRV_PORT:-8080}"
+IMG="${IMP_TEST_IMG:-imp:test}"
+CTR=imp_default_start_test
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+    echo "default-start: no GPU on this host, skipping (this stage is GPU-only)." >&2
+    exit 0
+fi
+
+# unset -> skip, set-but-missing -> red. A dangling path that silently skips is
+# how make test-e2e reported green while loading no model at all.
+if [ ! -r "$MODELS_DIR/$MODEL" ]; then
+    if [ -n "${IMP_DEFAULT_START_MODEL:-}" ]; then
+        echo "default-start: IMP_DEFAULT_START_MODEL=$MODEL not readable under $MODELS_DIR" >&2
+        exit 1
+    fi
+    echo "default-start: $MODEL not in $MODELS_DIR, skipping." >&2
+    exit 0
+fi
+
+cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+docker rm -f "$CTR" >/dev/null 2>&1 || true
+
+echo "== imp-server on shipped defaults ($MODEL) =="
+# --host/--port only: without them the container's server is unreachable, and
+# they are not capacity knobs, which is what this test is about.
+docker run -d --name "$CTR" --gpus all -v "$MODELS_DIR":/models -p "$PORT":"$PORT" "$IMG" \
+    imp-server --model "/models/$MODEL" --host 0.0.0.0 --port "$PORT" >/dev/null
+
+ok=0
+for _ in $(seq 1 90); do
+    if curl -s "localhost:$PORT/health" 2>/dev/null | grep -q '"model_loaded":true'; then
+        ok=1
+        break
+    fi
+    if ! docker ps -q --no-trunc | grep -q "$(docker inspect -f '{{.Id}}' "$CTR" 2>/dev/null)"; then
+        echo "default-start: FAIL - the container exited during startup." >&2
+        echo "               This is #1631: the planner commits more than the card has left" >&2
+        echo "               and the first cuBLASLt call OOMs. Logs:" >&2
+        docker logs "$CTR" 2>&1 | tail -25 >&2
+        exit 1
+    fi
+    sleep 2
+done
+if [ "$ok" != "1" ]; then
+    echo "default-start: FAIL - not healthy within 180s. Logs:" >&2
+    docker logs "$CTR" 2>&1 | tail -25 >&2
+    exit 1
+fi
+
+# A start that cannot answer is not a start. The OOM this guards against fires
+# on the first forward, which /health alone never triggers.
+body=$(curl -s -m 180 "localhost:$PORT/v1/chat/completions" -H 'Content-Type: application/json' \
+    -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Name the capital of France.\"}],\"max_tokens\":600}")
+if ! grep -q "Paris" <<<"$body"; then
+    echo "default-start: FAIL - server is healthy but the first generation did not answer." >&2
+    echo "               response: ${body:0:400}" >&2
+    docker logs "$CTR" 2>&1 | tail -25 >&2
+    exit 1
+fi
+
+# grep -q exits on the first match, the producer dies on EPIPE, and pipefail
+# turns a HIT into a non-zero pipeline (#1499). Feed it from a variable.
+oom=$(docker logs "$CTR" 2>&1 | grep -c "out of memory")
+if [ "$oom" != "0" ]; then
+    echo "default-start: FAIL - server answered but logged $oom 'out of memory' lines." >&2
+    exit 1
+fi
+
+kv=$(curl -s "localhost:$PORT/health" | grep -oP '"kv_capacity_tokens":\K[0-9]+')
+echo "default-start: PASS - healthy, answered, 0 OOM lines, kv_capacity_tokens=$kv"

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -399,10 +399,23 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
             // into cutlass_sf_estimate so both the strategy math and the
             // backstop see it.
             //
-            // Gated on a 2x divergence so heuristic-covered models (Q6_K/Q8
-            // dense — the tuned bench configs) keep their KV pools unchanged.
+            // Gated on ANY divergence, not on a 2x one (#1631). The 2x gate was
+            // there so "heuristic-covered models (Q6_K/Q8 dense - the tuned
+            // bench configs) keep their KV pools unchanged", and the model it
+            // was protecting is the one that stopped starting: Qwen3-8B-Q8_0
+            // at shipped defaults projects 6100 MiB against a 4511 MiB
+            // heuristic, 1.35x, so the reserve stayed at the heuristic, the KV
+            // pool took the difference, and the first cuBLASLt call OOMed with
+            // 537 error lines and exit 1. A pool that is 38% smaller is worth
+            // more than a server that does not start.
+            //
+            // Raising the reserve to the projection alone is NOT enough - that
+            // was measured too: it plans 9977 KV blocks and still OOMs, while
+            // the arm that works plans 7079. The margin the floor adds is
+            // load-bearing, and the 500 MiB between those two arms is why this
+            // is a floor rather than a tighter estimate.
             size_t heuristic = nvfp4_estimate + cutlass_sf_estimate;
-            if (plan.projected_vram_bytes > 2 * heuristic) {
+            if (plan.projected_vram_bytes > heuristic) {
                 size_t want =
                     plan.projected_vram_bytes + vram_reserve_floor(total_vram, reserve_floor_pct);
                 // Never squeeze the pool below one full max_seq_len sequence


### PR DESCRIPTION
Closes #1631.

`imp-server --model /models/Qwen3-8B-Q8_0.gguf`, no other flags, idle 32 GB card: 537 CUDA out-of-memory lines and exit 1. That is the model `tests/perf_baseline.json` pins, so the shipped defaults could not serve the repo's own baseline. Reproduced here before changing anything, identical to the report.

## Mechanism

`compute_vram_budget()` cross-checks its NVFP4 heuristic against the storage planner's projection, logs both, then acts only past a **2x** divergence (`vram_budget.cpp:405`). This model diverges 1.35x, so the reserve stayed at the heuristic and the KV pool absorbed the difference.

```
VRAM budget: planner projects 6100.0 MiB (254 entries), heuristic nvfp4=4059.8 MiB cutlass_sf=451.1 MiB.
VRAM budget: KV clamped 64000 -> 11390 blocks       <- takes the 1589 MiB the reserve did not
VRAM budget: strategy=NVFP4_DECODE, available=17325.0 MiB, kv=11390 blocks (12813.8 MiB), ...
imp_api.cpp:383: cublasLtMatmul + cublasGemmEx fallback both failed (status 14) M=16 K=4096 N=4096
```

The comment on that gate says it is there so "heuristic-covered models (Q6_K/Q8 dense — the tuned bench configs) keep their KV pools unchanged". The model it was protecting is the one that stopped starting.

## What was measured before choosing the fix

| arm | KV planned | result |
|---|---|---|
| shipped defaults (reserve 4511 MiB) | 11390 blocks / 12814 MiB | 537 OOM, exit 1 |
| `vram.library_reserve_mb=5000` | 11713 MiB | 537 OOM, exit 1 |
| `vram.library_reserve_mb=6000` | 10713 MiB | starts |
| `vram.library_reserve_mb=7460` (the 2026-07-30 measured value) | 9253 MiB | starts |
| reserve raised to the projection alone, 6100 MiB, no floor | 9977 blocks / 11224 MiB | 537 OOM, exit 1 |
| **this PR** (projection + reserve floor) | **7079 blocks / 7964 MiB** | **starts** |

Two things follow. The reserve floor the 2x branch already adds is load-bearing, so this is a floor and not a tighter estimate. And the edge between the last failing arm and the first passing one is ~500 MiB, which is why the change is to the gate rather than to the arithmetic behind it.

**The cuBLAS module load is not the missing term.** Standalone probe on a fresh context, at the shape that OOMs:

```
cublasCreate                            delta   +68.0 MiB
cublasLtCreate                          delta    +0.0 MiB
first cublasGemmEx (M=16 K=4096 N=4096) delta    +0.0 MiB
```

68 MiB, not gigabytes. The obvious explanation for why a 3900 MiB "library reserve" constant would be wrong is dead.

## Result

| | before | after |
|---|---|---|
| `/health` | never (exit 1) | 200 in 3 s |
| `out of memory` lines | 537 | 0 |
| `kv_capacity_tokens` | n/a | 105136 (2.5x `max_seq_len`) |
| 7021-token prompt | n/a | answered correctly |
| KV pool | 11390 blocks | 7079 blocks |

## Gate

```
perf gate: median of 3 independent runs (spread 0.12%)
decode  tg128 =  284.22 tok/s  (baseline  287.19, delta -1.03%)
prefill pp512 = 12423.40 tok/s (baseline 12406.87, delta 0.13%)
prefill pp4096 = 15422.43 tok/s (baseline 15324.70, delta 0.64%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  455.84 tok/s   (2.56x, threshold 1.3x)
=== verify fast: OK ===
```

Peak VRAM is unchanged: the bench path does not hit this divergence, so nothing that works today gets a smaller pool from this. Full GPU suite via the pre-commit hook: 2301 tests, 0 failures.

## New gate

`scripts/test_server_default_start.sh`, wired into `make test-server` ahead of the existing batteries. Every other server battery boots with `--max-concurrent`, `--rate-limit` and `--max-input-tokens`, and the audit's own runtime pass used `--set runtime.max_seq_len=8192 --max-batch 4` *because* the defaults did not start, so the one configuration a first-time reader runs was covered by nothing.

It requires `/health`, **a real generation**, and zero out-of-memory lines: `/health` alone returns 200 before the first forward, which is where the OOM fires. Negative control: with the 2x gate restored and the image rebuilt, it fails with exactly the reported error.

Not in here: the reserve is still an estimate with a floor, and a start that overcommits still aborts in `imp_context_create` instead of degrading to a smaller pool, so a model whose demand lands inside that 500 MiB edge can still fail to start. Filed as #1662 and written into `LIMITATIONS.md` rather than left implied.
