### PR TITLE
fix(attn): the YaRN angle, the -1 block-table sentinel, and a tile table that named the wrong Bq (#1630 #1678 #1679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,33 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The YaRN RoPE branch computed its angle in float and never reduced it**
+  (#1630). #1316 fixed exactly this in `rope_forward`'s other two branches; the
+  YaRN one kept calling the fast intrinsics on an unreduced argument, and the
+  long-context regression test could not see it because it runs at the default
+  `ext_factor = 0.0f` and so takes the linear branch. Both halves are fixed -
+  the angle is formed in double at all four call sites and reduced before the
+  intrinsic - and a second test drives the YaRN branch against double truth to
+  position 131071. Against the unfixed kernel it fails at that position.
+
+- **Quantised paged-decode kernels dereferenced the `-1` block-table sentinel**
+  (#1678). StreamingLLM eviction writes it, the FP16 kernel has skipped it as
+  defense-in-depth since #963, and the FP8, FP8-tile, INT8, INT4, NVFP4 and
+  NVFP4-TC twins read it straight into a pointer. 12 guards plus the tiled
+  kernel, which prefetches through a `cp_async` ring and so clamps the address
+  and drops the tokens with its validity mask instead of skipping the block.
+  Measured cost over 10 alternating runs on `Qwen3-8B-Q8_0.gguf` with
+  `--kv-fp8`: **not separable from the noise** - median 384.88 against 396.41
+  tok/s while the arms' own spread is 4.1% and 6.4%, and the guarded arm is
+  faster in 4 of the 10 paired rounds.
+
+- **The FMHA tile table named three `Bq` the selector never picks** (#1679).
+  Its first three branches compare against `max_smem / 2`, so at hd=64 it takes
+  Bq=64 (the comment said 128) and at hd=96 and hd=128 it takes Bq=32 (the
+  comment said 64). Corrected in the kernel comment and in
+  `docs/internals/KERNELS.md`, computed from `compute_smem_sm120` against the
+  measured `cudaDevAttrMaxSharedMemoryPerBlockOptin` of 101376.
+
 - **`/v1/messages` held the first SSE byte behind a 100 ms poll** (#1558). The
   wait existed so `message_start` could carry cache accounting, on the claim
   that it cost no measurable TTFT - and it inverted against its own

--- a/docs/internals/KERNELS.md
+++ b/docs/internals/KERNELS.md
@@ -62,8 +62,25 @@ O_acc       → REGISTERS, not smem (0 KB)
 **The lever that finances Bq=128:** `O_acc` leaves shared memory and lives as
 **MMA accumulator fragments in registers**, held by each warp across the *entire*
 KV loop (true FA2 register-resident). The tiled fallback keeps `O_acc` as a
-`float[Bq×HD]` = 64 KB smem block — which is precisely why it cannot fit Bq=128 in
-99 KB and degrades to Bq=64.
+`float[Bq×HD]` smem block, which is why it cannot fit Bq=128 in 99 KB.
+
+**What the fallback actually picks** (#1679). Its first three branches compare
+against `max_smem / 2`, because two blocks per SM beat a bigger tile at one - so
+the selection is against 50688 bytes, not 101376. Measured on this device
+(`cudaDevAttrMaxSharedMemoryPerBlockOptin` = 101376) and computed from
+`compute_smem_sm120`:
+
+| HD | Bkv | Bq | smem | branch |
+|---|---|---|---|---|
+| 64 | 64 | **64** | 48.5 KB | fits `occ2_cap` (Bq=128 would be 89.0 KB) |
+| 96 | 64 | **32** | 38.2 KB | fits `occ2_cap` (Bq=64 would be 64.5 KB) |
+| 128 | 64 | **32** | 48.2 KB | fits `occ2_cap` (Bq=64 would be 81.0 KB) |
+| 256 | 64 | 32 | 88.2 KB | `max_smem` only, occupancy 1 |
+| 512 | 32 | 16 | 82.1 KB | `max_smem` only, occupancy 1 |
+
+The three bold rows are the ones an earlier version of this section and the
+selector's own comment both got wrong: they named the Bq that fits the **full**
+limit, which is not the one the code takes.
 
 ### MMA: dual-precision, both f16-accumulate
 - **QK^T: `mma.sync.m16n8k16.f16.f16.f16.f16`** (f16 accumulator). Online-softmax

--- a/src/compute/attention_fmha_sm120.cu
+++ b/src/compute/attention_fmha_sm120.cu
@@ -465,12 +465,23 @@ bool fmha_sm120_prefill(const Tensor& Q, const Tensor& K, const Tensor& V, Tenso
     // opt-in; +40% at long context — see the kernel-side comment).
     const int Bkv = (head_dim >= 512) ? 32 : SM120_Bkv;
 
-    // Select Bq based on head_dim and shared memory fit.
-    // Prefer Bq=128 for higher throughput, fall back to 64 for larger HD.
-    // K and V share a single buffer, so smem = Q + KV + S + O_acc + row state.
-    //   HD=64:  Bq=128 -> 89 KB     HD=96:  Bq=64 -> 65 KB
-    //   HD=128: Bq=64  -> 81 KB     HD=256: Bq=32 -> 90 KB
-    //   HD=512: Bq=16  -> 82 KB (Bkv=32; only Bq that fits under the 99 KB opt-in)
+    // Select Bq from head_dim and shared-memory fit. K and V share one buffer,
+    // so smem = Q + KV + S + O_acc + row state (compute_smem_sm120 above).
+    //
+    // The first three branches compare against max_smem/2, not max_smem: two
+    // blocks per SM beat a bigger tile at one. That halving is what the table
+    // has to be read against, and the previous version of this comment was not
+    // - it listed the Bq each head_dim would take against the FULL limit and so
+    // named three Bq the selector never picks (#1679). Computed from
+    // compute_smem_sm120 at max_smem = 101376 (the sm_120 99 KB opt-in), so
+    // occ2_cap = 50688:
+    //
+    //   HD   Bkv   Bq   smem     which branch
+    //   64    64   64   48.5 KB  <= occ2_cap        (128 would be 89.0 KB)
+    //   96    64   32   38.2 KB  <= occ2_cap        (64 would be 64.5 KB)
+    //   128   64   32   48.2 KB  <= occ2_cap        (64 would be 81.0 KB)
+    //   256   64   32   88.2 KB  <= max_smem only   (occupancy 1)
+    //   512   32   16   82.1 KB  <= max_smem only   (occupancy 1)
     int Bq;
     {
         size_t smem_128 = compute_smem_sm120(128, Bkv, head_dim);

--- a/src/compute/attention_paged_fp8.cu
+++ b/src/compute/attention_paged_fp8.cu
@@ -138,6 +138,14 @@ __global__ void paged_attention_splitk_fp8_pipeline_kernel(
 
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 
@@ -340,6 +348,14 @@ __global__ void paged_attention_splitk_fp8_kernel(
     // ---- Iterate over assigned KV blocks ----
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 
@@ -491,6 +507,14 @@ __global__ void paged_attention_decode_fp8_kernel(const half* __restrict__ Q,
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
 

--- a/src/compute/attention_paged_fp8_tile.cu
+++ b/src/compute/attention_paged_fp8_tile.cu
@@ -164,10 +164,17 @@ __global__ void paged_attention_splitk_fp8_tile_kernel(
     const int chunk_begin = split_start * chunks_per_page;
     const int chunk_end = split_end * chunks_per_page;
 
+    // StreamingLLM eviction leaves -1 sentinels in the block table, and a
+    // negative physical block is an OOB read (#1678). This kernel prefetches
+    // through a cp_async ring, so it cannot `continue` past one the way the
+    // non-tiled twins do: the address is clamped into the pool and the tokens
+    // are dropped by the validity mask below instead.
+    auto page_live = [&](int ch) { return bt[ch / chunks_per_page] >= 0; };
     auto chunk_src = [&](int ch, const uint8_t* __restrict__ cache) {
         const int page = ch / chunks_per_page;
         const int slot0 = (ch - page * chunks_per_page) * kTileTokens;
-        return cache + (int64_t)bt[page] * kv_block_stride + slot0 * kv_slot_stride + kv_head_off;
+        const int phys = max(bt[page], 0);
+        return cache + (int64_t)phys * kv_block_stride + slot0 * kv_slot_stride + kv_head_off;
     };
 
     int chunk = chunk_begin + warp_id;
@@ -194,7 +201,7 @@ __global__ void paged_attention_splitk_fp8_tile_kernel(
         int tok_start = chunk * kTileTokens;
         int n_toks = min(ctx_len - tok_start, kTileTokens);
         int first_tok = max(effective_start - tok_start, 0);
-        const bool valid = (my_tok >= first_tok) && (my_tok < n_toks);
+        const bool valid = page_live(chunk) && (my_tok >= first_tok) && (my_tok < n_toks);
 
         // ---- Dot phase: lane (token, dim-half) computes a 64-dim partial ----
         const uint8_t* k_row = k_tiles[cur] + my_tok * kTileRowStride + my_half * (HEAD_DIM / 2);
@@ -381,10 +388,17 @@ __global__ void paged_attention_splitk_fp8_tile_gqa_kernel(
     const int chunk_begin = split_start * chunks_per_page;
     const int chunk_end = split_end * chunks_per_page;
 
+    // StreamingLLM eviction leaves -1 sentinels in the block table, and a
+    // negative physical block is an OOB read (#1678). This kernel prefetches
+    // through a cp_async ring, so it cannot `continue` past one the way the
+    // non-tiled twins do: the address is clamped into the pool and the tokens
+    // are dropped by the validity mask below instead.
+    auto page_live = [&](int ch) { return bt[ch / chunks_per_page] >= 0; };
     auto chunk_src = [&](int ch, const uint8_t* __restrict__ cache) {
         const int page = ch / chunks_per_page;
         const int slot0 = (ch - page * chunks_per_page) * kTileTokens;
-        return cache + (int64_t)bt[page] * kv_block_stride + slot0 * kv_slot_stride + kv_head_off;
+        const int phys = max(bt[page], 0);
+        return cache + (int64_t)phys * kv_block_stride + slot0 * kv_slot_stride + kv_head_off;
     };
 
     const int tid = threadIdx.x;
@@ -419,7 +433,7 @@ __global__ void paged_attention_splitk_fp8_tile_gqa_kernel(
         int tok_start = chunk * kTileTokens;
         int n_toks = min(ctx_len - tok_start, kTileTokens);
         int first_tok = max(effective_start - tok_start, 0);
-        const bool valid = (my_tok >= first_tok) && (my_tok < n_toks);
+        const bool valid = page_live(chunk) && (my_tok >= first_tok) && (my_tok < n_toks);
 
         // ---- Dot phase (identical to the per-head tile kernel) ----
         const uint8_t* k_row = k_tiles[cur] + my_tok * kTileRowStride + my_half * (HEAD_DIM / 2);

--- a/src/compute/attention_paged_int4.cu
+++ b/src/compute/attention_paged_int4.cu
@@ -85,6 +85,14 @@ __global__ void paged_attention_decode_int4_kernel(
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const half* K_sc_block = K_scales + (int64_t)phys_block * scale_block_stride;
@@ -242,6 +250,14 @@ __global__ void paged_attention_splitk_int4_kernel(
     // Iterate over assigned KV blocks
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const half* K_sc_block = K_scales + (int64_t)phys_block * scale_block_stride;
@@ -405,6 +421,14 @@ __global__ void paged_attention_splitk_int4_pipeline_kernel(
 
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const half* K_sc_block = K_scales + (int64_t)phys_block * scale_block_stride;

--- a/src/compute/attention_paged_int8.cu
+++ b/src/compute/attention_paged_int8.cu
@@ -125,6 +125,14 @@ __global__ void paged_attention_splitk_int8_kernel(
     // ---- Iterate over assigned KV blocks ----
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const int8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const int8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const half* K_sc_block = K_scales + (int64_t)phys_block * scale_block_stride;
@@ -340,6 +348,14 @@ __global__ void paged_attention_decode_int8_kernel(
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const int8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const int8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const half* K_sc_block = K_scales + (int64_t)phys_block * scale_block_stride;

--- a/src/compute/attention_paged_nvfp4.cu
+++ b/src/compute/attention_paged_nvfp4.cu
@@ -135,6 +135,14 @@ __global__ void paged_attention_decode_nvfp4_kernel(
 
     for (int blk = first_block + warp_id; blk < num_ctx_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* K_sc_block = K_scales + (int64_t)phys_block * sc_block_stride;
@@ -278,6 +286,14 @@ __global__ void paged_attention_splitk_nvfp4_kernel(
 
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* K_sc_block = K_scales + (int64_t)phys_block * sc_block_stride;

--- a/src/compute/attention_paged_nvfp4_tc.cu
+++ b/src/compute/attention_paged_nvfp4_tc.cu
@@ -185,6 +185,14 @@ __global__ void paged_attention_decode_nvfp4_tc_kernel(
 
     for (int blk = first_block + warp_id; blk < num_paged_blocks; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* K_sc_block = K_scales + (int64_t)phys_block * sc_block_stride;
@@ -683,6 +691,14 @@ __global__ void paged_attention_splitk_nvfp4_tc_kernel(
 
     for (int blk = split_start + warp_id; blk < split_end; blk += NUM_WARPS) {
         int phys_block = bt[blk];
+        // StreamingLLM eviction leaves -1 sentinels in the table; a negative
+        // physical block would be an OOB KV read. The FP16 twin has carried
+        // this since #963 and the quantised ones did not (#1678): host-side
+        // eviction keeps the window range valid, so this is defense-in-depth -
+        // future range drift degrades to a skipped block instead of an illegal
+        // access or silent garbage.
+        if (phys_block < 0)
+            continue;
         const uint8_t* K_block = K_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* V_block = V_cache + (int64_t)phys_block * kv_block_stride;
         const uint8_t* K_sc_block = K_scales + (int64_t)phys_block * sc_block_stride;

--- a/src/compute/mtp_forward.cu
+++ b/src/compute/mtp_forward.cu
@@ -371,8 +371,9 @@ __global__ void mtp_mrope_kernel(
         float c, s;
         if (ext_factor != 0.0f) {
             // YaRN mode: per-dimension frequency blending.
-            float theta_extrap =
-                static_cast<float>(pos) / powf(theta, static_cast<float>(2 * k) / static_cast<float>(rope_dim));
+            double theta_extrap = static_cast<double>(pos) /
+                                  pow(static_cast<double>(theta),
+                                      static_cast<double>(2 * k) / static_cast<double>(rope_dim));
             rope_yarn(theta_extrap, inv_scaling, corr_dim_0, corr_dim_1, 2 * k, ext_factor, attn_factor, c, s);
         } else {
             // Linear mode: frequency = theta^(-2k/rope_dim), scaled by inv_scaling.

--- a/src/compute/rope.cu
+++ b/src/compute/rope.cu
@@ -10,37 +10,8 @@
 
 namespace imp {
 
-// Accurate sin/cos for RoPE (#1316).
-//
-// __sinf/__cosf are the fast intrinsics; NVIDIA specifies their argument
-// reduction as accurate only for |x| < 48039. At pair_idx 0 the frequency is
-// exactly theta^0 = 1.0f, so the angle IS the token position — and the drift is
-// measurable long before that bound: against a CPU reference, max|gpu-cpu| goes
-// 3.0e-6 at position 40, 2.3e-4 at 2000, 1.0e-2 at 131071, the trained context
-// limit. That is above FP16 noise and it lands on the lowest-frequency rotary
-// pair, the one carrying long-range position information.
-//
-// The build is compiled with --use_fast_math (cmake/CompilerFlags.cmake:19),
-// which maps sinf/cosf/sincosf straight back onto the fast intrinsics — so
-// simply calling the accurate names changes nothing (measured: byte-identical
-// error at every position). The reduction has to happen before the call.
-//
-// Doing it in double costs one extra multiply and one floor per element and
-// leaves the intrinsic operating on an argument in [0, 2*pi), where it is
-// accurate. Full double sin/cos would also work but FP64 is 1/64 rate on
-// sm_120, and none of that throughput is needed to fix an argument-reduction
-// problem.
-__device__ __forceinline__ void rope_sincos(double angle_exact, float* s, float* c) {
-    constexpr double kTwoPi = 6.283185307179586476925286766559;
-    constexpr double kInvTwoPi = 0.15915494309189533576888376337251;
-    // Multiply by the reciprocal rather than divide: FP64 division is the
-    // expensive part on sm_120 (1/64 rate), and the reduction does not need
-    // the extra accuracy a true divide would buy.
-    double reduced = fma(-kTwoPi, floor(angle_exact * kInvTwoPi), angle_exact);
-    *s = __sinf(static_cast<float>(reduced));
-    *c = __cosf(static_cast<float>(reduced));
-}
-
+// rope_sincos (the #1316 argument reduction) lives in compute/rope_yarn.cuh,
+// because the YaRN branch needs it too (#1630).
 
 // YaRN device helpers (rope_yarn_ramp / rope_yarn) live in compute/rope_yarn.cuh,
 // shared with the MTP draft head so the two rope paths cannot drift (issue #897).
@@ -117,8 +88,12 @@ __global__ void rope_forward_kernel(T* __restrict__ Q, T* __restrict__ K, const 
         rope_sincos(angle, &sin_val, &cos_val);
     } else if (ext_factor != 0.0f) {
         // YaRN mode: per-dimension frequency blending
-        float theta_extrap = static_cast<float>(pos) /
-                             powf(theta, (2.0f * pair_idx) / static_cast<float>(2 * rope_pairs));
+        // Double, for the same reason the linear branch below is: at the
+        // context limit the position times the frequency does not survive
+        // float (#1630).
+        double theta_extrap = static_cast<double>(pos) /
+                              pow(static_cast<double>(theta),
+                                  (2.0 * pair_idx) / static_cast<double>(2 * rope_pairs));
         rope_yarn(theta_extrap, inv_scaling, corr_dim_0, corr_dim_1, 2 * pair_idx, ext_factor, attn_factor,
                   cos_val, sin_val);
     } else {
@@ -285,7 +260,8 @@ __global__ void qknorm_rope_fused_fp16_kernel(
                 double angle = (double)pos * (double)longrope_inv_freqs[pair];
                 rope_sincos(angle, &sin_val, &cos_val);
             } else if (ext_factor != 0.0f) {
-                float theta_extrap = (float)pos / powf(theta, (2.0f * pair) / (float)(2 * rope_pairs));
+                double theta_extrap = (double)pos /
+                                      pow((double)theta, (2.0 * pair) / (double)(2 * rope_pairs));
                 rope_yarn(theta_extrap, inv_scaling, corr_dim_0, corr_dim_1, 2 * pair, ext_factor,
                           attn_factor, cos_val, sin_val);
             } else {
@@ -347,7 +323,8 @@ __global__ void qknorm_rope_fused_fp16_kernel(
                 double angle = (double)pos * (double)longrope_inv_freqs[pair];
                 rope_sincos(angle, &sin_val, &cos_val);
             } else if (ext_factor != 0.0f) {
-                float theta_extrap = (float)pos / powf(theta, (2.0f * pair) / (float)(2 * rope_pairs));
+                double theta_extrap = (double)pos /
+                                      pow((double)theta, (2.0 * pair) / (double)(2 * rope_pairs));
                 rope_yarn(theta_extrap, inv_scaling, corr_dim_0, corr_dim_1, 2 * pair, ext_factor,
                           attn_factor, cos_val, sin_val);
             } else {

--- a/src/compute/rope.h
+++ b/src/compute/rope.h
@@ -48,8 +48,9 @@ struct MRopeParams {
 // YaRN parameters (ext_factor > 0 enables YaRN blending):
 //   ext_factor:  0 = linear/none, 1.0 = YaRN
 //   attn_factor: mscale for attention (pre-compensated)
-//   corr_dims:   [2] float, dimension boundaries for YaRN ramp
-//                (precomputed by rope_yarn_corr_dims())
+//   corr_dims:   [2] float on the HOST, dimension boundaries for YaRN ramp
+//                (precomputed by rope_yarn_corr_dims()). Read host-side and
+//                passed to the kernel by value - a device pointer here hangs.
 void rope_forward(Tensor& Q, Tensor& K, const int* positions, int head_dim, float theta = 10000.0f,
                   float scaling = 1.0f, int rope_dim = 0, bool neox = false, float ext_factor = 0.0f,
                   float attn_factor = 1.0f, const float* corr_dims = nullptr, cudaStream_t stream = nullptr,

--- a/src/compute/rope_yarn.cuh
+++ b/src/compute/rope_yarn.cuh
@@ -8,6 +8,30 @@
 
 namespace imp {
 
+// Accurate sin/cos for RoPE (#1316).
+//
+// __sinf/__cosf are the fast intrinsics; NVIDIA specifies their argument
+// reduction as accurate only for |x| < 48039. At the lowest-frequency rotary
+// pair the angle IS the token position, and the drift is measurable long
+// before that bound: against a CPU reference, max|gpu-cpu| goes 3.0e-6 at
+// position 40, 2.3e-4 at 2000, 1.0e-2 at 131071. The build is compiled with
+// --use_fast_math, which maps sinf/cosf straight back onto the intrinsics, so
+// the reduction has to happen before the call.
+//
+// It lives here rather than in rope.cu because the YaRN branch needs it too:
+// #1316 reduced two of rope_forward's three branches and left the YaRN one
+// calling the raw intrinsics on an unreduced angle (#1630).
+__device__ __forceinline__ void rope_sincos(double angle_exact, float* s, float* c) {
+    constexpr double kTwoPi = 6.283185307179586476925286766559;
+    constexpr double kInvTwoPi = 0.15915494309189533576888376337251;
+    // Multiply by the reciprocal rather than divide: FP64 division is the
+    // expensive part on sm_120 (1/64 rate), and the reduction does not need
+    // the extra accuracy a true divide would buy.
+    double reduced = fma(-kTwoPi, floor(angle_exact * kInvTwoPi), angle_exact);
+    *s = __sinf(static_cast<float>(reduced));
+    *c = __cosf(static_cast<float>(reduced));
+}
+
 // Linear ramp: 1.0 when i0/2 <= low, 0.0 when i0/2 >= high, linear blend between.
 static __device__ __forceinline__ float rope_yarn_ramp(float low, float high, int i0) {
     float y = (i0 / 2.0f - low) / fmaxf(0.001f, high - low);
@@ -17,20 +41,31 @@ static __device__ __forceinline__ float rope_yarn_ramp(float low, float high, in
 // YaRN frequency blending: blends between interpolated (freq_scale * theta_extrap)
 // and extrapolated (theta_extrap) based on the correction dimension ramp.
 // When ext_factor == 0, reduces to pure linear scaling (theta = freq_scale * theta_extrap).
-static __device__ __forceinline__ void rope_yarn(float theta_extrap, float freq_scale, float corr_dim_0,
+// theta_extrap is a DOUBLE because the angle it carries is the token position
+// scaled by a frequency, and at the context limit that number does not survive
+// float: reducing a float angle in double fixes the intrinsic's argument
+// reduction but not the angle it was handed. The linear branch has formed this
+// product in double since #1316; this one had it in float, which left it 1.3e-3
+// out at position 131071 against double truth after the reduction alone (#1630).
+static __device__ __forceinline__ void rope_yarn(double theta_extrap, float freq_scale, float corr_dim_0,
                                                  float corr_dim_1, int i0, float ext_factor, float mscale,
                                                  float& cos_theta, float& sin_theta) {
-    float theta_interp = freq_scale * theta_extrap;
-    float theta = theta_interp;
+    double theta_interp = static_cast<double>(freq_scale) * theta_extrap;
+    double theta = theta_interp;
 
     if (ext_factor != 0.0f) {
-        float ramp_mix = rope_yarn_ramp(corr_dim_0, corr_dim_1, i0) * ext_factor;
-        theta = theta_interp * (1.0f - ramp_mix) + theta_extrap * ramp_mix;
+        double ramp_mix = static_cast<double>(rope_yarn_ramp(corr_dim_0, corr_dim_1, i0)) *
+                          static_cast<double>(ext_factor);
+        theta = theta_interp * (1.0 - ramp_mix) + theta_extrap * ramp_mix;
         mscale *= 1.0f + 0.1f * logf(1.0f / freq_scale);
     }
 
-    cos_theta = __cosf(theta) * mscale;
-    sin_theta = __sinf(theta) * mscale;
+    // Reduced before the intrinsic, like the other two branches. mscale is
+    // applied after, so the scaling is unchanged.
+    float c, sn;
+    rope_sincos(theta, &sn, &c);
+    cos_theta = c * mscale;
+    sin_theta = sn * mscale;
 }
 
 }  // namespace imp

--- a/tests/test_attention_paged_nvfp4_tc.cu
+++ b/tests/test_attention_paged_nvfp4_tc.cu
@@ -3,6 +3,7 @@
 #include "core/tensor.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <cmath>
 #include <vector>
 
 namespace imp {
@@ -100,6 +101,108 @@ TEST_F(PagedAttentionNvfp4TCTest, LaunchSucceeds_HD128) {
     cudaStreamSynchronize(stream_);
 
     EXPECT_EQ(cudaGetLastError(), cudaSuccess) << "TC kernel launch failed";
+
+    cudaFree(d_Q);
+    cudaFree(d_K);
+    cudaFree(d_V);
+    cudaFree(d_Ks);
+    cudaFree(d_Vs);
+    cudaFree(d_O);
+    cudaFree(d_bt);
+    cudaFree(d_cl);
+}
+
+// A -1 in the block table is what StreamingLLM eviction leaves behind, and a
+// negative physical block turns into a read BEFORE the KV pool. The FP16 twin
+// has skipped those since #963; the quantised kernels dereferenced them
+// unguarded (#1678).
+//
+// The failure this pins is not a wrong number - it is an illegal access, which
+// is sticky: one fault takes every later test in the process down with it
+// (#1699 was 73 failures from one). So the assertion is "no CUDA error and no
+// NaN", and it has to run in a process that has not already faulted.
+TEST_F(PagedAttentionNvfp4TCTest, EvictedBlockSentinelIsSkipped) {
+    constexpr int batch = 1;
+    constexpr int n_heads = 32;
+    constexpr int n_kv_heads = 32;
+    constexpr int HEAD_DIM = 128;
+    constexpr int seqlen_kv = 64;
+    constexpr int block_size = 16;
+    constexpr int n_blocks = (seqlen_kv + block_size - 1) / block_size;
+
+    size_t q_bytes = static_cast<size_t>(batch) * n_heads * HEAD_DIM * sizeof(half);
+    size_t kv_bytes = static_cast<size_t>(n_blocks) * block_size * n_kv_heads * (HEAD_DIM / 2);
+    size_t sc_bytes = static_cast<size_t>(n_blocks) * block_size * n_kv_heads * (HEAD_DIM / 16);
+
+    std::vector<half> h_Q(batch * n_heads * HEAD_DIM, __float2half(0.05f));
+    std::vector<uint8_t> h_K(kv_bytes, 0x42), h_V(kv_bytes, 0x24);
+    std::vector<uint8_t> h_Ks(sc_bytes, 0x20), h_Vs(sc_bytes, 0x20);
+
+    void* d_Q = nullptr;
+    void* d_K = nullptr;
+    void* d_V = nullptr;
+    void* d_Ks = nullptr;
+    void* d_Vs = nullptr;
+    void* d_O = nullptr;
+    int* d_bt = nullptr;
+    int* d_cl = nullptr;
+    cudaMalloc(&d_Q, q_bytes);
+    cudaMalloc(&d_K, kv_bytes);
+    cudaMalloc(&d_V, kv_bytes);
+    cudaMalloc(&d_Ks, sc_bytes);
+    cudaMalloc(&d_Vs, sc_bytes);
+    cudaMalloc(&d_O, q_bytes);
+    cudaMalloc(&d_bt, n_blocks * sizeof(int));
+    cudaMalloc(&d_cl, sizeof(int));
+
+    cudaMemcpy(d_Q, h_Q.data(), q_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_K, h_K.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_V, h_V.data(), kv_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Ks, h_Ks.data(), sc_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_Vs, h_Vs.data(), sc_bytes, cudaMemcpyHostToDevice);
+
+    // Two evicted blocks, both still inside ctx_len - which is the point: a
+    // block past the context would never be read at all.
+    //
+    // -1 is the sentinel the eviction path actually writes. It alone does not
+    // make a good test: the read it produces lands one block BEFORE the pool,
+    // which is still mapped, so the kernel returns quiet garbage rather than
+    // faulting and the assertions below pass either way (measured: this test
+    // was green against the unguarded kernel when -1 was the only entry). The
+    // second entry is far enough out to leave the mapping, so "no negative
+    // block is dereferenced" becomes observable. One guard covers both.
+    std::vector<int> bt(n_blocks);
+    for (int i = 0; i < n_blocks; i++)
+        bt[i] = i;
+    ASSERT_GE(n_blocks, 3);
+    bt[1] = -1;
+    bt[2] = -(1 << 20);
+    cudaMemcpy(d_bt, bt.data(), n_blocks * sizeof(int), cudaMemcpyHostToDevice);
+    int ctx_len = seqlen_kv;
+    cudaMemcpy(d_cl, &ctx_len, sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemset(d_O, 0, q_bytes);
+
+    int64_t Q_shape[] = {batch, 1, n_heads, HEAD_DIM};
+    int64_t KV_shape[] = {n_blocks, block_size, n_kv_heads, HEAD_DIM / 2};
+    Tensor Q_t(d_Q, QType::F16, 4, Q_shape, true);
+    Tensor K_t(d_K, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor V_t(d_V, QType::FP4_E2M1, 4, KV_shape, true);
+    Tensor O_t(d_O, QType::F16, 4, Q_shape, true);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(HEAD_DIM));
+
+    paged_attention_decode_nvfp4_tc(Q_t, K_t, V_t, O_t, static_cast<const uint8_t*>(d_Ks),
+                                    static_cast<const uint8_t*>(d_Vs), d_bt, d_cl, block_size, scale, ctx_len,
+                                    /*sliding_window=*/0, /*softcap=*/0.0f, stream_);
+    cudaStreamSynchronize(stream_);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess) << "a -1 block table entry faulted the kernel";
+
+    std::vector<half> h_O(batch * n_heads * HEAD_DIM);
+    cudaMemcpy(h_O.data(), d_O, q_bytes, cudaMemcpyDeviceToHost);
+    for (size_t i = 0; i < h_O.size(); i++) {
+        const float v = __half2float(h_O[i]);
+        ASSERT_TRUE(std::isfinite(v)) << "output element " << i << " is not finite";
+    }
 
     cudaFree(d_Q);
     cudaFree(d_K);

--- a/tests/test_rope.cu
+++ b/tests/test_rope.cu
@@ -6,6 +6,7 @@
 #include "compute/mtp_forward.h"
 #include <vector>
 #include <cmath>
+#include <algorithm>
 #include <cstdlib>
 #include <numeric>
 
@@ -212,6 +213,84 @@ TEST(RoPETest, LongContextPositionsMatchDoubleReference) {
         Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
         Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
         rope_forward(Q, K, pos_dev, head_dim, theta, scaling);
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        auto q_out = to_host(q_dev, n);
+        auto k_out = to_host(k_dev, n);
+        for (int64_t i = 0; i < n; i++) {
+            EXPECT_NEAR(q_out[i], q_ref[i], kTol) << "Q drifted from double truth at pos=" << pos;
+            EXPECT_NEAR(k_out[i], k_ref[i], kTol) << "K drifted from double truth at pos=" << pos;
+        }
+
+        cudaFree(q_dev);
+        cudaFree(k_dev);
+        cudaFree(pos_dev);
+    }
+}
+
+// =========================================================================
+// The YaRN branch, against DOUBLE truth (#1630).
+//
+// LongContextPositionsMatchDoubleReference above calls rope_forward with the
+// default ext_factor = 0.0f, so it takes the linear branch and cannot reach
+// this one. #1316 reduced the angle before the fast intrinsics in two of
+// rope_forward's three branches and left YaRN calling __sinf/__cosf on an
+// unreduced angle - which is the same defect the test above exists to catch,
+// on the path a long-context model actually takes.
+//
+// The oracle mirrors rope_yarn(): ramp, blend, mscale, all in double.
+// =========================================================================
+TEST(RoPETest, YarnLongContextPositionsMatchDoubleReference) {
+    const int batch = 1, seq_len = 1, n_heads = 1, n_kv_heads = 1, head_dim = 8;
+    const float theta = 10000.0f;
+    const float ext_factor = 1.0f;  // YaRN on
+    const float attn_factor = 1.0f;
+    const float scaling = 0.25f;  // 4x context extension: inv_scaling in the kernel
+    constexpr float kTol = 5e-4f;
+    const std::vector<int> positions = {0, 40, 500, 2000, 8000, 32768, 131071};
+
+    float corr[2];
+    imp::rope_yarn_corr_dims(head_dim, /*n_ctx_orig=*/32768, theta, /*beta_fast=*/32.0f,
+                             /*beta_slow=*/1.0f, corr);
+
+    auto ramp = [](double low, double high, int i0) {
+        double y = (i0 / 2.0 - low) / std::max(0.001, high - low);
+        return 1.0 - std::min(1.0, std::max(0.0, y));
+    };
+
+    for (int pos : positions) {
+        const int64_t n = (int64_t)batch * seq_len * n_heads * head_dim;
+        std::vector<float> q_host(n), k_host(n);
+        fill_linear(q_host);
+        fill_linear(k_host);
+
+        std::vector<float> q_ref(q_host), k_ref(k_host);
+        for (int i = 0; i < head_dim / 2; i++) {
+            // The kernel passes inv_scaling = 1/scaling as rope_yarn's freq_scale
+            // (rope.cu:165, :93), so the oracle must too.
+            const double inv_scaling = 1.0 / (double)scaling;
+            const double theta_extrap = (double)pos / std::pow((double)theta, (2.0 * i) / head_dim);
+            const double theta_interp = inv_scaling * theta_extrap;
+            const double ramp_mix = ramp(corr[0], corr[1], 2 * i) * (double)ext_factor;
+            const double angle = theta_interp * (1.0 - ramp_mix) + theta_extrap * ramp_mix;
+            const double mscale = (double)attn_factor * (1.0 + 0.1 * std::log(1.0 / inv_scaling));
+            const double ca = std::cos(angle) * mscale, sa = std::sin(angle) * mscale;
+            for (auto* v : {&q_ref, &k_ref}) {
+                const float a = (*v)[2 * i], b = (*v)[2 * i + 1];
+                (*v)[2 * i] = (float)(a * ca - b * sa);
+                (*v)[2 * i + 1] = (float)(a * sa + b * ca);
+            }
+        }
+
+        std::vector<int> pos_host = {pos};
+        float* q_dev = to_device(q_host.data(), n);
+        float* k_dev = to_device(k_host.data(), n);
+        int* pos_dev = to_device(pos_host.data(), pos_host.size());
+        Tensor Q = make_device_tensor(q_dev, QType::F32, batch, seq_len, n_heads, head_dim);
+        Tensor K = make_device_tensor(k_dev, QType::F32, batch, seq_len, n_kv_heads, head_dim);
+        // corr_dims is read on the HOST (rope.cu:167), so this is a host array.
+        rope_forward(Q, K, pos_dev, head_dim, theta, scaling, /*rope_dim=*/0, /*neox=*/false, ext_factor,
+                     attn_factor, corr);
         CUDA_CHECK(cudaDeviceSynchronize());
 
         auto q_out = to_host(q_dev, n);

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -126,7 +126,7 @@ def main():
                     help="expected unlaned macro count (default: read PINNED below)")
     args = ap.parse_args()
 
-    PINNED = 973
+    PINNED = 975
 
     text = CMAKE.read_text()
     mods = module_sources(text)

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -66,13 +66,14 @@ roots = ["src", "tools", "tests"]
 "src/compute/attention_fmha_mxfp4_sm120.cu" = { code_loc = 1520, reason = "(c) single MXFP4 FA2 attention kernel family" }
 "src/compute/attention_fmha_sm120.cu" = { code_loc = 1480, reason = "(c) single FA2 attention family (base/fp8/fa2 variants) sharing one smem layout" }
 "src/compute/attention_paged.cu" = { code_loc = 1215, reason = "(c) one paged-attention family: gqa-prefill, decode, splitk, reduce, cluster - shared block/KV layout" }
-"src/compute/attention_paged_nvfp4_tc.cu" = { code_loc = 845, reason = "(c) NVFP4 tensor-core paged-attn family (decode/splitk/reduce) - shared TC path" }
+"src/compute/attention_paged_nvfp4_tc.cu" = { code_loc = 849, reason = "(c) NVFP4 tensor-core paged-attn family (decode/splitk/reduce) - shared TC path" }
+"src/compute/attention_paged_fp8.cu" = { code_loc = 603, reason = "(c) FP8 paged-attn family (decode/splitk/reduce) - same shape as its FP16 and NVFP4 siblings above; crossed 600 by the three -1 sentinel guards of #1678" }
 "src/compute/gemm.cu" = { code_loc = 727, reason = "(c) one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)" }
 "src/compute/gemm_dp4a.cu" = { code_loc = 601, reason = "(c) one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)" }
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = { code_loc = 693, reason = "(c) one small-M grouped-GEMM family (software-ref + prod + smoke variants)" }
 "src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }
 "src/compute/json_schema.cpp" = { code_loc = 1147, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
-"src/compute/mtp_forward.cu" = { code_loc = 855, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
+"src/compute/mtp_forward.cu" = { code_loc = 856, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
 "src/compute/schema_constrain.cu" = { code_loc = 1181, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
 "src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1061, reason = "(c) one path: batched-MoE forward dispatch (host-only)" }


### PR DESCRIPTION
Three attention findings, one subsystem.

## #1630 - the YaRN branch computed its angle in float and never reduced it

#1316 fixed exactly this in `rope_forward`'s other two branches. The YaRN one
kept calling `__sinf`/`__cosf` on an unreduced argument, and the long-context
regression test could not see it: it runs at the default `ext_factor = 0.0f`,
so it takes the linear branch.

**Reducing alone was not enough.** With the reduction in place the kernel was
still 1.3e-3 out at position 131071 against double truth, because the angle
itself - position times frequency - does not survive float there. `theta_extrap`
is `double` at all four call sites now (`rope.cu` x3, `mtp_forward.cu`),
`rope_yarn` blends in double, and `rope_sincos` moved into `rope_yarn.cuh` so
both users share one copy.

The new test sweeps the YaRN branch to 131071 against a double oracle that
mirrors `rope_yarn` (ramp, blend, mscale). Removing the reduction alone turns
it red at exactly that position.

## #1678 - the quantised twins dereferenced the eviction sentinel

StreamingLLM writes `-1`; the FP16 kernel has skipped it since #963 as
defense-in-depth; FP8, FP8-tile, INT8, INT4, NVFP4 and NVFP4-TC read it
straight into a pointer. 12 guards, plus the tiled kernel, which prefetches
through a `cp_async` ring and so cannot `continue` past a block: it clamps the
address into the pool and drops the tokens with its validity mask instead.

**Cost**, 10 alternating runs, `Qwen3-8B-Q8_0.gguf` with `--kv-fp8`, tg128:

| | median | mean | min | max | sd |
|---|---|---|---|---|---|
| guard | 384.88 | 381.14 | 356.01 | 400.28 | 4.1 % |
| no guard | 396.41 | 387.51 | 337.65 | 417.77 | 6.4 % |

The gap between the medians is -2.9 %, each arm's own spread is larger than
that, and **the guarded arm is faster in 4 of the 10 paired rounds**. The sign
flips round to round: this is not separable from the noise.

**The test needed sharpening to be worth anything.** With only `-1` in the
table it passed against the *unguarded* kernel - that read lands one block
before the pool, which is still mapped, so the kernel returns quiet garbage
rather than faulting. A second, far-negative entry leaves the mapping, and then
the unguarded kernel fails with `an illegal memory access was encountered`. One
guard covers both, and the test says why both entries are there.

## #1679 - the tile table described a selector that does not exist

`fmha_sm120_prefill`'s first three branches compare against `max_smem / 2`, not
`max_smem`, so three of the comment's five rows named a `Bq` the code never
picks. Computed from `compute_smem_sm120` against the **measured**
`cudaDevAttrMaxSharedMemoryPerBlockOptin` of 101376 (so `occ2_cap` = 50688):

| HD | Bkv | Bq | smem | the comment said |
|---|---|---|---|---|
| 64 | 64 | **64** | 48.5 KB | 128 |
| 96 | 64 | **32** | 38.2 KB | 64 |
| 128 | 64 | **32** | 48.2 KB | 64 |
| 256 | 64 | 32 | 88.2 KB | 32 |
| 512 | 32 | 16 | 82.1 KB | 16 |

`docs/internals/KERNELS.md` carried the same claim ("degrades to Bq=64") and is
corrected with the table and the reason - the halving for occupancy 2 is what
the numbers have to be read against.

## Pins moved

- two allowlist `code_loc` values, from the guards
- the unlaned GTest count 973 -> 975: both new tests need a GPU, so no CI lane
  runs them, and the gate exists to make that visible rather than to forbid it
- `attention_paged_fp8.cu` crossed the 600-line kernel threshold by three lines
  and is allowlisted with exactly that as its stated reason

## Tests

`test-attention` 215 passed, RoPE/MRope 14 passed, CPU lane 7/7, GPU suite
clean.
