### PR TITLE
fix(obs): five metrics that measured the wrong thing, or nothing (#1577 #1578 #1579 #1580 #1581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,40 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The ITL histogram measured a per-request mean on the wrong ladder**
+  (#1577). `imp_inter_token_seconds` observed one value per request - the mean
+  - on the request-duration bucket ladder, whose first bound is 5 ms. imp
+  decodes at 300-450 tok/s, so every observation landed in that first bucket
+  and `histogram_quantile` returned a function of the bounds rather than of the
+  data. It is one observation per token now, on a millisecond ladder. Measured
+  on a live server, four requests: 4 observations in one bucket before, **39
+  observations spread over three buckets** after (5 under 2 ms, 34 under 3 ms,
+  39 under 5 ms).
+
+- **TTFT was recorded on the streaming path only** (#1578), while
+  `imp_requests_total` counted both - so the histogram described half the
+  traffic and did not say which half. The non-streaming path records it at its
+  first token. Measured: 3 non-streaming plus 1 streaming request produce 4
+  observations, not 1.
+
+- **`imp_requests_failed_total` counted 5xx only** (#1579). Every refusal this
+  server is designed to make is a 4xx (`tools/imp-server/CLAUDE.md`), so the
+  error counter was blind to the entire designed error surface.
+  `imp_requests_rejected_total` is its own series, because "the server broke"
+  and "the server refused" want different alerts.
+
+- **Nothing measured queueing or batching** (#1580).
+  `imp_queue_time_seconds` is the admission wait with prefill excluded, so a
+  busy server can be told from a slow one; `imp_decode_batch_{steps,rows}_total`
+  and `imp_decode_batch_max` say how many sequences actually decoded together.
+  Measured with six concurrent requests: `decode_batch_max 6`, 775 rows over
+  289 steps (2.68 mean), and 5 of 10 queue-time observations above 5 ms.
+
+- **The shipped Grafana dashboard plotted only last-value gauges** (#1581). Six
+  panels added, all percentile timeseries off the histograms that already
+  existed: request duration, TTFT, ITL, queue time, decode batch size, and
+  refusals against failures.
+
 - **The YaRN RoPE branch computed its angle in float and never reduced it**
   (#1630). #1316 fixed exactly this in `rope_forward`'s other two branches; the
   YaRN one kept calling the fast intrinsics on an unreduced argument, and the

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -141,7 +141,7 @@ latency.
 | endpoint | use |
 |---|---|
 | `GET /health` | liveness. Answers before a model is loaded |
-| `GET /metrics` | Prometheus. TTFT and inter-token-latency histograms, cancellation counters, and a memory breakdown that separates capacity from occupancy |
+| `GET /metrics` | Prometheus. Latency histograms (request, TTFT, inter-token, queue), decode batch size, refusal and cancellation counters, and a memory breakdown that separates capacity from occupancy |
 | `GET /v1/models` | what is loaded, and what else is in the models directory |
 | `POST /admin/suspend` | park the weights in host RAM and free the GPU completely. Inference answers 503 while suspended |
 | `POST /admin/resume` | restore warm, in seconds, without re-reading weights |
@@ -149,6 +149,21 @@ latency.
 Suspend/resume is the answer to "I need the GPU for something else for ten
 minutes" without paying a cold load afterwards. Sessions and KV do not survive
 it; weights do.
+
+### Which series answer which question
+
+| question | series |
+|---|---|
+| how long did a request take | `imp_request_duration_seconds` (histogram) |
+| how long until the first token | `imp_ttft_seconds`. Recorded on **both** transports since #1578; before that, streaming only, while `imp_requests_total` counted everything |
+| how fast do tokens come out | `imp_inter_token_seconds`, **one observation per token** on a millisecond ladder (#1577). It used to be one per-request mean on the request-duration ladder, whose first bucket is 5 ms - at imp's own decode rates every observation landed in it, so `histogram_quantile` returned the bucket bounds rather than the data |
+| is the server busy or slow | `imp_queue_time_seconds` is the admission wait, prefill excluded (#1580). A rising queue time with flat request duration is load; the reverse is the model |
+| how much batching is happening | `rate(imp_decode_batch_rows_total[5m]) / rate(imp_decode_batch_steps_total[5m])`, and `imp_decode_batch_max` since start (#1580) |
+| did the server break, or refuse | `imp_requests_failed_total` is 5xx. Every refusal this server is designed to make is a **4xx**, and those are `imp_requests_rejected_total` (#1579). Two series because they want different alerts |
+
+`monitoring/grafana/dashboards/imp.json` plots the percentiles from those
+histograms. The `stat` panels beside them show the last value, which is a
+different thing and cannot show a tail.
 
 ## Capacity planning
 

--- a/monitoring/grafana/dashboards/imp.json
+++ b/monitoring/grafana/dashboards/imp.json
@@ -1,5 +1,7 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -8,170 +10,1106 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            {"options": {"0": {"color": "red", "text": "unloaded"}, "1": {"color": "green", "text": "loaded"}}, "type": "value"}
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "unloaded"
+                },
+                "1": {
+                  "color": "green",
+                  "text": "loaded"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         }
       },
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
       "pluginVersion": "10.0.0",
-      "targets": [{"expr": "imp_model_loaded", "refId": "A"}],
+      "targets": [
+        {
+          "expr": "imp_model_loaded",
+          "refId": "A"
+        }
+      ],
       "title": "Model status",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 4}]}
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 4
+              }
+            ]
+          }
         }
       },
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "id": 2,
-      "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "center", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_queue_depth", "refId": "A"}],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_queue_depth",
+          "refId": "A"
+        }
+      ],
       "title": "Queue depth",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1000}, {"color": "red", "value": 5000}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 5000
