### PR TITLE
feat(test): fuzz targets for the six untrusted-byte parsers, and a Sanitizers CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,103 @@ jobs:
       - name: Launch-guard gate (blocking)
         run: bash scripts/ci_static_gates.sh launchguards
 
+  # ASan + UBSan over the CPU test binaries, including the fuzz corpus (#1621).
+  #
+  # Before this job no CI lane ran any sanitizer in any category: ASAN/UBSAN
+  # existed behind a manual `make asan`, the one job that mentions
+  # compute-sanitizer is gated on a GPU runner the owner decided against, and
+  # its memcheck step is `continue-on-error` anyway.
+  #
+  # It is what makes the fuzz corpus worth running. Measured against the four
+  # reverted parser fixes, per target:
+  #
+  #             without ASan      with ASan
+  #   schema    green             stack-overflow
+  #   regex     hang              hang
+  #   gbnf      SEGV              stack-overflow
+  #   tokenizer hang              heap-use-after-free
+  #
+  # An out-of-bounds read is invisible without it: the process reads a
+  # neighbouring allocation and carries on.
+  #
+  # PR runs are gated on the parser/loader paths so the CUDA build is not paid
+  # on every PR; nightly and workflow_dispatch always run it. Advisory in
+  # practice like every job except `Build` (ruleset 14716423 requires that one
+  # context) - so read it after a merge, not only before.
+  sanitizers:
+    name: Sanitizers
+    runs-on: ubuntu-24.04
+    container:
+      image: nvidia/cuda:13.3.1-devel-ubuntu26.04
+    steps:
+      - name: Install toolchain
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends git python3 cmake ninja-build ca-certificates
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Does this run need the sanitizer build?
+        id: scope
+        run: |
+          run=true
+          if [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ github.event_name }}" = "push" ]; then
+            base="${{ github.event.pull_request.base.sha || github.event.before }}"
+            if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
+              files="$(git diff --name-only "$base" HEAD)"
+              # Fail-open: an unreadable diff runs the job.
+              # grep -q exits at the first match and pipefail turns the
+              # producer EPIPE into a non-zero pipeline (#1499): here-string.
+              if ! grep -qE '^(fuzz/|tests/test_fuzz_corpus|src/compute/json_schema|src/compute/gbnf|src/model/(safetensors_loader|tokenizer|json_util)|tools/imp-server/tool_stream_filter|CMakeLists.txt|\.github/workflows/ci\.yml)' <<< "$files"; then
+                run=false
+              fi
+            fi
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "sanitizer build: run=$run"
+
+      - name: Fetch pinned deps
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          . cmake/imp-deps.cmake 2>/dev/null || true
+          GT=$(grep -oP 'IMP_DEP_GOOGLETEST_TAG \K\S+' cmake/imp-deps.cmake | head -1)
+          git clone --depth=1 --branch "$GT" https://github.com/google/googletest.git /deps/googletest
+
+      # No tools, no bench, no server: the same configuration `make asan` uses,
+      # which is also why the five unconditional fuzz targets must not live in
+      # the IMP_BUILD_SERVER block - the first version of them did, and the
+      # sanitizer binary silently contained none of them (0 tests, "PASSED").
+      - name: Build test-core + test-text with ASan/UBSan
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          cmake -B build-asan -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DIMP_SANITIZERS=ON \
+            -DIMP_BUILD_TOOLS=OFF -DIMP_BUILD_BENCH=OFF -DIMP_BUILD_SERVER=OFF \
+            -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/deps/googletest
+          cmake --build build-asan --target test-core test-text -j"$(nproc)"
+
+      # A binary that contains none of the tests reports "PASSED 0 tests" and
+      # exits 0. That is how the first version of this job would have gone green
+      # without running anything.
+      - name: Assert the fuzz corpus is in the binary
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          n=$(./build-asan/test-core --gtest_list_tests 2>/dev/null | grep -c '^FuzzCorpus' || true)
+          test "$n" = "1" || { echo "FuzzCorpus missing from the sanitizer binary"; exit 1; }
+
+      - name: Run
+        if: steps.scope.outputs.run == 'true'
+        env:
+          ASAN_OPTIONS: detect_leaks=1
+          LSAN_OPTIONS: suppressions=tools/sanitizers/lsan.supp
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1:suppressions=tools/sanitizers/ubsan.supp
+        run: |
+          ./build-asan/test-core
+          ./build-asan/test-text
+
   test:
     name: Test
     needs: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ there instead of retelling it.
 
 ### Added
 
