### PR TITLE
fix(mem,graph): an unordered memset over live KV, a silent eager fallback, and a graph-captured per-step address (#1646 #1648 #1652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,36 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A growable KV pool zeroed new blocks on stream 0 and published them to a
+  non-blocking stream** (#1652). `cudaMemset` runs on the legacy default
+  stream; the engine decodes on a `cudaStreamNonBlocking` stream, which by
+  construction has no ordering relationship with it - so a memset could retire
+  *after* the first KV write into the same blocks and zero live KV. On a
+  36-layer model that is 72 unordered memsets over exactly the blocks the next
+  decode step fills. Stream 0 is synchronised before the new capacity is
+  published; growth is rare, and the path already commits driver pages.
+
+- **`max_batch_size` above the decode-graph pool ran eager, silently** (#1646).
+  Every graph path is gated on `n_sequences <= 64`, so a larger configured
+  batch fell to an eager forward with no clamp, no warning and no log line.
+  Measured on this box, graphs on against off: **454 vs 190 tok/s**, i.e. the
+  configured value costs 2.4x decode the moment it exceeds the pool. Not
+  clamped - the value also bounds admission and KV sizing - but said out loud,
+  once, where the number is resolved.
+
+- **The multi-sequence residual metadata buffer is persistent** (#1648). It was
+  `cudaMallocAsync`'d every decode step and its address baked into a captured
+  `forward_logits` graph that is then replayed, with no invalidation watching
+  it. That only ever worked because the default pool's release threshold is
+  pinned to `UINT64_MAX` so the same address came back - a pool setting, not an
+  invariant the graph path asserts. Allocated once beside `d_kv_slot_buf_`,
+  strided by capacity so a graph captured at one batch width stays correct at
+  another. It does **not** fix that path: measured on
+  `Qwen3-8B-Q8_0.gguf` with `--kv-nvfp4` and residual on, six concurrent
+  requests fault identically before and after (106998 / 111543 `illegal memory
+  access` lines), while `runtime.cuda_graphs=never` gives 0 and six correct
+  answers. Filed as #1708.
+
 - **`json_schema`: an unconstrained `integer` had no digit bound** (#1540). At
   the server's default temperature the sampler could sit in the digit state and
   emit `1020000000000000000000000000000000000000` for a population field - a

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -449,6 +449,22 @@ int KVCache::commit_blocks_(int blocks) {
         IMP_CUDA_CHECK_LOG(cudaMemset(k_ptr(l, first_new), 0, bytes));
         IMP_CUDA_CHECK_LOG(cudaMemset(v_ptr(l, first_new), 0, bytes));
     }
+    // The memsets above run on the LEGACY DEFAULT STREAM, and the engine
+    // decodes on a cudaStreamNonBlocking stream - which by construction has no
+    // ordering relationship with stream 0. Publishing the capacity without
+    // waiting let a memset retire AFTER the first KV write into the same
+    // blocks, zeroing live KV (#1652). On a 36-layer model that is 72
+    // unordered memsets over exactly the blocks the next decode step is about
+    // to fill, and it breaks the invariant this zeroing exists to keep in the
+    // worse direction: not "stale bytes" but "your bytes, erased".
+    //
+    // Synchronising stream 0 rather than the device: the only work being waited
+    // on is these memsets, and cudaDeviceSynchronize would additionally stall
+    // on whatever the engine has in flight, for no benefit. Growth is rare (it
+    // fires when the pool is under pressure, not per step), so this costs a
+    // sync on a path that already commits driver pages.
+    if (blocks > first_new)
+        IMP_CUDA_CHECK_LOG(cudaStreamSynchronize(0));
     committed_blocks_ = blocks;
     return blocks;
 }

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -144,6 +144,11 @@ Engine::~Engine() {
         cudaFree(d_kv_slot_buf_);
         d_kv_slot_buf_ = nullptr;
     }
+    if (residual_meta_d_buf_) {
+        cudaFree(residual_meta_d_buf_);
+        residual_meta_d_buf_ = nullptr;
+        residual_meta_capacity_ = 0;
+    }
     abandon_decode_pipeline();
     for (int p = 0; p < 2; ++p) {
         // T5b owners release themselves; the d_* mirrors are views into them, so

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -783,13 +783,16 @@ private:
     size_t d_penalty_tokens_capacity_ = 0;
 
     // ── BitDecoding Phase 3 residual metadata (per-step) ─────────────
-    // residual_meta_d_buf_ is the legacy multi-seq metadata buffer
-    // (cudaMallocAsync per step in step_decode_continuous). d_kv_slot_buf_ is
+    // residual_meta_d_buf_ is the multi-seq metadata buffer. d_kv_slot_buf_ is
     // a persistent [max_batch_size] device array of slot indices indexed by
     // batch position, updated lazily via cudaMemcpyAsync when the batch
     // composition changes — graph-capture-safe (kernels read from a stable
     // device pointer; host updates between graph replays).
+    // Persistent, allocated once beside d_kv_slot_buf_ (#1648). Was a
+    // cudaMallocAsync per decode step whose address a replayed graph had
+    // already captured.
     int* residual_meta_d_buf_ = nullptr;
+    int residual_meta_capacity_ = 0;  // sequences the buffer above can hold
     int* d_kv_slot_buf_ = nullptr;
     std::vector<int> residual_meta_h_seq_ids_;
     std::vector<int> residual_meta_h_slots_;

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -421,6 +421,23 @@ void Engine::init_resolve_kv_dtype_policy_() {
     } else {
         IMP_LOG_INFO("max_batch_size: %d (configured)", config_.max_batch_size);
     }
+
+    // Every decode-graph path is gated on n_sequences <= kMaxGraphPoolSize, so a
+    // batch above it runs the forward EAGERLY - with no clamp, no warning, and
+    // no branch that says so (#1646). Measured on this box, graphs on against
+    // off, tg256: 454 vs 190 tok/s, i.e. the configured value silently costs
+    // 2.4x decode the moment it exceeds the pool.
+    //
+    // Not clamped: the value also bounds admission and KV sizing, and silently
+    // serving fewer requests than asked is its own defect. Said out loud
+    // instead, once, at the place where the number is resolved.
+    if (config_.use_cuda_graphs && config_.max_batch_size > Engine::kMaxGraphPoolSize) {
+        IMP_LOG_WARN(
+            "max_batch_size %d exceeds the decode-graph pool (%d): any step with more than "
+            "%d sequences runs eager, which measured 2.4x slower decode on this box. "
+            "Lower max_batch_size, or accept eager decode above that width.",
+            config_.max_batch_size, Engine::kMaxGraphPoolSize, Engine::kMaxGraphPoolSize);
+    }
 }
 
 // Auto-detect SSM state dtype for hybrid models. Nemotron-H and similar

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -565,6 +565,20 @@ bool Engine::init_kv_cache() {
                 std::vector<int> init_slots(max_seqs, -1);
                 cudaMemcpy(d_kv_slot_buf_, init_slots.data(), slot_bytes, cudaMemcpyHostToDevice);
                 d_kv_slot_last_uploaded_.assign(max_seqs, -1);
+                // Same treatment for the multi-sequence metadata (#1648). It
+                // used to be cudaMallocAsync'd per decode step, and its address
+                // was baked into a captured forward_logits graph that is then
+                // REPLAYED - with none of the graph-invalidation triggers
+                // watching it. That only ever worked because the default pool's
+                // release threshold is pinned to UINT64_MAX so the same address
+                // came back; a pool setting, not an invariant the graph path
+                // asserts. Three [max_batch_size] int arrays, allocated once.
+                size_t meta_bytes = static_cast<size_t>(3) * max_seqs * sizeof(int);
+                if (cudaMalloc(&residual_meta_d_buf_, meta_bytes) == cudaSuccess) {
+                    residual_meta_capacity_ = max_seqs;
+                    std::vector<int> init_meta(3 * static_cast<size_t>(max_seqs), 0);
+                    cudaMemcpy(residual_meta_d_buf_, init_meta.data(), meta_bytes, cudaMemcpyHostToDevice);
+                }
             }
         } else if (residual_n > 0) {
             IMP_LOG_INFO("kv_cache.bitdecoding_residual_tokens=%d ignored (only active with kv_cache_dtype=NVFP4)",

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1731,19 +1731,38 @@ void Engine::decode_build_inference_state_(GPUBatch& gpu_batch,
                 residual_meta_h_counts_[i] = rs.fill_count;
                 residual_meta_h_widxes_[i] = rs.write_idx;
             }
-            const size_t meta_bytes = static_cast<size_t>(3) * N * sizeof(int);
-            if (cudaMallocAsync(&residual_meta_d_buf_, meta_bytes, dec_stream) == cudaSuccess) {
+            // The buffer is persistent and sized for max_batch_size (#1648):
+            // a per-step cudaMallocAsync address was baked into a captured
+            // graph that is replayed, and nothing invalidated the graph when
+            // the allocator handed back a different one. Stride by the
+            // CAPACITY, not by N, so the three sub-arrays keep fixed offsets
+            // across steps whatever the batch width - a graph captured at one
+            // N stays correct at another.
+            if (residual_meta_d_buf_ != nullptr && N <= residual_meta_capacity_) {
                 int* base = residual_meta_d_buf_;
-                cudaMemcpyAsync(base + static_cast<ptrdiff_t>(0) * N, residual_meta_h_slots_.data(),
-                                N * sizeof(int), cudaMemcpyHostToDevice, dec_stream);
-                cudaMemcpyAsync(base + static_cast<ptrdiff_t>(1) * N, residual_meta_h_counts_.data(),
-                                N * sizeof(int), cudaMemcpyHostToDevice, dec_stream);
-                cudaMemcpyAsync(base + static_cast<ptrdiff_t>(2) * N, residual_meta_h_widxes_.data(),
-                                N * sizeof(int), cudaMemcpyHostToDevice, dec_stream);
-                state.d_residual_seq_slots = base + static_cast<ptrdiff_t>(0) * N;
-                state.d_residual_counts = base + static_cast<ptrdiff_t>(1) * N;
-                state.d_residual_write_idxes = base + static_cast<ptrdiff_t>(2) * N;
+                const ptrdiff_t stride = residual_meta_capacity_;
+                cudaMemcpyAsync(base + 0 * stride, residual_meta_h_slots_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                cudaMemcpyAsync(base + 1 * stride, residual_meta_h_counts_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                cudaMemcpyAsync(base + 2 * stride, residual_meta_h_widxes_.data(), N * sizeof(int),
+                                cudaMemcpyHostToDevice, dec_stream);
+                state.d_residual_seq_slots = base + 0 * stride;
+                state.d_residual_counts = base + 1 * stride;
+                state.d_residual_write_idxes = base + 2 * stride;
                 state.h_residual_seq_ids = residual_meta_h_seq_ids_.data();
+            } else {
+                // Neither case is expected: the buffer is sized for
+                // max_batch_size at init and admission is clamped to it. Say
+                // so once rather than decoding with stale metadata.
+                static bool warned = false;
+                if (!warned) {
+                    warned = true;
+                    IMP_LOG_WARN(
+                        "residual metadata unavailable for a %d-sequence decode "
+                        "(buffer=%p, capacity=%d); this step runs without it",
+                        N, static_cast<const void*>(residual_meta_d_buf_), residual_meta_capacity_);
+                }
             }
         }
     }
@@ -2089,13 +2108,9 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
         gpu_batch.free();
     }
 
-    // Free per-step residual metadata buffer (allocated in step_decode_forward
-    // when residual is enabled). cudaFreeAsync orders behind the just-issued
-    // forward + sample on dec_stream.
-    if (residual_meta_d_buf_ != nullptr) {
-        IMP_CUDA_CHECK_LOG(cudaFreeAsync(residual_meta_d_buf_, dec_stream));
-        residual_meta_d_buf_ = nullptr;
-    }
+    // (The residual metadata buffer is persistent since #1648 - allocated once
+    // beside d_kv_slot_buf_ and freed with it in the destructor. Freeing it per
+    // step is what made a replayed graph hold a dangling address.)
 
     // Phase 3.5 telemetry: measure MTP-draft prediction accuracy without
     // changing generation. Single-sequence only (batch=1 simplifies hidden-

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -65,11 +65,11 @@ src/quant/nvfp4_gemm.cu  # 3
 src/quant/nvfp4_quant.cu  # 16
 src/runtime/batch.cpp  # 10
 src/runtime/cuda_graph.cu  # 26
-src/runtime/engine.cpp  # 5
+src/runtime/engine.cpp  # 6
 src/runtime/engine_graph_decode.cpp  # 30
 src/runtime/engine_internal.h  # 5
-src/runtime/engine_kv_cache_init.cpp  # 3
-src/runtime/engine_scheduler.cpp  # 24
+src/runtime/engine_kv_cache_init.cpp  # 4
+src/runtime/engine_scheduler.cpp  # 22
 src/runtime/engine_spec_ngram.cpp  # 13
 src/runtime/engine_workspace_warmup.cpp  # 2
 src/vision/vision_pipeline.cpp  # 2

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -87,7 +87,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 1995, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1980, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1985, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1159, reason = "(c) 59 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
Three findings on the KV/graph path. One is a correctness fix, one makes a
silent 2.4x cost audible, and one is a real fix that **does not** repair the
path it is on - which is the most useful thing in this PR.

## #1652 - the growable pool zeroed on stream 0 and published to another stream

`cudaMemset` runs on the **legacy default stream**. The engine decodes on a
`cudaStreamNonBlocking` stream, which by construction has no ordering
relationship with it. The new capacity was published immediately after, with no
sync and no event - so a memset could retire **after** the first KV write into
the same blocks and zero live KV.

On a 36-layer model that is 72 unordered memsets over exactly the blocks the
next decode step is about to fill, and it breaks the invariant the zeroing
exists to keep in the worse direction: not "stale bytes" but "your bytes,
erased".

Stream 0 is synchronised before publication. Not the device - the only work
being waited on is these memsets, and `cudaDeviceSynchronize` would
additionally stall whatever the engine has in flight for no benefit. Growth is
rare: it fires under pressure, not per step.

## #1646 - a batch above the graph pool ran eager, with nothing saying so

Every decode-graph path is gated on `n_sequences <= kMaxGraphPoolSize` (64), so
a larger configured `max_batch_size` falls to an eager forward. No clamp, no
warning, no branch that mentions it.

Measured on this box, graphs on against off, tg256: **454 vs 190 tok/s**. The
configured value costs 2.4x decode the moment it exceeds the pool.

**Not clamped**: the value also bounds admission and KV sizing, and silently
serving fewer requests than the operator asked for is its own defect. Said out
loud instead, once, at the resolver where the number is decided.

## #1648 - a per-step address baked into a replayed graph

`residual_meta_d_buf_` was `cudaMallocAsync`'d every decode step, its address
written into `InferenceState`, which a captured `forward_logits` graph closes
over and then replays - with none of the three invalidation triggers watching
it. It survived only because the default pool's release threshold is pinned to
`UINT64_MAX` so the same address came back: a pool setting, not an invariant
the graph path asserts.

It is allocated once beside `d_kv_slot_buf_` now - which the code already
called "graph-capture-safe" for exactly this reason - sized for
`max_batch_size`, and **strided by capacity rather than by N**, so the three
sub-arrays keep fixed offsets and a graph captured at one batch width stays
correct at another.

### It does not fix that path, and this PR does not claim it does

`Qwen3-8B-Q8_0.gguf`, `--kv-nvfp4 --set kv_cache.bitdecoding_residual_tokens=64`:

| arm | requests | outcome | `illegal memory access` lines |
|---|---|---|---|
| graphs on, **before** this change | 6 concurrent | degenerate `Okay!!!!!!` | 106998 |
| graphs on, **after** | 6 concurrent | same degeneration | 111543 |
| `cuda_graphs=never`, after | 6 concurrent | six correct answers | **0** |
| graphs on, after | 1 | correct answer | **0** |

So the address #1648 names is one thing a replayed graph holds wrongly on that
path, and **not the one that faults**. The `cuda_graphs=never` control is what
makes "a graph holds something it should not" the shape of the answer rather
than a guess, and the N=1 row locates it in the multi-sequence branch.

Filed as **#1708** with those controls. #1648 is commented with the same
numbers rather than closed by this PR.

The knob is off by default (`bitdecoding_residual_tokens = 0`), which is what
has kept this out of sight.

## Pins

`engine_scheduler.cpp` code_loc 1980 → 1985; the alloc-site budget drops by 2,
because the per-step allocate/free pair is gone.

CPU lane 7/7, GPU suite clean, static gates green.