+              }
+            ]
+          },
           "unit": "ms"
         }
       },
-      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "id": 3,
-      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_last_ttft_ms", "refId": "A"}],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_last_ttft_ms",
+          "refId": "A"
+        }
+      ],
       "title": "Last TTFT",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "ms"
         }
       },
-      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "id": 4,
-      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_last_request_duration_ms", "refId": "A"}],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_last_request_duration_ms",
+          "refId": "A"
+        }
+      ],
       "title": "Last request duration",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 30, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "unit": "tokps"
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 4},
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "id": 5,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"expr": "rate(imp_tokens_prompt_total[1m])", "legendFormat": "prompt", "refId": "A"},
-        {"expr": "rate(imp_tokens_completion_total[1m])", "legendFormat": "completion", "refId": "B"},
-        {"expr": "rate(imp_tokens_cached_total[1m])", "legendFormat": "cached", "refId": "C"}
+        {
+          "expr": "rate(imp_tokens_prompt_total[1m])",
+          "legendFormat": "prompt",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(imp_tokens_completion_total[1m])",
+          "legendFormat": "completion",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(imp_tokens_cached_total[1m])",
+          "legendFormat": "cached",
+          "refId": "C"
+        }
       ],
       "title": "Token throughput (1m rate)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 30, "gradientMode": "opacity", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": true, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "unit": "reqps"
         }
       },
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 4},
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "id": 6,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"expr": "rate(imp_requests_total[1m])", "legendFormat": "total", "refId": "A"},
-        {"expr": "rate(imp_requests_failed_total[1m])", "legendFormat": "failed", "refId": "B"}
+        {
+          "expr": "rate(imp_requests_total[1m])",
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(imp_requests_failed_total[1m])",
+          "legendFormat": "failed",
+          "refId": "B"
+        }
       ],
       "title": "Request rate (1m)",
       "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 13},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
       "id": 7,
-      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_requests_total", "refId": "A"}],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_requests_total",
+          "refId": "A"
+        }
+      ],
       "title": "Requests served (cumulative)",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 13},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
       "id": 8,
-      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_tokens_completion_total", "refId": "A"}],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_tokens_completion_total",
+          "refId": "A"
+        }
+      ],
       "title": "Completion tokens (cumulative)",
       "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "thresholds"},
-          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 0.1}, {"color": "green", "value": 0.5}]},
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.1
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
           "unit": "percentunit"
         }
       },
-      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 13},
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
       "id": 9,
