### PR TITLE
fix(server): the tool-arg UTF-8 split is in the filter, not the 48-byte chunker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,13 +174,15 @@ there instead of retelling it.
   that before the body is read, where `req.body` is empty, and a 10 000-level
   body still returned 200 from there.
 
-- **Streamed tool arguments were sliced every 48 bytes, so non-ASCII arrived as
-  U+FFFD** (#1554). A multi-byte character straddling a slice boundary was cut
-  in half and each half JSON-encoded separately, which `dump_safe` replaces.
-  Any tool argument with an umlaut, an accent or an emoji reached the client
-  corrupted, silently. Slices now end on codepoint boundaries on both affected
-  dialects (`/v1/messages` and `/v1/chat/completions`; `/v1/responses` never
-  chunked and was unaffected).
+- **Streamed tool arguments arrived as U+FFFD wherever a multi-byte character
+  crossed a delta boundary** (#1554). `StreamToolCallFilter` holds back
+  `close_tag_.size() - 1` **bytes** so a partially arrived close tag cannot leak
+  into the arguments, and that cut lands mid-character; each half is
+  JSON-encoded into its own SSE delta, where `dump_safe` substitutes. Measured
+  on Qwen3-8B-Q8_0 with a forced `tool_choice`: 10 replacement characters in one
+  argument, 0 after the fix, with the non-streaming control clean throughout.
+  The buffered 48-byte chunker was hardened at the same time, but it is not the
+  path a shipped model takes here.
 
 - **`image_url` was an SSRF primitive: any host, any port, redirects followed,
   no size cap, no read timeout** (#1610). An unauthenticated request body chose

--- a/tests/test_tool_stream_filter.cpp
+++ b/tests/test_tool_stream_filter.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "tool_call.h"
 #include "tool_stream_filter.h"
+#include "stream_pipeline.h"
 #include "model/chat_template.h"
 
 #include <random>
@@ -40,6 +41,7 @@ struct Collected {
     int n_arg_deltas = 0;               // CALL_ARGS_DELTA count
     std::string open_deltas;            // deltas of the currently-open call
     std::vector<std::string> delta_concats;  // per streamed call: concat(deltas)
+    std::vector<std::string> all_deltas;     // every CALL_ARGS_DELTA, in order
 };
 
 Collected feed_chunks(ChatTemplateFamily fam, const std::string& input,
@@ -67,6 +69,7 @@ Collected feed_chunks(ChatTemplateFamily fam, const std::string& input,
                 case Kind::CALL_ARGS_DELTA:
                     out.n_arg_deltas++;
                     out.open_deltas += seg.text;
+                    out.all_deltas.push_back(seg.text);
                     break;
                 case Kind::CALL_END:
                     out.delta_concats.push_back(out.open_deltas);
@@ -430,4 +433,88 @@ TEST(ParseGemmaToolCallBody, RejectsMalformed) {
     ASSERT_TRUE(parse_gemma_tool_call_body("call:f{broken", tc));
     EXPECT_EQ(tc.name, "f");
     EXPECT_EQ(tc.arguments, "{}");
+}
+
+// ---- #1554: an argument delta never ends mid-codepoint ----
+//
+// The emit loop pulls `limit` back by close_tag_.size() - 1 BYTES so a
+// partially arrived close tag cannot leak into the arguments. That cut lands
+// inside a multi-byte character whenever one sits at the boundary, and each
+// half is JSON-encoded into its own SSE delta, where dump_safe turns it into
+// U+FFFD. Measured on Qwen3-8B-Q8_0 with a forced tool_choice: ten replacement
+// characters in one argument string, and the non-streaming control clean.
+//
+// The first attempt at this issue hardened the BUFFERED 48-byte chunker
+// instead. That path is real but is not the one a shipped model takes here, so
+// the defect survived the fix. These tests drive the streaming path.
+
+// Every emitted delta must be valid UTF-8 on its own, because each one is
+// JSON-encoded separately.
+static bool all_deltas_are_whole_utf8(const Collected& c) {
+    for (const auto& d : c.all_deltas) {
+        if (imp::stream::utf8_complete_len(d) != d.size())
+            return false;
+    }
+    return true;
+}
+
+TEST(ToolStreamFilterUtf8, ArgumentDeltasNeverEndMidCodepoint) {
+    // Umlauts spread through the value so at least one lands on the hold
+    // boundary for some chunk size.
+    const std::string body =
+        "<tool_call>{\"name\": \"note\", \"arguments\": {\"text\": "
+        "\"ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß\"}}</tool_call>";
+    const std::string want_args = "{\"text\": \"ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß\"}";
+
+    // Byte-at-a-time is the worst case: every multi-byte character arrives
+    // split across feeds.
+    {
+        auto c = feed_chunks(ChatTemplateFamily::CHATML, body, {1});
+        ASSERT_EQ(c.delta_concats.size(), 1u);
+        EXPECT_EQ(c.delta_concats[0], want_args);
+        EXPECT_TRUE(all_deltas_are_whole_utf8(c)) << "a delta ended mid-character";
+    }
+    // And a spread of chunk sizes, including ones that straddle the 2-byte
+    // characters at every offset.
+    for (size_t n : {2u, 3u, 4u, 5u, 7u, 11u, 16u, 48u}) {
+        auto c = feed_chunks(ChatTemplateFamily::CHATML, body, {n});
+        ASSERT_EQ(c.delta_concats.size(), 1u) << "chunk=" << n;
+        EXPECT_EQ(c.delta_concats[0], want_args) << "chunk=" << n;
+        EXPECT_TRUE(all_deltas_are_whole_utf8(c)) << "chunk=" << n;
+    }
+}
+
+TEST(ToolStreamFilterUtf8, HoldingBackTheTailDoesNotLoseIt) {
+    // The tail held back for the next feed has to come out eventually. A
+    // three-byte character as the very last thing before the close tag is the
+    // case where "hold it back" and "there is no next feed" meet.
+    const std::string body = "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": \"中\"}}</tool_call>";
+    for (size_t n : {1u, 2u, 3u, 5u, 9u}) {
+        auto c = feed_chunks(ChatTemplateFamily::CHATML, body, {n});
+        ASSERT_EQ(c.delta_concats.size(), 1u) << "chunk=" << n;
+        EXPECT_EQ(c.delta_concats[0], "{\"t\": \"中\"}") << "chunk=" << n;
+        EXPECT_TRUE(all_deltas_are_whole_utf8(c)) << "chunk=" << n;
+    }
+}
+
+TEST(ToolStreamFilterUtf8, FourByteCharactersSurviveToo) {
+    const std::string body =
+        "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": \"a😀b😀c\"}}</tool_call>";
+    for (size_t n : {1u, 2u, 3u, 4u, 6u, 13u}) {
+        auto c = feed_chunks(ChatTemplateFamily::CHATML, body, {n});
+        ASSERT_EQ(c.delta_concats.size(), 1u) << "chunk=" << n;
+        EXPECT_EQ(c.delta_concats[0], "{\"t\": \"a😀b😀c\"}") << "chunk=" << n;
+        EXPECT_TRUE(all_deltas_are_whole_utf8(c)) << "chunk=" << n;
+    }
+}
+
+TEST(ToolStreamFilterUtf8, AsciiArgumentsAreUnchanged) {
+    // Negative control: holding a partial codepoint back must not change the
+    // delta sequence for input that has none.
+    const std::string body =
+        "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": \"plain ascii\"}}</tool_call>";
+    auto c = feed_chunks(ChatTemplateFamily::CHATML, body, {1});
+    ASSERT_EQ(c.delta_concats.size(), 1u);
+    EXPECT_EQ(c.delta_concats[0], "{\"t\": \"plain ascii\"}");
+    EXPECT_GT(c.n_arg_deltas, 1) << "the value should still stream incrementally";
 }

--- a/tools/imp-server/constraint_validation.cpp
+++ b/tools/imp-server/constraint_validation.cpp
@@ -96,10 +96,14 @@ bool validate_constraints(const json& body, httplib::Response& res) {
     // string rather than failing. Those are tolerances, not failures, so
     // turning them into 400s would break working clients.
     if (!schema.empty() && !imp::parse_json_schema(schema))
-        return reject("the JSON schema cannot be enforced as a constraint: it could not be "
-                      "parsed. An unresolvable or non-local \"$ref\" is the usual cause; "
-                      "only local \"#/$defs/...\" and \"#/definitions/...\" references are "
-                      "supported.");
+        return reject(
+            "the JSON schema cannot be enforced as a constraint: it could not be "
+            "parsed. Usual causes: a keyword this build cannot enforce "
+            "(minimum/maximum/multipleOf/allOf/not/uniqueItems and the rest listed "
+            "in docs/LIMITATIONS.md), a non-string \"enum\" or \"const\" member, "
+            "or an unresolvable \"$ref\" (only local \"#/$defs/...\" and "
+            "\"#/definitions/...\" are supported). The server log names the one "
+            "that fired.");
 
     return true;
 }

--- a/tools/imp-server/tool_stream_filter.h
+++ b/tools/imp-server/tool_stream_filter.h
@@ -28,6 +28,7 @@
 // that got that far virtually always completes the call.
 
 #include "tool_call.h"
+#include "stream_pipeline.h"  // imp::stream::utf8_complete_len (#1554)
 
 #include <algorithm>
 #include <string>
@@ -280,12 +281,36 @@ private:
             }
             size_t upto = (args_end_ != std::string::npos) ? args_end_ : i;
             if (upto > args_emitted_) {
-                Segment seg;
-                seg.kind = Segment::Kind::CALL_ARGS_DELTA;
-                seg.text = body_buf_.substr(args_emitted_, upto - args_emitted_);
-                streamed_args_ += seg.text;
-                r.push_back(std::move(seg));
-                args_emitted_ = upto;
+                std::string piece = body_buf_.substr(args_emitted_, upto - args_emitted_);
+                // #1554: `limit` above is pulled back by close_tag_.size() - 1
+                // BYTES so a partially arrived close tag cannot leak into the
+                // arguments. That cut lands mid-codepoint whenever a multi-byte
+                // character sits at the boundary, and each half is
+                // JSON-encoded into its own delta, where dump_safe turns it
+                // into U+FFFD. Measured on Qwen3-8B-Q8_0 with forced
+                // tool_choice: 10 replacement characters in one argument
+                // string. Hold the incomplete tail back for the next feed, the
+                // way the per-token content path has since #1310.
+                //
+                // Not when args_end_ is known: that is the real end of the
+                // value, there is no next feed to complete anything, and a tail
+                // there is genuinely ill-formed rather than split.
+                if (args_end_ == std::string::npos) {
+                    const size_t complete = imp::stream::utf8_complete_len(piece);
+                    // Same 3-byte bound as Utf8Stitch::feed: a split codepoint
+                    // is at most 3 bytes short, and holding a longer tail would
+                    // stall the stream on genuinely invalid input.
+                    if (complete < piece.size() && piece.size() - complete <= 3)
+                        piece.resize(complete);
+                }
+                if (!piece.empty()) {
+                    Segment seg;
+                    seg.kind = Segment::Kind::CALL_ARGS_DELTA;
+                    args_emitted_ += piece.size();
+                    streamed_args_ += piece;
+                    seg.text = std::move(piece);
+                    r.push_back(std::move(seg));
+                }
             }
             if (args_end_ != std::string::npos)
                 stream_state_ = StreamState::TAIL;


### PR DESCRIPTION
Reopens and closes #1554. **#1666 closed it against the wrong path.**

That PR hardened the buffered 48-byte chunker, which is real code with a real defect, but not the path a shipped model takes: with a forced `tool_choice` on Qwen3-8B-Q8_0 the argument deltas are one per token, and the corruption survived the fix byte for byte. Caught in review by the auditing session, reproduced here before touching anything.

## The cut is in the filter, not in any chunker

`tool_stream_filter.h:255-257` pulls `limit` back by `close_tag_.size() - 1` **bytes** so a partially arrived `</tool_call>` cannot leak into the arguments value:

```cpp
} else if (!close_tag_.empty()) {
    size_t hold = close_tag_.size() - 1;
    limit = (limit > args_emitted_ + hold) ? (limit - hold) : args_emitted_;
}
```

Byte arithmetic on a UTF-8 buffer. Whenever a multi-byte character sits at that boundary it is split, and each half is JSON-encoded into its own SSE delta, where `dump_safe` substitutes U+FFFD. `Utf8Stitch` sits two files away and solves exactly this for the per-token content path (`utils.h:32-36`) — the class existed, it was simply not wired here.

The incomplete tail is now held for the next `feed`, with the same 3-byte bound `Utf8Stitch::feed` uses. Not when `args_end_` is known: that is the real end of the value, there is no next feed, and a tail there is ill-formed rather than split.

## Measured, both dialects, same build

`tool_choice` forced, `stream: true`, `thinking: disabled`, Qwen3-8B-Q8_0, argument text `… ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß`:

| | deltas | U+FFFD |
|---|---|---|
| `/v1/chat/completions`, before | 47 | **10** |
| `/v1/chat/completions`, after | 47 | **0** |
| `/v1/messages`, after (`partial_json`, the counter the reviewer used) | 46 | **0** |
| non-streaming control, either build | — | 0 |

Reassembled after the fix, both dialects: `{"text": "Ein Text mit Umlauten der ueber 48 Byte hinausgeht: ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß ÄÖÜäöüß"}`.

(The reviewer counted 56 deltas where this run counts 47 on the OpenAI dialect. Different dialects and different generations; the U+FFFD count is the assertion, the delta count is not.)

## Tests

4 cases in `test_tool_stream_filter.cpp`, unit lane, driving the **streaming** path with 2-, 3- and 4-byte characters at chunk sizes 1 through 48. They assert two things, and the second is the one #1666 would have passed: the concatenation is correct **and every individual delta is valid UTF-8 on its own**, since each is JSON-encoded separately.

Negative control: with the hold-back removed and rebuilt, 3 of the 4 go red and the ASCII control stays green.

## Also in here

The 400 for an unenforceable schema said `An unresolvable or non-local "$ref" is the usual cause` and named nothing else, so a caller rejected for `minimum`/`maximum` (#1567, merged yesterday) went looking at their `$ref`s. It now names the three causes that exist and points at the log line saying which one fired. Reported by the same review.

## Gate

```
PASS fast gtest filter
SKIP perf gate (IMP_VERIFY_SKIP_PERF=1)
PASS peak VRAM within 10% of baseline      (20718 MiB, baseline 20716, delta 0.01%)
PASS graphs ON delivers >=1.3x decode speedup   (tg256 454.20 tok/s, 2.45x)
PASS Qwen3-4B Q8_0 (dense) smoke (distinct=11, contains 'Paris')
=== verify fast: OK ===
```

The perf gate is skipped by the hook itself, not by me: this diff touches only `tools/imp-server/` and `tests/`, outside the measured paths. Full GPU suite via the pre-commit hook: 2305 tests, 0 failures.

## What went wrong in #1666, since it is the more useful part

The issue body named the buffered 48-byte chunker as the site and quoted it. I hardened what was quoted without first measuring which path a real model takes, and I wrote in that PR body that no end-to-end fixture existed — when the repo's own perf-baseline model produces the failure on the default path, one server start away. Both halves are the same mistake: taking a written location as a measurement.
