### PR TITLE
ci(sanitizers): the job needs bash declared, the image has none

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,11 +513,19 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: nvidia/cuda:13.3.1-devel-ubuntu26.04
+    # This image ships no bash, so GitHub picks `sh -e {0}` and any bashism is a
+    # syntax error at step start. The first version used a here-string and the
+    # job died in 1m15s before building anything - with `Build` the only
+    # required check, that merged. Declared explicitly, and bash installed below.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Install toolchain
+        shell: sh
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends git python3 cmake ninja-build ca-certificates
+          apt-get install -y --no-install-recommends bash git python3 cmake ninja-build ca-certificates
 
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,22 @@ jobs:
       # A binary that contains none of the tests reports "PASSED 0 tests" and
       # exits 0. That is how the first version of this job would have gone green
       # without running anything.
+      # test-core links libcuda.so.1 and this runner has no driver, so the
+      # binary does not start: `error while loading shared libraries`. The CUDA
+      # image ships a stub for exactly this, under the name the linker wants but
+      # not the one the loader wants (libcuda.so, not .so.1) - hence the symlink.
+      # CUDA calls then fail at runtime, which is what the CPU lane expects
+      # anyway: those tests skip.
+      #
+      # Found only after making the assert print stderr. My first guess was the
+      # known ASan-vs-high-ASLR crash on Ubuntu 24.04; it was not that.
+      - name: CUDA driver stub (no GPU on this runner)
+        if: steps.scope.outputs.run == 'true'
+        run: |
+          mkdir -p "$RUNNER_TEMP/cudastub"
+          ln -sf /usr/local/cuda/lib64/stubs/libcuda.so "$RUNNER_TEMP/cudastub/libcuda.so.1"
+          echo "LD_LIBRARY_PATH=$RUNNER_TEMP/cudastub" >> "$GITHUB_ENV"
+
       - name: Assert the fuzz corpus is in the binary
         if: steps.scope.outputs.run == 'true'
         run: |
@@ -596,6 +612,10 @@ jobs:
             exit 1
           fi
 
+      # Measured locally on this tree, GPU-less, same flags: test-core 741 pass,
+      # test-text 200 pass, no ASan report. FuzzCorpus.Regex is 11 s of that
+      # under ASan against 0.5 s without - the NFA compiler over 1500 mutations
+      # is what the sanitizer slows down.
       - name: Run
         if: steps.scope.outputs.run == 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,8 +553,16 @@ jobs:
       - name: Fetch pinned deps
         if: steps.scope.outputs.run == 'true'
         run: |
-          . cmake/imp-deps.cmake 2>/dev/null || true
-          GT=$(grep -oP 'IMP_DEP_GOOGLETEST_TAG \K\S+' cmake/imp-deps.cmake | head -1)
+          # Two separate traps, both hit on the way here. The pin line is
+          #   set(IMP_DEP_GOOGLETEST_TAG    v1.18.0  CACHE STRING "...")
+          # with RUN-LENGTH whitespace, so a pattern with one space matches
+          # nothing, grep exits 1 and `-e` kills the step with no message at
+          # all. And `grep | head -1` under `-o pipefail` is #1499: head closes
+          # the pipe, grep dies of EPIPE, the pipeline is non-zero even on a
+          # hit. `\s+` fixes the first, `-m1` instead of a pipe the second.
+          GT="$(grep -m1 -oP 'IMP_DEP_GOOGLETEST_TAG\s+\K[^ )]+' cmake/imp-deps.cmake)"
+          test -n "$GT" || { echo "googletest pin not found in cmake/imp-deps.cmake"; exit 1; }
+          echo "googletest pin: $GT"
           git clone --depth=1 --branch "$GT" https://github.com/google/googletest.git /deps/googletest
 
       # No tools, no bench, no server: the same configuration `make asan` uses,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,8 +585,16 @@ jobs:
       - name: Assert the fuzz corpus is in the binary
         if: steps.scope.outputs.run == 'true'
         run: |
-          n=$(./build-asan/test-core --gtest_list_tests 2>/dev/null | grep -c '^FuzzCorpus' || true)
-          test "$n" = "1" || { echo "FuzzCorpus missing from the sanitizer binary"; exit 1; }
+          # `2>/dev/null` here hid WHY on the first red run: an ASan binary that
+          # cannot start prints to stderr and lists nothing, which reads
+          # identical to a binary built without the tests. Keep stderr.
+          ./build-asan/test-core --gtest_list_tests > /tmp/tests.txt
+          if ! grep -q '^FuzzCorpus' /tmp/tests.txt; then
+            echo "FuzzCorpus missing from the sanitizer binary."
+            echo "suites it does have:"
+            grep -E '^[A-Za-z]' /tmp/tests.txt | head -40
+            exit 1
+          fi
 
       - name: Run
         if: steps.scope.outputs.run == 'true'


### PR DESCRIPTION
Follow-up to #1686. The `Sanitizers` job it added died at its first step in 1m15s, having built nothing:

```
shell: sh -e {0}
.../1f3a43d0.sh: 9: Syntax error: redirection unexpected
##[error]Process completed with exit code 2
```

`nvidia/cuda:13.3.1-devel-ubuntu26.04` ships no bash, so GitHub falls back to `sh` and the here-string in the change-detection step is a syntax error. The `Build` job shares the image and survives because its own detection step is POSIX.

Fix: install bash, declare `defaults.run.shell: bash` on the job, pin the install step to `sh` since that is what installs bash.

#1686 merged with this job red because `Build` is the only required context (ruleset 14716423). That is the failure mode `shipping-prs` documents, hit on the first PR that adds a job. What the job actually does under ASan is still unproven in CI: this run is the first that gets past step 3.

---

**Green after four red runs.** Each failure was a different layer, and each was
found only by making the previous one report what it hit:

| run | failure | cause |
|---|---|---|
| 1 | 1m15s | `shell: sh -e {0}` — the CUDA image has no bash, the here-string was a syntax error |
| 2 | 1m14s | dep-pin grep matched nothing (`IMP_DEP_GOOGLETEST_TAG    v1.18.0`, run-length whitespace) and `-e` killed the step with no output |
| 3 | 15m46s | binary listed no tests; my `2>/dev/null` made "cannot start" look like "built without them" |
| 4 | 17m30s | with stderr kept: `libcuda.so.1: cannot open shared object file` — no driver on the runner |
| 5 | **pass, 18m17s** | CUDA stub symlinked into `LD_LIBRARY_PATH` |

Run 3 is the one worth keeping: I diagnosed it as the known ASan-vs-high-ASLR
crash and was wrong. The fix was to stop guessing and print stderr.

18 minutes is the ASan build. The job is path-gated on PRs (parser and loader
paths only) and unconditional on nightly.