-      "options": {"colorMode": "value", "graphMode": "area", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
-      "targets": [{"expr": "imp_tokens_cached_total / clamp_min(imp_tokens_prompt_total, 1)", "refId": "A"}],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "imp_tokens_cached_total / clamp_min(imp_tokens_prompt_total, 1)",
+          "refId": "A"
+        }
+      ],
       "title": "Prefix cache hit ratio",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(imp_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(imp_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(imp_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Request duration percentiles",
+      "type": "timeseries",
+      "description": "From imp_request_duration_seconds. The stat panels above show the LAST value, which cannot show a tail (#1581)."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(imp_ttft_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(imp_ttft_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(imp_ttft_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "TTFT percentiles",
+      "type": "timeseries",
+      "description": "Recorded on both transports since #1578; before that, streaming only."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(imp_inter_token_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(imp_inter_token_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(imp_inter_token_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Inter-token latency percentiles",
+      "type": "timeseries",
+      "description": "One observation per token on a millisecond ladder (#1577). It used to be one per-request mean on the request-duration ladder, where every value landed in the first bucket."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(imp_queue_time_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(imp_queue_time_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(imp_queue_time_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Queue time percentiles",
+      "type": "timeseries",
+      "description": "Admission wait, excluding prefill (#1580). Separates 'the server is busy' from 'the server is slow'."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(imp_decode_batch_rows_total[5m]) / clamp_min(rate(imp_decode_batch_steps_total[5m]), 1)",
+          "legendFormat": "mean rows/step",
+          "refId": "A"
+        },
+        {
+          "expr": "imp_decode_batch_max",
+          "legendFormat": "max since start",
+          "refId": "B"
+        }
+      ],
+      "title": "Decode batch size (5m average)",
+      "type": "timeseries",
+      "description": "How many sequences actually decoded together (#1580)."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(imp_requests_rejected_total[1m])",
+          "legendFormat": "4xx refused",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(imp_requests_failed_total[1m])",
+          "legendFormat": "5xx failed",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(imp_requests_timed_out_total[1m])",
+          "legendFormat": "server timeout",
+          "refId": "C"
+        }
+      ],
+      "title": "Refusals and failures (1m rate)",
+      "type": "timeseries",
+      "description": "requests_failed counts 5xx only, and every rejection this server is designed to emit is a 4xx (#1579)."
     }
   ],
   "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["imp"],
-  "templating": {"list": []},
-  "time": {"from": "now-15m", "to": "now"},
+  "tags": [
+    "imp"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "imp",
   "uid": "imp-overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/tests/test_server_request_limits.cpp
+++ b/tests/test_server_request_limits.cpp
@@ -5,6 +5,7 @@
 // keyed on something the client writes. The pieces that can be reached without
 // a running server are tested here; the rest is in the API battery.
 
+#include "handlers.h"
 #include "rate_limit.h"
 #include "utils.h"
 
@@ -265,6 +266,61 @@ TEST(ServableContext, ThePlanStandsWhenThePoolIsLarger) {
 TEST(ServableContext, UnknownCapacityLeavesThePlanAlone) {
     EXPECT_EQ(servable_context_tokens(8192, -1), 8192);
     EXPECT_EQ(servable_context_tokens(8192, 0), 8192);
+}
+
+// ---------------------------------------------------------------------------
+// Latency histogram ladders (#1577)
+// ---------------------------------------------------------------------------
+
+// The defect: inter-token latency was observed on the request-duration ladder,
+// whose first bucket is 5 ms. imp decodes at 300-450 tok/s, i.e. 2.2-3.3 ms per
+// token, so every observation fell in bucket 0 and histogram_quantile returned
+// a function of the bounds rather than of the data.
+TEST(LatencyLadder, TheSecondsLadderCannotResolveInterTokenLatency) {
+    LatencyHistogram seconds;  // the shared ladder, as ITL used to use it
+    for (double tok_per_s : {300.0, 350.0, 400.0, 450.0})
+        seconds.observe(1.0 / tok_per_s);
+    // All four in the first bucket: indistinguishable.
+    EXPECT_EQ(seconds.buckets[0].load(), 4);
+}
+
+TEST(LatencyLadder, TheItlLadderSeparatesThoseSameValues) {
+    LatencyHistogram itl{LatencyHistogram::kItlBounds};
+    for (double tok_per_s : {300.0, 350.0, 400.0, 450.0})
+        itl.observe(1.0 / tok_per_s);
+    // 2.22 / 2.50 / 2.86 / 3.33 ms against bounds 2 ms and 3 ms: the values
+    // land in different buckets, which is what makes a quantile mean anything.
+    EXPECT_EQ(itl.buckets[2].load(), 0);  // le = 2 ms
+    EXPECT_EQ(itl.buckets[3].load(), 3);  // le = 3 ms
+    EXPECT_EQ(itl.buckets[4].load(), 4);  // le = 5 ms
+    EXPECT_EQ(itl.count.load(), 4);
+}
+
+TEST(LatencyLadder, DefaultConstructionKeepsTheSecondsLadder) {
+    LatencyHistogram h;
+    EXPECT_EQ(h.bounds, LatencyHistogram::kSecondsBounds);
+    LatencyHistogram i{LatencyHistogram::kItlBounds};
+    EXPECT_EQ(i.bounds, LatencyHistogram::kItlBounds);
+}
+
+// Cumulative, so a bucket count is "at most this", and the sum is in seconds.
+TEST(LatencyLadder, BucketsAreCumulativeAndTheSumIsSeconds) {
+    LatencyHistogram h;
+    h.observe(0.02);
+    h.observe(2.0);
+    EXPECT_EQ(h.buckets[0].load(), 0);  // le = 0.005
+    EXPECT_EQ(h.buckets[2].load(), 1);  // le = 0.025
+    EXPECT_EQ(h.buckets[8].load(), 2);  // le = 2.5
+    EXPECT_EQ(h.count.load(), 2);
+    EXPECT_NEAR(h.sum_us.load() / 1e6, 2.02, 1e-6);
+}
+
+// A negative reading is a clock going backwards, not a fast request.
+TEST(LatencyLadder, NegativeObservationsClampToZero) {
+    LatencyHistogram h;
+    h.observe(-1.0);
+    EXPECT_EQ(h.buckets[0].load(), 1);
+    EXPECT_EQ(h.sum_us.load(), 0);
 }
 
 }  // namespace

--- a/tools/imp-server/batching_engine.cpp
+++ b/tools/imp-server/batching_engine.cpp
@@ -101,6 +101,7 @@ void BatchingEngine::resume() {
 }
 
 void BatchingEngine::submit(std::shared_ptr<ServerRequest> req) {
+    req->t_submit = std::chrono::steady_clock::now();
     {
         std::lock_guard<std::mutex> lock(queue_mutex_);
         pending_queue_.push_back(std::move(req));
@@ -175,6 +176,13 @@ void BatchingEngine::worker_loop() {
                     }
 
                     sr->notified_count = sr->request->output_tokens.size();
+                    // Waited-behind-others time, closed here rather than at the
+                    // first token: everything after this point is prefill and
+                    // decode, which the other histograms already describe.
+                    sr->queue_ms.store(std::chrono::duration<double, std::milli>(
+                                           std::chrono::steady_clock::now() - sr->t_submit)
+                                           .count(),
+                                       std::memory_order_relaxed);
                     engine->add_request(sr->request);
                     active_requests_.push_back(std::move(sr));
                 }
@@ -209,6 +217,25 @@ void BatchingEngine::worker_loop() {
         // mid-forward used to call std::terminate and kill the container,
         // taking every other in-flight request with it. Now we cancel all
         // active requests with a clear reason and keep the worker alive.
+        {
+            // What the engine is about to run together (#1580). Counted here
+            // rather than inside the engine because this is where the server
+            // already knows the set, and it keeps the metric out of the
+            // runtime's headers.
+            int rows = 0;
+            for (const auto& sr : active_requests_) {
+                if (sr->request->status != imp::RequestStatus::FINISHED &&
+                    sr->request->status != imp::RequestStatus::CANCELLED)
+                    rows++;
+            }
+            if (rows > 0) {
+                decode_steps.fetch_add(1, std::memory_order_relaxed);
+                decode_rows.fetch_add(rows, std::memory_order_relaxed);
+                int64_t prev = decode_batch_max.load(std::memory_order_relaxed);
+                while (rows > prev &&
+                       !decode_batch_max.compare_exchange_weak(prev, rows, std::memory_order_relaxed)) {}
+            }
+        }
         try {
             (void)engine->step();
         } catch (const std::exception& e) {

--- a/tools/imp-server/batching_engine.h
+++ b/tools/imp-server/batching_engine.h
@@ -5,6 +5,7 @@
 #include "api/imp_internal.h"
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -34,6 +35,14 @@ struct ServerRequest {
 
     // Track how many output tokens we have already delivered
     size_t notified_count = 0;
+
+    // Queue observability (#1580). t_submit is set by submit(); queue_ms is
+    // filled in when the worker moves this request from pending to active,
+    // i.e. it is the time spent waiting behind other requests and NOT the
+    // prefill. Nothing measured that before, so "the server is slow" and "the
+    // server is busy" looked the same from outside.
+    std::chrono::steady_clock::time_point t_submit{};
+    std::atomic<double> queue_ms{-1.0};
 
     // Push a token event (called from worker thread)
     void push_token(int32_t token_id, bool is_last, const char* reason) {
@@ -74,6 +83,13 @@ struct ServerRequest {
 // scheduler.
 class BatchingEngine {
 public:
+    // Decode-batch observability (#1580): the knob that bounds batch size is
+    // configurable and the result was unobservable. Counter pair rather than an
+    // average, so a dashboard can rate() both and divide over any window.
+    std::atomic<int64_t> decode_steps{0};
+    std::atomic<int64_t> decode_rows{0};
+    std::atomic<int64_t> decode_batch_max{0};
+
     BatchingEngine() = default;
     ~BatchingEngine();
 

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -67,23 +67,39 @@ struct RequestLogger {
 
 // Prometheus-style latency histogram (cumulative buckets, in seconds).
 // Lock-free: each observation bumps the matching cumulative buckets + sum +
-// count. Bucket upper bounds are shared by request-duration and TTFT; both
-// are sub-second-to-minutes scale so the same ladder fits.
+// count.
+//
+// The ladder is per-instance because one ladder does not fit every quantity
+// (#1577). Request duration and TTFT are sub-second-to-minutes; inter-token
+// latency is single-digit MILLISECONDS - at imp's own documented decode rates
+// every ITL observation landed in the first bucket of the shared ladder
+// (le=0.005), so histogram_quantile returned a function of the bucket bounds
+// rather than of the data.
 struct LatencyHistogram {
-    // le upper bounds in seconds; the implicit +Inf bucket is `count`.
     static constexpr int kNumBuckets = 11;
-    static constexpr double kBounds[kNumBuckets] = {0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
-                                                    0.5,   1.0,  2.5,   5.0,  10.0};
+    // Sub-second-to-minutes: request duration, TTFT.
+    static constexpr double kSecondsBounds[kNumBuckets] = {0.005, 0.01, 0.025, 0.05, 0.1, 0.25,
+                                                           0.5,   1.0,  2.5,   5.0,  10.0};
+    // Milliseconds: inter-token latency. 400 tok/s is 2.5 ms, so the ladder
+    // has to resolve either side of that; the top end covers a stalled or
+    // heavily batched step.
+    static constexpr double kItlBounds[kNumBuckets] = {0.0005, 0.001, 0.002, 0.003, 0.005, 0.0075,
+                                                       0.01,   0.025, 0.05,  0.1,   0.5};
+
+    const double* bounds = kSecondsBounds;  // set once at construction
     std::atomic<int64_t> buckets[kNumBuckets] = {};
     std::atomic<int64_t> count{0};
     // Sum of observed seconds, stored as micros to keep an integer atomic.
     std::atomic<int64_t> sum_us{0};
 
+    LatencyHistogram() = default;
+    explicit LatencyHistogram(const double* ladder) : bounds(ladder) {}
+
     void observe(double seconds) {
         if (seconds < 0)
             seconds = 0;
         for (int i = 0; i < kNumBuckets; ++i) {
-            if (seconds <= kBounds[i])
+            if (seconds <= bounds[i])
                 buckets[i].fetch_add(1, std::memory_order_relaxed);
         }
         count.fetch_add(1, std::memory_order_relaxed);
@@ -115,7 +131,22 @@ struct ServerMetrics {
     std::atomic<int64_t> model_loads_total{0};
     LatencyHistogram request_duration;  // end-to-end request latency
     LatencyHistogram ttft;              // time to first token
-    LatencyHistogram inter_token;       // mean inter-token latency (ITL) per request
+    // Per-TOKEN inter-token latency, on a millisecond ladder. It used to
+    // observe one per-request MEAN on the request-duration ladder, which
+    // answers neither "how long between tokens" nor "how does that vary"
+    // (#1577).
+    LatencyHistogram inter_token{LatencyHistogram::kItlBounds};
+    // Time from admission to the first decode step, i.e. how long a request
+    // waited behind others. Nothing measured queueing before (#1580).
+    LatencyHistogram queue_time;
+    // (Decode batch size lives on the BatchingEngine, where the batch is
+    // formed; /metrics reads it from there.)
+    // 4xx refusals. requests_failed counts 5xx only, and every rejection this
+    // server is designed to emit is a 4xx - so the error counter was blind to
+    // the whole designed error surface (#1579). Kept as its own series rather
+    // than folded in, because "the server broke" and "the server refused" are
+    // different alerts.
+    std::atomic<int64_t> requests_rejected{0};
     std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
 };
 

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -724,6 +724,7 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
     // For n > 1, run multiple independent generations sequentially
     json choices = json::array();
     int total_output_tokens = 0;
+    double ttft_ms = -1.0;  // first token of the FIRST completion (#1578)
     g_shim_stop_sequence.clear();
 
     for (int ci = 0; ci < ctx.params.n_completions; ci++) {
@@ -812,6 +813,20 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
                 finish = evt.finish_reason ? evt.finish_reason : "length";
             }
 
+            // TTFT was recorded on the streaming path only, while this one
+            // still incremented requests_total - so the histogram described
+            // half the traffic and said nothing about which half (#1578).
+            if (output_ids.empty() && ttft_ms < 0.0) {
+                ttft_ms = std::chrono::duration<double, std::milli>(
+                              std::chrono::high_resolution_clock::now() - ctx.t_start)
+                              .count();
+                // Same point as the streaming path: by the first token the
+                // worker has admitted the request, so queue_ms is final
+                // (#1580).
+                const double q = server_req->queue_ms.load(std::memory_order_relaxed);
+                if (q >= 0.0)
+                    state.metrics.queue_time.observe(q / 1000.0);
+            }
             output_ids.push_back(token);
 
             // Check text-level stop sequences
@@ -1041,6 +1056,10 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
     state.metrics.tokens_completion_total += total_output_tokens;
     state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
     state.metrics.request_duration.observe(ms / 1000.0);
+    if (ttft_ms >= 0.0) {
+        state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+        state.metrics.ttft.observe(ttft_ms / 1000.0);
+    }
 
     json usage = {{"prompt_tokens", ctx.snap.n_prompt_tokens},
                   {"completion_tokens", total_output_tokens},

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -223,7 +223,7 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
         out += " histogram\n";
         for (int i = 0; i < LatencyHistogram::kNumBuckets; ++i) {
             char le[32];
-            std::snprintf(le, sizeof(le), "%g", LatencyHistogram::kBounds[i]);
+            std::snprintf(le, sizeof(le), "%g", h.bounds[i]);
             out += name;
             out += "_bucket{le=\"";
             out += le;
@@ -249,8 +249,34 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
     emit_histogram("imp_request_duration_seconds", "Request end-to-end latency in seconds",
                    m.request_duration);
     emit_histogram("imp_ttft_seconds", "Time to first token in seconds", m.ttft);
-    emit_histogram("imp_inter_token_seconds", "Mean inter-token latency (ITL) per request in seconds",
+    emit_histogram("imp_inter_token_seconds", "Inter-token latency in seconds, one observation per token",
                    m.inter_token);
+    emit_histogram("imp_queue_time_seconds", "Seconds from admission to the first decode step", m.queue_time);
+    out += "# HELP imp_requests_rejected_total Requests refused with a 4xx\n";
+    out += "# TYPE imp_requests_rejected_total counter\n";
+    out += "imp_requests_rejected_total " + std::to_string(m.requests_rejected.load()) + "\n";
+    // Decode batch size, as a counter pair so a dashboard can rate() both and
+    // divide - the average over any window, without the server keeping one.
+    // The counters live on the BatchingEngine, which is where the batch is
+    // formed; read under the same bounded lock the rest of this endpoint uses.
+    {
+        int64_t steps = 0, rows = 0, bmax = 0;
+        std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
+        if (lock.owns_lock() && state.batching) {
+            steps = state.batching->decode_steps.load();
+            rows = state.batching->decode_rows.load();
+            bmax = state.batching->decode_batch_max.load();
+        }
+        out += "# HELP imp_decode_batch_steps_total Decode steps executed\n";
+        out += "# TYPE imp_decode_batch_steps_total counter\n";
+        out += "imp_decode_batch_steps_total " + std::to_string(steps) + "\n";
+        out += "# HELP imp_decode_batch_rows_total Sequences decoded, summed over steps\n";
+        out += "# TYPE imp_decode_batch_rows_total counter\n";
+        out += "imp_decode_batch_rows_total " + std::to_string(rows) + "\n";
+        out += "# HELP imp_decode_batch_max Largest decode batch seen since start\n";
+        out += "# TYPE imp_decode_batch_max gauge\n";
+        out += "imp_decode_batch_max " + std::to_string(bmax) + "\n";
+    }
     out += "# HELP imp_model_loaded Whether a model is currently loaded\n";
     out += "# TYPE imp_model_loaded gauge\n";
     bool loaded = false;

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -418,6 +418,12 @@ int main(int argc, char** argv) {
     svr.set_post_routing_handler([&state](const httplib::Request&, httplib::Response& res) {
         if (res.status >= 500)
             state.metrics.requests_failed++;
+        // 4xx is where this server puts every refusal it is designed to make
+        // (tools/imp-server/CLAUDE.md), so counting only 5xx left the entire
+        // designed error surface invisible (#1579). Separate series, because
+        // "the server broke" and "the server refused" want different alerts.
+        else if (res.status >= 400)
+            state.metrics.requests_rejected++;
     });
 
     // Graceful shutdown on SIGINT/SIGTERM

--- a/tools/imp-server/stream_driver.cpp
+++ b/tools/imp-server/stream_driver.cpp
@@ -37,6 +37,7 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
     const bool snap_have_template = ctx.snap.have_template;
     const auto& snap_stop_token_ids = ctx.snap.stop_token_ids;
     const auto t_start = ctx.t_start;
+    auto t_prev_token = t_start;  // for the per-token ITL observation (#1577)
 
     const char* finish = nullptr;
 
@@ -278,9 +279,23 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
         }
 
         out.n_output_tokens++;
-        if (out.n_output_tokens == 1) {
-            auto t_first = std::chrono::high_resolution_clock::now();
-            out.ttft_ms = std::chrono::duration<double, std::milli>(t_first - t_start).count();
+        {
+            // One ITL observation per token, taken here rather than as a
+            // per-request mean after the fact (#1577): a mean cannot show the
+            // variance, and variance is the whole reason to keep a histogram.
+            auto t_tok = std::chrono::high_resolution_clock::now();
+            if (out.n_output_tokens == 1) {
+                out.ttft_ms = std::chrono::duration<double, std::milli>(t_tok - t_start).count();
+                // Queue time is known once the worker has admitted the request,
+                // which is guaranteed by the time a token comes back (#1580).
+                const double q = server_req->queue_ms.load(std::memory_order_relaxed);
+                if (q >= 0.0)
+                    state.metrics.queue_time.observe(q / 1000.0);
+            } else {
+                state.metrics.inter_token.observe(
+                    std::chrono::duration<double>(t_tok - t_prev_token).count());
+            }
+            t_prev_token = t_tok;
         }
         // A token can end mid-character; hold the partial bytes until the next
         // one completes them, or the delta ships half a character as U+FFFD.
@@ -581,10 +596,8 @@ void finish_stream_accounting_(ServerState& state, ChatRequestContext& ctx,
     state.metrics.request_duration.observe(ms / 1000.0);
     if (out.n_output_tokens > 0)
         state.metrics.ttft.observe(out.ttft_ms / 1000.0);
-    // Mean inter-token latency: post-first-token decode time spread over the
-    // remaining tokens. Streaming-only (non-stream has no per-token cadence).
-    if (out.n_output_tokens > 1)
-        state.metrics.inter_token.observe((ms - out.ttft_ms) / 1000.0 / (out.n_output_tokens - 1));
+
+    // Inter-token latency is observed per token inside the loop (#1577).
 
     // Streaming response content is not accumulated across SSE chunks, so the
     // JSONL `response` field stays null. The request body, token counts,


### PR DESCRIPTION
Five observability findings. Every number below is from a live server
(`Qwen3-4B-Instruct-2507-Q8_0.gguf`), not from reading the code.

## #1577 - the ITL histogram measured a per-request mean, on the wrong ladder

Two defects in one series. `imp_inter_token_seconds` observed **one value per
request** - the mean - on the **request-duration** bucket ladder, whose first
bound is 5 ms. imp decodes at 300-450 tok/s, i.e. 2.2-3.3 ms per token, so
every observation fell in bucket 0 and `histogram_quantile` returned a function
of the bounds. A mean cannot show variance either, which is the reason to keep
a histogram rather than a gauge.

Four requests, same traffic:

```
before    4 observations, all in le=0.005
after    39 observations:  5 under 2 ms, 34 under 3 ms, 39 under 5 ms
```

`LatencyHistogram` carries its ladder per instance now, and `/metrics` emits
the bounds the histogram actually used instead of a shared constant.

## #1578 - TTFT existed only on the streaming path

...while `imp_requests_total` counted both, so the histogram described half the
traffic and did not say which half. It is recorded at the first token on both
paths now.

```
3 non-streaming + 1 streaming request
before   imp_ttft_seconds_count 1
after    imp_ttft_seconds_count 4
```

## #1579 - `requests_failed` counted 5xx only

Every refusal this server is designed to make is a 4xx - that is the documented
stance in `tools/imp-server/CLAUDE.md` - so the error counter was structurally
blind to the entire designed error surface. `imp_requests_rejected_total` is a
separate series rather than a widened definition, because "the server broke"
and "the server refused" want different alerts. One malformed body →
`imp_requests_rejected_total 1`.

## #1580 - nothing measured queueing or batching

| series | what it answers |
|---|---|
| `imp_queue_time_seconds` | admission wait, **prefill excluded** - so a busy server can be told from a slow one |
| `imp_decode_batch_{steps,rows}_total` | how many sequences actually decoded together, as a counter pair a dashboard can `rate()` and divide |
| `imp_decode_batch_max` | the largest batch since start |

Queue time is stamped at `submit()` and closed when the worker admits the
request. The batch counters live on `BatchingEngine`, where the batch is
formed, so the metric stays out of the runtime headers.

Six concurrent requests:

```
imp_decode_batch_max          6
imp_decode_batch_rows_total   775
imp_decode_batch_steps_total  289      -> 2.68 mean rows/step
imp_queue_time_seconds        5 of 10 observations above 5 ms
```

## #1581 - the dashboard plotted last-value gauges only

Six percentile timeseries added, all off histograms that already existed:
request duration, TTFT, ITL, queue time, decode batch size, and refusals
against failures. The `stat` panels stay - a last value is a different
question, not a wrong one.

## Tests

Five CPU cases pinning the two ladders against each other, including the exact
defect: four decode rates that are one bucket on the seconds ladder and three
on the ITL ladder. Plus cumulative-bucket semantics, the seconds ladder as the
default, and the negative-observation clamp.

CPU lane 7/7, test-core 1168 passed.

## Not in this PR

**#1582** (per-request log lines bypass `log_level`; two disjoint request-id
spaces). It touches every handler, and the id half needs a decision about which
space wins - `imp-N`, the Anthropic `req_imp_...` added in #1702, or a third.
Worth doing deliberately rather than folded in here.