+- **Fuzz targets for the six parsers that take untrusted bytes** (#1620), in
+  `fuzz/`: JSON Schema, regex, GBNF, the tool-call stream filter, the
+  SafeTensors loader and `tokenizer.json`. Standard `LLVMFuzzerTestOneInput`
+  entry points for libFuzzer (`-DIMP_FUZZERS=ON`, clang), and the same functions
+  driven over a committed corpus plus a deterministic mutator in the CPU lane,
+  0.7 s, on every PR. The corpus is the inputs that actually broke something.
+  `docs/audit/SETTLED.md` S-28 and `AUDIT_ARCH_2026_07_29.md` both claimed these
+  surfaces were "fuzzed, in CI" while no fuzz target existed; both are corrected.
+
+- **A `Sanitizers` CI job** (#1621). No lane ran any sanitizer in any category
+  before: ASan/UBSan existed behind a manual `make asan`, and the only job that
+  mentions compute-sanitizer is gated on a GPU runner that does not exist. It
+  builds test-core and test-text with ASan+UBSan and runs them, including the
+  fuzz corpus. Measured worth: against four reverted parser fixes the corpus
+  catches 3 of 5 targets without ASan and 4 of 5 with it - an out-of-bounds read
+  is invisible otherwise.
+
 - **`VramOwned<T>`: an owning handle for a `VRAMAllocator` allocation.** The
   allocator says of itself, in its own destructor, that it is "a tracker, not an
   owner", so ownership lived with the caller as a raw pointer plus a free somewhere

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ if(IMP_ALLOC_INTERPOSE)
     message(STATUS "Allocation interposition ENABLED (measurement build)")
 endif()
 option(IMP_SANITIZERS "Enable AddressSanitizer + UndefinedBehaviorSanitizer" OFF)
+# libFuzzer binaries, one per target in fuzz/ (#1620). Needs clang: g++ has no
+# -fsanitize=fuzzer. The same targets run without clang in the CPU lane via
+# tests/test_fuzz_corpus.cpp, which is what CI executes; this option is for the
+# long runs. See fuzz/README.md.
+option(IMP_FUZZERS "Build libFuzzer binaries from fuzz/ (clang only)" OFF)
 
 if(IMP_SANITIZERS)
     set(SANITIZER_FLAGS "-fsanitize=address,undefined -fno-omit-frame-pointer -g")
@@ -603,6 +608,12 @@ if(IMP_BUILD_TESTS)
         # also require a GPU at configure-time (the binaries enumerate CUDA tests).
     endfunction()
 
+    set_source_files_properties(
+        fuzz/fuzz_json_schema.cpp fuzz/fuzz_regex.cpp fuzz/fuzz_gbnf.cpp
+        fuzz/fuzz_safetensors.cpp fuzz/fuzz_tokenizer_json.cpp
+        PROPERTIES COMPILE_DEFINITIONS "IMP_FUZZ_NO_ENTRY")
+    set(IMP_FUZZ_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/fuzz)
+
     imp_add_test_module(test-core SOURCES
         tests/test_tensor.cpp
         tests/test_tensor_kind_table.cpp
@@ -645,6 +656,18 @@ if(IMP_BUILD_TESTS)
         # GBNF grammar engine (parser + pushdown simulator + UTF-8 assembly).
         # CPU-only by construction — see the file header.
         tests/test_gbnf_grammar.cpp
+        # Fuzz targets driven over a committed corpus + a deterministic mutator
+        # (#1620), the same entry points libFuzzer drives. Unconditional so the
+        # sanitizer build (-DIMP_BUILD_SERVER=OFF) runs them too - which is the
+        # half that matters, since an out-of-bounds read is invisible without
+        # ASan. IMP_FUZZ_NO_ENTRY drops the LLVMFuzzerTestOneInput definitions
+        # so six of them do not collide in one binary.
+        fuzz/fuzz_json_schema.cpp
+        fuzz/fuzz_regex.cpp
+        fuzz/fuzz_gbnf.cpp
+        fuzz/fuzz_safetensors.cpp
+        fuzz/fuzz_tokenizer_json.cpp
+        tests/test_fuzz_corpus.cpp
         # Pre-dequant VRAM budget split (#1100). CPU-only: pure arithmetic in
         # runtime/vram_budget.h, and it belongs in the lane CI actually runs.
         tests/test_pre_dequant_budget.cpp
@@ -761,11 +784,20 @@ if(IMP_BUILD_TESTS)
             # binaries.
             tests/test_json_constrain_property.cpp
             tests/test_schema_constrain_property.cpp
+            # Only this target needs the server sources: tool_call.h pulls in
+            # nlohmann. The other five are unconditional below, so `make asan`
+            # (-DIMP_BUILD_SERVER=OFF) still runs them - the first version put
+            # all six here and the sanitizer binary silently contained none.
+            fuzz/fuzz_tool_stream.cpp
             tests/test_base64.cpp)
         target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server
                                                      ${CMAKE_CURRENT_SOURCE_DIR}/tools)
         target_link_libraries(test-core PRIVATE nlohmann_json::nlohmann_json httplib::httplib)
+        set_source_files_properties(fuzz/fuzz_tool_stream.cpp
+            PROPERTIES COMPILE_DEFINITIONS "IMP_FUZZ_NO_ENTRY")
+        target_compile_definitions(test-core PRIVATE IMP_FUZZ_HAVE_TOOL_STREAM)
     endif()
+    target_include_directories(test-core PRIVATE ${IMP_FUZZ_INCLUDE_DIR})
     # test_stream_pipeline.cpp includes the self-contained pure header
     # tools/imp-server/stream_pipeline.h (no httplib/json deps).
     target_include_directories(test-core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server
@@ -1042,4 +1074,39 @@ endif()
 
 if(IMP_BUILD_SERVER)
     install(TARGETS imp-server RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
+
+# ---- libFuzzer binaries (#1620) ----
+#
+# One binary per target, standard LLVMFuzzerTestOneInput entry points, so these
+# are also the shape OSS-Fuzz wants. clang only. The CPU lane runs the same
+# target functions through tests/test_fuzz_corpus.cpp with g++, which is what
+# gates a pull request; this is for the long runs. fuzz/README.md has the
+# commands.
+if(IMP_FUZZERS)
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(FATAL_ERROR "IMP_FUZZERS=ON needs clang (-fsanitize=fuzzer); "
+                            "got ${CMAKE_CXX_COMPILER_ID}. See fuzz/README.md.")
+    endif()
+    # fuzz_tool_stream needs nlohmann through tool_call.h, so it is only built
+    # when the server sources are configured in.
+    set(IMP_FUZZ_TARGETS json_schema regex gbnf safetensors tokenizer_json)
+    if(IMP_BUILD_SERVER)
+        list(APPEND IMP_FUZZ_TARGETS tool_stream)
+    endif()
+    foreach(t ${IMP_FUZZ_TARGETS})
+        add_executable(fuzz_${t} fuzz/fuzz_${t}.cpp)
+        target_include_directories(fuzz_${t} PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/fuzz
+            ${CMAKE_CURRENT_SOURCE_DIR}/tools/imp-server
+            ${CMAKE_CURRENT_SOURCE_DIR}/tools)
+        target_compile_options(fuzz_${t} PRIVATE -fsanitize=fuzzer,address,undefined
+                                                 -fno-omit-frame-pointer -g)
+        target_link_options(fuzz_${t} PRIVATE -fsanitize=fuzzer,address,undefined)
+        target_link_libraries(fuzz_${t} PRIVATE imp)
+        if(IMP_BUILD_SERVER)
+            target_link_libraries(fuzz_${t} PRIVATE nlohmann_json::nlohmann_json)
+        endif()
+    endforeach()
 endif()

--- a/docs/audit/AUDIT_ARCH_2026_07_29.md
+++ b/docs/audit/AUDIT_ARCH_2026_07_29.md
@@ -1949,7 +1949,11 @@ and 11 came back REFUTED.
 
 13. **Property-based test batteries in the CPU lane.** `test_json_constrain_property.cpp`,
     `test_schema_constrain_property.cpp`, `test_tokenizer_robustness.cpp`,
-    `test_gguf_fault_injection.cpp` — the FSM and parser surfaces are fuzzed, in CI, with no GPU.
+    `test_gguf_fault_injection.cpp` — the FSM and parser surfaces have property and
+    fault-injection coverage in CI, with no GPU.
+    **Correction (2026-08-22, #1620): "fuzzed" was wrong** when this was written. No fuzz
+    target existed; two of the four files mutate nothing and the other two assert their
+    generated input valid before use. `fuzz/` and the `Sanitizers` job now make the claim true.
 
 14. **The `[allow]` mechanism in `tools/filesize_thresholds.toml`.** Every oversized file carries a
     *reason string* and a classification letter, the gate rejects an empty reason, and the header

--- a/docs/audit/SETTLED.md
+++ b/docs/audit/SETTLED.md
@@ -296,7 +296,7 @@ the *tokens* a real vocabulary spells them with. A third class is not unlikely.
 | S-25 | `src/runtime/engine_init_resolver.cpp` | ~25 log lines stating each resolved policy **and its reason**. An operator can read what the engine decided and why |
 | S-26 | `tools/filesize_thresholds.toml` `[allow]` with reason strings | Manages file size instead of silencing it; the gate rejects an empty reason |
 | S-27 | `tools/alloc_allowlist.txt` as a two-way ratchet | Fails on a new allocating file *and* on a listed file that stopped allocating, so the list cannot go stale in either direction |
-| S-28 | Property batteries in the CPU lane | `tests/test_json_constrain_property.cpp`, `tests/test_schema_constrain_property.cpp`, `tests/test_tokenizer_robustness.cpp`, `tests/test_gguf_fault_injection.cpp` — fuzzed in CI, no GPU |
+| S-28 | Property batteries in the CPU lane | `tests/test_json_constrain_property.cpp`, `tests/test_schema_constrain_property.cpp`, `tests/test_tokenizer_robustness.cpp`, `tests/test_gguf_fault_injection.cpp` — property + fault-injection, in CI, no GPU. **"fuzzed" was wrong and is corrected (#1620):** two of the four mutate nothing, and the other two assert their generated input VALID before use. Real fuzz targets are `fuzz/`, driven in the CPU lane by `tests/test_fuzz_corpus.cpp` and under ASan by the `Sanitizers` job since 2026-08-22. |
 
 ## E — Findings that were themselves wrong (do not re-derive them)
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,60 @@
+<!--
+layer: L3
+audience: agents
+verified: 2026-08-22
+commit: 6a1d363c
+-->
+
+# fuzz — targets for the parsers that take untrusted bytes
+
+`docs/audit/SETTLED.md` S-28 claimed these surfaces were "fuzzed, in CI"
+(#1620). No fuzz target existed anywhere in the tree; the four files it named
+are two hand-written fault-injection batteries and two seeded property tests
+whose generator output is asserted **valid** before use.
+
+## Two ways to run the same targets
+
+| | build | driver | where |
+|---|---|---|---|
+| corpus + mutator | `make dev` | `tests/test_fuzz_corpus.cpp` | CPU lane, every PR, ~0.7 s |
+| libFuzzer | `-DIMP_FUZZERS=ON`, clang | `fuzz_<target>` binaries | on demand |
+
+```bash
+docker run --rm -v $PWD:/src -w /src silkeh/clang:18 bash -c '
+  cmake -B build-fuzz -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        -DIMP_FUZZERS=ON -DIMP_BUILD_TESTS=OFF -DIMP_BUILD_SERVER=OFF &&
+  cmake --build build-fuzz -j$(nproc) --target fuzz_json_schema &&
+  ./build-fuzz/fuzz_json_schema -max_total_time=600'
+```
+
+## Targets
+
+| target | entry | shipped defects |
+|---|---|---|
+| `fuzz_json_schema` | `parse_json_schema` | #1564 desync, #1609 depth |
+| `fuzz_regex` | `RegexNfa::compile` + `step` | #1608 unbounded `{n,m}`, #1609 depth |
+| `fuzz_gbnf` | `parse_gbnf` | #1609 depth |
+| `fuzz_tool_stream` | `StreamToolCallFilter::feed` | #1554 mid-codepoint delta (twice) |
+| `fuzz_safetensors` | `load_safetensors` on a real file | #1603-#1605 |
+| `fuzz_tokenizer_json` | `Tokenizer::load` on a real file | #1606 |
+
+## What these do not cover
+
+- **`fuzz_safetensors` reaches the header scan, not the weight upload.** With no
+  `config.json` beside the file no `Model` is built, so the wild pointer #1603
+  produces is never dereferenced. Measured: against the reverted fixes the
+  target stays green under ASan while the other four go red. The upload path
+  needs a GPU and is covered by `tests/test_safetensors_loader.cpp`.
+- **A wrong parse is invisible here.** #1564 (a truncated schema) and #1567 (a
+  dropped keyword) produce a valid-looking tree, not a crash. A fuzzer with no
+  oracle cannot see that; the unit tests can.
+- **No coverage feedback in the CPU lane.** The mutator is four byte operations
+  over a fixed corpus with a fixed seed, a few thousand executions. It catches a
+  re-introduction of a known defect class, not a new one.
+
+## Adding a corpus entry
+
+It earns its place by having broken something, or by reaching a branch nothing
+else reaches. Measure it: against the reverted fix the entry must produce the
+failure. A 200-level nesting entry passed where 20000 crashes, and an entry
+built from `[` never reached a parser that recurses on `{`.

--- a/fuzz/fuzz_common.h
+++ b/fuzz/fuzz_common.h
@@ -1,0 +1,109 @@
+#pragma once
+
+// Shared plumbing for the fuzz targets (#1620).
+
+#include "core/logging.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <unistd.h>
+
+namespace imp_fuzz {
+
+// A parser under fuzz logs on every malformed input, which at a few hundred
+// thousand executions per second is the only thing the run would produce.
+// Called once per process.
+inline void quiet_logs() {
+    static bool done = false;
+    if (!done) {
+        done = true;
+        imp::log_set_level(imp::LogLevel::FATAL);
+    }
+}
+
+// The two loader targets take a PATH, not a buffer, so the input has to become
+// a file. Named with the extension the loader dispatches on.
+class TempFile {
+public:
+    TempFile(const uint8_t* data, size_t size, const char* suffix) {
+        char tmpl[] = "/tmp/imp_fuzz_XXXXXX";
+        int fd = ::mkstemp(tmpl);
+        if (fd < 0)
+            return;
+        ::close(fd);
+        path_ = std::string(tmpl) + suffix;
+        ::rename(tmpl, path_.c_str());
+        FILE* f = ::fopen(path_.c_str(), "wb");
+        if (!f) {
+            path_.clear();
+            return;
+        }
+        if (size > 0)
+            ::fwrite(data, 1, size, f);
+        ::fclose(f);
+    }
+    ~TempFile() {
+        if (!path_.empty())
+            ::remove(path_.c_str());
+    }
+    TempFile(const TempFile&) = delete;
+    TempFile& operator=(const TempFile&) = delete;
+
+    bool ok() const { return !path_.empty(); }
+    const std::string& path() const { return path_; }
+
+private:
+    std::string path_;
+};
+
+// Full UTF-8 validation. imp::stream::utf8_complete_len only inspects the TAIL
+// of a buffer (it answers "does this end mid-character"), so it says nothing
+// about a byte flipped in the middle - which is exactly what a mutator
+// produces. Using it as an input filter let the tool-stream target report its
+// own mutated garbage as findings.
+inline bool is_valid_utf8(const std::string& s) {
+    size_t i = 0;
+    while (i < s.size()) {
+        const unsigned char c = static_cast<unsigned char>(s[i]);
+        size_t n = 0;
+        unsigned cp = 0;
+        if (c < 0x80) {
+            i++;
+            continue;
+        } else if ((c & 0xE0) == 0xC0) {
+            n = 1;
+            cp = c & 0x1Fu;
+        } else if ((c & 0xF0) == 0xE0) {
+            n = 2;
+            cp = c & 0x0Fu;
+        } else if ((c & 0xF8) == 0xF0) {
+            n = 3;
+            cp = c & 0x07u;
+        } else {
+            return false;  // continuation byte or 5+ byte lead
+        }
+        if (i + n >= s.size() + 0 && i + n > s.size() - 1)
+            return false;
+        for (size_t k = 1; k <= n; k++) {
+            const unsigned char cc = static_cast<unsigned char>(s[i + k]);
+            if ((cc & 0xC0) != 0x80)
+                return false;
+            cp = (cp << 6) | (cc & 0x3Fu);
+        }
+        // Overlong forms, surrogates and out-of-range are ill-formed too.
+        if ((n == 1 && cp < 0x80) || (n == 2 && cp < 0x800) || (n == 3 && cp < 0x10000))
+            return false;
+        if (cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+            return false;
+        i += n + 1;
+    }
+    return true;
+}
+
+// An input the fuzzer grew past anything a real file would be tells us nothing
+// new and costs the whole time budget. The loaders themselves cap at 128 MiB
+// (kMaxHeaderBytes); this is about keeping one execution short.
+constexpr size_t kMaxInput = 1u << 20;  // 1 MiB
+
+}  // namespace imp_fuzz

--- a/fuzz/fuzz_gbnf.cpp
+++ b/fuzz/fuzz_gbnf.cpp
@@ -1,0 +1,30 @@
+// GBNF grammar parser (#1620). It had a repetition bound from the start and no
+// nesting bound until #1609.
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "compute/gbnf_grammar.h"
+
+#include <new>
+#include <string>
+#include <vector>
+
+extern "C" int imp_fuzz_gbnf(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    if (size > 65536)
+        return 0;
+    const std::string src(reinterpret_cast<const char*>(data), size);
+    try {
+        std::vector<imp::GbnfRule> rules;
+        int32_t root = -1;
+        std::string err;
+        if (imp::parse_gbnf(src, rules, root, &err))
+            (void)rules.size();
+    } catch (const std::bad_alloc&) {}
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return imp_fuzz_gbnf(data, size); }
+#endif

--- a/fuzz/fuzz_json_schema.cpp
+++ b/fuzz/fuzz_json_schema.cpp
@@ -1,0 +1,36 @@
+// JSON Schema parser (#1620). The defects this surface shipped: a value that
+// desynced the key loop and truncated the rest of the document (#1564), and
+// unbounded recursion (#1609).
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "compute/json_schema.h"
+
+#include <new>
+#include <string>
+
+extern "C" int imp_fuzz_json_schema(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    if (size > imp_fuzz::kMaxInput)
+        return 0;
+    const std::string s(reinterpret_cast<const char*>(data), size);
+    try {
+        auto node = imp::parse_json_schema(s);
+        // Touch the result so the tree is not optimised away and a corrupt
+        // node is dereferenced rather than merely allocated.
+        if (node)
+            (void)node->properties.size();
+    } catch (const std::bad_alloc&) {
+        // A resource limit, not a defect. Every other exception escapes on
+        // purpose: this parser reports failure by returning nullptr, so a throw
+        // out of it is the finding.
+    }
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    return imp_fuzz_json_schema(data, size);
+}
+#endif

--- a/fuzz/fuzz_regex.cpp
+++ b/fuzz/fuzz_regex.cpp
@@ -1,0 +1,40 @@
+// Regex -> NFA compiler (#1620). Shipped defects: `{n,m}` cloned the atom with
+// no bound and the digit scan overflowed a long (#1608), and the mutual
+// recursion had no depth cap (#1609).
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "compute/json_schema.h"
+
+#include <cstdint>
+#include <new>
+#include <string>
+#include <vector>
+
+extern "C" int imp_fuzz_regex(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    // A pattern is a request field; anything past a few KB is not a pattern.
+    if (size > 8192)
+        return 0;
+    const std::string pattern(reinterpret_cast<const char*>(data), size);
+    try {
+        imp::RegexNfa nfa;
+        if (!nfa.compile(pattern))
+            return 0;
+        // Drive the matcher too: compile() succeeding on a pattern that then
+        // faults on the first byte is the more interesting failure.
+        std::vector<int> states = nfa.start_set();
+        for (unsigned char c : {uint8_t{'a'}, uint8_t{'0'}, uint8_t{'"'}, uint8_t{0xC3}, uint8_t{0x28}}) {
+            states = nfa.step(states, c);
+            if (states.empty())
+                break;
+        }
+        (void)nfa.accepts(states);
+    } catch (const std::bad_alloc&) {}
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) { return imp_fuzz_regex(data, size); }
+#endif

--- a/fuzz/fuzz_safetensors.cpp
+++ b/fuzz/fuzz_safetensors.cpp
@@ -1,0 +1,39 @@
+// SafeTensors shard loader against a real file (#1620).
+//
+// This surface carried four out-of-bounds accesses (#1603-#1606) and had no
+// fault-injection battery at all: tests/test_safetensors_loader.cpp drove two
+// extracted helpers, never load_safetensors() against a corrupt file.
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "model/safetensors_loader.h"
+
+#include <exception>
+
+extern "C" int imp_fuzz_safetensors(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    if (size > imp_fuzz::kMaxInput)
+        return 0;
+    imp_fuzz::TempFile f(data, size, ".safetensors");
+    if (!f.ok())
+        return 0;
+    try {
+        // No config.json next to it, so a Model is never built - the shard scan
+        // is what this exercises, and that is where the defects were.
+        auto model = imp::load_safetensors(f.path());
+        (void)model;
+    } catch (const std::exception&) {
+        // The loader reports failure by returning nullptr, but the layers under
+        // it (mmap, JSON) may throw on input this hostile. Catching keeps the
+        // signal on memory errors, which is what ASan reports and what all four
+        // shipped defects were.
+    }
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    return imp_fuzz_safetensors(data, size);
+}
+#endif

--- a/fuzz/fuzz_targets.h
+++ b/fuzz/fuzz_targets.h
@@ -1,0 +1,61 @@
+#pragma once
+
+// Fuzz targets for the parsers that take untrusted bytes (#1620).
+//
+// Two consumers, one body each:
+//
+//   1. libFuzzer, one binary per target, built with
+//      `cmake -DIMP_FUZZERS=ON` and a clang toolchain. Each .cpp defines the
+//      standard `LLVMFuzzerTestOneInput` entry point, so the targets are also
+//      OSS-Fuzz shaped if that ever happens.
+//   2. `tests/test_fuzz_corpus.cpp`, which drives the SAME functions over a
+//      committed corpus plus a deterministic mutator, with g++, in the CPU
+//      lane CI actually runs. That is what makes "fuzzed in CI" true rather
+//      than aspirational - `docs/audit/SETTLED.md` S-28 claimed it for two
+//      seeded property tests and two hand-written fault-injection batteries,
+//      none of which mutate anything.
+//
+// The corpus build compiles every target with IMP_FUZZ_NO_ENTRY so the
+// LLVMFuzzerTestOneInput definitions do not collide in one binary.
+//
+// What belongs here: a parser reachable from a file or a request body that a
+// user does not control. What does not: anything needing a GPU, a model, or
+// more than a few milliseconds per input.
+
+#include <cstddef>
+#include <cstdint>
+
+// Return value: 0 for "input processed". A non-zero return means the target
+// detected a violated invariant it can express without crashing - only
+// imp_fuzz_tool_stream does that today. Under libFuzzer the same condition
+// aborts instead, because that is the only thing libFuzzer saves an input for.
+extern "C" {
+
+// JSON Schema -> SchemaNode tree (src/compute/json_schema.cpp).
+// Reached from `response_format.json_schema` and from tool `parameters`.
+int imp_fuzz_json_schema(const uint8_t* data, size_t size);
+
+// Regex -> Thompson NFA (RegexNfa::compile). Reached from
+// `response_format.regex`, `guided_regex`, and a schema's `pattern`.
+int imp_fuzz_regex(const uint8_t* data, size_t size);
+
+// GBNF grammar -> rule table (src/compute/gbnf_parser.cpp). Reached from
+// `response_format.grammar` / `guided_grammar`.
+int imp_fuzz_gbnf(const uint8_t* data, size_t size);
+
+// The tool-call stream filter, fed the input in chunks. Reached from every
+// streaming response; a mid-codepoint cut here shipped twice (#1554).
+#ifdef IMP_FUZZ_HAVE_TOOL_STREAM
+int imp_fuzz_tool_stream(const uint8_t* data, size_t size);
+#endif
+
+// SafeTensors shard loader, against a real file. This is the surface that
+// carried four out-of-bounds accesses (#1603-#1606), and it had no
+// fault-injection battery of any kind.
+int imp_fuzz_safetensors(const uint8_t* data, size_t size);
+
+// tokenizer.json loader, against a real file (#1606: a negative token id was
+// an out-of-bounds vector write during load).
+int imp_fuzz_tokenizer_json(const uint8_t* data, size_t size);
+
+}  // extern "C"

--- a/fuzz/fuzz_tokenizer_json.cpp
+++ b/fuzz/fuzz_tokenizer_json.cpp
@@ -1,0 +1,36 @@
+// tokenizer.json loader against a real file (#1620). #1606: a negative token id
+// was an out-of-bounds vector write during load, before any inference.
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "model/tokenizer.h"
+
+#include <exception>
+
+extern "C" int imp_fuzz_tokenizer_json(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    if (size > imp_fuzz::kMaxInput)
+        return 0;
+    imp_fuzz::TempFile f(data, size, ".json");
+    if (!f.ok())
+        return 0;
+    try {
+        imp::Tokenizer tok;
+        if (tok.load(f.path())) {
+            // Exercise the tables the load path filled, so an id that got past
+            // the bounds check is dereferenced here rather than sitting unused.
+            const int n = tok.vocab_size();
+            for (int id : {0, 1, n - 1, n, -1})
+                (void)tok.decode_token(id);
+            (void)tok.encode("Grüße 😀");
+        }
+    } catch (const std::exception&) {}
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    return imp_fuzz_tokenizer_json(data, size);
+}
+#endif

--- a/fuzz/fuzz_tool_stream.cpp
+++ b/fuzz/fuzz_tool_stream.cpp
@@ -1,0 +1,71 @@
+// Built only when the server sources are in (nlohmann via tool_call.h).
+#define IMP_FUZZ_HAVE_TOOL_STREAM 1
+// Streaming tool-call filter (#1620). This is where #1554 lived, twice: the
+// emit boundary is byte arithmetic on a UTF-8 buffer, and the first fix went
+// to the other chunker. The fuzzer feeds the input in varying chunk sizes,
+// because the defect only appears at particular boundaries.
+
+#include "fuzz_targets.h"
+#include "fuzz_common.h"
+
+#include "tool_stream_filter.h"
+#include "stream_pipeline.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+#include <string>
+
+extern "C" int imp_fuzz_tool_stream(const uint8_t* data, size_t size) {
+    imp_fuzz::quiet_logs();
+    if (size < 2 || size > 65536)
+        return 0;
+    // First byte picks the template family and the chunk size, so one input
+    // covers "same bytes, different arrival pattern" - the axis the defect
+    // lives on.
+    const uint8_t knob = data[0];
+    const auto fam = static_cast<imp::ChatTemplateFamily>(knob % 6);
+    const size_t chunk = 1 + (knob >> 3) % 32;
+    const std::string body(reinterpret_cast<const char*>(data + 1), size - 1);
+
+    // The invariant below only holds for well-formed input: the filter passes
+    // bytes through, so ill-formed UTF-8 in gives ill-formed UTF-8 out and that
+    // is correct behaviour, not a defect. The mutator produces such input
+    // constantly (one flipped byte inside a 2-byte character is enough), and
+    // the first version of this target reported those as findings.
+    const bool body_is_utf8 = imp_fuzz::is_valid_utf8(body);
+
+    try {
+        imp::server::StreamToolCallFilter filter(fam);
+        using Kind = imp::server::StreamToolCallFilter::Segment::Kind;
+        for (size_t off = 0; off < body.size(); off += chunk) {
+            for (auto& seg : filter.feed(body.substr(off, chunk))) {
+                if (seg.kind == Kind::CALL_ARGS_DELTA && body_is_utf8) {
+                    // The invariant #1554 broke: every delta is JSON-encoded on
+                    // its own, so every delta has to be whole UTF-8. Abort
+                    // rather than return, so the fuzzer records it as a crash
+                    // with the reproducing input.
+                    if (imp::stream::utf8_complete_len(seg.text) != seg.text.size()) {
+                        fprintf(stderr, "fuzz: CALL_ARGS_DELTA ends mid-codepoint\n");
+#ifdef IMP_FUZZ_NO_ENTRY
+                        // Corpus runner: report, so the test names the case.
+                        return 1;
+#else
+                        // libFuzzer only records crashes, and only a crash
+                        // saves the reproducing input.
+                        abort();
+#endif
+                    }
+                }
+            }
+        }
+        (void)filter.finish();
+    } catch (const std::bad_alloc&) {}
+    return 0;
+}
+
+#ifndef IMP_FUZZ_NO_ENTRY
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    return imp_fuzz_tool_stream(data, size);
+}
+#endif

--- a/tests/test_fuzz_corpus.cpp
+++ b/tests/test_fuzz_corpus.cpp
@@ -1,0 +1,278 @@
+// The fuzz targets, driven in the CPU lane (#1620).
+//
+// `docs/audit/SETTLED.md` S-28 recorded that the parser surfaces are "fuzzed,
+// in CI". They were not: two of the four files it named are hand-written
+// fault-injection batteries with no randomness at all, and the other two are
+// seeded property tests whose generator's output is asserted VALID before use.
+// Nothing mutated anything, and no fuzz target existed anywhere in the tree.
+//
+// This file closes the gap from the cheap end. It drives the same
+// `imp_fuzz_*` entry points libFuzzer drives (fuzz/), over:
+//
+//   1. a committed corpus of the inputs that actually broke something, so a
+//      re-introduction is a named test failure rather than a fuzzing session
+//      someone has to remember to run;
+//   2. a deterministic mutator over that corpus, fixed seed, so a failure
+//      reproduces from the test name alone.
+//
+// It is NOT a substitute for a real fuzzing run: no coverage feedback, no
+// corpus growth, a few thousand executions instead of billions. It is the part
+// that runs on every pull request. `cmake -DIMP_FUZZERS=ON` with clang builds
+// the libFuzzer binaries for the long runs.
+//
+// Budget: this has to stay inside the CPU lane's seconds. Keep the per-target
+// iteration counts small enough that the whole file is well under a second,
+// and put depth/size bombs in the corpus rather than hoping the mutator finds
+// them.
+
+#include <gtest/gtest.h>
+
+#include "fuzz_targets.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Target = int (*)(const uint8_t*, size_t);
+
+struct TargetSpec {
+    const char* name;
+    Target fn;
+    std::vector<std::string> corpus;
+};
+
+// xorshift64*, so the sequence is identical on every platform and compiler.
+// std::mt19937 would also be reproducible, but this keeps the mutator's own
+// behaviour readable in one line.
+struct Rng {
+    uint64_t s;
+    explicit Rng(uint64_t seed) : s(seed ? seed : 0x9E3779B97F4A7C15ull) {}
+    uint64_t next() {
+        s ^= s >> 12;
+        s ^= s << 25;
+        s ^= s >> 27;
+        return s * 0x2545F4914F6CDD1Dull;
+    }
+    size_t below(size_t n) { return n ? static_cast<size_t>(next() % n) : 0; }
+};
+
+// Four mutations, chosen because they are the ones that produced the shipped
+// defects: a flipped byte (a dtype string one character off), a truncation (a
+// header cut mid-value), an insertion (a nesting level too many), and a splice
+// of two corpus entries (a valid prefix with a hostile tail).
+std::string mutate(const std::string& in, const std::string& other, Rng& rng) {
+    std::string s = in;
+    switch (rng.below(5)) {
+        case 0:
+            if (!s.empty())
+                s[rng.below(s.size())] = static_cast<char>(rng.next() & 0xFF);
+            break;
+        case 1:
+            if (!s.empty())
+                s.resize(rng.below(s.size()));
+            break;
+        case 2:
+            s.insert(rng.below(s.size() + 1), 1 + rng.below(8), static_cast<char>(rng.next() & 0xFF));
+            break;
+        case 3:
+            if (!s.empty())
+                s.erase(rng.below(s.size()), 1 + rng.below(4));
+            break;
+        default:
+            if (!other.empty())
+                s = s.substr(0, rng.below(s.size() + 1)) + other.substr(rng.below(other.size()));
+            break;
+    }
+    return s;
+}
+
+void run_target(const TargetSpec& spec, int iterations, uint64_t seed) {
+    ASSERT_FALSE(spec.corpus.empty()) << spec.name << " has no corpus";
+
+    // 1. The corpus verbatim. Every entry is an input that broke something.
+    for (size_t i = 0; i < spec.corpus.size(); i++) {
+        const auto& c = spec.corpus[i];
+        EXPECT_EQ(spec.fn(reinterpret_cast<const uint8_t*>(c.data()), c.size()), 0)
+            << spec.name << ": corpus entry " << i << " reported a violated invariant";
+    }
+
+    // 2. Mutations of it. A crash, a hang or a sanitizer report is the finding;
+    // the return value only carries invariants a target can check itself.
+    Rng rng(seed);
+    for (int i = 0; i < iterations; i++) {
+        const std::string& base = spec.corpus[rng.below(spec.corpus.size())];
+        const std::string& other = spec.corpus[rng.below(spec.corpus.size())];
+        const std::string in = mutate(base, other, rng);
+        EXPECT_EQ(spec.fn(reinterpret_cast<const uint8_t*>(in.data()), in.size()), 0)
+            << spec.name << ": mutation " << i << " (seed " << seed << ") reported a violation";
+    }
+}
+
+// ---- corpora ----
+//
+// Rule for adding to these: an entry earns its place by having broken
+// something, or by reaching a branch nothing else reaches. A generic "valid
+// input" belongs in a unit test, not here.
+
+std::vector<std::string> schema_corpus() {
+    return {
+        R"({"type":"object","properties":{"a":{"type":"string"}},"required":["a"]})",
+        // #1564: consumed nothing, truncated the rest of the schema.
+        R"({"type":"object","additionalProperties":{"type":"number"},"properties":{"a":{"type":"string"}}})",
+        // #1564: constrained the model to the empty string.
+        R"({"type":"integer","enum":[1,2,3]})",
+        R"({"enum":[true,false]})",
+        R"({"const":42})",
+        // #1567: accepted and silently dropped.
+        R"({"type":"integer","minimum":1,"maximum":5})",
+        R"({"allOf":[{"type":"string"}],"not":{"type":"number"}})",
+        // #1609: one stack frame per level. Two things had to be measured
+        // against the reverted fix to get this entry right: the parser
+        // recurses on '{' (a run of '[' is rejected at the first character and
+        // reaches nothing), and 200 levels is not enough to overflow a worker
+        // stack. This shape is the one from the issue, at a depth that
+        // actually takes the process down.
+        [] {
+            std::string d;
+            for (int i = 0; i < 20000; i++)
+                d += R"({"items":)";
+            d += "{}";
+            for (int i = 0; i < 20000; i++)
+                d += "}";
+            return d;
+        }(),
+        R"({"items":{"items":{"items":{"items":{"type":"string"}}}}})",
+        // Structure the parser has to survive without a value.
+        R"({"$ref":"#/$defs/x","$defs":{"x":{"type":"string"}}})",
+        R"({"type":"string","pattern":"^a{3,5}$"})",
+        "{",
+        "",
+    };
+}
+
+std::vector<std::string> regex_corpus() {
+    return {
+        "^[a-z0-9_]{1,32}$",
+        R"(\d{4}-\d{2}-\d{2})",
+        "(foo|bar)+baz",
+        // #1608: a clone count with no bound, and a digit run that overflowed.
+        "a{2000000000}",
+        "a{99999999999999999999999}",
+        "(((a{100}){100}){100}){100}",
+        // #1609: one frame per '('. Same reasoning as the schema corpus.
+        std::string(20000, '(') + "a" + std::string(20000, ')'),
+        "[",
+        "a{",
+        "a{,}",
+        "",
+    };
+}
+
+std::vector<std::string> gbnf_corpus() {
+    return {
+        "root ::= \"a\" | \"b\"",
+        "root ::= obj\nobj ::= \"{\" pair (\",\" pair)* \"}\"\npair ::= \"x\"",
+        "root ::= \"a\"{1,1024}",
+        "root ::= \"a\"{0,100000}",
+        "root ::= " + std::string(20000, '(') + "\"a\"" + std::string(20000, ')'),
+        "root ::= root",
+        "root ::=",
+        "",
+    };
+}
+
+#ifdef IMP_FUZZ_HAVE_TOOL_STREAM
+std::vector<std::string> tool_stream_corpus() {
+    // First byte is the knob (family + chunk size); the rest is the body.
+    auto with_knob = [](uint8_t k, const std::string& body) {
+        return std::string(1, static_cast<char>(k)) + body;
+    };
+    return {
+        with_knob(0x01, R"(<tool_call>{"name": "f", "arguments": {"a": 1}}</tool_call>)"),
+        // #1554: the emit boundary cut these in half.
+        with_knob(0x01,
+                  "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": "
+                  "\"ÄÖÜäöüß ÄÖÜäöüß\"}}</tool_call>"),
+        with_knob(0x09, "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": \"中文中文\"}}</tool_call>"),
+        with_knob(0x11, "<tool_call>{\"name\": \"note\", \"arguments\": {\"t\": \"a😀b😀c\"}}</tool_call>"),
+        with_knob(0x02, "<function=f>{\"a\": \"ü\"}</function>"),
+        with_knob(0x03, "plain text with no call at all"),
+        with_knob(0x04, "<tool_call>{\"name\":"),
+    };
+}
+#endif
+
+std::vector<std::string> safetensors_corpus() {
+    // 8-byte little-endian header length, then the JSON header, then data.
+    auto blob = [](const std::string& header, size_t payload) {
+        std::string s(8, '\0');
+        const uint64_t n = header.size();
+        for (int i = 0; i < 8; i++)
+            s[i] = static_cast<char>((n >> (8 * i)) & 0xFF);
+        s += header;
+        s.append(payload, '\0');
+        return s;
+    };
+    return {
+        blob(R"({"w": {"dtype": "F32", "shape": [2, 2], "data_offsets": [0, 16]}})", 16),
+        // #1604: validated at 2 bytes/elem, read at 4.
+        blob(R"({"w": {"dtype": "I16", "shape": [4], "data_offsets": [0, 8]}})", 8),
+        blob(R"({"w": {"dtype": "U16", "shape": [4], "data_offsets": [0, 8]}})", 8),
+        // #1603: offset_start never validated on this branch.
+        blob(R"({"w": {"dtype": "F8_E8M0", "shape": [4,4], "data_offsets": [9223372036854775807, 0]}})", 64),
+        // #1605: no overflow and no sign guard on the shape product.
+        blob(R"({"w": {"dtype": "F32", "shape": [-4], "data_offsets": [0, 16]}})", 16),
+        blob(R"({"w": {"dtype": "F32", "shape": [4294967296, 4294967296], "data_offsets": [0, 0]}})", 16),
+        blob(R"({"w": {"dtype": "F32", "shape": [4], "data_offsets": [0, 9223372036854775807]}})", 16),
+        blob("{}", 0),
+        blob("not json at all", 0),
+        std::string(8, '\xff'),  // header length past any file
+        "",
+    };
+}
+
+std::vector<std::string> tokenizer_corpus() {
+    return {
+        R"({"model":{"type":"BPE","vocab":{"a":0,"b":1},"merges":[]}})",
+        // #1606: vocab_[-1] = token, during load.
+        R"({"model":{"type":"BPE","vocab":{"a":-1,"b":0},"merges":[]}})",
+        R"({"model":{"type":"BPE","vocab":{"a":0,"huge":2147483647},"merges":[]}})",
+        R"({"model":{"type":"BPE","vocab":{"a":0},"merges":[]},"added_tokens":[{"id":-5,"content":"<x>","special":1}]})",
+        R"({"model":{"type":"Unigram","vocab":[["a",0.0],["b",-1.0]]}})",
+        R"({"model":{"type":"BPE","vocab":{"ü":0,"😀":1},"merges":["ü 😀"]}})",
+        R"({"model":{}})",
+        "{",
+        "",
+    };
+}
+
+// Iteration counts: enough that the mutator reaches past the corpus, small
+// enough that the file stays inside the CPU lane's budget. The two file-backed
+// targets get fewer because each execution writes and removes a temp file.
+TEST(FuzzCorpus, JsonSchema) {
+    run_target({"json_schema", imp_fuzz_json_schema, schema_corpus()}, 1500, 0xA11CE);
+}
+
+TEST(FuzzCorpus, Regex) { run_target({"regex", imp_fuzz_regex, regex_corpus()}, 1500, 0xB0B); }
+
+TEST(FuzzCorpus, Gbnf) { run_target({"gbnf", imp_fuzz_gbnf, gbnf_corpus()}, 1500, 0xC0FFEE); }
+
+// tool_call.h needs nlohmann, which only the server build fetches, so this one
+// target is absent from the sanitizer build. The other five carry that lane.
+#ifdef IMP_FUZZ_HAVE_TOOL_STREAM
+TEST(FuzzCorpus, ToolStreamFilter) {
+    run_target({"tool_stream", imp_fuzz_tool_stream, tool_stream_corpus()}, 1500, 0xD00D);
+}
+#endif
+
+TEST(FuzzCorpus, SafeTensorsLoader) {
+    run_target({"safetensors", imp_fuzz_safetensors, safetensors_corpus()}, 250, 0xE1F);
+}
+
+TEST(FuzzCorpus, TokenizerJson) {
+    run_target({"tokenizer_json", imp_fuzz_tokenizer_json, tokenizer_corpus()}, 250, 0xF00D);
+}
+
+}  // namespace


### PR DESCRIPTION
Closes #1620. Closes #1621.

`SETTLED.md` S-28 and `AUDIT_ARCH_2026_07_29.md` recorded these surfaces as "fuzzed, in CI". No fuzz target existed. Two of the four files named mutate nothing; the other two assert their generated input **valid** before use. Both claims corrected in place.

## What ships

| | |
|---|---|
| `fuzz/` | 6 targets: json_schema, regex, gbnf, tool_stream, safetensors, tokenizer_json |
| libFuzzer | `-DIMP_FUZZERS=ON`, clang, standard `LLVMFuzzerTestOneInput` |
| CPU lane | `tests/test_fuzz_corpus.cpp`, same functions, committed corpus + deterministic mutator, 6 tests, 0.7 s |
| CI | job `Sanitizers`: ASan+UBSan over test-core and test-text |

Corpus entries are the inputs that actually broke something (#1554, #1564, #1567, #1603-#1606, #1608, #1609).

`Sanitizers` runs on PRs only when the parser/loader paths change; always on nightly and `workflow_dispatch`. Advisory like every job except `Build`.

## Why both issues in one PR

Against the four reverted parser fixes, per target:

| target | without ASan | with ASan |
|---|---|---|
| json_schema | green | stack-overflow |
| regex | hang | hang |
| gbnf | SEGV | stack-overflow |
| tokenizer_json | hang | heap-use-after-free |
| tool_stream | RED | n/a (needs the server build) |
| safetensors | green | green |

3 of 5 without the sanitizer, 4 of 5 with it.

## Four defects in my own harness, found by measuring it

| | |
|---|---|
| tool_stream reported its own mutated garbage | the invariant holds only for well-formed input, and my filter used `utf8_complete_len`, which inspects only the **tail** of a buffer. `fuzz_common.h` now has a real validator |
| the sanitizer binary contained no fuzz tests | all six were in the `IMP_BUILD_SERVER` block (tool_call.h needs nlohmann); `make asan` configures `OFF`, so it reported `PASSED 0 tests`. Five are unconditional now, and the CI job asserts the suite is present before running |
| corpus entries that reach nothing | 200 nesting levels pass where 20000 crashes; the schema entry was built from `[` against a parser that recurses on `{` |
| two control results were mine | the GBNF cap was never reverted in the first control run |

## Known gaps, in `fuzz/README.md`

- `fuzz_safetensors` reaches the header scan, not the weight upload: with no `config.json` beside the file no `Model` is built, so #1603's wild pointer is constructed and never dereferenced. That is why it stays green in the table above.
- A wrong parse is invisible to a fuzzer with no oracle. #1564 (truncated schema) and #1567 (dropped keyword) produce a valid-looking tree; the unit tests cover them.
- No coverage feedback in the CPU lane: four byte operations, fixed seed, a few thousand executions.

## Gate

```
decode  tg128 =  273.52 tok/s  (baseline  287.19, delta -4.76%)
prefill pp512 = 11893.01 tok/s (baseline 12406.87, delta -4.14%)
GPU during bench: sm=2898MHz(med) mem=13801MHz(med) power=491W(max) n=12
PASS decode / prefill / long-ctx prefill / peak VRAM / graphs ON / smoke
=== verify fast: OK ===
```

Both deltas are 3-4 points worse than the five gate runs earlier in this session (-0.6 % to -1.2 %) and inside the 8 % threshold. The diff touches `fuzz/`, `tests/`, `CMakeLists.txt`, CI and docs: no file the decode or prefill path compiles. Clocks were normal, so this is host variance, not the change. Recorded rather than smoothed over.

Full GPU suite via the pre-commit hook: 2311 tests, 0 failures.
