### PR TITLE
fix(api,server): an integer with no digit bound, and an MTP head nobody sees (#1537 #1540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,23 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`json_schema`: an unconstrained `integer` had no digit bound** (#1540). At
+  the server's default temperature the sampler could sit in the digit state and
+  emit `1020000000000000000000000000000000000000` for a population field - a
+  value no int64 consumer can read back; at temperature 0 the same request
+  answered `13528079`. The FSM stops the digit run at 19, int64's width, and
+  masks further digits so the model closes the value instead. `number` is
+  unchanged: there the digits carry precision, not magnitude.
+
+- **A checkpoint's unloaded MTP head is visible in `/health`** (#1537).
+  `speculative.mtp_k` defaults to 0, so a checkpoint that ships a head runs
+  without a documented +8 to +22% decode, and the only notice was one INFO line
+  an operator running a container never sees. `GET /health` reports
+  `mtp_head_available` with the trade. Measured on `Qwen3.8-27B-NVFP4`: present
+  by default, absent with `--set speculative.mtp_k=2`, where the head loads
+  (15 tensors, 0.79 GiB). The default is unchanged - turning it on for everyone
+  costs VRAM and is a decision, not a fix.
+
 - **What `runtime.deterministic` covers is now written down, and gated**
   (#1574). It reaches four kernel sites through
   `process_diag_deterministic_gemm()`; `gemm_cutlass_grouped_3x.cu` - the

--- a/docs/API.md
+++ b/docs/API.md
@@ -104,7 +104,7 @@ post-validation.
 | form | status |
 |---|---|
 | `response_format: {"type": "json_object"}` | ✅ |
-| `response_format: {"type": "json_schema", ...}` | ✅ whole-token validated |
+| `response_format: {"type": "json_schema", ...}` | ✅ whole-token validated. An `integer` is bounded at 19 digits (int64's width): unbounded, the sampler could stay in the digit state above temperature 0 and emit a 40-digit population (#1540) |
 | `response_format: {"type": "regex"}` / `guided_regex` | ✅ |
 | `response_format: {"type": "grammar"}` / `grammar` / `guided_grammar` | ✅ GBNF, a pushdown simulator, so recursive and bracket-balanced formats work |
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -178,7 +178,11 @@ them invisible here - the legend's whole point.
 - **MTP is released for one model class, and the class that is left out has a
   measured defect, not a missing feature.** `speculative.mtp_k` stays **0
   everywhere** — nothing below is on by default; the table says what a user opts
-  into and what they get.
+  into and what they get. On a checkpoint that ships a head, `GET /health`
+  reports `mtp_head_available` with the trade, so an operator can see the
+  switched-off gain without reading the startup log (#1537). The default itself
+  is unchanged: the head costs VRAM (0.79 GiB on Qwen3.8-27B-NVFP4) and turning
+  it on for everyone is a decision, not a fix.
 
   | class | example | cached verify graph vs an eager forward of the same state | MTP |
   |---|---|---|---|

--- a/src/compute/schema_constrain.cu
+++ b/src/compute/schema_constrain.cu
@@ -18,6 +18,13 @@ namespace imp {
 // schema-valid — any finite nesting satisfies a recursive schema).
 static constexpr size_t kMaxSchemaStackDepth = 192;
 
+// Digits an `integer` may run to (#1540). int64 is 19 digits wide, and a JSON
+// integer past it is not a value the caller can read back into anything - the
+// schema's own `maximum` would be the precise bound, but it is refused at parse
+// time as unenforceable (#1567). Applies to `integer` only; `number` keeps its
+// JSON-legal mantissa.
+static constexpr int kMaxIntegerDigits = 19;
+
 // Effective item ceiling for an array frame: explicit "maxItems" wins; an
 // enum-items array without one is capped at the enum's cardinality — a list
 // that repeats an enum member more often than the enum has members carries no
@@ -1274,6 +1281,20 @@ bool SchemaConstrainer::sim_advance(std::vector<SchemaFrame>& stk, char c) const
                 }
                 if (f.num_leading_zero)
                     return false;  // JSON forbids leading zeros: `0` then digit
+                // #1540: an unconstrained `integer` had no digit bound, so
+                // above temperature 0 the sampler could sit in the digit state
+                // and emit 1020000000000000000000000000000000000000. JSON puts
+                // no bound on an integer literal, but every practical consumer
+                // does: int64 is 19 digits, and a value past it is not a number
+                // the caller can read back. `maximum` would be the precise
+                // bound - it is refused at parse time as unenforceable (#1567),
+                // so this is the floor that keeps the output usable.
+                //
+                // The FSM masks further digits rather than erroring: at 19
+                // digits the value is complete and legal, so the model's next
+                // legal tokens are the ones that close it.
+                if (is_int && f.string_len >= kMaxIntegerDigits)
+                    return false;
                 f.string_len++;
                 f.num_need_digit = false;
                 f.num_sign_ok = false;

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -141,6 +141,13 @@ public:
     // Phase 2+: forward+verify wiring.
     std::optional<MtpHead> mtp_;
 
+    // The checkpoint carries an MTP head that this load did NOT take, because
+    // speculative.mtp_k defaults to 0 (#1537). The loader logs one INFO line
+    // about it; this makes the same fact readable, so /health can say it and an
+    // operator does not have to grep a startup log to learn a documented
+    // +8 to +22% decode is sitting switched off.
+    bool mtp_head_available_unloaded_ = false;
+
     // Load-time scratch for NVFP4 prequant scale tensors.
     // Keys:
     //   "L{idx}.{slot}"          per-layer dense (e.g. "L5.wq", "L5.w_gate_shared")

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1050,6 +1050,9 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         return head;
     };
 
+    // Set when the checkpoint carries an MTP head this load did not take
+    // (#1537), so /health can report it instead of only the startup log.
+    bool mtp_available_unloaded = false;
     if (load_mtp_head && !model_dir.empty()) {
         std::string mtp_path = model_dir + "/model_mtp.safetensors";
         std::error_code ec;
@@ -1099,10 +1102,12 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
             "Qwen3.8-27B-NVFP4, range +8 to +22 %%, in exchange for the head's VRAM "
             "(0.79 GiB there) and reproducible output across processes. "
             "See docs/LIMITATIONS.md");
+        mtp_available_unloaded = true;
     }
 
     // Create model
     auto model = std::make_unique<Model>();
+    model->mtp_head_available_unloaded_ = mtp_available_unloaded;
     model->source_path_ = path;
     if (mtp_local.has_value()) {
         model->mtp_ = std::move(mtp_local);

--- a/tests/test_schema_constrain_property.cpp
+++ b/tests/test_schema_constrain_property.cpp
@@ -315,6 +315,43 @@ TEST(SchemaParserDesync, UnclosedObjectIsAnError) {
     EXPECT_EQ(parse_json_schema(R"({"type":"object","properties":{"a":{"type":"string"})"), nullptr);
 }
 
+// #1540: an unconstrained `integer` had no digit bound. At the server's default
+// temperature the sampler stayed in the digit state and emitted
+// 1020000000000000000000000000000000000000 for a population field - a value no
+// int64 consumer can read back. Measured on Qwen3.8-27B-NVFP4 at temperature
+// 0.6; at temperature 0 the same request answered 13528079.
+TEST(SchemaIntegerBound, DigitsStopAtInt64Width) {
+    auto sc = make_fsm(R"({"type":"object","properties":{"pop":{"type":"integer"}},)"
+                       R"("required":["pop"]})");
+    ASSERT_NE(sc, nullptr);
+
+    // 19 digits is int64's width and stays legal.
+    EXPECT_TRUE(sc->token_legal(R"({"pop": 9223372036854775807})"));
+    // 20 does not: the FSM masks the digit, so the model has to close the value.
+    EXPECT_FALSE(sc->token_legal(R"({"pop": 92233720368547758070})"));
+    // The reported output, at 40 digits.
+    EXPECT_FALSE(sc->token_legal(R"({"pop": 1020000000000000000000000000000000000000})"));
+}
+
+TEST(SchemaIntegerBound, ShortIntegersAreUnaffected) {
+    auto sc = make_fsm(R"({"type":"object","properties":{"pop":{"type":"integer"}},)"
+                       R"("required":["pop"]})");
+    ASSERT_NE(sc, nullptr);
+    for (const char* doc :
+         {R"({"pop": 0})", R"({"pop": 42})", R"({"pop": -13528079})", R"({"pop": 3691000})"}) {
+        EXPECT_TRUE(sc->token_legal(doc)) << doc;
+    }
+}
+
+// The bound is on `integer`. A `number` keeps its JSON-legal mantissa, because
+// there the digits carry precision rather than magnitude.
+TEST(SchemaIntegerBound, NumberIsNotBounded) {
+    auto sc = make_fsm(R"({"type":"object","properties":{"x":{"type":"number"}},)"
+                       R"("required":["x"]})");
+    ASSERT_NE(sc, nullptr);
+    EXPECT_TRUE(sc->token_legal(R"({"x": 1.02000000000000000000000000000000000000001})"));
+}
+
 // #1567: thirteen standard assertion keywords were accepted and dropped by
 // skip_value(). A caller that bounds its output was answered as if it had not.
 TEST(SchemaUnenforceableKeywords, AssertionKeywordsAreRefused) {

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -74,7 +74,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }
 "src/compute/json_schema.cpp" = { code_loc = 1147, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
 "src/compute/mtp_forward.cu" = { code_loc = 856, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
-"src/compute/schema_constrain.cu" = { code_loc = 1181, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
+"src/compute/schema_constrain.cu" = { code_loc = 1184, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
 "src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1061, reason = "(c) one path: batched-MoE forward dispatch (host-only)" }
 "src/exec/executor_workspace_buffers.cu" = { code_loc = 1350, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
@@ -82,7 +82,7 @@ roots = ["src", "tools", "tests"]
 "src/model/gguf_loader.cpp" = { code_loc = 820, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
 "src/model/jinja.cpp" = { code_loc = 2366, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
-"src/model/safetensors_loader.cpp" = { code_loc = 1152, reason = "(c) one loader: header validation + tensor assign + arch inference" }
+"src/model/safetensors_loader.cpp" = { code_loc = 1155, reason = "(c) one loader: header validation + tensor assign + arch inference" }
 "src/model/tokenizer.cpp" = { code_loc = 1818, reason = "(c) one tokenizer: BPE/SPM/WordPiece encode + merge + cache (JSON parsing now via shared model/json_util)" }
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 1995, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -117,6 +117,19 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
         // caller to derive it from a pair that cannot express it.
         body["kv_pool_growable"] = kv_growable;
     }
+    // #1537: the checkpoint carries an MTP head this load did not take, because
+    // speculative.mtp_k defaults to 0. That is a documented +8 to +22% decode
+    // sitting switched off, and the only notice was one INFO line at startup -
+    // which an operator running a container never sees. Reported here so it is
+    // discoverable without grepping a log.
+    if (state.model && state.model->model && state.model->model->mtp_head_available_unloaded_) {
+        body["mtp_head_available"] = true;
+        body["mtp_head_hint"] =
+            "this checkpoint ships an MTP head that is not loaded "
+            "(speculative.mtp_k=0). --set speculative.mtp_k=2 measured +15% decode "
+            "on Qwen3.8-27B-NVFP4 (range +8 to +22%), for the head's VRAM.";
+    }
+
     if (!unservable.empty()) {
         // A client has to tell a permanent 503 from a transient one, or it
         // retries a condition retrying cannot fix and burns its budget doing


### PR DESCRIPTION
Two defects from the four-issue "server defaults" cluster. The other two are
decisions, and they stay decisions - see the last section.

## #1540 - `json_schema`: an unconstrained `integer` had no digit bound

The schema permits unbounded digits, and the mask is applied *before* sampling,
so this is not an ordering bug - the sampler simply stays in the digit state:

```
temperature 0    {"city": "Berlin", "pop": 13528079}
temperature 0.6  {"city": "Berlin", "pop": 1020000000000000000000000000000000000000}
```

JSON puts no bound on an integer literal. **Every practical consumer does**:
int64 is 19 digits, and past it the value is not one the caller can read back
into anything. `maximum` would be the precise bound and is refused at parse time
as unenforceable (#1567), so 19 digits is the floor that keeps the output
usable.

The FSM **masks** further digits rather than erroring: at 19 the value is
complete and legal, so the model's next legal tokens are the ones that close it.

`number` is untouched - there the digits carry precision, not magnitude, and a
long mantissa is a legitimate answer.

Three CPU tests, including the reported 40-digit output. Removing the bound
turns `DigitsStopAtInt64Width` red and leaves the other two green, which is the
shape you want: the bound is what the test measures.

## #1537 - the head is in the checkpoint and the notice was one log line

`speculative.mtp_k` defaults to 0, so a checkpoint that ships an MTP head runs
without a documented +8 to +22% decode. The only notice was an `IMP_LOG_INFO`
at startup - which an operator running a container never sees.

`GET /health` reports it now. Measured on `Qwen3.8-27B-NVFP4`, both directions:

```
default                    "mtp_head_available": true, plus the hint with the trade
--set speculative.mtp_k=2   field ABSENT, and the head loads:
                            "MTP head loaded: (15 tensors, dense MLP, BF16)"
                            "MTP head: uploaded to GPU (0.79 GiB on disk)"
```

**The default is unchanged.** Turning the head on for every checkpoint that has
one costs VRAM and changes output reproducibility; that is the decision the
issue asks for, and it belongs to the owner rather than to a fix that happened
to be nearby.

## Not decided here: #1538 and #1539

They are two conditions on the same gate. `spec_verify_gates_ok_` requires
`temperature <= 0 || top_k == 1` (#1538) **and** `!(think_budget > 0 &&
in_think_block)` (#1539), because the verify compares argmax tokens and is
therefore only correct for greedy.

Both go away with proper speculative sampling - accept with `min(1, p/q)`,
resample from the corrected distribution, which is exact at any temperature -
and not with a change to either condition. Relaxing one alone would trade a
documented limit for an undocumented approximation.

#1538's own measurement is the reason not to rush it: **82-86 tok/s with and
without `temperature: 0`** on Qwen3.8-27B-NVFP4, i.e. lifting the gate buys
nothing today on that model. Commented on both issues rather than changing
them.

## Pins

`schema_constrain.cu` 1181 → 1184, `safetensors_loader.cpp` 1152 → 1155.

CPU lane 7/7, GPU suite clean, static gates green.
