### PR TITLE
fix(server): remote image_url is opt-in, and bounded when it is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,18 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`image_url` was an SSRF primitive: any host, any port, redirects followed,
+  no size cap, no read timeout** (#1610). An unauthenticated request body chose
+  where the server connected, which on a container host means loopback, the
+  compose network and the cloud metadata address. Measured, not read: with a
+  listener in the server's own network namespace, the pre-fix binary fetched
+  `http://127.0.0.1:9999/` on request; the fixed one does not, with the flag off
+  or on. Remote fetching is now behind `--allow-remote-images` (default off);
+  with it on the destination is resolved and refused if loopback, link-local,
+  RFC1918, CGNAT or ULA, redirects are not followed, the body is capped at
+  32 MiB and reads time out at 10 s. The error string is uniform and no longer
+  echoes the URL, so it cannot report which ports are open.
+
 - **`imp-server` did not start at shipped defaults on the repo's own
   perf-baseline model** (#1631). `imp-server --model Qwen3-8B-Q8_0.gguf` on an
   idle 32 GB card ended in 537 CUDA out-of-memory lines and exit 1: the planner

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,6 +542,7 @@ if(IMP_BUILD_SERVER)
         tools/imp-server/handlers_chat.cpp
         tools/imp-server/handlers_chat_core.cpp
         tools/imp-server/handlers_chat_params.cpp
+        tools/imp-server/image_fetch.cpp
         tools/imp-server/handlers_chat_stream.cpp
         tools/imp-server/stream_driver.cpp
         tools/imp-server/handlers_messages.cpp
@@ -743,6 +744,11 @@ if(IMP_BUILD_TESTS)
             tools/imp-server/constraint_validation.cpp
             tests/test_constraint_validation.cpp
             tests/test_server_args.cpp
+            # SSRF destination classifier (#1610). Pure address arithmetic plus
+            # getaddrinfo on literals, so it belongs in the CPU lane, which is
+            # the only lane CI runs.
+            tools/imp-server/image_fetch.cpp
+            tests/test_image_fetch.cpp
             # Generative FSM battery for the schema-less json_object grammar.
             # Lives in the CPU lane on purpose: the FSM is CUDA-free without
             # init(), and every past grammar bug escaped CI because its tests

--- a/docs/API.md
+++ b/docs/API.md
@@ -147,13 +147,23 @@ never replayed.
 
 ## Images
 
-✅ on `/v1/chat/completions`, as `image_url` content parts, data-URI or fetched
-over HTTP. Several images in one request are encoded in prompt order.
+✅ on `/v1/chat/completions`, as `image_url` content parts. Several images in one
+request are encoded in prompt order.
+
+**A data URI works out of the box; an `http(s)` URL does not.** Fetching one
+makes the server open a connection to a host the caller names, and the caller is
+unauthenticated by default, so it is behind `--allow-remote-images` (#1610).
+With the flag on, the destination is resolved and refused if it is loopback,
+link-local (including the cloud metadata address), RFC1918, CGNAT or ULA;
+redirects are not followed, the body is capped at 32 MiB and the read has a
+10 s timeout. See [`LIMITATIONS.md`](LIMITATIONS.md) for the residual.
 
 Two refusals worth knowing, both deliberate:
 
 - An `image_url` that cannot be read is a `400`, not a skipped picture. Dropping
-  one would slide every later image onto the wrong placeholder.
+  one would slide every later image onto the wrong placeholder. The message is
+  the same whatever went wrong, and does not echo the URL, so the endpoint
+  cannot be used to tell an open port from a closed one.
 - A model whose vision tower imp cannot read loads **text-only** and says so; a
   request that sends it an image gets `400 vision_unavailable` rather than a
   confident description of a picture the model never received.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -40,6 +40,14 @@ These have a code path and no gate. They may work; nothing proves it.
 
 ## Known-bad and known-limited behaviour
 
+- **Remote `image_url` fetching is off by default, and when on it is still
+  vulnerable to DNS rebinding.** `--allow-remote-images` classifies the
+  destination before connecting, but the check and the connection are two
+  separate resolutions, so a name whose records change in between still reaches
+  a private address. Closing that needs a connect-time callback, which httplib
+  does not expose. The off-by-default is what carries this; treat the flag as
+  "the network this server sits on is trusted".
+
 - **The VRAM planner's weight-cache reserve is an estimate with a floor, not a
   measurement, and there is no retry if it is wrong.** A start that overcommits
   still ends in `imp_context_create` aborting rather than degrading to a smaller

--- a/tests/test_image_fetch.cpp
+++ b/tests/test_image_fetch.cpp
@@ -1,0 +1,143 @@
+// Destination classification for remote `image_url` fetching (#1610).
+//
+// The fetch was an SSRF primitive: host taken verbatim from an unauthenticated
+// request body, redirects followed, no allowlist, no body cap, no read timeout.
+// The default is now off, and this file pins the part that decides where the
+// server is allowed to connect when it is on.
+//
+// CPU lane on purpose. Everything here is address arithmetic plus getaddrinfo
+// on literals; nothing opens a socket, so CI - which has no GPU and no network
+// guarantee - runs it on every pull request.
+
+#include <gtest/gtest.h>
+
+#include "image_fetch.h"
+
+#include <string>
+
+namespace {
+
+using imp_server::classify_host;
+using imp_server::classify_ip_literal;
+using imp_server::DestinationVerdict;
+
+TEST(SsrfClassifier, RejectsLoopback) {
+    EXPECT_EQ(classify_ip_literal("127.0.0.1"), DestinationVerdict::Loopback);
+    // The whole /8, not just .1 - 127.1 and 127.0.0.53 are the same machine.
+    EXPECT_EQ(classify_ip_literal("127.255.255.254"), DestinationVerdict::Loopback);
+    EXPECT_EQ(classify_ip_literal("127.0.0.53"), DestinationVerdict::Loopback);
+    EXPECT_EQ(classify_ip_literal("::1"), DestinationVerdict::Loopback);
+}
+
+TEST(SsrfClassifier, RejectsCloudMetadata) {
+    // The single most valuable target of an SSRF: instance credentials.
+    EXPECT_EQ(classify_ip_literal("169.254.169.254"), DestinationVerdict::LinkLocal);
+    EXPECT_EQ(classify_ip_literal("169.254.0.1"), DestinationVerdict::LinkLocal);
+    EXPECT_EQ(classify_ip_literal("fe80::1"), DestinationVerdict::LinkLocal);
+}
+
+TEST(SsrfClassifier, RejectsPrivateRanges) {
+    EXPECT_EQ(classify_ip_literal("10.0.0.1"), DestinationVerdict::PrivateRange);
+    EXPECT_EQ(classify_ip_literal("172.16.0.1"), DestinationVerdict::PrivateRange);
+    EXPECT_EQ(classify_ip_literal("172.31.255.255"), DestinationVerdict::PrivateRange);
+    EXPECT_EQ(classify_ip_literal("192.168.1.1"), DestinationVerdict::PrivateRange);
+    // The docker-compose network this repo ships lives here.
+    EXPECT_EQ(classify_ip_literal("172.17.0.2"), DestinationVerdict::PrivateRange);
+    // RFC6598, which is neither RFC1918 nor public and is easy to forget.
+    EXPECT_EQ(classify_ip_literal("100.64.0.1"), DestinationVerdict::PrivateRange);
+    EXPECT_EQ(classify_ip_literal("fd00::1"), DestinationVerdict::PrivateRange);
+}
+
+TEST(SsrfClassifier, RejectsTheBoundariesOfEachRangeCorrectly) {
+    // 172.15 and 172.32 are public; only 172.16-31 is not. An off-by-one here
+    // either opens the network or breaks a legitimate host.
+    EXPECT_EQ(classify_ip_literal("172.15.0.1"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("172.32.0.1"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("100.63.255.255"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("100.128.0.1"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("11.0.0.1"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("126.255.255.255"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("128.0.0.1"), DestinationVerdict::Allowed);
+}
+
+TEST(SsrfClassifier, RejectsV4MappedLoopbackHoweverItIsSpelled) {
+    // ::ffff:127.0.0.1 reaches 127.0.0.1. A classifier that only looks at the
+    // v6 prefix calls this a public address.
+    EXPECT_EQ(classify_ip_literal("::ffff:127.0.0.1"), DestinationVerdict::Loopback);
+    EXPECT_EQ(classify_ip_literal("::ffff:169.254.169.254"), DestinationVerdict::LinkLocal);
+    EXPECT_EQ(classify_ip_literal("::ffff:10.0.0.1"), DestinationVerdict::PrivateRange);
+    // And the same addresses written as hex quads.
+    EXPECT_EQ(classify_ip_literal("::ffff:7f00:1"), DestinationVerdict::Loopback);
+}
+
+TEST(SsrfClassifier, RejectsUnspecifiedAndMulticast) {
+    // 0.0.0.0 routes to localhost on Linux.
+    EXPECT_EQ(classify_ip_literal("0.0.0.0"), DestinationVerdict::Unspecified);
+    EXPECT_EQ(classify_ip_literal("::"), DestinationVerdict::Unspecified);
+    EXPECT_EQ(classify_ip_literal("224.0.0.1"), DestinationVerdict::Multicast);
+    EXPECT_EQ(classify_ip_literal("255.255.255.255"), DestinationVerdict::Reserved);
+}
+
+TEST(SsrfClassifier, AllowsOrdinaryPublicAddresses) {
+    // Negative control: the check must not refuse the thing it exists to allow.
+    EXPECT_EQ(classify_ip_literal("8.8.8.8"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("1.1.1.1"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("93.184.216.34"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_ip_literal("2606:4700:4700::1111"), DestinationVerdict::Allowed);
+}
+
+TEST(SsrfClassifier, NonAddressesAreNotAddresses) {
+    EXPECT_EQ(classify_ip_literal(""), DestinationVerdict::NotAnIpOrUnresolvable);
+    EXPECT_EQ(classify_ip_literal("example.com"), DestinationVerdict::NotAnIpOrUnresolvable);
+    EXPECT_EQ(classify_ip_literal("999.1.1.1"), DestinationVerdict::NotAnIpOrUnresolvable);
+}
+
+TEST(SsrfClassifier, HostFormAcceptsLiteralsAndBrackets) {
+    // classify_host resolves, but a literal resolves to itself with no DNS.
+    EXPECT_EQ(classify_host("127.0.0.1"), DestinationVerdict::Loopback);
+    EXPECT_EQ(classify_host("[::1]"), DestinationVerdict::Loopback);
+    EXPECT_EQ(classify_host("169.254.169.254"), DestinationVerdict::LinkLocal);
+    EXPECT_EQ(classify_host("8.8.8.8"), DestinationVerdict::Allowed);
+    EXPECT_EQ(classify_host(""), DestinationVerdict::NotAnIpOrUnresolvable);
+    // "localhost" is the name every SSRF payload reaches for, and it resolves
+    // without leaving the machine, so this stays hermetic.
+    EXPECT_EQ(classify_host("localhost"), DestinationVerdict::Loopback);
+}
+
+// The default is what actually carries this defence: with the flag off, no
+// URL reaches the network at all, whatever it names.
+TEST(SsrfFetch, RemoteFetchIsOffByDefault) {
+    auto r = imp_server::fetch_remote_image("http://127.0.0.1:9/probe", /*allow_remote=*/false);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.detail.find("--allow-remote-images"), std::string::npos) << r.detail;
+    EXPECT_TRUE(r.bytes.empty());
+}
+
+TEST(SsrfFetch, PrivateDestinationsAreRefusedEvenWhenEnabled) {
+    // Port 9 (discard) is closed on this host; the point is that the refusal
+    // happens before any connect, so the result must be the classifier's, not
+    // a connection error.
+    for (const char* u : {"http://127.0.0.1:9/x", "http://169.254.169.254/latest/meta-data/",
+                          "http://10.0.0.1/x", "http://[::1]:9/x", "http://localhost:9/x"}) {
+        auto r = imp_server::fetch_remote_image(u, /*allow_remote=*/true);
+        EXPECT_FALSE(r.ok) << u;
+        EXPECT_NE(r.detail.find("destination rejected"), std::string::npos) << u << ": " << r.detail;
+    }
+}
+
+TEST(SsrfFetch, UserinfoDoesNotHideTheRealHost) {
+    // http://allowed.example@127.0.0.1/ connects to 127.0.0.1. A parser that
+    // splits on the first '/' and keeps everything before it as the host reads
+    // this as "allowed.example@127.0.0.1" and hands that to the client.
+    auto r = imp_server::fetch_remote_image("http://example.com@127.0.0.1:9/x", /*allow_remote=*/true);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.detail.find("destination rejected"), std::string::npos) << r.detail;
+}
+
+TEST(SsrfFetch, NonHttpSchemesAreNotFetched) {
+    auto r = imp_server::fetch_remote_image("file:///etc/passwd", /*allow_remote=*/true);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.detail.find("scheme"), std::string::npos) << r.detail;
+}
+
+}  // namespace

--- a/tools/imp-server/CLAUDE.md
+++ b/tools/imp-server/CLAUDE.md
@@ -20,6 +20,12 @@ adapters on a shared core; the engine lives in `src/runtime/`.
 - **A request the server cannot honour is a 4xx, not a best-effort answer.** An
   uncompilable constraint, an unreadable image, a `tool_choice` naming an absent
   function: all 400. This is a deliberate, breaking-by-design stance.
+- **The server never connects to a host a request names, unless the operator
+  opted in.** `--allow-remote-images` gates the only such path (`image_url`),
+  and even then the destination is classified before the connect and redirects
+  are not followed (#1610, `image_fetch.h`). An error string that varies with
+  the destination is the same defect wearing a different hat: it makes the
+  endpoint a port scanner.
 - **Reasoning goes to `reasoning_content`**, never into `content`. This was once
   wrong on the streaming path only, which our own batteries could not see.
 

--- a/tools/imp-server/args.cpp
+++ b/tools/imp-server/args.cpp
@@ -42,6 +42,8 @@ void print_server_usage(const char* prog) {
             "  --models-dir <path>   Directory to scan for .gguf models (auto-load on select)\n"
             "  --api-key <key>       Require Bearer token authentication\n"
             "  --metrics-require-auth  Also gate /metrics behind --api-key\n"
+            "  --allow-remote-images Fetch http(s) image_url from request bodies (default: off).\n"
+            "                        Off, the server never connects anywhere a caller names.\n"
             "  --reasoning-format <f> deepseek (default) or none\n"
             "  --mem-report          Print the full VRAM attribution table at init\n"
             "  --vram-budget <mb>    Hard per-process VRAM cap in MiB — size everything as if\n"
@@ -89,6 +91,8 @@ ServerArgs parse_server_args(int argc, char** argv) {
             args.api_key = argv[++i];
         } else if (std::strcmp(arg, "--metrics-require-auth") == 0) {
             args.metrics_require_auth = true;
+        } else if (std::strcmp(arg, "--allow-remote-images") == 0) {
+            args.allow_remote_images = true;
         } else if (std::strcmp(arg, "--reasoning-format") == 0 && i + 1 < argc) {
             args.reasoning_format = argv[++i];
         } else if (std::strcmp(arg, "--think-budget") == 0 && i + 1 < argc) {

--- a/tools/imp-server/args.h
+++ b/tools/imp-server/args.h
@@ -36,6 +36,14 @@ struct ServerArgs : CommonArgs {
     int request_timeout = 300;      // --request-timeout: per-request timeout in seconds (0=unlimited)
     int rate_limit = 0;             // --rate-limit: max requests per minute per IP (0=unlimited)
     int max_input_tokens = 0;       // --max-input-tokens: reject prompts longer than this (0=unlimited)
+    // --allow-remote-images: fetch http(s) image_url from a request body.
+    // Default OFF (#1610). With it on, an unauthenticated caller chooses which
+    // host and port this server connects to, and the interesting targets are
+    // the ones only the server can reach: loopback, the compose network, the
+    // cloud metadata endpoint. A data URI needs none of this and is what every
+    // real client sends. When on, the destination is classified and redirects
+    // are not followed - see image_fetch.h.
+    bool allow_remote_images = false;
     std::string prefix_cache_path;  // --prefix-cache: path to persist prefix cache
     std::string log_requests_path;  // --log-requests: append JSONL of every chat/messages request
 };

--- a/tools/imp-server/handlers_chat_params.cpp
+++ b/tools/imp-server/handlers_chat_params.cpp
@@ -11,6 +11,7 @@
 #include "tool_call.h"
 #include "anthropic.h"
 #include "stream_pipeline.h"
+#include "image_fetch.h"
 #include "reasoning_split.h"
 
 #include "api/imp_internal.h"
@@ -363,40 +364,41 @@ bool parse_chat_request_params(const httplib::Request& req, httplib::Response& r
                             image_bytes = base64_decode(url.substr(comma + 1));
                         }
                     } else if (url.rfind("http://", 0) == 0 || url.rfind("https://", 0) == 0) {
-                        // Remote URL: fetch image via HTTP
-                        // Parse URL into host + path
-                        bool is_https = (url.rfind("https://", 0) == 0);
-                        std::string rest = url.substr(is_https ? 8 : 7);
-                        auto slash = rest.find('/');
-                        std::string host = (slash != std::string::npos) ? rest.substr(0, slash) : rest;
-                        std::string path_str = (slash != std::string::npos) ? rest.substr(slash) : "/";
-                        if (is_https) {
-#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
-                            httplib::SSLClient cli(host);
-                            cli.set_follow_location(true);
-                            cli.set_connection_timeout(10);
-                            auto img_res = cli.Get(path_str);
-                            if (img_res && img_res->status == 200) {
-                                image_bytes.assign(img_res->body.begin(), img_res->body.end());
-                            }
-#else
-                            ctx.params.image_error = "https image_url needs an imp built with OpenSSL";
-#endif
+                        // #1610: this used to build an httplib client straight
+                        // from the request's host, follow redirects, and buffer
+                        // whatever came back. That is an SSRF primitive on an
+                        // endpoint that is unauthenticated by default: the
+                        // caller picks the host and port and the server has
+                        // reach the caller does not. Off by default now, and
+                        // bounded when on. See image_fetch.h.
+                        auto fetched = imp_server::fetch_remote_image(url,
+                                                                      state.default_args.allow_remote_images);
+                        if (fetched.ok) {
+                            image_bytes = std::move(fetched.bytes);
                         } else {
-                            httplib::Client cli(host);
-                            cli.set_follow_location(true);
-                            cli.set_connection_timeout(10);
-                            auto img_res = cli.Get(path_str);
-                            if (img_res && img_res->status == 200) {
-                                image_bytes.assign(img_res->body.begin(), img_res->body.end());
-                            }
+                            IMP_LOG_WARN("image_url not fetched: %s", fetched.detail.c_str());
                         }
                     }
                     // A scheme we do not fetch (file://, plain paths) leaves the
                     // slot empty, same as a failed request. Both are refused
                     // below rather than silently dropping a picture.
-                    if (image_bytes.empty() && ctx.params.image_error.empty())
-                        ctx.params.image_error = "could not read image_url: " + url.substr(0, 64);
+                    //
+                    // One string for every cause, and it does NOT echo the URL.
+                    // Distinguishable errors turned this into a port scanner of
+                    // the server's own network: "connection refused" and "200
+                    // with unparseable bytes" read differently from outside.
+                    //
+                    // The two variants below differ by SERVER CONFIGURATION,
+                    // never by what the URL named, so neither tells a caller
+                    // anything about the destination.
+                    if (image_bytes.empty() && ctx.params.image_error.empty()) {
+                        const bool remote = url.rfind("http://", 0) == 0 || url.rfind("https://", 0) == 0;
+                        ctx.params.image_error =
+                            (remote && !state.default_args.allow_remote_images)
+                                ? "could not read image_url: remote URLs are disabled on this "
+                                  "server; send a data: URI, or start it with --allow-remote-images"
+                                : "could not read image_url";
+                    }
                 }
             }
             ctx.params.chat_msgs.push_back({role, text_parts});

--- a/tools/imp-server/image_fetch.cpp
+++ b/tools/imp-server/image_fetch.cpp
@@ -1,0 +1,258 @@
+#include "image_fetch.h"
+
+#include "core/logging.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <cstring>
+
+#include <httplib.h>
+
+namespace imp_server {
+
+namespace {
+
+DestinationVerdict classify_v4(uint32_t addr_host_order) {
+    const uint32_t a = addr_host_order;
+    const uint8_t b0 = static_cast<uint8_t>(a >> 24);
+    const uint8_t b1 = static_cast<uint8_t>(a >> 16);
+
+    if (a == 0)
+        return DestinationVerdict::Unspecified;
+    if (b0 == 127)
+        return DestinationVerdict::Loopback;
+    if (b0 == 169 && b1 == 254)
+        return DestinationVerdict::LinkLocal;  // includes 169.254.169.254
+    if (b0 == 10)
+        return DestinationVerdict::PrivateRange;
+    if (b0 == 172 && b1 >= 16 && b1 <= 31)
+        return DestinationVerdict::PrivateRange;
+    if (b0 == 192 && b1 == 168)
+        return DestinationVerdict::PrivateRange;
+    if (b0 == 100 && b1 >= 64 && b1 <= 127)
+        return DestinationVerdict::PrivateRange;  // RFC6598 CGNAT
+    if (b0 >= 224 && b0 <= 239)
+        return DestinationVerdict::Multicast;
+    if (b0 >= 240)
+        return DestinationVerdict::Reserved;  // 240/4, incl. 255.255.255.255
+    // 192.0.0.0/24, 192.0.2.0/24, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24
+    if (b0 == 192 && b1 == 0)
+        return DestinationVerdict::Reserved;
+    if (b0 == 198 && (b1 == 18 || b1 == 19 || b1 == 51))
+        return DestinationVerdict::Reserved;
+    if (b0 == 203 && b1 == 0)
+        return DestinationVerdict::Reserved;
+    return DestinationVerdict::Allowed;
+}
+
+DestinationVerdict classify_v6(const in6_addr& a) {
+    const uint8_t* b = a.s6_addr;
+
+    // An IPv4-mapped or IPv4-compatible v6 address reaches the v4 host it
+    // names. ::ffff:127.0.0.1 is loopback however it is spelled.
+    static const uint8_t v4mapped_prefix[12] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff};
+    if (std::memcmp(b, v4mapped_prefix, 12) == 0) {
+        uint32_t v4 = (static_cast<uint32_t>(b[12]) << 24) | (static_cast<uint32_t>(b[13]) << 16) |
+                      (static_cast<uint32_t>(b[14]) << 8) | static_cast<uint32_t>(b[15]);
+        return classify_v4(v4);
+    }
+    bool first12_zero = true;
+    for (int i = 0; i < 12; i++)
+        if (b[i] != 0)
+            first12_zero = false;
+    if (first12_zero) {
+        uint32_t v4 = (static_cast<uint32_t>(b[12]) << 24) | (static_cast<uint32_t>(b[13]) << 16) |
+                      (static_cast<uint32_t>(b[14]) << 8) | static_cast<uint32_t>(b[15]);
+        if (v4 == 1)
+            return DestinationVerdict::Loopback;  // ::1
+        if (v4 == 0)
+            return DestinationVerdict::Unspecified;
+        return DestinationVerdict::Reserved;  // ::a.b.c.d, deprecated
+    }
+
+    if ((b[0] & 0xfe) == 0xfc)
+        return DestinationVerdict::PrivateRange;  // fc00::/7 ULA
+    if (b[0] == 0xfe && (b[1] & 0xc0) == 0x80)
+        return DestinationVerdict::LinkLocal;  // fe80::/10
+    if (b[0] == 0xff)
+        return DestinationVerdict::Multicast;
+    if (b[0] == 0x20 && b[1] == 0x01 && b[2] == 0x00 && (b[3] & 0xf0) == 0x00)
+        return DestinationVerdict::Reserved;  // 2001:0::/24 teredo/benchmarking block
+    return DestinationVerdict::Allowed;
+}
+
+const char* verdict_name(DestinationVerdict v) {
+    switch (v) {
+        case DestinationVerdict::Allowed:
+            return "allowed";
+        case DestinationVerdict::NotAnIpOrUnresolvable:
+            return "unresolvable";
+        case DestinationVerdict::Loopback:
+            return "loopback";
+        case DestinationVerdict::LinkLocal:
+            return "link-local";
+        case DestinationVerdict::PrivateRange:
+            return "private";
+        case DestinationVerdict::Unspecified:
+            return "unspecified";
+        case DestinationVerdict::Multicast:
+            return "multicast";
+        case DestinationVerdict::Reserved:
+            return "reserved";
+    }
+    return "unknown";
+}
+
+}  // namespace
+
+DestinationVerdict classify_ip_literal(const std::string& ip) {
+    in_addr v4{};
+    if (inet_pton(AF_INET, ip.c_str(), &v4) == 1)
+        return classify_v4(ntohl(v4.s_addr));
+    in6_addr v6{};
+    if (inet_pton(AF_INET6, ip.c_str(), &v6) == 1)
+        return classify_v6(v6);
+    return DestinationVerdict::NotAnIpOrUnresolvable;
+}
+
+DestinationVerdict classify_host(const std::string& host) {
+    // A bracketed v6 literal arrives as [::1]; strip before resolving.
+    std::string h = host;
+    if (h.size() >= 2 && h.front() == '[' && h.back() == ']')
+        h = h.substr(1, h.size() - 2);
+    if (h.empty())
+        return DestinationVerdict::NotAnIpOrUnresolvable;
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo* res = nullptr;
+    if (getaddrinfo(h.c_str(), nullptr, &hints, &res) != 0 || !res)
+        return DestinationVerdict::NotAnIpOrUnresolvable;
+
+    // ALL records must be public. One public and one loopback record is a
+    // rebinding primitive, not a partial success.
+    DestinationVerdict worst = DestinationVerdict::NotAnIpOrUnresolvable;
+    bool any = false;
+    for (addrinfo* p = res; p; p = p->ai_next) {
+        DestinationVerdict v = DestinationVerdict::NotAnIpOrUnresolvable;
+        if (p->ai_family == AF_INET) {
+            auto* sa = reinterpret_cast<sockaddr_in*>(p->ai_addr);
+            v = classify_v4(ntohl(sa->sin_addr.s_addr));
+        } else if (p->ai_family == AF_INET6) {
+            auto* sa = reinterpret_cast<sockaddr_in6*>(p->ai_addr);
+            v = classify_v6(sa->sin6_addr);
+        } else {
+            continue;
+        }
+        any = true;
+        if (v != DestinationVerdict::Allowed) {
+            freeaddrinfo(res);
+            return v;
+        }
+        worst = v;
+    }
+    freeaddrinfo(res);
+    return any ? worst : DestinationVerdict::NotAnIpOrUnresolvable;
+}
+
+FetchResult fetch_remote_image(const std::string& url, bool allow_remote) {
+    FetchResult out;
+    if (!allow_remote) {
+        out.detail = "remote image_url fetching is off (--allow-remote-images)";
+        return out;
+    }
+
+    const bool is_https = (url.rfind("https://", 0) == 0);
+    if (!is_https && url.rfind("http://", 0) != 0) {
+        out.detail = "scheme is not http/https";
+        return out;
+    }
+    std::string rest = url.substr(is_https ? 8 : 7);
+    // Strip userinfo: http://allowed.example@127.0.0.1/ connects to the host
+    // AFTER the '@', which is not the one a naive reader sees.
+    auto at = rest.find('@');
+    auto first_slash_for_at = rest.find('/');
+    if (at != std::string::npos && (first_slash_for_at == std::string::npos || at < first_slash_for_at))
+        rest = rest.substr(at + 1);
+
+    auto slash = rest.find('/');
+    std::string authority = (slash != std::string::npos) ? rest.substr(0, slash) : rest;
+    std::string path_str = (slash != std::string::npos) ? rest.substr(slash) : "/";
+
+    // Split host from port, keeping a bracketed v6 literal intact.
+    std::string host = authority;
+    if (!authority.empty() && authority.front() == '[') {
+        auto close = authority.find(']');
+        if (close == std::string::npos) {
+            out.detail = "malformed IPv6 authority";
+            return out;
+        }
+        host = authority.substr(0, close + 1);
+    } else {
+        auto colon = authority.find(':');
+        if (colon != std::string::npos)
+            host = authority.substr(0, colon);
+    }
+
+    DestinationVerdict verdict = classify_host(host);
+    if (verdict != DestinationVerdict::Allowed) {
+        out.detail = std::string("destination rejected: ") + verdict_name(verdict);
+        IMP_LOG_WARN("image_url refused: %s resolves to a %s address", host.c_str(), verdict_name(verdict));
+        return out;
+    }
+
+    auto run = [&](auto& cli) {
+        // Redirects OFF. Following one re-runs the whole decision on a host
+        // this function never saw, and httplib offers no per-hop hook.
+        cli.set_follow_location(false);
+        cli.set_connection_timeout(10);
+        cli.set_read_timeout(kRemoteImageReadTimeoutSec);
+        cli.set_write_timeout(kRemoteImageReadTimeoutSec);
+
+        std::string body;
+        bool too_large = false;
+        auto res = cli.Get(path_str, httplib::Headers{}, [&](const char* data, size_t len) {
+            if (body.size() + len > kMaxRemoteImageBytes) {
+                too_large = true;
+                return false;  // abort the transfer
+            }
+            body.append(data, len);
+            return true;
+        });
+        if (too_large) {
+            out.detail = "image body over the cap";
+            return;
+        }
+        if (!res) {
+            out.detail = "request failed";
+            return;
+        }
+        if (res->status != 200) {
+            out.detail = "status " + std::to_string(res->status);
+            return;
+        }
+        out.bytes.assign(body.begin(), body.end());
+        out.ok = !out.bytes.empty();
+        if (!out.ok)
+            out.detail = "empty body";
+    };
+
+    if (is_https) {
+#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
+        httplib::SSLClient cli(authority);
+        run(cli);
+#else
+        out.detail = "https image_url needs an imp built with OpenSSL";
+#endif
+    } else {
+        httplib::Client cli(authority);
+        run(cli);
+    }
+    return out;
+}
+
+}  // namespace imp_server

--- a/tools/imp-server/image_fetch.h
+++ b/tools/imp-server/image_fetch.h
@@ -1,0 +1,74 @@
+#pragma once
+
+// Remote `image_url` fetching, with the destination checks that make it safe to
+// hand a request-supplied URL to an HTTP client (#1610).
+//
+// The fetch itself is opt-in (`--allow-remote-images`, default off). A data URI
+// is the path every real client uses and needs none of this; a remote URL turns
+// the server into an HTTP client that an unauthenticated caller aims, which on
+// this host means loopback, the container network, and the cloud metadata
+// endpoint are all one request body away.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace imp_server {
+
+// Largest image body accepted from a remote URL. The peer chooses the size
+// otherwise, and the buffer is host RAM.
+constexpr size_t kMaxRemoteImageBytes = 32ull * 1024 * 1024;
+
+// Read timeout for the fetch. A connection timeout alone does not bound a
+// slow-drip server, which holds the worker thread for as long as it likes.
+constexpr int kRemoteImageReadTimeoutSec = 10;
+
+// Why a destination was rejected. Kept separate from the caller-visible error
+// string on purpose: the caller returns one uniform message, so the endpoint
+// cannot be used to tell "port open" from "connection refused".
+enum class DestinationVerdict {
+    Allowed,
+    NotAnIpOrUnresolvable,
+    Loopback,      // 127.0.0.0/8, ::1
+    LinkLocal,     // 169.254.0.0/16 (cloud metadata), fe80::/10
+    PrivateRange,  // RFC1918, RFC4193 ULA, RFC6598 CGNAT
+    Unspecified,   // 0.0.0.0, ::
+    Multicast,
+    Reserved,  // everything else IANA does not route publicly
+};
+
+// Classify one textual IP address (v4 or v6, no host name, no port).
+// Pure and allocation-free apart from the parse: this is the part that gets
+// unit-tested, because the interesting cases are the ones nobody reaches by
+// accident (0x7f.1, ::ffff:127.0.0.1, 100.64/10).
+DestinationVerdict classify_ip_literal(const std::string& ip);
+
+// Resolve `host` and classify every address it maps to. A host is allowed only
+// when it resolves to at least one address and ALL of them are public: a name
+// with one public and one loopback record is a rebinding primitive, not a
+// partial success.
+//
+// NOTE the residual risk, which is not fixable at this layer: the check and the
+// connection are two separate resolutions, so a name whose records change in
+// between still reaches a private address (DNS rebinding). Closing that needs a
+// connect-time callback, which httplib does not expose. The opt-in default is
+// what actually carries this.
+DestinationVerdict classify_host(const std::string& host);
+
+struct FetchResult {
+    bool ok = false;
+    std::vector<uint8_t> bytes;
+    // For the log only. Never returned to the client, see the uniform-error
+    // note above.
+    std::string detail;
+};
+
+// Fetch an http/https image URL with every bound this header describes:
+// destination classified, redirects NOT followed (each hop would need its own
+// check and httplib gives no hook for one), body capped, read timeout set.
+//
+// `allow_remote` false returns ok=false without touching the network.
+FetchResult fetch_remote_image(const std::string& url, bool allow_remote);
+
+}  // namespace imp_server


### PR DESCRIPTION
Closes #1610.

`handlers_chat_params.cpp` built an httplib client from the request URL's host verbatim, followed redirects, buffered the response with no cap, and set a connection timeout but no read timeout. The caller is unauthenticated by default, so the caller chose where the server connected. On a container host the reachable-only-from-there targets are the interesting ones: `127.0.0.1`, the compose network, `169.254.169.254`.

## Measured, with a listener on 127.0.0.1:9999 inside the server's own network namespace

| arm | listener hits |
|---|---|
| positive control (`curl` from inside the server container) | 1 — `GET /positive-control` |
| **pre-fix binary**, `image_url: http://127.0.0.1:9999/…` | **1 — `GET /ssrf-negative-control HTTP/1.1`** |
| fixed binary, flag off | 0 |
| fixed binary, `--allow-remote-images` | 0, plus `image_url refused: 127.0.0.1 resolves to a loopback address` |

The positive control is load-bearing. The request is rejected with `vision_unavailable` on a text-only model, so without it "0 hits" is indistinguishable from a harness that cannot measure. The fetch runs during parameter parsing, ahead of that check, which is why the pre-fix arm still connects.

## What changed

Remote fetching moves behind `--allow-remote-images`, default off. A data URI is unaffected and is the path real clients use. With the flag on, `tools/imp-server/image_fetch.{h,cpp}`:

- resolves the destination and refuses loopback, link-local (`169.254/16`, `fe80::/10`), RFC1918, RFC6598 CGNAT, ULA, unspecified, multicast and the non-routable reserved blocks, in v4 and v6, **including IPv4-mapped spellings** — `::ffff:127.0.0.1` reaches `127.0.0.1` whatever it is written as;
- requires **all** of a name's records to be public: one public and one loopback record is a rebinding primitive, not a partial success;
- strips userinfo before reading the host, so `http://example.com@127.0.0.1/` classifies as `127.0.0.1`;
- does **not** follow redirects — each hop needs its own decision and httplib exposes no per-hop hook;
- caps the body at 32 MiB through a content receiver that aborts the transfer, and sets a 10 s read/write timeout. A connection timeout alone does not bound a slow-drip peer, which held a worker thread for as long as it liked.

The error string no longer varies with the destination and no longer echoes the URL: it used to separate "200 with unparseable bytes" from "connection refused", which is a port scanner of the server's own network. The one remaining variant differs by **server configuration**, not by target, so an operator can still learn why a URL that works elsewhere does not work here.

## Tests

13 cases in `tests/test_image_fetch.cpp`, unit lane, no socket opened. They pin the range boundaries (`172.15` and `172.32` public, `172.16-31` not; `100.63` vs `100.64`), the v4-mapped spellings, the userinfo form, and that the default is off.

Negative control: dropping three ranges from the classifier turns 5 of the 13 red, and `PrivateDestinationsAreRefusedEvenWhenEnabled` then takes 10 s instead of 0 ms — the fetch is actually attempted and the new read timeout is what ends it.

## Gate

```
decode  tg128 =  284.01 tok/s  (baseline  287.19, delta -1.11%)
prefill pp512 = 12502.72 tok/s (baseline 12406.87, delta 0.77%)
prefill pp4096 = 15426.02 tok/s (baseline 15324.70, delta 0.66%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  455.92 tok/s   (2.83x, threshold 1.3x)
=== verify fast: OK ===
```

Full GPU suite via the pre-commit hook: 2301 tests, 0 failures.

Not in here, and now in `LIMITATIONS.md`: the classification and the connection are two separate resolutions, so DNS rebinding still reaches a private address while the flag is on. Closing it needs a connect-time callback httplib does not offer, so the off-by-default is what carries this.

Also not in here: #1607, the unbounded recursion through `tools[].function.parameters`, which is the other unauthenticated crash on this surface. Measured while working here and worth recording — nlohmann has **no** depth cap of its own: 50 000 nested arrays parse and `dump()` fine, 100 000 segfaults, i.e. ~100 KB of request body against a 100 MiB body cap. So that fix belongs at the HTTP boundary, before `json::parse`, not only in imp's own parser.
