### PR TITLE
fix(api): six things /v1/messages said that Anthropic's contract does not define (#1550 #1551 #1552 #1553 #1556 #1557 #1561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,44 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`/v1/messages` never reported which stop sequence ended a turn** (#1550).
+  A match came back as `stop_reason: "end_turn"` with `stop_sequence: null` on
+  both transports; the Anthropic value `"stop_sequence"` was produced by no
+  code path. The matched text now rides out of the holdback matcher and the
+  non-streaming path alike. Measured on `Qwen3-4B-Instruct-2507-Q8_0.gguf` with
+  `stop_sequences: ["4"]`: `stop_reason: "stop_sequence"`, `stop_sequence: "4"`,
+  streaming and not. While making the match reportable, the matcher started
+  cutting at the **earliest** occurrence rather than at the first list entry
+  that occurs anywhere - list order shipped the text between two stops.
+
+- **A 429 on `/v1/messages` came back in the OpenAI envelope** (#1551). Both
+  pre-routing guards wrote `{"error":{...}}` with no top-level `"type":"error"`,
+  so an Anthropic SDK could not classify it, twenty lines above an auth path
+  that did branch. One helper now picks the envelope from the path, and the six
+  sites that spelled the test out use it.
+
+- **Anthropic error types are Anthropic's** (#1556). `server_error` and
+  `capacity_error` are this server's inventions and were emitted at seven sites
+  plus forwarded verbatim through the non-streaming shim. They map to
+  `api_error` and `overloaded_error`; anything unrecognised falls back on the
+  status. `content_filter` -> `refusal` for the same reason.
+
+- **A mid-stream fault is an `error` SSE event, not a completed turn** (#1552,
+  #1553). The event did not exist: a request timeout arrived as `stop_reason:
+  "max_tokens"` (indistinguishable from the model reaching its budget) and an
+  admission refusal as `"capacity"`, which is not an Anthropic stop_reason at
+  all, while the non-streaming path answered 503 for the same condition.
+  Measured with `--request-timeout 1`: `event: error` with
+  `{"type":"timeout_error"}`.
+
+- **`tool_result.is_error` was read by nothing** (#1557). A failed tool became
+  an ordinary successful `role: "tool"` turn, so the model was told the call
+  worked. The failure is labelled in the content, which is the only channel the
+  OpenAI tool turn has.
+
+- **Every `/v1/messages` response carries a `request-id`** (#1561), and error
+  bodies repeat it as `request_id`. Neither existed anywhere in the server.
+
 - **Jinja: `{% set x %}...{% endset %}` printed its body and left the variable
   empty, and macro default parameters never parsed** (#1565, #1566). The block
   form of `set` is what Gemma-4's shipped `chat_template.jinja` builds

--- a/docs/API.md
+++ b/docs/API.md
@@ -220,6 +220,18 @@ Every error is a JSON envelope, never a bare status with an empty body, and
 `/v1/messages*` paths get the Anthropic error shape rather than the OpenAI one.
 An unmatched route answers with an envelope too.
 
+On `/v1/messages` the `error.type` is always one of Anthropic's own -
+`invalid_request_error`, `authentication_error`, `billing_error`,
+`permission_error`, `not_found_error`, `request_too_large`, `rate_limit_error`,
+`api_error`, `overloaded_error`, `timeout_error`. Every response from that
+endpoint also carries a `request-id` header, and error bodies repeat it as
+`request_id`.
+
+A stream that ends on a server-side fault emits an `error` SSE event instead of
+`message_delta`/`message_stop`: a request timeout and an admission refusal used
+to arrive as an ordinary completed turn, indistinguishable from the model
+finishing.
+
 Internal engine errors are translated to `ImpError` at the C API boundary
 (`src/api/imp_api.cpp`); this is intentional and is why a load failure surfaces
 as a typed message rather than a crash.

--- a/tests/test_anthropic_transform.cpp
+++ b/tests/test_anthropic_transform.cpp
@@ -531,7 +531,12 @@ TEST(AnthropicResponse, FinishReasonMapping) {
     EXPECT_EQ(stop_for("length"), "max_tokens");
     EXPECT_EQ(stop_for("tool_calls"), "tool_use");
     EXPECT_EQ(stop_for("cancelled"), "end_turn");
-    EXPECT_EQ(stop_for("content_filter"), "content_filter");  // unknown → passthrough
+    // Was `content_filter` passed straight through. That is OpenAI's name and
+    // not a member of Anthropic's stop_reason enum; "refusal" is (#1552).
+    EXPECT_EQ(stop_for("content_filter"), "refusal");
+    // Nothing unknown escapes the enum any more.
+    EXPECT_EQ(stop_for("capacity"), "end_turn");
+    EXPECT_EQ(stop_for("whatever"), "end_turn");
 }
 
 TEST(AnthropicResponse, UsageSplitsCacheReadFromInput) {
@@ -717,4 +722,79 @@ TEST(AnthropicGuidedPassthrough, AbsentFieldsAreNotInvented) {
     EXPECT_FALSE(oai.contains("guided_grammar"));
     EXPECT_FALSE(oai.contains("grammar"));
     EXPECT_FALSE(oai.contains("response_format"));
+}
+
+// ---------------------------------------------------------------------------
+// stop_reason / stop_sequence (#1550, #1552) and tool_result.is_error (#1557)
+// ---------------------------------------------------------------------------
+
+namespace {
+json minimal_oai_response(const char* finish) {
+    return json{{"id", "chatcmpl-1"},
+                {"choices", json::array({{{"index", 0},
+                                          {"finish_reason", finish},
+                                          {"message", {{"role", "assistant"}, {"content", "hi"}}}}})},
+                {"usage", {{"prompt_tokens", 3}, {"completion_tokens", 1}}}};
+}
+}  // namespace
+
+TEST(AnthropicStopReason, StopWithoutASequenceIsEndTurn) {
+    json out = openai_to_anthropic_response(minimal_oai_response("stop"), "m");
+    EXPECT_EQ(out["stop_reason"], "end_turn");
+    EXPECT_TRUE(out["stop_sequence"].is_null());
+}
+
+// The whole point of #1550: the same finish_reason, two different turns.
+TEST(AnthropicStopReason, StopWithASequenceNamesIt) {
+    json out = openai_to_anthropic_response(minimal_oai_response("stop"), "m", "</done>");
+    EXPECT_EQ(out["stop_reason"], "stop_sequence");
+    EXPECT_EQ(out["stop_sequence"], "</done>");
+}
+
+TEST(AnthropicStopReason, LengthAndToolCallsAreUnchanged) {
+    EXPECT_EQ(openai_to_anthropic_response(minimal_oai_response("length"), "m")["stop_reason"], "max_tokens");
+    EXPECT_EQ(openai_to_anthropic_response(minimal_oai_response("tool_calls"), "m")["stop_reason"],
+              "tool_use");
+}
+
+// "capacity" and "cancelled" are engine reasons, not Anthropic stop_reasons.
+// The streaming path used to ship "capacity" verbatim (#1552).
+TEST(AnthropicStopReason, EngineReasonsNeverShipVerbatim) {
+    using imp_server::anthropic::anthropic_stop_reason;
+    EXPECT_STREQ(anthropic_stop_reason("capacity", false), "end_turn");
+    EXPECT_STREQ(anthropic_stop_reason("cancelled", false), "end_turn");
+    EXPECT_STREQ(anthropic_stop_reason("anything_else", false), "end_turn");
+}
+
+TEST(AnthropicToolResult, IsErrorIsLabelledForTheModel) {
+    json req = {{"model", "m"},
+                {"max_tokens", 16},
+                {"messages",
+                 json::array({{{"role", "user"},
+                               {"content", json::array({{{"type", "tool_result"},
+                                                         {"tool_use_id", "toolu_1"},
+                                                         {"is_error", true},
+                                                         {"content", "connection refused"}}})}}})}};
+    json oai = anthropic_to_openai_body(req);
+    bool found = false;
+    for (const auto& m : oai["messages"]) {
+        if (m.value("role", "") == "tool") {
+            found = true;
+            EXPECT_EQ(m["content"], "[tool error] connection refused");
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(AnthropicToolResult, SuccessfulResultIsUnlabelled) {
+    json req = {{"model", "m"},
+                {"max_tokens", 16},
+                {"messages", json::array({{{"role", "user"},
+                                           {"content", json::array({{{"type", "tool_result"},
+                                                                     {"tool_use_id", "toolu_1"},
+                                                                     {"content", "ok"}}})}}})}};
+    json oai = anthropic_to_openai_body(req);
+    for (const auto& m : oai["messages"])
+        if (m.value("role", "") == "tool")
+            EXPECT_EQ(m["content"], "ok");
 }

--- a/tests/test_server_request_limits.cpp
+++ b/tests/test_server_request_limits.cpp
@@ -184,4 +184,67 @@ TEST(SystemFingerprint, AnEmptyModelNameStillProducesOne) {
     EXPECT_NE(f, system_fingerprint("x"));
 }
 
+// ---------------------------------------------------------------------------
+// The Anthropic error envelope (#1551, #1556, #1561)
+// ---------------------------------------------------------------------------
+
+TEST(AnthropicEnvelope, PathDecidesTheShape) {
+    EXPECT_TRUE(is_anthropic_path("/v1/messages"));
+    EXPECT_TRUE(is_anthropic_path("/v1/messages/count_tokens"));
+    EXPECT_FALSE(is_anthropic_path("/v1/chat/completions"));
+    EXPECT_FALSE(is_anthropic_path("/v1/completions"));
+}
+
+// A 429 came back in the OpenAI shape on /v1/messages, so an Anthropic SDK
+// could not classify it: no top-level "type":"error" (#1551).
+TEST(AnthropicEnvelope, DialectErrorPicksTheRightWrapper) {
+    httplib::Response anth;
+    send_dialect_error(anth, "/v1/messages", 429, "rate_limit_error", "overloaded_error", "busy");
+    json a = json::parse(anth.body);
+    EXPECT_EQ(a["type"], "error");
+    EXPECT_EQ(a["error"]["type"], "overloaded_error");
+    EXPECT_EQ(anth.status, 429);
+
+    httplib::Response oai;
+    send_dialect_error(oai, "/v1/chat/completions", 429, "rate_limit_error", "overloaded_error", "busy");
+    json o = json::parse(oai.body);
+    EXPECT_FALSE(o.contains("type"));
+    EXPECT_EQ(o["error"]["type"], "rate_limit_error");
+}
+
+TEST(AnthropicEnvelope, RequestIdRidesBodyAndHeader) {
+    httplib::Response res;
+    send_anthropic_error(res, 500, "api_error", "boom", "req_imp_0000000000000001");
+    json j = json::parse(res.body);
+    EXPECT_EQ(j["request_id"], "req_imp_0000000000000001");
+    EXPECT_EQ(res.get_header_value("request-id"), "req_imp_0000000000000001");
+}
+
+TEST(AnthropicEnvelope, NoRequestIdMeansNoKeyAndNoHeader) {
+    httplib::Response res;
+    send_anthropic_error(res, 400, "invalid_request_error", "bad");
+    json j = json::parse(res.body);
+    EXPECT_FALSE(j.contains("request_id"));
+    EXPECT_FALSE(res.has_header("request-id"));
+}
+
+// server_error and capacity_error are this server's inventions; neither is an
+// Anthropic error type, and both reached SDK clients verbatim (#1556).
+TEST(AnthropicEnvelope, TypeTranslationCoversTheInventedOnes) {
+    EXPECT_STREQ(anthropic_error_type_for("server_error", 500), "api_error");
+    EXPECT_STREQ(anthropic_error_type_for("capacity_error", 503), "overloaded_error");
+    // The name decides, not the status: at 500 the fallback would answer
+    // api_error anyway, so only a 4xx proves the mapping is doing the work.
+    EXPECT_STREQ(anthropic_error_type_for("server_error", 400), "api_error");
+    EXPECT_STREQ(anthropic_error_type_for("capacity_error", 429), "overloaded_error");
+    // Already-valid types pass through.
+    EXPECT_STREQ(anthropic_error_type_for("invalid_request_error", 400), "invalid_request_error");
+    EXPECT_STREQ(anthropic_error_type_for("rate_limit_error", 429), "rate_limit_error");
+    EXPECT_STREQ(anthropic_error_type_for("not_found_error", 404), "not_found_error");
+    // Unknown: the status decides, so nothing outside the set can escape.
+    EXPECT_STREQ(anthropic_error_type_for("something_new", 500), "api_error");
+    EXPECT_STREQ(anthropic_error_type_for("something_new", 422), "invalid_request_error");
+    EXPECT_STREQ(anthropic_error_type_for("", 500), "api_error");
+}
+
 }  // namespace

--- a/tests/test_stream_pipeline.cpp
+++ b/tests/test_stream_pipeline.cpp
@@ -78,6 +78,45 @@ TEST(Holdback, EmptyBufferFlushesNothing) {
 // Stop-sequence holdback across chunk boundaries.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Which stop sequence matched (#1550), and where.
+// ---------------------------------------------------------------------------
+
+TEST(Holdback, ReportsWhichStopSequenceMatched) {
+    std::string pending = "hello</tool>rest";
+    auto d = holdback_decision(pending, 7, {"</tool>"});
+    ASSERT_TRUE(d.complete_match);
+    EXPECT_EQ(d.matched_index, 0);
+    EXPECT_EQ(d.flush_len, 5u);
+}
+
+TEST(Holdback, NoMatchLeavesTheIndexUnset) {
+    std::string pending = "hello";
+    auto d = holdback_decision(pending, 7, {"</tool>"});
+    EXPECT_FALSE(d.complete_match);
+    EXPECT_EQ(d.matched_index, -1);
+}
+
+// The list order used to decide, so with {"B", "A"} on "xAyB" the cut landed at
+// offset 3 and the reported sequence was "B" - while the text the model
+// produced ended at "A", offset 1. The documented contract always said "first
+// occurrence".
+TEST(Holdback, EarliestOccurrenceWinsNotListOrder) {
+    std::string pending = "xAyB";
+    auto d = holdback_decision(pending, 1, {"B", "A"});
+    ASSERT_TRUE(d.complete_match);
+    EXPECT_EQ(d.flush_len, 1u);
+    EXPECT_EQ(d.matched_index, 1);  // "A"
+}
+
+TEST(Holdback, EmptyStopSequenceIsSkippedNotMatched) {
+    std::string pending = "abc";
+    auto d = holdback_decision(pending, 3, {"", "c"});
+    ASSERT_TRUE(d.complete_match);
+    EXPECT_EQ(d.matched_index, 1);
+    EXPECT_EQ(d.flush_len, 2u);
+}
+
 TEST(Holdback, HoldsBackPotentialPartialPrefix) {
     // stop="STOP" (len 4) -> max_stop_len 4. Buffer "helloST" could still grow
     // into "...STOP", so keep the last (4-1)=3 bytes ("lST"... actually the
@@ -104,26 +143,25 @@ TEST(Holdback, CompleteMatchFlushesPrefixAndSignalsStop) {
     EXPECT_EQ(d.flush_len, 3u);  // "abc"; the stop and "xyz" are dropped
 }
 
-TEST(Holdback, FirstStopInListOrderWins) {
-    // Contract (mirrors handlers.cpp's loop): stops are tried in LIST order and
-    // the first one that occurs anywhere wins — NOT the earliest position. Here
-    // "STOP" (list index 0) is found at byte 7 and reported even though "END"
-    // sits earlier at byte 2. This is intentional: it matches the production
-    // loop `for (stop : stops) { if (find(stop)) break; }`.
+// This used to assert the opposite - "stops are tried in LIST order and the
+// first one that occurs anywhere wins, NOT the earliest position ... this is
+// intentional" - and it was pinning the loop, not a requirement: the function's
+// own contract two screens up always said "byte offset of the FIRST such
+// occurrence", and list order shipped the text BETWEEN the two stops, which the
+// model was never supposed to have generated past. Both orders now cut at byte
+// 2 (#1550, found while making the matched sequence reportable).
+TEST(Holdback, EarliestOccurrenceWinsWhicheverOrderTheListIsIn) {
     std::vector<std::string> stops = {"STOP", "END"};
     auto d = holdback_decision("hiENDxxSTOP", 4, stops);
     EXPECT_TRUE(d.complete_match);
-    EXPECT_EQ(d.flush_len, 7u);  // flush up to "STOP" at byte 7 -> "hiENDxx"
-}
+    EXPECT_EQ(d.flush_len, 2u);  // "hi", cut at "END"
+    EXPECT_EQ(d.matched_index, 1);
 
-TEST(Holdback, EarlierListEntryMatchesAtItsPosition) {
-    // When the FIRST list entry ("END") does occur, its position (byte 2) is the
-    // flush length, regardless of a later-listed stop. Confirms the loop returns
-    // on the first list entry, at that entry's own match position.
-    std::vector<std::string> stops = {"END", "STOP"};
-    auto d = holdback_decision("hiENDxxSTOP", 4, stops);
-    EXPECT_TRUE(d.complete_match);
-    EXPECT_EQ(d.flush_len, 2u);  // "hi"
+    std::vector<std::string> reversed = {"END", "STOP"};
+    auto d2 = holdback_decision("hiENDxxSTOP", 4, reversed);
+    EXPECT_TRUE(d2.complete_match);
+    EXPECT_EQ(d2.flush_len, 2u);
+    EXPECT_EQ(d2.matched_index, 0);
 }
 
 TEST(StreamSim, StopMatchSplitAcrossChunksIsCaught) {

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -183,6 +183,14 @@ void push_user_turn(json& out, const json& anth_msg) {
                 body += "[" + std::to_string(n_images) +
                         " image(s) from this tool result follow in the next user message]";
             }
+            // is_error was read by nothing, so a tool that failed reached the
+            // model as an ordinary successful result and it went on as if the
+            // call had worked (#1557). OpenAI's role:"tool" turn has no field
+            // for this - the content IS the channel - so the failure is
+            // labelled in the text, which is what the model reads either way.
+            if (block.value("is_error", false)) {
+                body = body.empty() ? "[tool error]" : "[tool error] " + body;
+            }
             tool_results.push_back({
                 {"role", "tool"},
                 {"tool_call_id", block.value("tool_use_id", "")},
@@ -501,7 +509,29 @@ std::string tool_call_id_to_anthropic(const std::string& openai_id) {
     return std::string("toolu_") + openai_id;
 }
 
-json openai_to_anthropic_response(const json& oai, const std::string& anth_model) {
+const char* anthropic_stop_reason(const std::string& openai_finish, bool stop_sequence_matched) {
+    if (openai_finish == "stop")
+        return stop_sequence_matched ? "stop_sequence" : "end_turn";
+    if (openai_finish == "length")
+        return "max_tokens";
+    if (openai_finish == "tool_calls")
+        return "tool_use";
+    // Anthropic's name for the same thing. "content_filter" is OpenAI's and is
+    // not in Anthropic's stop_reason enum, so it used to pass through as an
+    // unknown value.
+    if (openai_finish == "content_filter")
+        return "refusal";
+    // "cancelled" is a client disconnect and "capacity" an admission refusal.
+    // Neither is an Anthropic stop_reason, and "capacity" used to ship verbatim
+    // on the streaming path while the non-streaming path answered 503 for the
+    // same condition (#1552). The stream cannot change its status once
+    // message_start is out, so it ends the turn and reports the fault as an
+    // `error` event (#1553).
+    return "end_turn";
+}
+
+json openai_to_anthropic_response(const json& oai, const std::string& anth_model,
+                                  const std::string& stop_sequence) {
     // Pass through OpenAI error envelopes unchanged but flip the type.
     if (oai.contains("error")) {
         return {
@@ -564,17 +594,7 @@ json openai_to_anthropic_response(const json& oai, const std::string& anth_model
 
     // Map finish_reason -> stop_reason.
     std::string finish = choice.value("finish_reason", "stop");
-    std::string stop_reason;
-    if (finish == "stop")
-        stop_reason = "end_turn";
-    else if (finish == "length")
-        stop_reason = "max_tokens";
-    else if (finish == "tool_calls")
-        stop_reason = "tool_use";
-    else if (finish == "cancelled")
-        stop_reason = "end_turn";
-    else
-        stop_reason = finish;  // pass through
+    std::string stop_reason = anthropic_stop_reason(finish, !stop_sequence.empty());
 
     json usage_out = {
         {"input_tokens", 0},
@@ -623,7 +643,7 @@ json openai_to_anthropic_response(const json& oai, const std::string& anth_model
         {"content", std::move(content)},
         {"model", anth_model},
         {"stop_reason", std::move(stop_reason)},
-        {"stop_sequence", nullptr},
+        {"stop_sequence", stop_sequence.empty() ? json(nullptr) : json(stop_sequence)},
         {"usage", std::move(usage_out)},
     };
 }

--- a/tools/imp-server/anthropic.h
+++ b/tools/imp-server/anthropic.h
@@ -24,7 +24,20 @@ json anthropic_to_openai_body(const json& anth);
 // `anth_model` is the model name passed in the original Anthropic request
 // (used verbatim in the response — Anthropic clients expect the name they
 // sent, not whatever alias the OpenAI side resolved to).
-json openai_to_anthropic_response(const json& oai, const std::string& anth_model);
+// `stop_sequence` is the text that ended the generation, when one did. OpenAI's
+// finish_reason "stop" means both "the model ended its turn" and "a stop
+// sequence matched"; Anthropic reports them as end_turn and stop_sequence, and
+// names the matched text (#1550). The caller reads it off the shim
+// (g_shim_stop_sequence) or the stream loop result.
+json openai_to_anthropic_response(const json& oai, const std::string& anth_model,
+                                  const std::string& stop_sequence = {});
+
+// OpenAI finish_reason -> Anthropic stop_reason, in one place because the
+// streaming and non-streaming paths had two copies that disagreed: the
+// streaming one passed the engine's "capacity" straight through as a
+// stop_reason, which is not in Anthropic's enum (#1552), and neither could
+// produce "stop_sequence" (#1550).
+const char* anthropic_stop_reason(const std::string& openai_finish, bool stop_sequence_matched);
 
 // Generate an Anthropic message id (msg_XXXX). Uses the same atomic counter
 // semantics as make_completion_id; callers pass in a fresh integer.

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -36,6 +36,17 @@ std::string make_completion_id(ServerState& state) {
     return "imp-" + std::to_string(state.next_id.fetch_add(1));
 }
 
+// The id a client quotes when reporting a problem, and the one that ties a
+// response to its line in the JSONL request log. No error body carried one and
+// no response carried the header (#1561). Same counter as the completion id, so
+// the two cannot collide.
+std::string make_request_id(ServerState& state) {
+    char buf[48];
+    std::snprintf(buf, sizeof(buf), "req_imp_%016llx",
+                  static_cast<unsigned long long>(state.next_id.fetch_add(1)));
+    return std::string(buf);
+}
+
 int64_t unix_timestamp() {
     return std::chrono::duration_cast<std::chrono::seconds>(
                std::chrono::system_clock::now().time_since_epoch())

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -224,6 +224,10 @@ extern std::atomic<httplib::Server*> g_server;
 
 void signal_handler(int sig);
 std::string make_completion_id(ServerState& state);
+
+// A `req_imp_...` id for one HTTP request: set as the `request-id` response
+// header and echoed in Anthropic error bodies (#1561).
+std::string make_request_id(ServerState& state);
 int64_t unix_timestamp();
 
 std::vector<std::pair<std::string, std::string>> scan_gguf_files(const std::string& dir);

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -37,6 +37,15 @@
 // so the Anthropic call only logs once at the outer handler.
 thread_local bool g_in_anthropic_shim = false;
 
+// The stop sequence that ended the last non-streaming generation on this
+// thread, or empty. The Anthropic shim runs the OpenAI handler in-process and
+// reads its JSON body back, and that body has no field for this - OpenAI's
+// finish_reason "stop" covers both "the model ended its turn" and "a stop
+// sequence matched". Anthropic distinguishes the two (#1550), so the fact
+// travels beside the body rather than inside it, the same way the log-suppress
+// flag above does.
+thread_local std::string g_shim_stop_sequence;
+
 // Write one JSONL line capturing this request: timing, endpoint, raw client
 // body, token counts, finish reason, and (for non-streaming) the response.
 // Streaming responses pass an empty `response_body` since per-chunk text is
@@ -715,6 +724,7 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
     // For n > 1, run multiple independent generations sequentially
     json choices = json::array();
     int total_output_tokens = 0;
+    g_shim_stop_sequence.clear();
 
     for (int ci = 0; ci < ctx.params.n_completions; ci++) {
         // For subsequent completions, create a new request and submit it
@@ -735,6 +745,7 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
         std::vector<int32_t> output_ids;
         const char* finish = nullptr;
         std::string output_text;  // accumulated output for stop matching
+        std::string matched_stop;  // which stop sequence ended it, for the Anthropic shim (#1550)
 
         auto ns_request_start = std::chrono::steady_clock::now();
         for (;;) {
@@ -807,16 +818,25 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
             if (!ctx.params.stop_sequences.empty()) {
                 output_text += ctx.snap.tok->decode_token(token);
                 bool stop_found = false;
+                // Earliest occurrence, and remember which one: the Anthropic
+                // shim reports the matched sequence (#1550), and taking the
+                // first list entry that occurs anywhere cuts at the wrong
+                // offset when two stops are present.
+                size_t best = std::string::npos;
                 for (const auto& stop : ctx.params.stop_sequences) {
                     auto pos = output_text.find(stop);
-                    if (pos != std::string::npos) {
-                        output_text = output_text.substr(0, pos);
-                        stop_found = true;
-                        break;
+                    if (pos != std::string::npos && (best == std::string::npos || pos < best)) {
+                        best = pos;
+                        matched_stop = stop;
                     }
+                }
+                if (best != std::string::npos) {
+                    output_text = output_text.substr(0, best);
+                    stop_found = true;
                 }
                 if (stop_found) {
                     finish = "stop";
+                    g_shim_stop_sequence = matched_stop;
                     break;
                 }
             }

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -206,6 +206,11 @@ inline nlohmann::json prompt_tokens_details_(const std::shared_ptr<imp::Request>
 // call only logs once at the outer handler. Defined in handlers_chat_core.cpp.
 extern thread_local bool g_in_anthropic_shim;
 
+// Set by the non-streaming path to the stop sequence that ended the
+// generation, empty otherwise. Read by the Anthropic shim, which cannot
+// recover it from the OpenAI body (#1550).
+extern thread_local std::string g_shim_stop_sequence;
+
 // ---------------------------------------------------------------------------
 // Shared server-private helpers (definitions split across handlers_*.cpp).
 // ---------------------------------------------------------------------------

--- a/tools/imp-server/handlers_messages.cpp
+++ b/tools/imp-server/handlers_messages.cpp
@@ -87,6 +87,7 @@ enum class AnthBlock { NONE, THINKING, TEXT, TOOL_USE };
 bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
                                   const std::shared_ptr<ServerRequest>& server_req,
                                   const std::string& anth_model, const std::string& msg_id) {
+    namespace anth = imp_server::anthropic;
     AnthropicSSE out{sink};
     auto active_req = server_req->request;
     int n_prompt_tokens = ctx.snap.n_prompt_tokens;
@@ -194,7 +195,6 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
             return false;
         ++block_index;
         open_block = AnthBlock::TOOL_USE;
-        namespace anth = imp_server::anthropic;
         return out.emit("content_block_start",
                         json{{"type", "content_block_start"},
                              {"index", block_index},
@@ -266,18 +266,24 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     // Close any block still open.
     stop_block();
 
-    // Map finish_reason -> Anthropic stop_reason.
-    std::string stop_reason;
-    if (strcmp(res.finish, "stop") == 0)
-        stop_reason = "end_turn";
-    else if (strcmp(res.finish, "length") == 0)
-        stop_reason = "max_tokens";
-    else if (strcmp(res.finish, "tool_calls") == 0)
-        stop_reason = "tool_use";
-    else if (strcmp(res.finish, "cancelled") == 0)
-        stop_reason = "end_turn";
-    else
-        stop_reason = res.finish;
+    // Map finish_reason -> Anthropic stop_reason, through the same function the
+    // non-streaming builder uses. This copy passed "capacity" through verbatim
+    // (#1552) and could not report a stop-sequence match (#1550).
+    const std::string stop_reason = anth::anthropic_stop_reason(res.finish, !res.stop_sequence.empty());
+
+    // A fault that ends the stream is an `error` event, not a completed turn
+    // (#1553). The status line is long gone by here, so the event is the only
+    // way to say the answer is not the model's: a server-side timeout used to
+    // arrive as stop_reason "max_tokens", indistinguishable from the model
+    // reaching its budget, and an admission refusal as "capacity", which is not
+    // an Anthropic stop_reason at all.
+    if (res.error_type) {
+        out.emit("error", json{{"type", "error"},
+                               {"error", {{"type", res.error_type}, {"message", res.error_message}}}});
+        sink.done();
+        finish_stream_accounting_(state, ctx, active_req, res, msg_id, "messages stream: ");
+        return true;
+    }
 
     // ---- message_delta + message_stop ------------------------------------
     // Cache accounting is only known after prefill ran, so it rides on the
@@ -294,7 +300,9 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     }
     out.emit("message_delta",
              json{{"type", "message_delta"},
-                  {"delta", {{"stop_reason", stop_reason}, {"stop_sequence", nullptr}}},
+                  {"delta",
+                   {{"stop_reason", stop_reason},
+                    {"stop_sequence", res.stop_sequence.empty() ? json(nullptr) : json(res.stop_sequence)}}},
                   {"usage", std::move(delta_usage)}});
     out.emit("message_stop", json{{"type", "message_stop"}});
     sink.done();
@@ -309,9 +317,16 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
 // Non-streaming reuses the OpenAI path via a shim; streaming drives the real
 // per-token loop above.
 // ===========================================================================
-static void handle_messages_impl(const httplib::Request& req, httplib::Response& res, ServerState& state);
+static void handle_messages_impl(const httplib::Request& req, httplib::Response& res, ServerState& state,
+                                 const std::string& request_id);
 
 void handle_messages(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+    // One id for this request, on every answer this endpoint gives - success or
+    // error (#1561). It is what a client quotes in a bug report and what ties
+    // the response to its line in the JSONL log.
+    const std::string request_id = make_request_id(state);
+    res.set_header("request-id", request_id);
+
     // Any exception escaping the impl — notably from the inner
     // handle_chat_completions shim on the non-streaming path — must return the
     // Anthropic error envelope ({"type":"error",...}), not the OpenAI-shaped one
@@ -319,19 +334,19 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
     // fail to parse (#891). res is untouched by the shim (it writes a separate
     // shim_res) when the throw propagates, so it is safe to rewrite here.
     try {
-        handle_messages_impl(req, res, state);
+        handle_messages_impl(req, res, state, request_id);
     } catch (const std::exception& e) {
-        res.status = 500;
-        json err = {{"type", "error"}, {"error", {{"type", "server_error"}, {"message", e.what()}}}};
-        res.set_content(dump_safe(err), "application/json");
+        // api_error, not server_error: the latter is not one of Anthropic's
+        // error types, so an SDK switching on it lands in its default branch
+        // (#1556).
+        send_anthropic_error(res, 500, "api_error", e.what(), request_id);
     } catch (...) {
-        res.status = 500;
-        json err = {{"type", "error"}, {"error", {{"type", "server_error"}, {"message", "internal error"}}}};
-        res.set_content(dump_safe(err), "application/json");
+        send_anthropic_error(res, 500, "api_error", "internal error", request_id);
     }
 }
 
-static void handle_messages_impl(const httplib::Request& req, httplib::Response& res, ServerState& state) {
+static void handle_messages_impl(const httplib::Request& req, httplib::Response& res, ServerState& state,
+                                 const std::string& request_id) {
     namespace anth = imp_server::anthropic;
 
     // Capture original Anthropic request data for opt-in JSONL logging.
@@ -351,21 +366,14 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     try {
         anth_body = json::parse(req.body);
     } catch (const std::exception& e) {
-        res.status = 400;
-        json err = {{"type", "error"},
-                    {"error",
-                     {{"type", "invalid_request_error"},
-                      {"message", std::string("Invalid JSON: ") + e.what()}}}};
-        res.set_content(dump_safe(err), "application/json");
+        send_anthropic_error(res, 400, "invalid_request_error", std::string("Invalid JSON: ") + e.what(),
+                             request_id);
         return;
     }
 
     if (!anth_body.is_object()) {
-        res.status = 400;
-        json err = {{"type", "error"},
-                    {"error",
-                     {{"type", "invalid_request_error"}, {"message", "Request body must be a JSON object"}}}};
-        res.set_content(dump_safe(err), "application/json");
+        send_anthropic_error(res, 400, "invalid_request_error", "Request body must be a JSON object",
+                             request_id);
         return;
     }
 
@@ -379,12 +387,8 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     try {
         oai_body = anth::anthropic_to_openai_body(anth_body);
     } catch (const std::exception& e) {
-        res.status = 400;
-        json err = {{"type", "error"},
-                    {"error",
-                     {{"type", "invalid_request_error"},
-                      {"message", std::string("Failed to transform Anthropic body: ") + e.what()}}}};
-        res.set_content(dump_safe(err), "application/json");
+        send_anthropic_error(res, 400, "invalid_request_error",
+                             std::string("Failed to transform Anthropic body: ") + e.what(), request_id);
         return;
     }
 
@@ -440,11 +444,8 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
         {
             std::lock_guard<std::timed_mutex> lock(state.mtx);
             if (!state.batching || !state.batching->is_running()) {
-                res.status = 503;
-                json err = {{"type", "error"},
-                            {"error",
-                             {{"type", "server_error"}, {"message", "Inference engine not ready. Please retry."}}}};
-                res.set_content(dump_safe(err), "application/json");
+                send_anthropic_error(res, 503, "overloaded_error",
+                                     "Inference engine not ready. Please retry.", request_id);
                 return;
             }
             state.batching->submit(server_req);
@@ -486,15 +487,25 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     // a real error we should forward.
     const bool is_error = shim_res.status >= 400;
     if (is_error) {
-        res.status = shim_res.status;
-        json parsed;
+        // The shim answers in the OpenAI dialect, and its `type` was forwarded
+        // verbatim inside the Anthropic envelope - so `capacity_error` and
+        // `server_error`, neither of which Anthropic defines, reached SDK
+        // clients (#1556). Translate; keep param/code, which are additive.
+        json inner;
         try {
-            parsed = json::parse(shim_res.body);
+            inner = json::parse(shim_res.body).value("error", json::object());
         } catch (...) {
-            parsed = {{"error", {{"message", shim_res.body}, {"type", "server_error"}}}};
+            inner = json::object();
         }
-        json out = {{"type", "error"},
-                    {"error", parsed.value("error", json{{"type", "server_error"}, {"message", "unknown"}})}};
+        const std::string msg = inner.value("message", shim_res.body.empty() ? "unknown" : shim_res.body);
+        const std::string oai_type = inner.value("type", "");
+        json e = {{"type", anthropic_error_type_for(oai_type, shim_res.status)}, {"message", msg}};
+        if (inner.contains("code") && !inner["code"].is_null())
+            e["code"] = inner["code"];
+        if (inner.contains("param") && !inner["param"].is_null())
+            e["param"] = inner["param"];
+        json out = {{"type", "error"}, {"error", std::move(e)}, {"request_id", request_id}};
+        res.status = shim_res.status;
         res.set_content(dump_safe(out), "application/json");
         return;
     }
@@ -503,16 +514,15 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     try {
         oai_response = json::parse(shim_res.body);
     } catch (const std::exception& e) {
-        res.status = 500;
-        json err = {{"type", "error"},
-                    {"error",
-                     {{"type", "server_error"},
-                      {"message", std::string("Upstream returned non-JSON: ") + e.what()}}}};
-        res.set_content(dump_safe(err), "application/json");
+        send_anthropic_error(res, 500, "api_error", std::string("Upstream returned non-JSON: ") + e.what(),
+                             request_id);
         return;
     }
 
-    json anth_response = anth::openai_to_anthropic_response(oai_response, anth_model);
+    // The shim's OpenAI body cannot say which stop sequence ended the
+    // generation; the handler that matched it left the answer beside the body
+    // (#1550).
+    json anth_response = anth::openai_to_anthropic_response(oai_response, anth_model, g_shim_stop_sequence);
 
     // JSONL log — built from Anthropic shapes so /v1/messages clients see
     // exactly what they sent and what they got back.

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -228,9 +228,11 @@ int main(int argc, char** argv) {
             const std::string ip = state.rate_limit_key(req.remote_addr,
                                                         req.get_header_value("X-Forwarded-For"));
             if (!state.check_rate_limit(ip)) {
-                res.status = 429;
-                json err = {{"error", {{"message", "Rate limit exceeded"}, {"type", "rate_limit_error"}}}};
-                res.set_content(err.dump(), "application/json");
+                // Both dialects call this rate_limit_error; only the envelope
+                // differs, and this site shipped the OpenAI one to every
+                // endpoint (#1551).
+                send_dialect_error(res, req.path, 429, "rate_limit_error", "rate_limit_error",
+                                   "Rate limit exceeded");
                 return httplib::Server::HandlerResponse::Handled;
             }
         }
@@ -244,11 +246,11 @@ int main(int argc, char** argv) {
                     queue = state.batching->queue_depth();
             }
             if (queue >= state.max_concurrent) {
-                res.status = 429;
-                json err = {{"error",
-                             {{"message", "Server overloaded, too many concurrent requests"},
-                              {"type", "rate_limit_error"}}}};
-                res.set_content(err.dump(), "application/json");
+                // Anthropic's name for "too many in flight right now" is
+                // overloaded_error (529 upstream; the status here stays 429,
+                // which is what this server's own docs and clients expect).
+                send_dialect_error(res, req.path, 429, "rate_limit_error", "overloaded_error",
+                                   "Server overloaded, too many concurrent requests");
                 return httplib::Server::HandlerResponse::Handled;
             }
         }
@@ -262,16 +264,8 @@ int main(int argc, char** argv) {
             std::string auth = req.get_header_value("Authorization");
             std::string xkey = req.get_header_value("x-api-key");
             if (!api_key_matches(auth, xkey, state.api_key)) {
-                res.status = 401;
-                json err;
-                if (req.path.rfind("/v1/messages", 0) == 0) {
-                    err = {{"type", "error"},
-                           {"error", {{"type", "authentication_error"}, {"message", "Invalid API key"}}}};
-                } else {
-                    err = {{"error",
-                            {{"message", "Invalid API key"}, {"type", "invalid_request_error"}}}};
-                }
-                res.set_content(err.dump(), "application/json");
+                send_dialect_error(res, req.path, 401, "invalid_request_error", "authentication_error",
+                                   "Invalid API key");
                 return httplib::Server::HandlerResponse::Handled;
             }
         }
@@ -376,18 +370,18 @@ int main(int argc, char** argv) {
     // those to 400. Everything else is a genuine internal failure → 500, but
     // still with a JSON body. dump_safe (inside send_json_error) guarantees the
     // envelope itself can't throw on bad bytes.
-    svr.set_exception_handler(
-        [](const httplib::Request&, httplib::Response& res, std::exception_ptr ep) {
-            try {
-                std::rethrow_exception(std::move(ep));
-            } catch (const nlohmann::json::exception& e) {
-                send_json_error(res, 400, "invalid_request_error", e.what());
-            } catch (const std::exception& e) {
-                send_json_error(res, 500, "server_error", e.what());
-            } catch (...) {
-                send_json_error(res, 500, "server_error", "unknown internal error");
-            }
-        });
+    svr.set_exception_handler([](const httplib::Request& req, httplib::Response& res, std::exception_ptr ep) {
+        try {
+            std::rethrow_exception(std::move(ep));
+        } catch (const nlohmann::json::exception& e) {
+            send_dialect_error(res, req.path, 400, "invalid_request_error", "invalid_request_error",
+                               e.what());
+        } catch (const std::exception& e) {
+            send_dialect_error(res, req.path, 500, "server_error", "api_error", e.what());
+        } catch (...) {
+            send_dialect_error(res, req.path, 500, "server_error", "api_error", "unknown internal error");
+        }
+    });
 
     // Any error response that would go out with an empty body gets the same
     // JSON envelope every handler uses. The reachable case is an unmatched
@@ -409,18 +403,14 @@ int main(int argc, char** argv) {
         const std::string msg = not_found ? "Unknown endpoint: " + sanitize_for_echo(req.method, 16) + " " +
                                                 sanitize_for_echo(req.path, 128)
                                           : "Request failed with status " + std::to_string(res.status);
-        if (req.path.rfind("/v1/messages", 0) == 0) {
-            json err = {{"type", "error"},
-                        {"error",
-                         {{"type", not_found ? "not_found_error" : "invalid_request_error"},
-                          {"message", msg}}}};
-            res.set_content(dump_safe(err), "application/json");
-        } else {
-            json err = {
-                {"error",
-                 {{"message", msg}, {"type", res.status >= 500 ? "server_error" : "invalid_request_error"}}}};
-            res.set_content(dump_safe(err), "application/json");
-        }
+        // api_error, not server_error: the latter is not an Anthropic error
+        // type (#1556).
+        const char* anthropic_type = not_found           ? "not_found_error"
+                                     : res.status >= 500 ? "api_error"
+                                                         : "invalid_request_error";
+        const char* openai_type = res.status >= 500 ? "server_error" : "invalid_request_error";
+        const int status = res.status;
+        send_dialect_error(res, req.path, status, openai_type, anthropic_type, msg);
         return httplib::Server::HandlerResponse::Handled;
     });
 

--- a/tools/imp-server/stream_driver.cpp
+++ b/tools/imp-server/stream_driver.cpp
@@ -198,6 +198,9 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
                     "token budget - see imp_requests_timed_out_total",
                     state.request_timeout);
                 finish = "length";
+                out.error_type = "timeout_error";
+                out.error_message = "request exceeded the server's --request-timeout of " +
+                                    std::to_string(state.request_timeout) + " s";
                 break;
             }
         }
@@ -471,6 +474,8 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
                 return false;
             if (hd.complete_match) {
                 text_stop_matched = true;
+                if (hd.matched_index >= 0 && static_cast<size_t>(hd.matched_index) < stop_sequences.size())
+                    out.stop_sequence = stop_sequences[hd.matched_index];
                 finish = "stop";
                 break;
             }
@@ -543,6 +548,17 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
         finish = out.tool_calls_emitted ? "tool_calls" : "length";
     else if (out.tool_calls_emitted && std::strcmp(finish, "stop") == 0)
         finish = "tool_calls";
+
+    // The engine's "capacity" reaches here from four emission sites in
+    // batching_engine.cpp. Non-streaming answers 503 for the same condition;
+    // the stream cannot, so it says so in an `error` event instead of shipping
+    // "capacity" as a stop_reason no dialect defines (#1552, #1553).
+    if (std::strcmp(finish, "capacity") == 0 && !out.error_type) {
+        out.error_type = "overloaded_error";
+        out.error_message =
+            "the KV pool cannot hold this request; it was admitted and then dropped. "
+            "Shorten the prompt or retry when the server is less loaded.";
+    }
     out.finish = finish;
     return true;
 }

--- a/tools/imp-server/stream_driver.h
+++ b/tools/imp-server/stream_driver.h
@@ -66,6 +66,20 @@ struct StreamDialect {
 // (see StreamDialect::emit_content_token / on_call_begin).
 struct StreamLoopResult {
     const char* finish = nullptr;
+    // The stop sequence that ended the generation, empty otherwise. The
+    // Anthropic wire format reports it (`stop_reason: "stop_sequence"`,
+    // `stop_sequence: "<text>"`); with only `finish = "stop"` to go on, a stop
+    // match was indistinguishable from the model ending its turn (#1550).
+    std::string stop_sequence;
+    // Set when the stream ended on a server-side fault rather than on the
+    // model finishing. The Anthropic dialect turns this into an `error` SSE
+    // event; without it a timeout arrived as stop_reason "max_tokens" and an
+    // admission refusal as "capacity", both reading as a completed turn
+    // (#1552, #1553). `error_type` is an Anthropic error type; null means no
+    // fault. The OpenAI dialect ignores both: its finish_reason enum has no
+    // member for either, which is deliberate (#1590).
+    const char* error_type = nullptr;
+    std::string error_message;
     int n_output_tokens = 0;
     int n_reasoning_tokens = 0;
     double ttft_ms = 0.0;

--- a/tools/imp-server/stream_pipeline.h
+++ b/tools/imp-server/stream_pipeline.h
@@ -52,6 +52,11 @@ inline size_t utf8_complete_len(const std::string& s) {
 struct HoldbackDecision {
     bool complete_match = false;  // a full stop sequence is present in the buffer
     size_t flush_len = 0;         // bytes safe to emit now (always <= buffer size)
+    // Index into `stop_sequences` of the sequence that matched, or -1. The
+    // Anthropic wire format reports which stop ended the turn
+    // (`stop_reason: "stop_sequence"`, `stop_sequence: "<text>"`), and it had
+    // nothing to report because the match was a bool (#1550).
+    int matched_index = -1;
 };
 
 // Decide how much of `pending` may be flushed.
@@ -72,15 +77,26 @@ struct HoldbackDecision {
 inline HoldbackDecision holdback_decision(const std::string& pending, size_t max_stop_len,
                                           const std::vector<std::string>& stop_sequences) {
     HoldbackDecision d;
-    for (const auto& stop : stop_sequences) {
+    // The EARLIEST occurrence, not the first sequence in the list that happens
+    // to occur anywhere: with stops {"B", "A"} on "xAyB" the list order used to
+    // cut at "B" (offset 3) and report "B", while the text the model produced
+    // ended at "A" (offset 1). The contract above always said "first
+    // occurrence"; only the loop disagreed.
+    size_t best = std::string::npos;
+    for (size_t i = 0; i < stop_sequences.size(); i++) {
+        const std::string& stop = stop_sequences[i];
         if (stop.empty())
             continue;
         size_t pos = pending.find(stop);
-        if (pos != std::string::npos) {
-            d.complete_match = true;
-            d.flush_len = pos;  // pos <= size, no clamp needed
-            return d;
+        if (pos != std::string::npos && (best == std::string::npos || pos < best)) {
+            best = pos;
+            d.matched_index = static_cast<int>(i);
         }
+    }
+    if (best != std::string::npos) {
+        d.complete_match = true;
+        d.flush_len = best;  // best <= size, no clamp needed
+        return d;
     }
     if (pending.size() > max_stop_len) {
         size_t safe = pending.size() - max_stop_len + 1;

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -59,15 +59,8 @@ bool reject_body_too_deep(const httplib::Request& req, httplib::Response& res) {
     if (req.body.empty() || json_nesting_depth(req.body, kMaxBodyNesting) <= kMaxBodyNesting)
         return false;
 
-    res.status = 400;
-    const char* msg = "request body nests deeper than 100 levels";
-    json err;
-    if (req.path.rfind("/v1/messages", 0) == 0) {
-        err = {{"type", "error"}, {"error", {{"type", "invalid_request_error"}, {"message", msg}}}};
-    } else {
-        err = {{"error", {{"message", msg}, {"type", "invalid_request_error"}}}};
-    }
-    res.set_content(err.dump(), "application/json");
+    send_dialect_error(res, req.path, 400, "invalid_request_error", "invalid_request_error",
+                       "request body nests deeper than 100 levels");
     return true;
 }
 
@@ -165,6 +158,50 @@ void send_json_error(httplib::Response& res, int status, const char* type, const
     json err = {{"error", std::move(e)}};
     res.status = status;
     res.set_content(dump_safe(err), "application/json");
+}
+
+bool is_anthropic_path(const std::string& path) { return path.rfind("/v1/messages", 0) == 0; }
+
+void send_anthropic_error(httplib::Response& res, int status, const char* type, const std::string& message,
+                          const std::string& request_id) {
+    json e = {{"type", type}, {"message", message}};
+    json err = {{"type", "error"}, {"error", std::move(e)}};
+    if (!request_id.empty()) {
+        err["request_id"] = request_id;
+        res.set_header("request-id", request_id);
+    }
+    res.status = status;
+    res.set_content(dump_safe(err), "application/json");
+}
+
+const char* anthropic_error_type_for(std::string_view openai_type, int status) {
+    // Anthropic's complete set. A type already in it passes through; the two
+    // this server invented do not (#1556).
+    static constexpr const char* kAnthropicTypes[] = {"invalid_request_error", "authentication_error",
+                                                      "billing_error",         "permission_error",
+                                                      "not_found_error",       "request_too_large",
+                                                      "rate_limit_error",      "api_error",
+                                                      "overloaded_error",      "timeout_error"};
+    for (const char* t : kAnthropicTypes)
+        if (openai_type == t)
+            return t;
+    if (openai_type == "capacity_error")
+        return "overloaded_error";
+    if (openai_type == "server_error")
+        return "api_error";
+    return status >= 500 ? "api_error" : "invalid_request_error";
+}
+
+void send_dialect_error(httplib::Response& res, const std::string& path, int status, const char* openai_type,
+                        const char* anthropic_type, const std::string& message,
+                        const std::string& request_id) {
+    if (is_anthropic_path(path)) {
+        send_anthropic_error(res, status, anthropic_type, message, request_id);
+        return;
+    }
+    if (!request_id.empty())
+        res.set_header("request-id", request_id);
+    send_json_error(res, status, openai_type, message);
 }
 
 bool answer_lost_to_reasoning(bool has_tool_calls, const std::string& content, const std::string& reasoning) {

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -106,6 +106,41 @@ size_t utf8_chunk_len(const std::string& s, size_t off, size_t max);
 void send_json_error(httplib::Response& res, int status, const char* type, const std::string& message,
                      const char* param = nullptr, const char* code = nullptr);
 
+// True for the endpoints that speak the Anthropic dialect, whose errors have a
+// different envelope: `{"type":"error","error":{...}}` rather than
+// `{"error":{...}}`. Four call sites in main.cpp used to spell this test out
+// and two more forgot it, so a 429 on /v1/messages came back in the OpenAI
+// shape and no Anthropic SDK could classify it (#1551).
+bool is_anthropic_path(const std::string& path);
+
+// The Anthropic error envelope, with `request_id` when one is known.
+//
+// `type` must be one of Anthropic's error types - invalid_request_error,
+// authentication_error, billing_error, permission_error, not_found_error,
+// request_too_large, rate_limit_error, api_error, overloaded_error,
+// timeout_error. `server_error` and `capacity_error` are not among them and
+// were being emitted at seven sites (#1556).
+//
+// request_id is what support and log correlation are asked for first; no error
+// body carried one and no response carried a request-id header (#1561).
+void send_anthropic_error(httplib::Response& res, int status, const char* type, const std::string& message,
+                          const std::string& request_id = {});
+
+// Translate an OpenAI-dialect `error.type` into the Anthropic one.
+//
+// The non-streaming /v1/messages path runs through the OpenAI handler and
+// forwards whatever it produced, so `server_error` and `capacity_error` - which
+// are not Anthropic error types - reached Anthropic SDK clients verbatim
+// (#1556). Anything unrecognised falls back on the status: 5xx is api_error,
+// everything else invalid_request_error.
+const char* anthropic_error_type_for(std::string_view openai_type, int status);
+
+// Send whichever envelope `path` calls for. `openai_type` and `anthropic_type`
+// are the two dialects' names for the same condition.
+void send_dialect_error(httplib::Response& res, const std::string& path, int status, const char* openai_type,
+                        const char* anthropic_type, const std::string& message,
+                        const std::string& request_id = {});
+
 // Constant-time Bearer-token check. Returns true iff `authorization` equals
 // "Bearer " + api_key, compared without early-out so response timing cannot leak
 // the key prefix (std::string::operator== short-circuits on the first differing


### PR DESCRIPTION
Seven issues on one endpoint, one theme: `/v1/messages` answered with values
Anthropic's contract does not define, so an SDK could not act on them. Batched
because they share `handlers_messages.cpp`, `anthropic.cpp` and `main.cpp`.

## Measured against a running server

`Qwen3-4B-Instruct-2507-Q8_0.gguf`, `build-dev/imp-server`.

**#1550 - which stop sequence ended the turn**

```
stop_sequences ["4"], non-streaming
  before   stop_reason "end_turn"        stop_sequence null
  after    stop_reason "stop_sequence"   stop_sequence "4"   content "1,2,3,"

same, streaming
  after    message_delta {"stop_reason":"stop_sequence","stop_sequence":"4"}
```

**#1552, #1553 - a mid-stream fault is an event, not a completed turn**

```
--request-timeout 1, streaming
  before   message_delta stop_reason "max_tokens"   (= the model hit its budget)
  after    event: error
           {"type":"timeout_error","message":"request exceeded the server's
             --request-timeout of 1 s"}
```

**#1551 - the 429 envelope**

```
--rate-limit 3, five requests -> 200 200 429 429 429

/v1/messages          {"type":"error","error":{"type":"rate_limit_error",...}}
/v1/chat/completions  {"error":{"type":"rate_limit_error",...}}
```

Before, both were the second shape.

## What changed

| issue | change |
|---|---|
| #1550 | `HoldbackDecision::matched_index` carries the match out of the matcher; the non-streaming loop records it too |
| #1551 | `is_anthropic_path` / `send_dialect_error`: one place decides the envelope. Six sites spelled the test out by hand; the two 429 guards forgot it |
| #1552 | `capacity` no longer ships as a `stop_reason`. Non-streaming answered 503 for the same condition |
| #1553 | `error` SSE event on a server-side fault; the status line is long gone by then |
| #1556 | `server_error` -> `api_error`, `capacity_error` -> `overloaded_error`, `content_filter` -> `refusal`. Unknown types fall back on the status, so nothing outside the enum can escape |
| #1557 | `tool_result.is_error` is labelled in the tool content. A failed tool reached the model as a success |
| #1561 | `request-id` header on every response from the endpoint, repeated as `request_id` in error bodies |

## A pinned test that was pinning the implementation

Making the match reportable exposed that the matcher took the first **list
entry** occurring anywhere rather than the **earliest occurrence**: with stops
`{"STOP","END"}` on `"hiENDxxSTOP"` it cut at byte 7 and shipped `"hiENDxx"` -
text the model was never supposed to have generated past. The test asserting
that said "this is intentional", while the function's own contract two screens
above said "byte offset of the FIRST such occurrence". Both paths cut at the
earliest now, and the test asserts the same answer for both list orders.

## Not in this PR

- **#1541** (`content[0]` is a thinking block): imp is contract-correct here.
  Anthropic's own extended-thinking responses put `thinking` before `text`. What
  makes it surprising is the default `think_budget` of 0.5, which is #1539.
- **#1555** (thinking signatures), **#1558** (100 ms wait before
  `message_start`), **#1559**, **#1560**, **#1562**: the second half of the
  Anthropic surface, next batch.

## Tests

15 new CPU cases: holdback matching and the matched index, the stop_reason
mapping (including the values that must never ship), both error envelopes,
`request_id` presence and absence, `is_error`.

Mutation-checked per `tests/CLAUDE.md`:

```
drop the stop_sequence branch           -> StopWithASequenceNamesIt fails
drop the server_error -> api_error line -> SURVIVED at status 500
```

The second one survived because the fallback answers `api_error` at 5xx anyway,
so the assertion moved to status 400, where only the mapping can produce it.
The mutant is caught there.

CPU lane: 7/7, test-core 1153 passed. Mock API suite: 85 passed, 32 skipped.
