### PR TITLE
fix(tooling): four tools that described themselves wrongly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,26 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Four tools that described themselves wrongly** (#1585, #1586, #1587,
+  #1663). The pre-push gate's gtest filter carried `AttentionTest.*`, a suite
+  renamed away before the pattern was added on 2026-04-27: gtest reports
+  success for a filter that matches nothing, so the only gate that runs CUDA
+  kernels against correctness ran **zero attention tests for four months**. The
+  corrected pattern adds 67 tests and 2 seconds (3 s / 268 to 5 s / 335), and a
+  new `guard_verify_filter` fails when any pattern matches nothing. `CLAUDE.md`
+  priced `verify-fast` at 90 s while the target's own prerequisite is a full
+  image build; measured, the script half is 37 s and the build is what costs
+  minutes. `docs_lint.py` walked gitignored paths, so a local scratch directory
+  produced 160 errors on every run and the working answer became a `grep -v`.
+  And the ten-value `ImpError` taxonomy never reached a process exit code:
+  every binary collapsed onto 1, so a caller had to parse English to tell "no
+  such file" from "out of VRAM". Exit codes are the taxonomy, 1 to 9, and
+  `imp-quantize`'s undocumented 2 for usage errors is now 1 like everywhere
+  else. The teardown guard added with #1632 was itself a pure negative test
+  (a grep that passes when it finds nothing, which is also what it does when
+  pointed at the wrong file); it now asserts the six replacement calls are
+  present too.
+
 - **Three things a request left behind when it did not end normally** (#1632,
   #1633, #1644). Six cancellation sites in the scheduler freed the sequence's
   KV and never released its recurrent-state slot; the pool is fixed-size, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ The host has **no CUDA toolkit** by design — build inside Docker. `build/` and
 ```
 make dev / make dev-test   # incremental (2-14 s) + the real CI lane — iterate here
 make build                 # full image (~3.5 min) — the gate, benchmarks, pre-push
-make verify-fast           # ~90 s pre-push gate    make verify   # ~5 min full
+make verify-fast           # pre-push gate: build + 37 s script (#1587)   make verify   # full
 ```
 
 `make build` for anything you *measure* or push; `make dev` for everything else. `make test-unit` is a different binary from the CI lane — green there is not green in CI. Details, target list and CI job names: skill **building-and-testing**.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,8 @@ if(IMP_BUILD_TOOLS)
         tools/imp-quantize/awq.cu
     )
     target_link_libraries(imp-quantize PRIVATE imp imp_warnings)
-    target_include_directories(imp-quantize PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_include_directories(imp-quantize PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
+                                                   ${CMAKE_CURRENT_SOURCE_DIR}/tools)
 
     # imp-bench
     if(IMP_BUILD_BENCH)
@@ -719,6 +720,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mla.cpp
         tests/test_weight_map_expert_gate.cpp
         tests/test_checkpoint_limits.cpp
+        tests/test_exit_codes.cpp
         # imp-quantize's tensor-selection rule. The tool is not otherwise
         # covered, and this is the part of it that has already shipped a broken
         # checkpoint (#1159), so it is compiled into the CPU lane directly.
@@ -1004,8 +1006,17 @@ if(IMP_BUILD_TESTS)
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_cancel_teardown.sh
                 ${CMAKE_CURRENT_SOURCE_DIR})
 
+    # #1586: the pre-push gate's filter is a string literal in verify.sh, and a
+    # pattern that matches nothing is a gtest success. Reads the filter out of
+    # verify.sh rather than keeping a copy; skips when imp-tests cannot run.
+    # imp-tests is a generated wrapper script, not a target, so it is a path.
+    add_test(NAME guard_verify_filter
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_verify_filter.sh
+                ${CMAKE_CURRENT_BINARY_DIR}/imp-tests ${CMAKE_CURRENT_SOURCE_DIR}/scripts/verify.sh)
+
     set_tests_properties(unit_core unit_text unit_e2e_subset guard_e2e_lane_split
                          guard_det_suite_filter guard_cancel_teardown
+                         guard_verify_filter
         PROPERTIES LABELS "unit")
 
     add_test(NAME gpu_compute   COMMAND test-compute)

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,9 @@ test-golden: build
 verify: build check-gpu
 	@scripts/verify.sh full
 
-# verify-fast: pre-push gate (~90s). filtered tests + 1 smoke.
+# verify-fast: pre-push gate. `build` + filtered tests + perf + 1 smoke.
+# Measured on an unchanged tree: 3 s cached build + 37 s script. A source
+# change adds the full image build (#1587).
 # Perf gate uses --prefill-chunk-size 0 to stay apples-to-apples with tests/perf_baseline.json.
 verify-fast: build check-gpu
 	@scripts/verify.sh fast

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,6 +62,27 @@ The settings that most often need changing in a deployment:
 | `server.model_swap` | default on: a request naming another model in the directory swaps to it |
 | `moe.expert_cache_budget_pct` | only relevant when MoE experts do not fit; see [`PERF.md`](PERF.md) |
 
+## Exit codes
+
+The binaries return the C API's error taxonomy rather than a bare 1 (#1585), so
+a supervisor can tell a bad argument from a full GPU without parsing prose.
+
+| code | meaning | retry? |
+|---|---|---|
+| 0 | success | |
+| 1 | invalid argument, including a usage error | no, fix the call |
+| 2 | out of memory (host) | maybe, with less concurrency |
+| 3 | CUDA error | no |
+| 4 | file not found | no |
+| 5 | invalid model | no |
+| 6 | unsupported | no |
+| 7 | internal error | worth one retry |
+| 8 | cancelled | n/a |
+| 9 | capacity: the KV pool cannot fit this prompt | yes, shorter prompt or more VRAM |
+
+Codes above 9 are unused. `imp-quantize` returned 2 for usage errors before
+this; it returns 1 now, with every other invalid argument.
+
 ## Auth and exposure
 
 ```bash

--- a/scripts/check_cancel_teardown.sh
+++ b/scripts/check_cancel_teardown.sh
@@ -28,6 +28,22 @@ fi
 # elsewhere (eviction, reset) are not request teardown and are not in scope.
 HITS=$(grep -n 'free_sequence(req->id)' "$FILE" || true)
 
+# A guard that only ever says "I found nothing bad" is indistinguishable from
+# one pointed at the wrong file. This one asserts the positive too: the six
+# cancel sites the helper replaced must still be calling it. Rename the file,
+# move the code, or delete the helper, and this fails instead of passing.
+CALLS=$(grep -c 'cancel_sequence_(req)' "$FILE" || true)
+MIN_CALLS=6
+
+if [ "$CALLS" -lt "$MIN_CALLS" ]; then
+    echo "check_cancel_teardown: FAIL" >&2
+    echo "" >&2
+    echo "Found $CALLS call(s) to cancel_sequence_(req), expected at least $MIN_CALLS." >&2
+    echo "Either a cancel path was removed, or this guard is looking at the wrong" >&2
+    echo "file and would have passed without checking anything. See #1632." >&2
+    exit 1
+fi
+
 if [ -n "$HITS" ]; then
     echo "check_cancel_teardown: FAIL" >&2
     echo "" >&2
@@ -39,4 +55,4 @@ if [ -n "$HITS" ]; then
     exit 1
 fi
 
-echo "check_cancel_teardown: PASS (no direct free_sequence(req->id) in the scheduler)"
+echo "check_cancel_teardown: PASS ($CALLS teardown calls, no direct free_sequence(req->id))"

--- a/scripts/check_verify_filter.sh
+++ b/scripts/check_verify_filter.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Guard the pre-push gate's gtest filter against silent suite-rename drift
+# (#1586).
+#
+# scripts/verify.sh carries a 12-pattern gtest filter for the fast lane. It is
+# the only place several of those suites ever run: VramBudget* and
+# ForwardPassTest.* are SKIP_IF_NO_CUDA, so CI structurally cannot execute
+# them, and DecodeLogitsInvariantToBatchComposition is the tree's only assert
+# that a sequence's logits do not depend on its batch neighbours (#1314, the
+# class #1044/#1045 came from).
+#
+# A pattern that matches nothing is not an error in gtest. It runs zero tests
+# and reports success, so renaming a suite out of the filter silently deletes
+# the only coverage it had. Two sibling filters are already guarded
+# (guard_e2e_lane_split, guard_det_suite_filter); this one was not.
+#
+# The filter is READ OUT OF verify.sh rather than copied here. A guard with its
+# own copy of the string guards the copy.
+#
+# Usage: check_verify_filter.sh <path-to-imp-tests> [<path-to-verify.sh>]
+# Exit 0 = every pattern matches at least one test.
+
+set -eu
+
+BIN="${1:?usage: check_verify_filter.sh <imp-tests> [verify.sh]}"
+VERIFY="${2:-$(dirname "$0")/verify.sh}"
+
+if [ ! -x "$BIN" ]; then
+    echo "check_verify_filter: $BIN not executable — skipping" >&2
+    exit 0   # fail-open: the GPU test binary is not built in every configuration
+fi
+if [ ! -f "$VERIFY" ]; then
+    echo "check_verify_filter: $VERIFY not found" >&2
+    exit 2
+fi
+
+FILTER=$(grep -m1 '^ *FILTER="' "$VERIFY" | sed 's/^ *FILTER="//; s/"$//')
+if [ -z "$FILTER" ]; then
+    echo "check_verify_filter: no FILTER= line in $VERIFY — the gate lost its filter" >&2
+    exit 1
+fi
+
+# Can the binary run at all? On a host without the CUDA runtime it exits before
+# main and prints nothing, and then EVERY pattern looks empty. A guard that
+# reports twelve findings when it in fact could not measure is worse than one
+# that stays quiet: it teaches the reader to ignore it.
+TOTAL=$("$BIN" --gtest_list_tests 2>/dev/null | grep -c '^  ' || true)
+if [ "$TOTAL" -eq 0 ]; then
+    echo "check_verify_filter: SKIP ($BIN lists no tests at all — no CUDA runtime here?)"
+    exit 0
+fi
+
+EMPTY=""
+PATTERNS=$(printf '%s' "$FILTER" | tr ':' '\n')
+for pat in $PATTERNS; do
+    [ -z "$pat" ] && continue
+    # --gtest_list_tests runs no test body, so this needs no GPU.
+    COUNT=$("$BIN" --gtest_list_tests --gtest_filter="$pat" 2>/dev/null |
+            grep -c '^  ' || true)
+    if [ "$COUNT" -eq 0 ]; then
+        EMPTY="$EMPTY $pat"
+    fi
+done
+
+if [ -n "$EMPTY" ]; then
+    echo "check_verify_filter: FAIL" >&2
+    echo "" >&2
+    echo "These patterns in the pre-push filter match no test:" >&2
+    for pat in $EMPTY; do echo "  $pat" >&2; done
+    echo "" >&2
+    echo "gtest reports success for a filter that matches nothing, so the suite" >&2
+    echo "was not skipped - it was silently dropped from the only gate that runs" >&2
+    echo "it. Fix the pattern in scripts/verify.sh, or delete it deliberately." >&2
+    exit 1
+fi
+
+echo "check_verify_filter: PASS ($(printf '%s' "$PATTERNS" | grep -c .) patterns, all non-empty)"

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -35,6 +35,7 @@ import datetime as dt
 import json
 import pathlib
 import re
+import subprocess
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -152,6 +153,36 @@ def _edits_since(sha: str, path: str):
 
 
 BASELINE = ROOT / "tests" / "perf_baseline.json"
+
+
+def _ignored_paths(candidates: list[str]) -> set[str]:
+    """The subset of `candidates` that .gitignore excludes (#1663).
+
+    Without this the linter walks whatever happens to be in the tree. A local
+    scratch directory - `_audit/` during the 2026-08 audit - produced 160
+    errors on every run, and the working answer became `| grep -v '^FAIL
+    _audit/'`. A gate whose output has to be filtered by hand is one command
+    away from not being read at all.
+
+    `git check-ignore` rather than `git ls-files`: a doc that is written but
+    not yet added is still in scope, and would otherwise pass locally and fail
+    in CI. Falls back to "nothing is ignored" when git is unavailable, which is
+    the old behaviour.
+    """
+    if not candidates:
+        return set()
+    try:
+        r = subprocess.run(
+            ["git", "check-ignore", "--stdin"],
+            input="\n".join(candidates),
+            capture_output=True, text=True, cwd=ROOT, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    # exit 0 = some paths ignored, 1 = none, 128 = not a git repo
+    if r.returncode not in (0, 1):
+        return set()
+    return {line.strip() for line in r.stdout.splitlines() if line.strip()}
 
 
 def in_scope(rel: str) -> bool:
@@ -301,9 +332,11 @@ def check_budgets(errors: list) -> None:
         if t > CLAUDE_ROOT_MAX_TOKENS:
             errors.append(f"CLAUDE.md: ~{t} tokens > {CLAUDE_ROOT_MAX_TOKENS}")
 
-    for p in ROOT.rglob("CLAUDE.md"):
-        rel = p.relative_to(ROOT).as_posix()
-        if rel == "CLAUDE.md" or rel.startswith(EXCLUDED_PREFIXES):
+    claude_files = [p.relative_to(ROOT).as_posix() for p in ROOT.rglob("CLAUDE.md")]
+    ignored = _ignored_paths(claude_files)
+    for rel in claude_files:
+        p = ROOT / rel
+        if rel == "CLAUDE.md" or rel in ignored or rel.startswith(EXCLUDED_PREFIXES):
             continue
         t = approx_tokens(p.read_text(encoding="utf-8"))
         if t > CLAUDE_DIR_MAX_TOKENS:
@@ -314,11 +347,12 @@ def main() -> int:
     errors: list[str] = []
     warnings: list[str] = []
 
-    for path in sorted(ROOT.rglob("*.md")):
-        rel = path.relative_to(ROOT).as_posix()
-        if not in_scope(rel):
+    candidates = [p.relative_to(ROOT).as_posix() for p in sorted(ROOT.rglob("*.md"))]
+    ignored = _ignored_paths(candidates)
+    for rel in candidates:
+        if rel in ignored or not in_scope(rel):
             continue
-        check_file(path, rel, errors, warnings)
+        check_file(ROOT / rel, rel, errors, warnings)
 
     check_generated_blocks(errors)
     check_budgets(errors)

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -279,7 +279,14 @@ else
         # CI cannot run it, and DecodeLogitsInvariantToBatchComposition (#1314)
         # is the only assert in the tree that a sequence's logits do not depend
         # on its batch neighbours — the class #1044/#1045 came from.
-        FILTER="TensorTest.*:GgufLoaderTest.*:Tokenizer*:ChatTemplate*:KVCache*:GemmTest.*:FP8GemmTest.*:SamplingTest.*:SoftmaxTest.*:AttentionTest.*:VramBudget*:ForwardPassTest.*"
+        #
+        # `*Attention*` was `AttentionTest.*` from 2026-04-27 until #1586. That
+        # suite had already been renamed, so the pattern matched nothing and
+        # gtest reported success for it: the gate ran ZERO attention tests for
+        # four months, in the subsystem with the most kernel churn in the tree.
+        # check_verify_filter.sh now fails when any pattern here matches
+        # nothing.
+        FILTER="TensorTest.*:GgufLoaderTest.*:Tokenizer*:ChatTemplate*:KVCache*:GemmTest.*:FP8GemmTest.*:SamplingTest.*:SoftmaxTest.*:*Attention*:VramBudget*:ForwardPassTest.*"
         if "$TESTS_BIN" --gtest_filter="$FILTER" >/tmp/imp_verify_tests.log 2>&1; then
             pass "fast gtest filter"
         else

--- a/tests/test_exit_codes.cpp
+++ b/tests/test_exit_codes.cpp
@@ -1,0 +1,55 @@
+// The C API taxonomy reaching a process exit code (#1585).
+//
+// Before this the four binaries collapsed every failure onto 1, so a
+// supervisor had to parse English to tell "no such file" from "out of VRAM".
+// Exactly one of those is worth retrying.
+
+#include "common/exit_codes.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+
+namespace {
+
+TEST(ExitCodes, SuccessIsZero) { EXPECT_EQ(imp::tools::exit_code_for(IMP_SUCCESS), 0); }
+
+// The mapping is the taxonomy's own order made positive, because an exit
+// status is an unsigned byte. One table, not two.
+TEST(ExitCodes, TheTaxonomyMapsOneToOne) {
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_INVALID_ARG), 1);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_OUT_OF_MEMORY), 2);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_CUDA), 3);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_FILE_NOT_FOUND), 4);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_INVALID_MODEL), 5);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_UNSUPPORTED), 6);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_INTERNAL), 7);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_CANCELLED), 8);
+    EXPECT_EQ(imp::tools::exit_code_for(IMP_ERROR_CAPACITY), 9);
+}
+
+// Every code is distinct and fits a byte, or the shell truncates it into
+// another meaning.
+TEST(ExitCodes, EveryCodeIsDistinctAndFitsAByte) {
+    const ImpError all[] = {IMP_ERROR_INVALID_ARG,    IMP_ERROR_OUT_OF_MEMORY, IMP_ERROR_CUDA,
+                            IMP_ERROR_FILE_NOT_FOUND, IMP_ERROR_INVALID_MODEL, IMP_ERROR_UNSUPPORTED,
+                            IMP_ERROR_INTERNAL,       IMP_ERROR_CANCELLED,     IMP_ERROR_CAPACITY};
+    std::set<int> seen;
+    for (ImpError e : all) {
+        const int c = imp::tools::exit_code_for(e);
+        EXPECT_GT(c, 0);
+        EXPECT_LE(c, 255);
+        EXPECT_TRUE(seen.insert(c).second) << "duplicate exit code " << c;
+    }
+    EXPECT_EQ(seen.size(), 9u);
+}
+
+// A value added to the enum without touching the table must degrade to the old
+// behaviour rather than invent a meaning.
+TEST(ExitCodes, AnUnknownErrorDegradesToOne) {
+    EXPECT_EQ(imp::tools::exit_code_for(static_cast<ImpError>(-42)), 1);
+    EXPECT_EQ(imp::tools::exit_code_for(static_cast<ImpError>(-10)), 1);
+    EXPECT_EQ(imp::tools::exit_code_for(static_cast<ImpError>(7)), 1);
+}
+
+}  // namespace

--- a/tools/common/exit_codes.h
+++ b/tools/common/exit_codes.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Process exit codes for the imp binaries (#1585).
+//
+// The C API carries a ten-value error taxonomy (`include/imp/error.h`) that
+// stopped at the API boundary: every binary printed `imp_error_string(err)` and
+// returned 1, so a caller had to parse English prose to tell "this model file
+// does not exist" from "this GPU is out of memory". Only one of those is worth
+// retrying, and only one of them means the caller passed something wrong.
+//
+// The mapping is the taxonomy's own order, made positive, because a process
+// exit status is an unsigned byte: IMP_ERROR_INVALID_ARG (-1) is exit 1, and so
+// on down to IMP_ERROR_CAPACITY (-9) at exit 9. That keeps one table instead of
+// two, and it keeps 1 as the code every existing script already handles, since
+// INVALID_ARG is what a usage error was reported as.
+//
+// imp-quantize used 2 for usage errors, undocumented. It is 1 now, the same as
+// every other invalid argument, because two codes for one condition is what
+// made this worth filing. That is a behaviour change for anyone who tested
+// `-eq 2`; the code stays non-zero, so `if ! cmd` is unaffected. Anything above
+// 9 is free for a binary's own conditions; none use it.
+//
+// Documented for readers in `docs/DEPLOYMENT.md`.
+
+#include "imp/error.h"
+
+namespace imp::tools {
+
+// 0 for success, 1..9 for the taxonomy, 1 for anything unrecognised.
+//
+// Unrecognised maps to 1 rather than to a new code, so an ImpError added
+// without touching this table degrades to the old behaviour instead of
+// inventing a meaning.
+inline int exit_code_for(ImpError err) {
+    if (err == IMP_SUCCESS)
+        return 0;
+    const int code = -static_cast<int>(err);
+    if (code < 1 || code > 9)
+        return 1;
+    return code;
+}
+
+}  // namespace imp::tools

--- a/tools/imp-cli/main.cpp
+++ b/tools/imp-cli/main.cpp
@@ -1,4 +1,5 @@
 #include "api/imp_internal.h"
+#include "common/exit_codes.h"
 #include "args.h"
 #include "model/chat_template.h"
 #include "model/image_placeholders.h"
@@ -168,8 +169,12 @@ int main(int argc, char** argv) {
     if (format == IMP_FORMAT_GGUF) {
         resolved_model = imp::resolve_model_gguf(args.model_path, args.revision);
         if (resolved_model.empty()) {
+            // The most common failure of all, and the one a caller most wants
+            // to distinguish: a path that is not there. It never reached
+            // imp_model_load_ex, so it needs its own code rather than the
+            // generic 1 (#1585).
             fprintf(stderr, "Failed to resolve model: %s\n", args.model_path.c_str());
-            return 1;
+            return imp::tools::exit_code_for(IMP_ERROR_FILE_NOT_FOUND);
         }
         if (resolved_model != args.model_path) {
             printf("Resolved model: %s -> %s\n", args.model_path.c_str(), resolved_model.c_str());
@@ -188,7 +193,7 @@ int main(int argc, char** argv) {
                                      /*load_mtp_head=*/args.mtp_spec_decode_k > 0, &model);
     if (err != IMP_SUCCESS) {
         fprintf(stderr, "Error loading model: %s\n", imp_error_string(err));
-        return 1;
+        return imp::tools::exit_code_for(err);
     }
 
     ImpConfig config = imp_config_default();
@@ -333,7 +338,7 @@ int main(int argc, char** argv) {
     if (err != IMP_SUCCESS) {
         fprintf(stderr, "Error creating context: %s\n", imp_error_string(err));
         imp_model_free(model);
-        return 1;
+        return imp::tools::exit_code_for(err);
     }
 
     auto t_init_end = std::chrono::high_resolution_clock::now();
@@ -741,7 +746,7 @@ int main(int argc, char** argv) {
                     fprintf(stderr, "Error loading image '%s': %s\n", p, imp_error_string(err));
                     imp_context_free(ctx);
                     imp_model_free(model);
-                    return 1;
+                    return imp::tools::exit_code_for(err);
                 }
                 fprintf(stderr, "Image loaded: %s\n", p);
             }
@@ -820,7 +825,7 @@ int main(int argc, char** argv) {
                 fprintf(stderr, "Prefill error: %s\n", imp_error_string(err));
                 imp_context_free(ctx);
                 imp_model_free(model);
-                return 1;
+                return imp::tools::exit_code_for(err);
             }
 
             // Compute max stop length for buffering

--- a/tools/imp-quantize/main.cpp
+++ b/tools/imp-quantize/main.cpp
@@ -70,6 +70,7 @@
 // Useful today for: getting a model onto the NVFP4 path at all, and for
 // performance work where the weights only need to be the right shape.
 
+#include "common/exit_codes.h"
 #include "awq.h"
 #include "checkpoint_out.h"
 #include "fp8_source.h"
@@ -342,7 +343,7 @@ int main(int argc, char** argv) {
             const std::string f = next();
             if (!quantize::parse_output_format(f, opt.format)) {
                 fprintf(stderr, "imp-quantize: unknown --format '%s' (modelopt | vllm)\n", f.c_str());
-                return 2;
+                return imp::tools::exit_code_for(IMP_ERROR_INVALID_ARG);
             }
         } else if (a == "--calib-groups") {
             opt.calib_groups = next();
@@ -354,7 +355,7 @@ int main(int argc, char** argv) {
             if (opt.calib_groups.find_first_not_of(awq::kAwqAllGroups) != std::string::npos) {
                 fprintf(stderr, "imp-quantize: --calib-groups '%s' has a letter outside %s\n",
                         opt.calib_groups.c_str(), awq::kAwqAllGroups);
-                return 2;
+                return imp::tools::exit_code_for(IMP_ERROR_INVALID_ARG);
             }
         } else if (a == "--dry-run")
             opt.dry_run = true;
@@ -364,12 +365,12 @@ int main(int argc, char** argv) {
         } else {
             fprintf(stderr, "unknown argument: %s\n", a.c_str());
             usage();
-            return 2;
+            return imp::tools::exit_code_for(IMP_ERROR_INVALID_ARG);
         }
     }
     if (opt.in_dir.empty() || (opt.out_dir.empty() && !opt.dry_run)) {
         usage();
-        return 2;
+        return imp::tools::exit_code_for(IMP_ERROR_INVALID_ARG);
     }
 
     std::vector<fs::path> shards;


### PR DESCRIPTION
Four tools whose self-description was wrong. One of them cost real coverage.

## #1586 - the pre-push filter selected zero attention tests for four months

`scripts/verify.sh` filters the fast lane with 12 gtest patterns. One of them is `AttentionTest.*`. **No such suite exists** - it was renamed before the pattern was added on 2026-04-27 (#67), and gtest reports *success* for a filter that matches nothing.

So the only gate in this repo that runs CUDA kernels against correctness ran no attention test at all, in the subsystem with the most kernel churn in the tree. Yesterday's #1693 changed 17 attention launchers; only the pre-commit hook's full suite caught anything.

| | tests | time |
|---|---|---|
| old filter | 268 | 3 s |
| corrected `*Attention*` | 335 | 5 s |

Two seconds. The dead pattern never saved anything; it was simply dead, which is why nothing pointed at it.

`scripts/check_verify_filter.sh` now fails when any pattern matches nothing, wired as `guard_verify_filter` in the CPU lane. It **reads the filter out of verify.sh** rather than keeping a copy: a guard with its own copy of the string guards the copy.

**Its own first run was wrong, and that shaped it.** It reported all twelve patterns empty, because I ran it on the host where the test binary exits before `main` for lack of a CUDA runtime - empty listing, every pattern looks dead. It separates "found nothing" from "could not measure" now and reports SKIP for the second. A guard that fires on valid input is one someone turns off.

The same review found the teardown guard from #1632 was a pure negative test: a grep that passes when it finds nothing, which is also what it does pointed at the wrong file. It asserts the six replacement calls are present now.

## #1587 - verify-fast priced at 90 s, excluding its own 3.5 min build

`verify-fast: build check-gpu`, and `build` is a full docker build.

| | measured |
|---|---|
| `make build`, unchanged tree | 3 s (layer cache) |
| `scripts/verify.sh fast` | 37 s |
| after a source change | + the full image build |

I quoted the 90 s to another session as a wait time today. That is the second way a wrong number in a doc does damage: it becomes a wrong promise the moment someone passes it on in good faith.

## #1663 - docs_lint walked gitignored paths

A local scratch directory produced 160 errors on every run, and the working answer had become `| grep -v '^FAIL  _audit/'`. A gate whose output is filtered by hand is one command from not being read.

Filters through `git check-ignore`, not `git ls-files`: a doc written but not yet `git add`ed stays in scope, and would otherwise pass locally and fail in CI.

## #1585 - the error taxonomy never reached an exit code

Ten values in `include/imp/error.h`; every binary printed the string and returned 1. A supervisor had to parse English to tell "no such file" from "out of VRAM", and exactly one of those is worth retrying.

Exit codes are the taxonomy made positive, 1 to 9, documented in `docs/DEPLOYMENT.md` with a retry column. Unrecognised values map to 1, so an enum entry added without touching the table degrades to the old behaviour instead of inventing a meaning.

**Behaviour changes:**

| | before | after |
|---|---|---|
| `imp-quantize`, usage error | 2, undocumented | 1, like every invalid argument |
| `imp-cli --model /nope` | 1 | 4 (measured after the change) |

Both stay non-zero, so `if ! cmd` is unaffected.

## Tests

4 cases in `tests/test_exit_codes.cpp`: the table is 1:1, every code is distinct and inside a byte, an unknown `ImpError` degrades to 1.

| negative control | result |
|---|---|
| dead pattern restored in verify.sh | guard exits 1, names `AttentionTest.*` |
| teardown calls removed | guard exits 1, "found 0, expected at least 6" |
| guard run on the host | SKIP, not twelve false findings |

Every gate checked by **exit code** rather than an output tail. That is how the file-size violation in #1697 got past me: `| tail -2` showed the re-pinning instructions, which sit *below* the finding and read as reassurance.

## Gate

```
PASS fast gtest filter
  decode  tg128 =  275.69 tok/s  (baseline  287.19, delta -4.00%)
  prefill pp512 = 12120.33 tok/s  (baseline 12406.87, delta -2.31%)
  prefill pp4096 = 14461.65 tok/s  (baseline 15324.70, delta -5.63%, FA2)
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
```

All within threshold, but lower than the previous run on this tree (-0.89% decode). **Not attributable to this change**: `git diff HEAD~1 HEAD -- src/` is empty, so no compute code is touched. Host load average was 2.31 over the 5-minute window during the run. Recorded as measured rather than re-run to a nicer number.

GPU suite: 2367 passed, 0 failed.

Closes #1585. Closes #1586. Closes #1587. Closes #1663.
