### PR TITLE
fix(server): bound request-body nesting, and stop splitting UTF-8 in tool args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,25 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A nested `tools[].function.parameters` crashed the whole server** (#1607).
+  Every parser on the request path is recursive and none bounded depth,
+  nlohmann included and it runs first: measured here, 50 000 nested arrays parse
+  and `dump()` fine and 100 000 segfault the process, i.e. ~100 KB of body
+  against a 100 MiB cap, unauthenticated, taking every in-flight stream with it.
+  Bodies deeper than 100 levels are now a `400` at all nine request-parse sites,
+  and `json_string_to_value` and the `tojson` walker have their own caps behind
+  that. The check does **not** live in the pre-routing handler: httplib calls
+  that before the body is read, where `req.body` is empty, and a 10 000-level
+  body still returned 200 from there.
+
+- **Streamed tool arguments were sliced every 48 bytes, so non-ASCII arrived as
+  U+FFFD** (#1554). A multi-byte character straddling a slice boundary was cut
+  in half and each half JSON-encoded separately, which `dump_safe` replaces.
+  Any tool argument with an umlaut, an accent or an emoji reached the client
+  corrupted, silently. Slices now end on codepoint boundaries on both affected
+  dialects (`/v1/messages` and `/v1/chat/completions`; `/v1/responses` never
+  chunked and was unaffected).
+
 - **`image_url` was an SSRF primitive: any host, any port, redirects followed,
   no size cap, no read timeout** (#1610). An unauthenticated request body chose
   where the server connected, which on a container host means loopback, the

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -583,6 +583,12 @@ static jinja::Value json_string_to_value(const std::string& json_str) {
     };
 
     std::function<jinja::Value()> parse_value;
+    // #1607: this parser recurses once per nesting level over a string that
+    // came from a request body. The HTTP boundary caps the body at 100 levels,
+    // which is what actually bounds this today - the cap here is so a second
+    // caller, from a source that has no such boundary, cannot reintroduce it.
+    int depth = 0;
+    constexpr int kMaxDepth = 128;
 
     auto parse_string = [&]() -> std::string {
         if (pos >= json_str.size() || json_str[pos] != '"')
@@ -681,6 +687,14 @@ static jinja::Value json_string_to_value(const std::string& json_str) {
     };
 
     parse_value = [&]() -> jinja::Value {
+        if (depth >= kMaxDepth)
+            return jinja::Value();
+        depth++;
+        struct Pop {
+            int& d;
+            ~Pop() { d--; }
+        } pop{depth};
+
         skip_ws();
         if (pos >= json_str.size())
             return jinja::Value();

--- a/src/model/jinja.cpp
+++ b/src/model/jinja.cpp
@@ -2509,7 +2509,13 @@ private:
         return Value();
     }
 
-    static std::string value_to_json(const Value& val) {
+    // #1607: the tojson filter walks the value tree recursively, and that tree
+    // comes from a request-supplied schema. Depth is bounded at the HTTP
+    // boundary; this is the second line, for a tree built any other way.
+    static std::string value_to_json(const Value& val, int depth = 0) {
+        constexpr int kMaxJsonDepth = 128;
+        if (depth >= kMaxJsonDepth)
+            return "null";
         if (val.is_none())
             return "null";
         if (val.is_bool())
@@ -2564,7 +2570,7 @@ private:
             for (size_t i = 0; i < arr.size(); i++) {
                 if (i > 0)
                     r += ", ";
-                r += value_to_json(arr[i]);
+                r += value_to_json(arr[i], depth + 1);
             }
             r += "]";
             return r;
@@ -2575,7 +2581,7 @@ private:
             for (auto& [k, v] : *val.as_object()) {
                 if (!first)
                     r += ", ";
-                r += "\"" + k + "\": " + value_to_json(v);
+                r += "\"" + k + "\": " + value_to_json(v, depth + 1);
                 first = false;
             }
             r += "}";

--- a/tests/test_sse_stream_utils.cpp
+++ b/tests/test_sse_stream_utils.cpp
@@ -607,3 +607,114 @@ TEST(HealthUnservable, UnknownCapacityIsNotAVerdict) {
     EXPECT_TRUE(health_unservable_reason(false, false, -1, -1).empty());
     EXPECT_STREQ(health_unservable_code(false, false), "");
 }
+
+// ---- #1554: tool-argument chunks end on codepoint boundaries ----
+//
+// Buffered tool calls were sliced every 48 BYTES and each slice JSON-encoded on
+// its own, so a multi-byte character straddling a boundary was cut in half and
+// dump_safe replaced each half with U+FFFD. The client concatenates the pieces
+// and gets a corrupt argument. Two of the three dialects did this; /v1/responses
+// does not chunk and was immune.
+
+TEST(Utf8ChunkLen, NeverSplitsAMultiByteCharacter) {
+    // "ü" is 2 bytes. With max=5 over "aaaaü", a byte slice takes 5 bytes and
+    // cuts the ü in half.
+    const std::string s =
+        "aaaa\xc3\xbc"
+        "bbbb";
+    const size_t n = utf8_chunk_len(s, 0, 5);
+    EXPECT_EQ(n, 4u) << "must stop before the split character, not inside it";
+    // Continuing from there takes the whole character.
+    EXPECT_EQ(utf8_chunk_len(s, 4, 5), 5u);
+}
+
+TEST(Utf8ChunkLen, HandlesThreeAndFourByteSequences) {
+    const std::string cjk = "ab\xe4\xb8\xad";  // 'ab' + U+4E2D (3 bytes)
+    EXPECT_EQ(utf8_chunk_len(cjk, 0, 3), 2u);  // stop before the CJK char
+    EXPECT_EQ(utf8_chunk_len(cjk, 0, 4), 2u);
+    EXPECT_EQ(utf8_chunk_len(cjk, 0, 5), 5u);       // whole string fits
+    const std::string emoji = "x\xf0\x9f\x98\x80";  // 'x' + U+1F600 (4 bytes)
+    EXPECT_EQ(utf8_chunk_len(emoji, 0, 3), 1u);
+    EXPECT_EQ(utf8_chunk_len(emoji, 0, 5), 5u);
+}
+
+TEST(Utf8ChunkLen, ReassemblingTheChunksReproducesTheInput) {
+    // The property that actually matters: chunking and concatenating is the
+    // identity, for any max, on real tool-argument content.
+    const std::string args = R"({"city":"München","note":"Grüße aus Köln 😀","path":"/tmp/übung"})";
+    for (size_t max : {1u, 2u, 3u, 4u, 5u, 7u, 16u, 48u}) {
+        std::string rebuilt;
+        for (size_t off = 0; off < args.size();) {
+            const size_t n = utf8_chunk_len(args, off, max);
+            ASSERT_GT(n, 0u) << "max=" << max << " off=" << off;
+            const std::string piece = args.substr(off, n);
+            // Every piece must be valid UTF-8 on its own - that is the whole
+            // point, since each one is JSON-encoded separately.
+            EXPECT_EQ(imp::stream::utf8_complete_len(piece), piece.size())
+                << "max=" << max << " produced a piece ending mid-character";
+            rebuilt += piece;
+            off += n;
+        }
+        EXPECT_EQ(rebuilt, args) << "max=" << max;
+    }
+}
+
+TEST(Utf8ChunkLen, AlwaysMakesProgress) {
+    const std::string s = "\xc3\xbc\xc3\xbc";  // two 2-byte chars
+    // max=1 cannot fit a character; it must still advance rather than loop.
+    EXPECT_GT(utf8_chunk_len(s, 0, 1), 0u);
+    EXPECT_EQ(utf8_chunk_len(s, 4, 8), 0u);  // nothing left
+}
+
+// ---- #1607: request-body nesting depth, counted without parsing ----
+
+TEST(JsonNestingDepth, CountsPlainNesting) {
+    EXPECT_EQ(json_nesting_depth("{}", 100), 1);
+    EXPECT_EQ(json_nesting_depth("[[[]]]", 100), 3);
+    EXPECT_EQ(json_nesting_depth(R"({"a":{"b":{"c":1}}})", 100), 3);
+    EXPECT_EQ(json_nesting_depth("", 100), 0);
+    EXPECT_EQ(json_nesting_depth("123", 100), 0);
+}
+
+TEST(JsonNestingDepth, IgnoresBracesInsideStrings) {
+    // A brace in a string is text. Counting it would reject legitimate bodies -
+    // a prompt containing JSON, which is most agent traffic.
+    EXPECT_EQ(json_nesting_depth(R"({"a":"{{{{{{{{{{"})", 100), 1);
+    EXPECT_EQ(json_nesting_depth(R"({"a":"[[[["})", 100), 1);
+    // ...including an escaped quote, which must not end the string early.
+    EXPECT_EQ(json_nesting_depth(R"({"a":"he said \"{{{\" to me"})", 100), 1);
+    EXPECT_EQ(json_nesting_depth(R"({"a":"trailing backslash \\"})", 100), 1);
+}
+
+TEST(JsonNestingDepth, TracksTheMaximumNotTheFinalDepth) {
+    // Two siblings, each one level inside the root: depth returns to 1 between
+    // them and the maximum is 2, not the sum and not the last value.
+    EXPECT_EQ(json_nesting_depth(R"({"a":{"b":1},"c":{"d":1}})", 100), 2);
+    // Deepen only the second sibling: the maximum has to follow it.
+    EXPECT_EQ(json_nesting_depth(R"({"a":{"b":1},"c":{"d":{"e":{"f":1}}}})", 100), 4);
+}
+
+TEST(JsonNestingDepth, StopsEarlyOnceTheLimitIsExceeded) {
+    // 200 levels against a limit of 100: the answer only has to prove "over".
+    std::string deep(200, '[');
+    deep.append(200, ']');
+    const int d = json_nesting_depth(deep, 100);
+    EXPECT_GT(d, 100);
+    EXPECT_LE(d, 101) << "the scan must stop at the limit, not count to 200";
+}
+
+TEST(JsonNestingDepth, TheHostileBodyIsOverTheLimitAndARealOneIsNot) {
+    // The payload from the issue: ~100 KB of '[' segfaults nlohmann (measured:
+    // 50k levels parse fine, 100k crash).
+    std::string bomb(100000, '[');
+    EXPECT_GT(json_nesting_depth(bomb, 100), 100);
+
+    // A realistic body with tools, nested schema and multi-part content is
+    // nowhere near it. This is the arm that says the limit is not too tight.
+    const std::string real =
+        R"({"model":"m","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],)"
+        R"("tools":[{"type":"function","function":{"name":"f","parameters":{"type":"object",)"
+        R"("properties":{"a":{"type":"array","items":{"type":"object","properties":)"
+        R"({"b":{"type":"string"}}}}}}}}]})";
+    EXPECT_LE(json_nesting_depth(real, 100), 12);
+}

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -80,7 +80,7 @@ roots = ["src", "tools", "tests"]
 "src/memory/kv_cache_manager.cpp" = { code_loc = 1200, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
 "src/model/gguf_loader.cpp" = { code_loc = 812, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
-"src/model/jinja.cpp" = { code_loc = 2294, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
+"src/model/jinja.cpp" = { code_loc = 2297, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
 "src/model/safetensors_loader.cpp" = { code_loc = 1128, reason = "(c) one loader: header validation + tensor assign + arch inference" }
 "src/model/tokenizer.cpp" = { code_loc = 1818, reason = "(c) one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)" }
 "src/model/weight_map.cpp" = { code_loc = 1068, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -76,6 +76,9 @@ void handle_chat_completions(const httplib::Request& req, httplib::Response& res
 }
 
 void handle_completions(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
     // Parse request body
     json body;
     try {
@@ -682,6 +685,10 @@ void handle_count_tokens(const httplib::Request& req, httplib::Response& res, Se
         json err = {{"type", "error"}, {"error", {{"type", type}, {"message", message}}}};
         res.set_content(dump_safe(err), "application/json");
     };
+
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
 
     json anth_body;
     try {

--- a/tools/imp-server/handlers_chat_params.cpp
+++ b/tools/imp-server/handlers_chat_params.cpp
@@ -52,6 +52,10 @@ bool parse_chat_request_params(const httplib::Request& req, httplib::Response& r
     ctx.log_raw_body = req.body;
     ctx.log_skip = g_in_anthropic_shim;
 
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return false;
+
     // Parse request body
     json body;
     try {

--- a/tools/imp-server/handlers_chat_stream.cpp
+++ b/tools/imp-server/handlers_chat_stream.cpp
@@ -156,14 +156,17 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
             sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
             sink.write(sse.data(), sse.size());
         }
-        for (size_t aoff = 0; aoff < full_args.size(); aoff += kArgChunk) {
-            size_t an = std::min(kArgChunk, full_args.size() - aoff);
+        // #1554: codepoint-aligned slices, same reason as the Anthropic
+        // dialect. The /v1/responses dialect never chunked and was immune.
+        for (size_t aoff = 0; aoff < full_args.size();) {
+            const size_t an = utf8_chunk_len(full_args, aoff, kArgChunk);
             json args_delta = {
                 {"tool_calls",
                  json::array({{{"index", idx},
                                {"function", {{"arguments", full_args.substr(aoff, an)}}}}})}};
             sse = sse_chunk(comp_id, created, snap_model_name, args_delta, nullptr);
             sink.write(sse.data(), sse.size());
+            aoff += an;
         }
         return true;
     };

--- a/tools/imp-server/handlers_messages.cpp
+++ b/tools/imp-server/handlers_messages.cpp
@@ -219,10 +219,15 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
             return false;
         const std::string& args = tc.arguments;
         constexpr size_t kChunk = 48;
-        for (size_t off = 0; off < args.size(); off += kChunk) {
-            size_t n = std::min(kChunk, args.size() - off);
+        // #1554: the slice is at most kChunk bytes AND ends on a codepoint
+        // boundary. A fixed byte slice cut multi-byte characters in half and
+        // each half became U+FFFD in dump_safe, so a tool argument with a
+        // German city name or an emoji reached the client corrupted.
+        for (size_t off = 0; off < args.size();) {
+            const size_t n = utf8_chunk_len(args, off, kChunk);
             if (!emit_tool_args_delta(args.substr(off, n)))
                 return false;
+            off += n;
         }
         return stop_block();
     };
@@ -308,6 +313,10 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     if (log_client_ip.empty())
         log_client_ip = req.remote_addr;
     const std::string log_raw_body = req.body;
+
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
 
     json anth_body;
     try {

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -27,6 +27,9 @@
 #include <cuda_runtime.h>
 
 void handle_tokenize(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
     json body;
     try {
         body = json::parse(req.body);
@@ -80,6 +83,9 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
 }
 
 void handle_detokenize(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
     json body;
     try {
         body = json::parse(req.body);
@@ -249,6 +255,9 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
 }
 
 void handle_embeddings(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
     // Parse request body
     json body;
     try {

--- a/tools/imp-server/handlers_rerank.cpp
+++ b/tools/imp-server/handlers_rerank.cpp
@@ -74,6 +74,9 @@ bool single_token(ServerState& state, const char* text, int32_t& out) {
 }  // namespace
 
 void handle_rerank(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
     json body;
     try {
         body = json::parse(req.body);

--- a/tools/imp-server/handlers_responses.cpp
+++ b/tools/imp-server/handlers_responses.cpp
@@ -311,6 +311,10 @@ void handle_responses(const httplib::Request& req, httplib::Response& res, Serve
         log_client_ip = req.remote_addr;
     const std::string log_raw_body = req.body;
 
+    // #1607: bound the nesting before any recursive parser sees it.
+    if (reject_body_too_deep(req, res))
+        return;
+
     json body;
     try {
         body = json::parse(req.body);

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 #include "stream_pipeline.h"
 
+#include <algorithm>
 #include <cstdio>
 
 std::string dump_safe(const json& j) {
@@ -25,6 +26,93 @@ void drop_incomplete_utf8_tail(std::string& s) {
     const size_t complete = imp::stream::utf8_complete_len(s);
     if (complete < s.size() && s.size() - complete <= 3)
         s.resize(complete);
+}
+
+bool reject_body_too_deep(const httplib::Request& req, httplib::Response& res) {
+    // Every parser downstream is recursive and none bounds depth, nlohmann
+    // included and it runs first: measured on this tree, 50 000 nested arrays
+    // parse and dump() fine, 100 000 segfault the process. That is ~100 KB
+    // against a 100 MiB body cap, from an unauthenticated request, and one
+    // process means the SIGSEGV takes every in-flight stream with it.
+    constexpr int kMaxBodyNesting = 100;
+    if (req.body.empty() || json_nesting_depth(req.body, kMaxBodyNesting) <= kMaxBodyNesting)
+        return false;
+
+    res.status = 400;
+    const char* msg = "request body nests deeper than 100 levels";
+    json err;
+    if (req.path.rfind("/v1/messages", 0) == 0) {
+        err = {{"type", "error"}, {"error", {{"type", "invalid_request_error"}, {"message", msg}}}};
+    } else {
+        err = {{"error", {{"message", msg}, {"type", "invalid_request_error"}}}};
+    }
+    res.set_content(err.dump(), "application/json");
+    return true;
+}
+
+int json_nesting_depth(const std::string& body, int stop_at) {
+    int depth = 0, max_depth = 0;
+    bool in_string = false, escaped = false;
+    for (char c : body) {
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (c) {
+            case '"':
+                in_string = true;
+                break;
+            case '{':
+            case '[':
+                depth++;
+                if (depth > max_depth) {
+                    max_depth = depth;
+                    if (max_depth > stop_at)
+                        return max_depth;  // proven hostile, stop reading
+                }
+                break;
+            case '}':
+            case ']':
+                if (depth > 0)
+                    depth--;
+                break;
+            default:
+                break;
+        }
+    }
+    return max_depth;
+}
+
+size_t utf8_chunk_len(const std::string& s, size_t off, size_t max) {
+    if (off >= s.size())
+        return 0;
+    const size_t remaining = s.size() - off;
+    if (remaining <= max)
+        return remaining;  // the tail fits; whatever it is, it is not a split
+    const size_t complete = imp::stream::utf8_complete_len(s.substr(off, max));
+    if (complete > 0)
+        return complete;
+    // complete == 0 means no whole character fits in `max`. Emitting `max`
+    // bytes here would be the very split this function exists to prevent, so
+    // the cap yields: one character, whole, even if it is longer than `max`.
+    // A chunk size is a hint about frame size; a half character is wrong at any
+    // size. Falls back to one byte only for input that is ill-formed at `off`,
+    // where there is no character to keep intact and stalling is worse.
+    const unsigned char lead = static_cast<unsigned char>(s[off]);
+    size_t char_len = 1;
+    if ((lead & 0xE0) == 0xC0)
+        char_len = 2;
+    else if ((lead & 0xF0) == 0xE0)
+        char_len = 3;
+    else if ((lead & 0xF8) == 0xF0)
+        char_len = 4;
+    return std::min(char_len, remaining);
 }
 
 std::string Utf8Stitch::feed(const std::string& piece) {

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -42,6 +42,47 @@ private:
     std::string carry_;
 };
 
+// Nesting depth of a JSON document, counted WITHOUT parsing it (#1607).
+//
+// The parsers on this surface are all recursive and none of them bounds depth,
+// nlohmann included: measured on this tree, 50 000 nested arrays parse and
+// dump() fine and 100 000 segfault, i.e. ~100 KB of body against a 100 MiB body
+// cap. The parse is where the stack dies, so the check has to happen before it,
+// on the raw bytes.
+//
+// Scans left to right, skipping string contents so a brace inside a string does
+// not count, and stops as soon as `stop_at` is exceeded - so a hostile body
+// costs only as many bytes as it takes to prove it hostile. Returns the depth
+// reached, capped at `stop_at + 1`.
+int json_nesting_depth(const std::string& body, int stop_at);
+
+// Reject a request body that nests deeper than the cap, with the dialect's own
+// error envelope (#1607). Returns true when the request was answered and the
+// caller must stop.
+//
+// NOT in the pre-routing handler, where the other cross-cutting checks live:
+// httplib calls that handler from Server::routing() BEFORE the body has been
+// read, so `req.body` is empty there. Measured, after writing it there first -
+// a 10 000-level body still returned 200.
+bool reject_body_too_deep(const httplib::Request& req, httplib::Response& res);
+
+// Length of a chunk starting at `off` that is at most `max` bytes AND ends on a
+// UTF-8 codepoint boundary (#1554).
+//
+// Tool arguments were sliced every 48 bytes and each slice JSON-encoded on its
+// own, so a multi-byte character straddling a boundary was cut in half and
+// dump_safe turned each half into U+FFFD. The per-token content path has
+// stitched for exactly this reason since #1310; the tool-argument path did not.
+//
+// Requires `off` to be on a boundary, which holds inductively when every chunk
+// comes from this function. Always returns at least 1 when bytes remain, so a
+// pathological input cannot stall the loop.
+//
+// `max` yields to a character: when no whole character fits, the single
+// character is returned even if it is longer than `max`. A chunk size is a hint
+// about frame size, and half a character is wrong at any size.
+size_t utf8_chunk_len(const std::string& s, size_t off, size_t max);
+
 // Send an OpenAI-style error envelope {"error":{"message":..,"type":..}} with
 // the given HTTP status. Dumps via dump_safe so an invalid-UTF-8 byte echoed
 // into the message (e.g. a parse-error what() on byte-truncated input) can


### PR DESCRIPTION
Closes #1607. Closes #1554.

Two defects on the request surface, unrelated in cause, adjacent in the files.

## #1607 — nested `tools[].function.parameters` crashed the process

Every parser on the path is recursive and none bounded depth. nlohmann included, and it runs first, so a cap in imp's own parsers would never be reached. Measured on this tree:

| nesting | nlohmann `parse` + `dump` |
|---|---|
| 50 000 | fine |
| 100 000 | SIGSEGV |

~100 KB of body against a 100 MiB cap, unauthenticated by default. One process, so the SIGSEGV takes every in-flight stream with it, and `restart: unless-stopped` turns it into a restart loop.

Bodies deeper than 100 levels are a `400` at all nine `json::parse(req.body)` sites across four dialects. `json_string_to_value` and the `tojson` walker get their own caps behind that, for a tree built from any other source.

**The check is not in the pre-routing handler, where I put it first.** httplib calls that handler from `Server::routing()` *before* the body is read, so `req.body` is empty there — with the check in that position a 10 000-level body still returned 200. Found by measuring the fix, not by reading it.

| request | before | after |
|---|---|---|
| depth 50 | 200 | **200** (legitimate nesting still works) |
| depth 99 | 200 | 400 |
| depth 10 000 | 200 | 400 |
| depth 100 000 | `HTTP 000`, container dead | 400, server alive |
| same 100k body on `/v1/messages`, `/v1/responses`, `/v1/embeddings`, `/tokenize` | — | 400 each |
| a normal completion afterwards | — | answers (`"OK! 😊 How can I assist you today?"`) |

## #1554 — tool arguments split mid-character

Buffered tool calls sliced arguments every 48 **bytes** and JSON-encoded each slice on its own, so a multi-byte character straddling a boundary was cut in half and `dump_safe` replaced each half with U+FFFD. Any tool argument with an umlaut, an accent or an emoji reached the client corrupted, silently. The per-token content path has stitched for exactly this reason since #1310; the tool-argument path did not.

Slices now end on codepoint boundaries in both affected dialects. `/v1/responses` does not chunk and was never affected.

`utf8_chunk_len` lets the cap yield to a character: when no whole character fits in `max`, it returns the character anyway. The first version returned one byte instead — which is the very split the function exists to prevent — and the round-trip property test caught it at `max=1`.

## Tests

9 cases in `test_sse_stream_utils.cpp`, unit lane.

The chunker is tested as a property: chunk-then-concatenate is the identity, **and every piece is valid UTF-8 on its own**, over real argument text (`{"city":"München","note":"Grüße aus Köln 😀",…}`) at eight chunk sizes. The second half is the one that matters, because each piece is JSON-encoded separately.

The depth scanner is tested for braces inside strings, escaped quotes, sibling nesting, early exit at the limit rather than counting to the end, and that a realistic tools+schema body measures 12 levels against the limit of 100 — the arm that says the limit is not too tight.

One of those tests was wrong when written: it expected depth 3 for `{"a":{"b":1},"c":{"d":1}}`, which is 2. The scanner was right and the expectation was corrected.

## Gate

```
decode  tg128 =  284.40 tok/s  (baseline  287.19, delta -0.97%)
prefill pp512 = 12474.47 tok/s (baseline 12406.87, delta 0.54%)
prefill pp4096 = 15431.11 tok/s (baseline 15324.70, delta 0.69%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  457.45 tok/s   (2.50x, threshold 1.3x)
=== verify fast: OK ===
```

Full GPU suite via the pre-commit hook: 2301 tests, 0 failures. `filesize_thresholds.toml`: `jinja.cpp` 2294 -> 2297.

Not in here: the UTF-8 fix is verified by unit test and by reading the two call sites, not end to end. Reaching the buffered path needs a model that emits a non-JSON tool-call layout with non-ASCII arguments, which is a fixture this repo does not have.
