### PR TITLE
fix: seven knobs and gates that did not do what they said

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,14 @@ jobs:
             imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-
             imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-
             imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-
+      # #1626: without this the job's first `git` call dies with exit 128
+      # ("dubious ownership" — the container UID is not the checkout's owner),
+      # the file list comes back empty, the step prints "nothing to lint" and
+      # `continue-on-error` reports green. It had never linted a file. The Build
+      # job has carried this line since check-release.sh hit the same wall.
+      - name: Trust the checkout (container UID differs from the runner's)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: clang-tidy (changed .cpp only, advisory)
         continue-on-error: true  # advisory — flip to a hard gate once baseline-clean
         run: |
@@ -283,8 +291,16 @@ jobs:
           if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
             base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
           fi
-          mapfile -t changed < <(git diff --name-only "$base" HEAD | grep -E '^(src|tools)/.*\.cpp$' || true)
+          # `|| true` on the pipeline made "git failed" and "no .cpp changed"
+          # the same outcome (#1626). Fail the diff loudly, keep the empty list
+          # quiet - only one of those two is normal.
+          if ! diff_out="$(git diff --name-only "$base" HEAD)"; then
+            echo "::error::git diff failed against base $base — the lint list would be empty"
+            exit 1
+          fi
+          mapfile -t changed < <(printf '%s\n' "$diff_out" | grep -E '^(src|tools)/.*\.cpp$' || true)
           if [ ${#changed[@]} -eq 0 ]; then echo "no src/tools .cpp changed — nothing to lint"; exit 0; fi
+          echo "linting ${#changed[@]} file(s): ${changed[*]}"
           # compile_commands.json comes from the cached build/. If the cache missed
           # (cold key), reconfigure — _deps in the restored build/ keeps it cheap;
           # a fully cold _deps fetch is the rare worst case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,34 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`--set` accepted any value for 157 of the 185 bound keys** (#1627). The key
+  half was rejected, the value half was not: `parse_bool`/`parse_int`/
+  `parse_float` returned the current value for input they could not read, with
+  no warning, so `--set server.prefix_cache=disabled` kept the default and said
+  nothing. `stoi` also stopped at the first non-digit, making `16k` parse as 16.
+  Both are a rejection now, in `--set` and in `imp.conf`.
+
+- **`speculative.batch_rr` could not be set** (#1638). A default-on scheduling
+  switch read on the decode path (`engine_scheduler.cpp:1422,2882`) whose own
+  comment calls it a kill switch for A/B, bound to no config key.
+
+- **`runtime.debug_raw` did four of its seven effects through dead env vars**
+  (#1628). `IMP_NO_WARMUP`, `IMP_DETERMINISTIC_GEMM`, `IMP_NO_EXPERT_CACHE` and
+  `IMP_GDN_REF` are read by nothing in the tree, so warmup, deterministic
+  cuBLAS, the MoE expert cache and the GDN scan all stayed at their normal
+  settings while the log line and `imp.conf.example:97` said otherwise. All
+  four are config assignments now; the switch each stood for existed.
+
+- **The `clang-tidy` CI job had never linted a file** (#1626). Its first `git`
+  call died with exit 128 (`dubious ownership` - the container UID is not the
+  checkout's owner), the file list came back empty, and `continue-on-error`
+  reported green. It trusts the checkout now, and a failing `git diff` is an
+  error rather than an empty list.
+
+- **`make gen-perf-baseline` had no GPU guard** (#1623) while every other bench
+  target does - the one target that re-pins what the perf gate compares against.
+
+
 - **Twelve stale or self-contradicting documentation claims** (#1543, #1594,
   #1651, #1668-#1673, #1680-#1682, #1684). The load-bearing ones: `CLAUDE.md` and
   `AGENTS.md` told every agent that sm_120a has no TMA-WS grouped GEMM, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,17 @@ there instead of retelling it.
   reported green. It trusts the checkout now, and a failing `git diff` is an
   error rather than an empty list.
 
+- **`prefill_chunk_size` had no `imp.conf` key** (#1645) while the knob that
+  merely caps it did. It sets the TTFT/ITL trade for every prefill and was
+  reachable only from the CLI and a per-request override. `runtime.prefill_chunk_size`
+  now, CLI wins over the file. Two comments documenting the retired default 512
+  are corrected to 2048.
+
+- **`runtime.debug_raw` printed `graphs=0(none)`** (#1658): "graphs are off,
+  reason: graphs still enabled". It wrote `use_cuda_graphs = 0` directly instead
+  of going through `demote_graphs_`, so the reason stayed `None`. It has its own
+  reason now.
+
 - **`make gen-perf-baseline` had no GPU guard** (#1623) while every other bench
   target does - the one target that re-pins what the perf gate compares against.
 

--- a/Makefile
+++ b/Makefile
@@ -375,7 +375,11 @@ verify-north-star: build check-gpu
 # `-u` matches the host UID so the write succeeds.
 MODEL ?= /models/Qwen3-8B-Q8_0.gguf
 MODELS_DIR ?= $(HOME)/models
-gen-perf-baseline: build
+# #1623: every other bench target takes check-gpu; this one - the one that
+# re-pins what the gate compares against - did not. A baseline measured next to
+# a co-tenant becomes the number every later run is judged by, and nothing
+# downstream can tell.
+gen-perf-baseline: check-gpu build
 	@docker run --rm --gpus all \
 		-v $(MODELS_DIR):/models \
 		-v $(PWD):/src -w /src \

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -94,7 +94,9 @@ max_seq_len          = 0
 vram_budget_mb       = 0
 # Disable Programmatic Dependent Launch (PDL). Diagnostic; small perf impact.
 no_pdl               = false
-# Naked FP16 path with FP8/NVFP4/graphs/warmup all forced off.
+# Naked FP16 path: FP8/NVFP4/graphs/warmup/FP8-KV and the MoE expert cache off,
+# deterministic cuBLAS and the GDN reference scan on. Four of those went through
+# dead env vars until #1628 and did nothing at all.
 debug_raw            = false
 # Disable SigLIP vision encoder CUDA-graph capture (debug).
 no_vision_graph      = false

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -47,6 +47,13 @@ max_batch_size       = 0
 # paths are unaffected. 0 = legacy unbounded behavior. Ignored when
 # deterministic = true (the unbounded loop stays for bit-reproducible evals).
 decode_burst         = 128
+# Prefill chunk size. -1 = per-arch default (2048 where chunked prefill is
+# supported, 0 otherwise), 0 = no chunking. Sets the TTFT/ITL trade for every
+# prefill: chunked prefill re-reads every weight once per chunk, so 512-token
+# chunks cost NVFP4-MoE -43 % prefill at pp4096 against 2048. A --prefill-chunk
+# CLI value wins over this. Had no key at all until #1645, while the cap below
+# did.
+prefill_chunk_size   = -1
 # Cap the prefill chunk while other sequences are decoding: prefill and decode
 # share one stream, so every chunk forward inserts its full latency between two
 # decode steps of the active sessions. 1024 is the measured compromise (decoder

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -128,7 +128,9 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
 // Deliberately unfused: state lives in global memory, per-token loop serial,
 // L2-norm of Q/K applied in-kernel but via shared-memory reductions (no
 // register-cached state). Same delta-rule math as `gdn_scan_fused_f32` but
-// trivially inspectable for validation. Enable via `IMP_GDN_REF=1`.
+// trivially inspectable for validation. Selected by `gdn.ref_kernel` (and by
+// `runtime.debug_raw`, which sets it). The `IMP_GDN_REF=1` this comment named
+// until #1628 is read by nothing.
 // ---------------------------------------------------------------------------
 void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                             const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -639,7 +639,7 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
                     moe_.d_slot_idx_count = moe_.d_slot_idx ? idx_count : 0;
                 }
             } else if (has_host_experts) {
-                IMP_LOG_INFO("Expert LRU cache disabled via IMP_NO_EXPERT_CACHE (staging fallback)");
+                IMP_LOG_INFO("Expert LRU cache disabled via moe.no_expert_cache (staging fallback)");
             }
 
             // Whole-layer staging buffer for the NVFP4 host prefill. Sized for

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -159,6 +159,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("runtime.prefill_graph", cfg.runtime.prefill_graph);
     I("runtime.max_batch_size", cfg.runtime.max_batch_size);
     I("runtime.decode_burst", cfg.runtime.decode_burst);
+    I("runtime.prefill_chunk_size", cfg.runtime.prefill_chunk_size);
     I("runtime.prefill_chunk_decode_cap", cfg.runtime.prefill_chunk_decode_cap);
     I("runtime.hybrid_decode_quantum", cfg.runtime.hybrid_decode_quantum);
     B("runtime.decode_pipeline", cfg.runtime.decode_pipeline);

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -45,30 +45,57 @@ std::string strip_quotes(const std::string& s) {
     return s;
 }
 
-bool parse_bool(const std::string& v, bool fallback) {
+// #1627: these returned `fallback` for anything they did not recognise, with
+// no signal, so `--set server.prefix_cache=disabled` kept the default and said
+// nothing. The key half was already rejected; the value half was not, and 157
+// of the 185 bound keys go through these three. `ok` is set to false on a value
+// the parser cannot read, and the caller turns that into a rejection.
+bool parse_bool(const std::string& v, bool fallback, bool* ok = nullptr) {
     if (v == "true" || v == "True" || v == "1" || v == "yes" || v == "on")
         return true;
     if (v == "false" || v == "False" || v == "0" || v == "no" || v == "off")
         return false;
+    if (ok)
+        *ok = false;
     return fallback;
 }
 
-int parse_int(const std::string& v, int fallback) {
-    if (v.empty())
+int parse_int(const std::string& v, int fallback, bool* ok = nullptr) {
+    if (v.empty()) {
+        if (ok)
+            *ok = false;
         return fallback;
+    }
     try {
-        return std::stoi(v);
+        size_t used = 0;
+        int out = std::stoi(v, &used);
+        // stoi stops at the first non-digit, so "16k" and "1,2" parsed as 16
+        // and 1 without complaint. Trailing garbage is a bad value.
+        if (used != v.size() && ok)
+            *ok = false;
+        return out;
     } catch (...) {
+        if (ok)
+            *ok = false;
         return fallback;
     }
 }
 
-float parse_float(const std::string& v, float fallback) {
-    if (v.empty())
+float parse_float(const std::string& v, float fallback, bool* ok = nullptr) {
+    if (v.empty()) {
+        if (ok)
+            *ok = false;
         return fallback;
+    }
     try {
-        return std::stof(v);
+        size_t used = 0;
+        float out = std::stof(v, &used);
+        if (used != v.size() && ok)
+            *ok = false;
+        return out;
     } catch (...) {
+        if (ok)
+            *ok = false;
         return fallback;
     }
 }
@@ -77,7 +104,8 @@ float parse_float(const std::string& v, float fallback) {
 // Returns false when the key is not bound — the caller decides what that
 // means: an imp.conf may legitimately carry a key this build does not know,
 // a `--set` on the command line is a typo and must not pass silently.
-bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::string& raw) {
+bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::string& raw,
+               bool* value_ok = nullptr) {
     std::string val = strip_quotes(trim(raw));
 
     // Typed key binders. Each binds one dotted key to its destination field;
@@ -85,14 +113,24 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // to a wrong-typed field. First match wins (the `matched` guard mirrors the
     // old else-if short-circuit); unknown keys fall through to the warning.
     bool matched = false;
+    bool value_ok_local = true;
     auto B = [&](const char* k, bool& f) {
-        if (!matched && dotted_key == k) { f = parse_bool(val, f); matched = true; }
+        if (!matched && dotted_key == k) {
+            f = parse_bool(val, f, &value_ok_local);
+            matched = true;
+        }
     };
     auto I = [&](const char* k, int& f) {
-        if (!matched && dotted_key == k) { f = parse_int(val, f); matched = true; }
+        if (!matched && dotted_key == k) {
+            f = parse_int(val, f, &value_ok_local);
+            matched = true;
+        }
     };
     auto F = [&](const char* k, float& f) {
-        if (!matched && dotted_key == k) { f = parse_float(val, f); matched = true; }
+        if (!matched && dotted_key == k) {
+            f = parse_float(val, f, &value_ok_local);
+            matched = true;
+        }
     };
     auto S = [&](const char* k, std::string& f) {
         if (!matched && dotted_key == k) { f = val; matched = true; }
@@ -101,7 +139,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     // [runtime]
     B("runtime.deterministic_gemm", cfg.runtime.deterministic_gemm);
     if (!matched && dotted_key == "runtime.deterministic") {
-        cfg.runtime.deterministic = parse_bool(val, cfg.runtime.deterministic);
+        cfg.runtime.deterministic = parse_bool(val, cfg.runtime.deterministic, &value_ok_local);
         // Full determinism implies deterministic GEMM algo selection — the
         // compute kernels gate routing/sampling determinism on the same
         // process_diag_deterministic_gemm() snapshot, so this one switch
@@ -228,10 +266,14 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     S("gemm.nvfp4_lm_head", cfg.gemm.nvfp4_lm_head);
     if (!matched && dotted_key == "gemm.cublas_fp16_acc") {
         // tri-state auto|on|off; legacy bool spellings stay valid
-        if (val == "auto" || val == "on" || val == "off")
+        if (val == "auto" || val == "on" || val == "off") {
             cfg.gemm.cublas_fp16_acc = val;
-        else
-            cfg.gemm.cublas_fp16_acc = parse_bool(val, false) ? "on" : "off";
+        } else {
+            // A tri-state that also takes booleans; anything else is a bad
+            // value, not a third spelling of off (#1627).
+            bool b = parse_bool(val, false, &value_ok_local);
+            cfg.gemm.cublas_fp16_acc = b ? "on" : "off";
+        }
         matched = true;
     }
     B("gemm.nvfp4_lm_head_gdn", cfg.gemm.nvfp4_lm_head_gdn);
@@ -341,9 +383,14 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("speculative.mtp_k", cfg.speculative.mtp_k);
     B("speculative.mtp_nvfp4_head", cfg.speculative.mtp_nvfp4_head);
     F("speculative.mtp_econ_min_emit", cfg.speculative.mtp_econ_min_emit);
+    // #1638: read at engine_scheduler.cpp:1422 and :2882, its own comment calls
+    // it a "kill switch for A/B", and it was bound to no key at all.
+    B("speculative.batch_rr", cfg.speculative.batch_rr);
     B("speculative.capture", cfg.speculative.capture);
     I("speculative.capture_ctx_cap", cfg.speculative.capture_ctx_cap);
 
+    if (value_ok)
+        *value_ok = value_ok_local;
     return matched;
 }
 
@@ -464,8 +511,12 @@ bool RuntimeConfig::load_from_file(const std::string& path) {
             dotted += '.';
             dotted += key;
         }
-        if (!apply_one(*this, dotted, val))
+        bool value_ok = true;
+        if (!apply_one(*this, dotted, val, &value_ok))
             IMP_LOG_WARN("imp.conf: unknown key '%s' (value '%s') — ignoring", dotted.c_str(), val.c_str());
+        else if (!value_ok)
+            IMP_LOG_WARN("imp.conf: key '%s' has an unreadable value '%s' — the default is kept (#1627)",
+                         dotted.c_str(), val.c_str());
     }
     return true;
 }
@@ -480,8 +531,11 @@ std::vector<std::string> RuntimeConfig::apply_overrides(const std::vector<std::s
         }
         std::string key = trim(kv.substr(0, eq));
         std::string val = trim(kv.substr(eq + 1));
-        if (!apply_one(*this, key, val))
+        bool value_ok = true;
+        if (!apply_one(*this, key, val, &value_ok))
             rejected.push_back(kv + "  (no such key)");
+        else if (!value_ok)
+            rejected.push_back(kv + "  (value not readable for this key; the default is kept)");
     }
     return rejected;
 }

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -130,6 +130,11 @@ struct RuntimeConfig {
         // 65 ms at +85%. 1024 is the default compromise; set 512 for
         // latency-critical multi-tenant serving, 0 to disable (full chunk).
         // The full chunk returns as soon as nobody is decoding.
+        // -1 = per-arch default (2048 where chunked prefill is supported, 0
+        // otherwise). #1645: only the CLI flag and a per-request override could
+        // reach this, while the knob that merely CAPS it - the line below - had
+        // a key. A CLI value wins over the file.
+        int prefill_chunk_size = -1;
         int prefill_chunk_decode_cap = 1024;
         // Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are
         // single-sequence, so concurrent sessions time-slice the decode.

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -58,8 +58,12 @@ void Engine::init_apply_debug_raw_overrides_() {
     // imp.conf.example:97 said otherwise. `grep -rn 'getenv("IMP_NO_WARMUP"'`
     // and the other three: zero hits each. They are config assignments now.
     //
-    // CUDA graphs off (graph capture can mask state bugs)
-    config_.use_cuda_graphs = 0;
+    // CUDA graphs off (graph capture can mask state bugs). Through
+    // demote_graphs_, not by writing the field: setting use_cuda_graphs
+    // directly left graph_demotion_ at None, so the resolved-dispatch summary
+    // printed `graphs=0(none)` - "graphs are off, reason: graphs still
+    // enabled" (#1658).
+    demote_graphs_(GraphDemotionReason::DebugRaw);
     // No warmup (warmup can leak state into first request)
     runtime_config_.runtime.warmup = false;
     // Deterministic cuBLAS (bit-exact across runs, no algo jitter)

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -46,24 +46,33 @@ void Engine::init_apply_debug_raw_overrides_() {
     if (!debug_raw_)
         return;
     IMP_LOG_INFO(
-        "[runtime] debug_raw=true: naked FP16 path (FP8/NVFP4/graphs/warmup/FP8-KV off; deterministic "
-        "cuBLAS)");
+        "[runtime] debug_raw=true: naked FP16 path (FP8/NVFP4/graphs/warmup/FP8-KV and the MoE expert "
+        "cache off; deterministic cuBLAS, GDN reference scan)");
     // Weight storage: keep FP16 (skip the lossy cache paths)
     config_.use_fp8_prefill = 0;
     config_.use_nvfp4_decode = 0;
     config_.dual_path_quant = false;
+    // #1628: four of these were `setenv()` on IMP_* variables that NOTHING in
+    // the tree reads, so warmup, deterministic cuBLAS and the MoE expert cache
+    // all stayed at their normal settings while the log line above and
+    // imp.conf.example:97 said otherwise. `grep -rn 'getenv("IMP_NO_WARMUP"'`
+    // and the other three: zero hits each. They are config assignments now.
+    //
     // CUDA graphs off (graph capture can mask state bugs)
     config_.use_cuda_graphs = 0;
-    setenv("IMP_NO_CUDA_GRAPH", "1", 0);
     // No warmup (warmup can leak state into first request)
-    setenv("IMP_NO_WARMUP", "1", 0);
+    runtime_config_.runtime.warmup = false;
     // Deterministic cuBLAS (bit-exact across runs, no algo jitter)
-    setenv("IMP_DETERMINISTIC_GEMM", "1", 0);
+    runtime_config_.runtime.deterministic_gemm = true;
+    // CUBLAS_WORKSPACE_CONFIG is read by cuBLAS itself, not by imp, so this one
+    // stays an environment variable.
     setenv("CUBLAS_WORKSPACE_CONFIG", ":4096:8", 0);
     // MoE: no expert LRU cache (state-carrying)
-    setenv("IMP_NO_EXPERT_CACHE", "1", 0);
-    // GDN: use reference unfused scan (no register-state reordering)
-    setenv("IMP_GDN_REF", "1", 0);
+    runtime_config_.moe.no_expert_cache = true;
+    // GDN: reference unfused scan (no register-state reordering). The env var
+    // this used to set is dead, but the switch it stood for exists as a config
+    // key (`gdn.ref_kernel`, read at executor_ssm_gdn.cu:526).
+    runtime_config_.gdn.ref_kernel = true;
     // NOTE: intentionally NOT forcing IMP_FORCE_CUBLAS_DECODE / IMP_NO_FMHA_SM120 /
     // IMP_NO_MMVQ — those trigger incompatible kernel paths that produce IMAs on
     // some combinations. The RAW flag is about disabling *caches and approximations*,

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -391,8 +391,13 @@ bool Engine::supports_chunked_prefill_() const {
 
 int Engine::resolve_prefill_chunk_size_() const {
     int explicit_val = config_.prefill_chunk_size;
+    // #1645: the EngineConfig field is set by the CLI flag and the per-request
+    // override; imp.conf reaches it through runtime.prefill_chunk_size, which
+    // yields to an explicit CLI value.
+    if (explicit_val < 0 && runtime_config_.runtime.prefill_chunk_size >= 0)
+        explicit_val = runtime_config_.runtime.prefill_chunk_size;
     if (explicit_val < 0) {
-        // Default 2048 (was 512 until 2026-06-11). Chunked prefill re-reads
+        // Default 2048 since 2026-06-11. Chunked prefill re-reads
         // every weight once per chunk, so the memory-bound GEMMs pay the
         // weight traffic per chunk: at pp4096, 512-token chunks cost
         // NVFP4-MoE −43% prefill vs 2048 (14.8k -> 26.2k tok/s) and dense

--- a/src/runtime/graph_eligibility.cpp
+++ b/src/runtime/graph_eligibility.cpp
@@ -8,6 +8,8 @@ const char* graph_demotion_reason_name(GraphDemotionReason r) {
             return "none";
         case GraphDemotionReason::ConfigNever:
             return "runtime.cuda_graphs=never";
+        case GraphDemotionReason::DebugRaw:
+            return "runtime.debug_raw=true";
         case GraphDemotionReason::Gemma4NoGraphs:
             return "gemma4.no_graphs=true";
         case GraphDemotionReason::CalibrationActive:

--- a/src/runtime/graph_eligibility.h
+++ b/src/runtime/graph_eligibility.h
@@ -30,6 +30,7 @@ enum class GraphDemotionReason {
 
     // ── init-time ────────────────────────────────────────────────────
     ConfigNever,                 // runtime.cuda_graphs = "never"
+    DebugRaw,                    // runtime.debug_raw = true (naked FP16 path)
     Gemma4NoGraphs,              // [gemma4] no_graphs = true (regression bisect knob)
     CalibrationActive,           // the collector allocates on first sight of a weight
     StreamingKvConfigured,       // block table mutates per decode step

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -262,3 +262,68 @@ TEST(RuntimeConfigTest, MissingFileFallsBackToDefaults) {
 
 }  // namespace
 }  // namespace imp
+
+// ---- #1627: an unreadable VALUE is rejected, not silently dropped ----
+//
+// `--set` refused an unknown KEY and accepted anything as a value: the three
+// parsers returned the current value for input they could not read, with no
+// warning, so `--set server.prefix_cache=disabled` kept the default and said
+// nothing. 157 of the 185 bound keys go through those three.
+
+TEST(ConfigBadValue, BoolKeyRejectsANonBoolean) {
+    imp::RuntimeConfig cfg;
+    const bool before = cfg.speculative.capture;
+    auto rejected = cfg.apply_overrides({"speculative.capture=disabled"});
+    ASSERT_EQ(rejected.size(), 1u) << "an unreadable value must be reported";
+    EXPECT_NE(rejected[0].find("value not readable"), std::string::npos) << rejected[0];
+    EXPECT_EQ(cfg.speculative.capture, before) << "and the default must be kept";
+}
+
+TEST(ConfigBadValue, IntKeyRejectsWordsAndTrailingGarbage) {
+    imp::RuntimeConfig cfg;
+    EXPECT_EQ(cfg.apply_overrides({"speculative.k=one"}).size(), 1u);
+    // stoi stops at the first non-digit, so this parsed as 16 and reported
+    // nothing. The whole string has to be consumed.
+    EXPECT_EQ(cfg.apply_overrides({"speculative.k=16k"}).size(), 1u);
+    EXPECT_EQ(cfg.apply_overrides({"speculative.k=1,2"}).size(), 1u);
+}
+
+TEST(ConfigBadValue, FloatKeyRejectsANonNumber) {
+    imp::RuntimeConfig cfg;
+    EXPECT_EQ(cfg.apply_overrides({"speculative.mtp_econ_min_emit=high"}).size(), 1u);
+}
+
+TEST(ConfigBadValue, EveryAcceptedBooleanSpellingStillWorks) {
+    // Negative control. imp.conf.example uses table values on all 107 boolean
+    // lines, so a stricter parser must not start rejecting them.
+    for (const char* v : {"true", "True", "1", "yes", "on"}) {
+        imp::RuntimeConfig cfg;
+        EXPECT_TRUE(cfg.apply_overrides({std::string("speculative.capture=") + v}).empty()) << v;
+        EXPECT_TRUE(cfg.speculative.capture) << v;
+    }
+    for (const char* v : {"false", "False", "0", "no", "off"}) {
+        imp::RuntimeConfig cfg;
+        EXPECT_TRUE(cfg.apply_overrides({std::string("speculative.capture=") + v}).empty()) << v;
+        EXPECT_FALSE(cfg.speculative.capture) << v;
+    }
+}
+
+TEST(ConfigBadValue, TriStateKeyKeepsItsThreeSpellings) {
+    for (const char* v : {"auto", "on", "off"}) {
+        imp::RuntimeConfig cfg;
+        EXPECT_TRUE(cfg.apply_overrides({std::string("gemm.cublas_fp16_acc=") + v}).empty()) << v;
+        EXPECT_EQ(cfg.gemm.cublas_fp16_acc, v) << v;
+    }
+    imp::RuntimeConfig cfg;
+    EXPECT_EQ(cfg.apply_overrides({"gemm.cublas_fp16_acc=sometimes"}).size(), 1u);
+}
+
+// ---- #1638: a decode-path switch nothing could set ----
+
+TEST(ConfigBinding, SpeculativeBatchRrIsBound) {
+    imp::RuntimeConfig cfg;
+    ASSERT_TRUE(cfg.speculative.batch_rr) << "default is on";
+    EXPECT_TRUE(cfg.apply_overrides({"speculative.batch_rr=false"}).empty())
+        << "read at engine_scheduler.cpp:1422 and :2882, bound to no key until #1638";
+    EXPECT_FALSE(cfg.speculative.batch_rr);
+}

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -327,3 +327,16 @@ TEST(ConfigBinding, SpeculativeBatchRrIsBound) {
         << "read at engine_scheduler.cpp:1422 and :2882, bound to no key until #1638";
     EXPECT_FALSE(cfg.speculative.batch_rr);
 }
+
+// #1645: the knob that sets the prefill TTFT/ITL trade had no imp.conf key,
+// while the knob that merely caps it did.
+TEST(ConfigBinding, PrefillChunkSizeIsBound) {
+    imp::RuntimeConfig cfg;
+    EXPECT_EQ(cfg.runtime.prefill_chunk_size, -1) << "default is the per-arch resolver";
+    EXPECT_TRUE(cfg.apply_overrides({"runtime.prefill_chunk_size=512"}).empty());
+    EXPECT_EQ(cfg.runtime.prefill_chunk_size, 512);
+    EXPECT_TRUE(cfg.apply_overrides({"runtime.prefill_chunk_size=0"}).empty());
+    EXPECT_EQ(cfg.runtime.prefill_chunk_size, 0);
+    // And it is still a number, not anything (#1627).
+    EXPECT_EQ(cfg.apply_overrides({"runtime.prefill_chunk_size=large"}).size(), 1u);
+}

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -86,7 +86,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1068, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 1995, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1968, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1970, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1159, reason = "(c) 59 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
Closes #1623. Closes #1626. Closes #1627. Closes #1628. Closes #1638. Closes #1645. Closes #1658.

One defect class: something announces an effect and does not deliver it. Grouped because a reviewer checks them the same way — read what the switch claims, then find the code that would apply it.

## Config values

| # | claim | reality |
|---|---|---|
| 1627 | `--set` validates | key half only. `parse_bool/int/float` returned the current value for anything unreadable, silently, for **157 of 185 bound keys**. `--set server.prefix_cache=disabled` kept the default and said nothing; `stoi` stopped at the first non-digit so `k=16k` parsed as 16 |
| 1638 | `speculative.batch_rr` is "a kill switch for A/B" | bound to no key. Read on the decode path at `engine_scheduler.cpp:1422,2882` |
| 1645 | `prefill_chunk_size` is configurable | CLI and per-request only. The knob that *caps* it had a key; the one that sets it did not |
| 1628 | `debug_raw` turns off warmup, expert cache, GDN fusion; forces deterministic cuBLAS | four `setenv()` on `IMP_*` variables **nothing reads** — 0 `getenv` hits each. Every one had a real switch already |

## Gates

| # | claim | reality |
|---|---|---|
| 1626 | the `clang-tidy` job lints changed files | it had **never linted a file**: first `git` call exits 128 (`dubious ownership`), the list comes back empty, `continue-on-error` reports green |
| 1623 | bench targets require a free GPU | `gen-perf-baseline` — the one that re-pins what the gate compares against — took no `check-gpu` |
| 1658 | the dispatch summary names why graphs are off | `graphs=0(none)`: "graphs are off, reason: graphs still enabled". `debug_raw` wrote the field instead of calling `demote_graphs_` |

## Tests

7 in `test_config.cpp`, unit lane. Including the negative controls that matter here: all five true- and all five false-spellings still parse (`imp.conf.example` uses table values on all 107 boolean lines), and the `gemm.cublas_fp16_acc` tri-state keeps `auto`/`on`/`off`.

Not covered by a test: #1626 and #1623 are CI and Makefile wiring, and #1628's four assignments are observable only on a GPU run with `debug_raw=true`.

## Gate

```
decode  tg128 =  283.80 tok/s  (baseline  287.19, delta -1.18%)
prefill pp512 = 12377.22 tok/s (baseline 12406.87, delta -0.24%)
prefill pp4096 = 15319.50 tok/s (baseline 15324.70, delta -0.03%, FA2)
own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
graphs ON  tg256 =  451.48 tok/s   (2.53x, threshold 1.3x)
=== verify fast: OK ===
```

Full GPU suite via the pre-commit hook, both commits: 2318 tests, 0 failures.
`filesize_thresholds.toml`: `engine_scheduler.cpp` 1968 -> 1970.

## Behaviour changes worth knowing

- A config value that cannot be parsed is now a rejection instead of a silent default. `imp.conf.example` was checked: all 107 boolean lines use spellings the parser accepts.
- `debug_raw` now actually disables warmup and the MoE expert cache, and actually selects the GDN reference scan. Anything measured under `debug_raw` before this was measured with those on.