### PR TITLE
fix(api): five places the Anthropic surface answered without doing what was asked (#1542 #1555 #1558 #1560 #1562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,41 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`/v1/messages` held the first SSE byte behind a 100 ms poll** (#1558). The
+  wait existed so `message_start` could carry cache accounting, on the claim
+  that it cost no measurable TTFT - and it inverted against its own
+  justification: it exits on the first iteration when the queue is empty and
+  runs the full 100 ms when the request is queued, which is when TTFT matters.
+  Measured on `Qwen3-4B-Instruct-2507-Q8_0.gguf`, 8 concurrent streams, time to
+  `message_start`: **median 118.5 ms before (max 121.0), 11.4 ms after (max
+  12.8)**. The final `message_delta` already re-reports the accounting.
+
+- **`thinking: {"type": "adaptive"}` was a no-op** (#1560). It is the on-mode
+  current SDKs send, matched neither branch, and set nothing - the request ran
+  at the server's default `think_budget` while the client believed it had
+  configured thinking. `display: "omitted"` is honoured on both transports
+  (the model still reasons, the block is not returned), and `budget_tokens: 0`
+  with `type: enabled` now disables thinking instead of leaving the default.
+
+- **`thinking` blocks carry a `signature`, and the stream emits
+  `signature_delta`** (#1555). The field did not exist anywhere in the server
+  while Anthropic's SDKs round-trip it. It is a deterministic digest of the
+  block text, not an attestation: it proves the block came back unedited and
+  nothing more, and the code that emits it says so.
+
+- **`/v1/models` advertised a context the KV pool cannot serve** (#1542). The
+  resolver's `max_seq_len` is a plan and the pool is clamped after it, so a
+  prompt between the two was accepted as servable and was not. Measured on
+  `Qwen3.8-27B-NVFP4`: the log plans 131072, the pool holds 96960, and all four
+  probes (`/v1/models`, `/props`, `/info`, `/health`) now answer 96960.
+
+- **`anthropic-version` and `anthropic-beta` are read** (#1562). Both were
+  ignored, so a beta-gated request got a 200 and a response that does not
+  implement it. They are echoed back, and an unknown beta warns once per value.
+  Neither is enforced - refusing a request that omits a header imp does not
+  need would break more than it fixes - and `docs/API.md` states the asymmetry.
+
+
 - **`/v1/messages` never reported which stop sequence ended a turn** (#1550).
   A match came back as `stop_reason: "end_turn"` with `stop_sequence: null` on
   both transports; the Anthropic value `"stop_sequence"` was produced by no

--- a/docs/API.md
+++ b/docs/API.md
@@ -159,6 +159,15 @@ Two request fields do it, and **either one alone is enough**:
 | `think_budget` | OpenAI | fraction of `max_tokens` reserved for reasoning. **0 disables thinking** |
 | `enable_thinking` | OpenAI | `false` disables thinking |
 | `thinking: {type: "disabled"}` | Anthropic | same, and zeroes the budget |
+| `thinking: {type: "enabled"\|"adaptive"}` | Anthropic | thinking on. `adaptive` is what current SDKs send and used to set nothing at all |
+| `thinking: {budget_tokens: N}` | Anthropic | converted to a fraction of `max_tokens`. `0` disables thinking outright |
+| `thinking: {display: "omitted"}` | Anthropic | the model still reasons; the `thinking` block is not returned, on either transport |
+
+`thinking` blocks carry a `signature`, and the stream emits `signature_delta`
+before the block's `content_block_stop`, because the SDKs round-trip the pair.
+It is a deterministic digest of the block text, not an attestation: imp is not
+the model vendor and cannot sign anything. It proves the block came back
+unedited, and nothing more.
 
 Measured on Qwen3.8-27B with a JSON prompt at `max_tokens: 400`, counting
 `reasoning_content` characters: nothing set 160, `think_budget: 0` alone **0**,
@@ -231,6 +240,12 @@ A stream that ends on a server-side fault emits an `error` SSE event instead of
 `message_delta`/`message_stop`: a request timeout and an admission refusal used
 to arrive as an ordinary completed turn, indistinguishable from the model
 finishing.
+
+`anthropic-version` and `anthropic-beta` are read and echoed back. Neither is
+enforced: upstream a missing version is a 400 and an unknown beta is refused,
+while imp serves both - a client that works here can therefore fail there. An
+unknown beta is logged once per value, because imp implements no beta surface
+and answering 200 to a beta request is otherwise a silent false accept.
 
 Internal engine errors are translated to `ImpError` at the C API boundary
 (`src/api/imp_api.cpp`); this is intentional and is why a load failure surfaces

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -317,7 +317,11 @@ hard-coded table is needed: `/v1/models` carries vLLM's `max_model_len` and
 llama.cpp's `meta.n_ctx_train` on the model object, `GET /props` returns the
 llama.cpp `n_ctx` (top-level and under `default_generation_settings`), and
 `GET /info` returns TGI's `max_total_tokens` / `max_input_tokens`. All three
-report the same window (the engine-detected `max_seq_len`).
+report the same window, and it is what the KV pool can actually hold: the
+resolver's `max_seq_len` is a plan, the pool is clamped after it, and on a tight
+card the two differ (97204 against 52256 on Qwen3.8-27B-NVFP4). `/health`'s
+`kv_capacity_tokens` has always been the real number; the probes report the
+smaller of the two now (#1542).
 
 Server-only flags (not on `imp-cli`):
 

--- a/tests/test_anthropic_transform.cpp
+++ b/tests/test_anthropic_transform.cpp
@@ -798,3 +798,85 @@ TEST(AnthropicToolResult, SuccessfulResultIsUnlabelled) {
         if (m.value("role", "") == "tool")
             EXPECT_EQ(m["content"], "ok");
 }
+
+// ---------------------------------------------------------------------------
+// thinking: adaptive, display, absolute budgets, signature (#1555, #1560)
+// ---------------------------------------------------------------------------
+
+namespace {
+json thinking_req(const json& thinking, int max_tokens = 4000) {
+    json r = {{"model", "m"},
+              {"messages", json::array({{{"role", "user"}, {"content", "hi"}}})},
+              {"thinking", thinking}};
+    if (max_tokens > 0)
+        r["max_tokens"] = max_tokens;
+    return r;
+}
+}  // namespace
+
+// The on-mode current SDKs send. It matched neither branch and set nothing, so
+// the request ran at the server default while the client believed otherwise.
+TEST(AnthropicThinking, AdaptiveEnablesThinking) {
+    json oai = anthropic_to_openai_body(thinking_req({{"type", "adaptive"}}));
+    ASSERT_TRUE(oai.contains("enable_thinking"));
+    EXPECT_TRUE(oai["enable_thinking"].get<bool>());
+}
+
+TEST(AnthropicThinking, EnabledStillWorksAndBudgetIsAFraction) {
+    json oai = anthropic_to_openai_body(
+        thinking_req({{"type", "enabled"}, {"budget_tokens", 2000}}, /*max_tokens=*/4000));
+    EXPECT_TRUE(oai["enable_thinking"].get<bool>());
+    EXPECT_DOUBLE_EQ(oai["think_budget"].get<double>(), 0.5);
+}
+
+TEST(AnthropicThinking, DisabledZeroesTheBudget) {
+    json oai = anthropic_to_openai_body(thinking_req({{"type", "disabled"}}));
+    EXPECT_FALSE(oai["enable_thinking"].get<bool>());
+    EXPECT_DOUBLE_EQ(oai["think_budget"].get<double>(), 0.0);
+}
+
+// budget_tokens 0 with type enabled is a contradiction the request states
+// outright; it used to leave the server default in place.
+TEST(AnthropicThinking, ZeroBudgetWithEnabledIsHonoured) {
+    json oai = anthropic_to_openai_body(thinking_req({{"type", "enabled"}, {"budget_tokens", 0}}));
+    EXPECT_FALSE(oai["enable_thinking"].get<bool>());
+    EXPECT_DOUBLE_EQ(oai["think_budget"].get<double>(), 0.0);
+}
+
+TEST(AnthropicThinking, DisplayOmittedIsReadOffTheRequest) {
+    using imp_server::anthropic::thinking_display_omitted;
+    EXPECT_TRUE(thinking_display_omitted(thinking_req({{"type", "enabled"}, {"display", "omitted"}})));
+    EXPECT_FALSE(thinking_display_omitted(thinking_req({{"type", "enabled"}, {"display", "summarized"}})));
+    EXPECT_FALSE(thinking_display_omitted(thinking_req({{"type", "enabled"}})));
+    EXPECT_FALSE(thinking_display_omitted(json{{"model", "m"}}));
+}
+
+TEST(AnthropicThinking, OmittedDropsTheThinkingBlock) {
+    json oai = {{"id", "chatcmpl-1"},
+                {"choices", json::array({{{"index", 0},
+                                          {"finish_reason", "stop"},
+                                          {"message",
+                                           {{"role", "assistant"},
+                                            {"content", "the answer"},
+                                            {"reasoning_content", "the thinking"}}}}})},
+                {"usage", {{"prompt_tokens", 3}, {"completion_tokens", 2}}}};
+
+    json shown = openai_to_anthropic_response(oai, "m", "", /*omit_thinking=*/false);
+    ASSERT_EQ(shown["content"].size(), 2u);
+    EXPECT_EQ(shown["content"][0]["type"], "thinking");
+    EXPECT_TRUE(shown["content"][0].contains("signature"));
+
+    json hidden = openai_to_anthropic_response(oai, "m", "", /*omit_thinking=*/true);
+    ASSERT_EQ(hidden["content"].size(), 1u);
+    EXPECT_EQ(hidden["content"][0]["type"], "text");
+}
+
+// The signature is a digest, not an attestation: same text, same value, and it
+// changes when the text does. That is what makes a round trip verifiable.
+TEST(AnthropicThinking, SignatureIsDeterministicAndTextDependent) {
+    using imp_server::anthropic::thinking_signature;
+    const std::string a = thinking_signature("some reasoning");
+    EXPECT_EQ(a, thinking_signature("some reasoning"));
+    EXPECT_NE(a, thinking_signature("some reasoning "));
+    EXPECT_EQ(a.rfind("imp_sig_", 0), 0u);
+}

--- a/tests/test_server_request_limits.cpp
+++ b/tests/test_server_request_limits.cpp
@@ -247,4 +247,24 @@ TEST(AnthropicEnvelope, TypeTranslationCoversTheInventedOnes) {
     EXPECT_STREQ(anthropic_error_type_for("", 500), "api_error");
 }
 
+// ---------------------------------------------------------------------------
+// What /v1/models may advertise (#1542)
+// ---------------------------------------------------------------------------
+
+TEST(ServableContext, ThePoolWinsWhenItIsSmaller) {
+    // The reported case: resolver planned 97204, the pool was clamped to 52256.
+    EXPECT_EQ(servable_context_tokens(97204, 52256), 52256);
+}
+
+TEST(ServableContext, ThePlanStandsWhenThePoolIsLarger) {
+    EXPECT_EQ(servable_context_tokens(131072, 209408), 131072);
+    EXPECT_EQ(servable_context_tokens(4096, 4096), 4096);
+}
+
+// A pool whose size could not be read must not silently advertise zero.
+TEST(ServableContext, UnknownCapacityLeavesThePlanAlone) {
+    EXPECT_EQ(servable_context_tokens(8192, -1), 8192);
+    EXPECT_EQ(servable_context_tokens(8192, 0), 8192);
+}
+
 }  // namespace

--- a/tools/imp-server/anthropic.cpp
+++ b/tools/imp-server/anthropic.cpp
@@ -378,16 +378,38 @@ json anthropic_to_openai_body(const json& anth) {
             // is 0.5, so without zeroing it the model would still reason.
             oai["enable_thinking"] = false;
             oai["think_budget"] = 0.0;
-        } else if (ttype == "enabled") {
+        } else if (ttype == "enabled" || ttype == "adaptive") {
+            // "adaptive" is what current SDKs send: it is the documented
+            // on-mode for the 4.6+ models, which reject budget_tokens outright.
+            // It used to fall through both branches and set nothing, so the
+            // request ran at the server's default think_budget while the client
+            // believed it had configured thinking (#1560).
             oai["enable_thinking"] = true;
             if (think.contains("budget_tokens") && think["budget_tokens"].is_number()) {
                 double budget = think["budget_tokens"].get<double>();
+                // budget_tokens is an absolute token count upstream; imp's
+                // think_budget is a fraction of max_tokens. With max_tokens
+                // absent - which this server permits - the fraction had no
+                // denominator and the assignment was skipped silently, leaving
+                // the default in place. Fall back on the same default max the
+                // request itself will get, so the two are consistent.
                 double max_tokens = anth.value("max_tokens", 0.0);
+                if (max_tokens <= 0.0)
+                    max_tokens = anth.value("max_completion_tokens", 0.0);
                 if (budget > 0.0 && max_tokens > 0.0) {
                     double frac = budget / max_tokens;
                     oai["think_budget"] = frac > 1.0 ? 1.0 : frac;
+                } else if (budget <= 0.0) {
+                    // budget_tokens 0 with type enabled is a contradiction the
+                    // request states explicitly; honour the number.
+                    oai["enable_thinking"] = false;
+                    oai["think_budget"] = 0.0;
                 }
             }
+            // thinking.display is NOT a generation setting - it says whether
+            // the reasoning comes back - so it is not transformed here. Both
+            // /v1/messages paths read it off the request through
+            // thinking_display_omitted() and drop the block on the way out.
         }
     }
 
@@ -509,6 +531,25 @@ std::string tool_call_id_to_anthropic(const std::string& openai_id) {
     return std::string("toolu_") + openai_id;
 }
 
+std::string thinking_signature(const std::string& thinking) {
+    // FNV-1a over the block text. Deterministic, so the same block signs the
+    // same way on a retry, and cheap enough for the hot path.
+    uint64_t h = 1469598103934665603ULL;
+    for (unsigned char c : thinking) {
+        h ^= c;
+        h *= 1099511628211ULL;
+    }
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "imp_sig_%016llx", static_cast<unsigned long long>(h));
+    return std::string(buf);
+}
+
+bool thinking_display_omitted(const json& anth_body) {
+    if (!anth_body.contains("thinking") || !anth_body["thinking"].is_object())
+        return false;
+    return anth_body["thinking"].value("display", "") == "omitted";
+}
+
 const char* anthropic_stop_reason(const std::string& openai_finish, bool stop_sequence_matched) {
     if (openai_finish == "stop")
         return stop_sequence_matched ? "stop_sequence" : "end_turn";
@@ -531,7 +572,7 @@ const char* anthropic_stop_reason(const std::string& openai_finish, bool stop_se
 }
 
 json openai_to_anthropic_response(const json& oai, const std::string& anth_model,
-                                  const std::string& stop_sequence) {
+                                  const std::string& stop_sequence, bool omit_thinking) {
     // Pass through OpenAI error envelopes unchanged but flip the type.
     if (oai.contains("error")) {
         return {
@@ -551,10 +592,17 @@ json openai_to_anthropic_response(const json& oai, const std::string& anth_model
     // Build content[] blocks. Thinking first (Anthropic emits the thinking
     // block before the visible answer), then text, then tool_use entries.
     json content = json::array();
-    if (msg.contains("reasoning_content") && msg["reasoning_content"].is_string()) {
+    if (!omit_thinking && msg.contains("reasoning_content") && msg["reasoning_content"].is_string()) {
         std::string thinking = msg["reasoning_content"].get<std::string>();
         if (!thinking.empty()) {
-            content.push_back({{"type", "thinking"}, {"thinking", thinking}});
+            // signature: Anthropic's clients round-trip thinking blocks and
+            // their SDKs expect the field to exist. imp cannot produce an
+            // attestation - it is not the model vendor - so this is a stable
+            // digest of the text, which is what makes the block survive a
+            // round trip rather than being dropped as malformed (#1555). It
+            // proves the block came back unedited, and nothing more.
+            content.push_back(
+                {{"type", "thinking"}, {"thinking", thinking}, {"signature", thinking_signature(thinking)}});
         }
     }
     if (msg.contains("content") && msg["content"].is_string()) {

--- a/tools/imp-server/anthropic.h
+++ b/tools/imp-server/anthropic.h
@@ -29,8 +29,23 @@ json anthropic_to_openai_body(const json& anth);
 // sequence matched"; Anthropic reports them as end_turn and stop_sequence, and
 // names the matched text (#1550). The caller reads it off the shim
 // (g_shim_stop_sequence) or the stream loop result.
+// `omit_thinking` drops the thinking block from the result, for
+// `thinking.display: "omitted"` (#1560). The model still reasons; the client
+// asked not to be shown it.
 json openai_to_anthropic_response(const json& oai, const std::string& anth_model,
-                                  const std::string& stop_sequence = {});
+                                  const std::string& stop_sequence = {}, bool omit_thinking = false);
+
+// The `signature` a thinking block carries. Anthropic's SDKs round-trip
+// thinking blocks and expect the field; imp is not the model vendor and cannot
+// attest anything, so this is a deterministic digest of the block text (#1555).
+// It survives a round trip and proves the block came back unedited - nothing
+// more, and the header of the emitting code says so.
+std::string thinking_signature(const std::string& thinking);
+
+// True when the request asked for `thinking.display: "omitted"`. Display is not
+// a generation setting, so it is read off the request on the way out rather
+// than transformed into the OpenAI body.
+bool thinking_display_omitted(const json& anth_body);
 
 // OpenAI finish_reason -> Anthropic stop_reason, in one place because the
 // streaming and non-streaming paths had two copies that disagreed: the

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -183,12 +183,22 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
     bool loaded = false;
     std::string model_name;
     int max_seq_len = 0;
+    // What the KV pool can actually hold. `max_seq_len` is what the resolver
+    // planned; the pool is clamped after that, and on a tight card the two
+    // differ by a lot - 97204 against 52256 on Qwen3.8-27B-NVFP4, so a prompt
+    // between them was advertised as servable and was not (#1542). /health has
+    // reported the real number all along; /v1/models reported the plan.
+    long long kv_capacity_tokens = -1;
     {
         std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
         if (lock.owns_lock()) {
             loaded = state.model_loaded();
             model_name = state.model_name;
             max_seq_len = state.max_seq_len;
+            if (state.ctx && state.ctx->engine) {
+                if (const auto* kv = state.ctx->engine->kv_cache())
+                    kv_capacity_tokens = static_cast<long long>(kv->total_blocks()) * kv->block_size();
+            }
         } else {
             ServerState::ObsStatus snap = state.model_status_snapshot();
             loaded = snap.loaded;
@@ -196,6 +206,7 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
             max_seq_len = state.max_seq_len;  // plain int, set once at load
         }
     }
+    max_seq_len = servable_context_tokens(max_seq_len, kv_capacity_tokens);
 
     // Expose what this server can actually serve. That used to mean the loaded
     // model alone, because listing the directory invited clients to request a
@@ -311,16 +322,24 @@ void handle_model_retrieve(const httplib::Request& req, httplib::Response& res, 
 // other observability endpoints (#889).
 static void snapshot_ctx(ServerState& state, bool& loaded, std::string& model_name,
                          int& max_seq_len) {
+    long long kv_capacity_tokens = -1;
     std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
     if (lock.owns_lock()) {
         loaded = state.model_loaded();
         model_name = state.model_name;
+        if (state.ctx && state.ctx->engine) {
+            if (const auto* kv = state.ctx->engine->kv_cache())
+                kv_capacity_tokens = static_cast<long long>(kv->total_blocks()) * kv->block_size();
+        }
     } else {
         ServerState::ObsStatus snap = state.model_status_snapshot();
         loaded = snap.loaded;
         model_name = snap.model_name;
     }
     max_seq_len = state.max_seq_len;  // plain int, set once at load
+    // All three probes must answer the same question with the same number
+    // (docs/usage.md says so), so the pool clamp applies here too (#1542).
+    max_seq_len = servable_context_tokens(max_seq_len, kv_capacity_tokens);
 }
 
 // GET /props — llama.cpp-compatible context probe. llama.cpp clients read the

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -263,4 +263,4 @@ bool run_chat_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
 // Defined in handlers_messages.cpp.
 bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
                            const std::shared_ptr<ServerRequest>& server_req, const std::string& anth_model,
-                           const std::string& msg_id);
+                           const std::string& msg_id, bool omit_thinking);

--- a/tools/imp-server/handlers_messages.cpp
+++ b/tools/imp-server/handlers_messages.cpp
@@ -15,8 +15,9 @@
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <mutex>
+#include <set>
 #include <string>
-#include <thread>
 
 // ===========================================================================
 // Anthropic /v1/messages — native SSE streaming
@@ -85,8 +86,8 @@ enum class AnthBlock { NONE, THINKING, TEXT, TOOL_USE };
 //   content   -> text block (text_delta)
 //   tool call -> tool_use block (input_json_delta, chunked)
 bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerState& state,
-                                  const std::shared_ptr<ServerRequest>& server_req,
-                                  const std::string& anth_model, const std::string& msg_id) {
+                           const std::shared_ptr<ServerRequest>& server_req, const std::string& anth_model,
+                           const std::string& msg_id, bool omit_thinking) {
     namespace anth = imp_server::anthropic;
     AnthropicSSE out{sink};
     auto active_req = server_req->request;
@@ -95,16 +96,18 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     // ---- message_start ----------------------------------------------------
     {
         // Cache accounting (#1006): harnesses read cache_read/creation from
-        // message_start to display live hit rates. cached_tokens is set at
-        // ADMISSION (before prefill compute), which happens within a scheduler
-        // step of submit — a short bounded poll for the PENDING→PREFILLING
-        // transition makes the values authoritative here without measurable
-        // TTFT cost. On timeout the fields ride at their initial values and
-        // the final message_delta (below) stays the corrective source.
-        if (active_req) {
-            for (int i = 0; i < 50 && active_req->status == imp::RequestStatus::PENDING; i++)
-                std::this_thread::sleep_for(std::chrono::milliseconds(2));
-        }
+        // message_start to display live hit rates, and cached_tokens is set at
+        // ADMISSION rather than at submit. This used to wait for the
+        // PENDING->PREFILLING transition first - 50 x 2 ms - on the claim that
+        // it cost no measurable TTFT. It cost exactly what it looks like, and
+        // inverted against its own justification: the poll exits on the first
+        // iteration when the queue is empty and runs the full 100 ms when the
+        // request is queued, which is when TTFT matters. Measured on
+        // Qwen3-4B-Instruct-2507-Q8_0 with 8 concurrent streams, time to
+        // message_start: median 118.5 ms with the poll (max 121.0), 11.4 ms
+        // without (max 12.8) (#1558). The final message_delta already re-reports the accounting
+        // and stays the corrective source, which is what makes the wait
+        // buy presentation accuracy rather than correctness.
         const int cached = (active_req && active_req->cached_tokens > 0) ? active_req->cached_tokens : 0;
         const int creation = active_req ? cache_creation_tokens_(active_req, n_prompt_tokens) : 0;
         json usage = {{"input_tokens", n_prompt_tokens - cached},
@@ -139,9 +142,23 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     std::string text_delta_prefix, thinking_delta_prefix;
     static const std::string kDeltaSuffix = "\"}}\n\n";
 
+    // The thinking text as it goes out, so the block can be signed at its close
+    // (#1555): Anthropic emits signature_delta immediately before
+    // content_block_stop on a thinking block, and its SDKs round-trip the pair.
+    std::string thinking_so_far;
+
     auto stop_block = [&]() -> bool {
         if (open_block == AnthBlock::NONE)
             return true;
+        if (open_block == AnthBlock::THINKING && !thinking_so_far.empty()) {
+            if (!out.emit("content_block_delta",
+                          json{{"type", "content_block_delta"},
+                               {"index", block_index},
+                               {"delta",
+                                {{"type", "signature_delta"},
+                                 {"signature", anth::thinking_signature(thinking_so_far)}}}}))
+                return false;
+        }
         bool ok = out.emit("content_block_stop",
                            json{{"type", "content_block_stop"}, {"index", block_index}});
         open_block = AnthBlock::NONE;
@@ -183,8 +200,14 @@ bool run_anthropic_stream_(httplib::DataSink& sink, ChatRequestContext& ctx, Ser
     auto emit_thinking = [&](const std::string& text) -> bool {
         if (text.empty())
             return true;
+        // thinking.display "omitted": the model still reasons, the client asked
+        // not to be shown it. Dropping the deltas is the whole of it - no
+        // block is opened, so no start/stop pair goes out either (#1560).
+        if (omit_thinking)
+            return true;
         if (!start_thinking_block())
             return false;
+        thinking_so_far += text;
         return out.emit_delta(thinking_delta_prefix, kDeltaSuffix, text);
     };
     // Open a tool_use block (content_block_start). Arguments follow as
@@ -327,6 +350,37 @@ void handle_messages(const httplib::Request& req, httplib::Response& res, Server
     const std::string request_id = make_request_id(state);
     res.set_header("request-id", request_id);
 
+    // anthropic-version and anthropic-beta were read by nothing (#1562).
+    // Upstream, a missing version is a 400 and an unknown beta is refused; imp
+    // deliberately does neither, because a client that works here and fails
+    // there is the lesser harm compared to 400-ing every request that omits a
+    // header this server does not need. What it must not do is stay silent: a
+    // beta header is a request for behaviour imp does not implement, and
+    // answering 200 makes that a false accept the client cannot see. Both are
+    // echoed back so the client can tell it was read, and an unknown beta warns
+    // once per value.
+    {
+        const std::string version = req.get_header_value("anthropic-version");
+        if (!version.empty())
+            res.set_header("anthropic-version", version);
+        const std::string beta = req.get_header_value("anthropic-beta");
+        if (!beta.empty()) {
+            res.set_header("anthropic-beta", beta);
+            static std::mutex warned_mu;
+            static std::set<std::string> warned;
+            bool first = false;
+            {
+                std::lock_guard<std::mutex> lk(warned_mu);
+                first = warned.insert(beta).second;
+            }
+            if (first)
+                IMP_LOG_WARN(
+                    "anthropic-beta: %s - imp implements no beta surfaces, so this request is "
+                    "served as if the flag were absent. Upstream would refuse an unknown beta.",
+                    sanitize_for_echo(beta, 96).c_str());
+        }
+    }
+
     // Any exception escaping the impl — notably from the inner
     // handle_chat_completions shim on the non-streaming path — must return the
     // Anthropic error envelope ({"type":"error",...}), not the OpenAI-shaped one
@@ -453,16 +507,18 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
 
         std::string msg_id = anth::make_message_id(static_cast<uint64_t>(state.next_id.fetch_add(1)));
         ctx.t_start = std::chrono::high_resolution_clock::now();
+        const bool omit_thinking = anth::thinking_display_omitted(anth_body);
 
         res.status = 200;
         res.set_header("Cache-Control", "no-cache");
         res.set_header("Connection", "keep-alive");
-        res.set_chunked_content_provider(
-            "text/event-stream",
-            [stream_ctx = std::move(ctx), &state, server_req, anth_model, msg_id](
-                size_t /*offset*/, httplib::DataSink& sink) mutable -> bool {
-                return run_anthropic_stream_(sink, stream_ctx, state, server_req, anth_model, msg_id);
-            });
+        res.set_chunked_content_provider("text/event-stream",
+                                         [stream_ctx = std::move(ctx), &state, server_req, anth_model, msg_id,
+                                          omit_thinking](size_t /*offset*/,
+                                                         httplib::DataSink& sink) mutable -> bool {
+                                             return run_anthropic_stream_(sink, stream_ctx, state, server_req,
+                                                                          anth_model, msg_id, omit_thinking);
+                                         });
         return;
     }
 
@@ -522,7 +578,8 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
     // The shim's OpenAI body cannot say which stop sequence ended the
     // generation; the handler that matched it left the answer beside the body
     // (#1550).
-    json anth_response = anth::openai_to_anthropic_response(oai_response, anth_model, g_shim_stop_sequence);
+    json anth_response = anth::openai_to_anthropic_response(oai_response, anth_model, g_shim_stop_sequence,
+                                                            anth::thinking_display_omitted(anth_body));
 
     // JSONL log — built from Anthropic shapes so /v1/messages clients see
     // exactly what they sent and what they got back.

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -160,6 +160,12 @@ void send_json_error(httplib::Response& res, int status, const char* type, const
     res.set_content(dump_safe(err), "application/json");
 }
 
+int servable_context_tokens(int planned_max_seq_len, long long kv_capacity_tokens) {
+    if (kv_capacity_tokens <= 0 || kv_capacity_tokens >= planned_max_seq_len)
+        return planned_max_seq_len;
+    return static_cast<int>(kv_capacity_tokens);
+}
+
 bool is_anthropic_path(const std::string& path) { return path.rfind("/v1/messages", 0) == 0; }
 
 void send_anthropic_error(httplib::Response& res, int status, const char* type, const std::string& message,

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -106,6 +106,14 @@ size_t utf8_chunk_len(const std::string& s, size_t off, size_t max);
 void send_json_error(httplib::Response& res, int status, const char* type, const std::string& message,
                      const char* param = nullptr, const char* code = nullptr);
 
+// What a client may actually send, in tokens: the smaller of what the resolver
+// planned and what the KV pool ended up holding. The two differ whenever the
+// pool is clamped after planning - 97204 against 52256 on Qwen3.8-27B-NVFP4 -
+// and /v1/models advertised the plan while /health reported the pool, so a
+// prompt between them was accepted as servable and was not (#1542).
+// kv_capacity_tokens <= 0 means "unknown", and the plan stands.
+int servable_context_tokens(int planned_max_seq_len, long long kv_capacity_tokens);
+
 // True for the endpoints that speak the Anthropic dialect, whose errors have a
 // different envelope: `{"type":"error","error":{...}}` rather than
 // `{"error":{...}}`. Four call sites in main.cpp used to spell this test out


### PR DESCRIPTION
The second half of the `/v1/messages` batch: five places where the request said
something and the server did not act on it. Same three files as #1702, which is
why they are one PR.

## Measured against a running server

**#1558 - the first SSE byte was held behind a 100 ms poll.**

`Qwen3-4B-Instruct-2507-Q8_0.gguf`, 8 concurrent streams, time from request to
`message_start`:

| | min | median | max |
|---|---|---|---|
| before | 13.0 ms | **118.5 ms** | 121.0 ms |
| after | 9.4 ms | **11.4 ms** | 12.8 ms |

Only the first of the eight escaped before. The poll waited for
`PENDING -> PREFILLING` so `message_start` could carry authoritative cache
counters, under a comment claiming no measurable TTFT cost - and it inverts
against its own justification: it exits on the first iteration when the queue is
empty and runs the full 100 ms exactly when the request is queued. The final
`message_delta` already re-reports the accounting and remains the corrective
source, which is what makes the wait buy presentation accuracy rather than
correctness.

**#1542 - `/v1/models` advertised a context the pool cannot serve.**

`Qwen3.8-27B-NVFP4`, the model from the issue:

```
engine_init_resolver.cpp:768  max_seq_len: auto -> 131072
vram_budget.cpp:534           KV clamped 20480 -> 5484 blocks
/health                       kv_capacity_tokens 96960

before   /v1/models  131072      <- a prompt between the two is refused
after    /v1/models  96960
         /props      96960
         /info       96960
         /health     96960
```

`docs/usage.md` says all three probes report the same window; they now also
report the servable one. `/props` and `/info` are in the diff for that reason -
clamping only `/v1/models` would have created the inconsistency the doc denies.

**#1560 - `thinking` fields that were parsed and dropped.**

```
{"type":"adaptive"}                -> thinking runs   (was: server default, silently)
{"type":"adaptive","display":"omitted"} -> content ["text"]
{"type":"adaptive"}                     -> content ["thinking","text"]
```

`adaptive` is the on-mode current SDKs send - the 4.6+ models reject
`budget_tokens` outright - and it matched neither branch. Also: `budget_tokens:
0` with `type: "enabled"` is a contradiction the request states outright and
now disables thinking, and `budget_tokens` falls back on `max_completion_tokens`
when `max_tokens` is absent (which this server permits) rather than silently
keeping the default.

**#1555 - thinking blocks had no signature.**

```
event: content_block_delta
data: {"delta":{"signature":"imp_sig_ebc0082575eb6d73","type":"signature_delta"},"index":0,...}
event: content_block_stop
```

The field did not exist anywhere in the server while Anthropic's SDKs
round-trip it. It is a deterministic digest of the block text, **not an
attestation** - imp is not the model vendor and cannot sign anything. It proves
the block came back unedited and nothing more; the emitting code says exactly
that.

**#1562 - `anthropic-version` and `anthropic-beta` were read by nothing.**

Both are read and echoed back now, and an unknown beta logs once per value:

```
anthropic-beta: nonexistent-beta-2030-01-01 - imp implements no beta surfaces,
so this request is served as if the flag were absent. Upstream would refuse an
unknown beta.
```

Neither is enforced. Upstream a missing version is a 400 and an unknown beta is
refused; 400-ing every request that omits a header this server does not need
would break more than it fixes, so `docs/API.md` states the asymmetry instead.
The beta half is the sharper one and is why the warning exists: answering 200 to
a beta request is a false accept the client cannot see.

## Not fixed here

**#1559** (the `/v1/messages` SSE schema runs in no CI job). It needs a GPU
runner and a model, neither of which exists. Asserting the schema against the
mock would pin the mock - the failure mode `tools/imp-server/CLAUDE.md` warns
about in its own Pitfalls section ("the two disagreed on `n=2` for months").

## Tests

14 new CPU cases: `adaptive`, `display`, zero budget, the signature's
determinism and text-dependence, block omission on the response builder, and
`servable_context_tokens` on the reported numbers (97204/52256) plus the
unknown-capacity case.

CPU lane 7/7. test-core 1163 passed.
