### PR TITLE
fix(test): the degeneration battery had no call sites, and its stand-in saw one shape (#1573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,23 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The degeneration battery had zero call sites, and the gate that stood in
+  for it saw one shape** (#1573). `tools/analysis/degen_suite.py` is 41 checks
+  that exit non-zero correctly and that nothing ever ran; it is wired into
+  `make test-server` now, where the running server it needs already exists.
+  First run: **35 checks, 0 fail, 5 s**. Against `--kv-nvfp4` plus the residual
+  knob it found a real one on its first attempt (stream and non-stream
+  disagreeing at greedy) - added to #1708.
+
+  The pre-push smoke gate also gained the two criteria the skill it stands in
+  for already specifies: no token more than 4 times in a row, no 3-gram more
+  than 3 times. The old distinct-token count could not see a loop: a stream
+  with **15** distinct tokens in its last 32 passes it while repeating a 3-gram
+  four times. The token floor is per-prompt, because this gate's own prompt is
+  the "single-word factual" case the skill excepts - it answers in 11 tokens,
+  one above a flat limit of 10.
+
+
 - **`json_schema`: an unconstrained `integer` had no digit bound** (#1540). At
   the server's default temperature the sampler could sit in the digit state and
   emit `1020000000000000000000000000000000000000` for a population field - a

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -99,6 +99,15 @@ run "thinking toggle"     python3 tests/test_server_thinking_toggle.py
 run "vision refusal + utf8 (#1197/#1198)" python3 tests/test_server_vision_and_utf8.py
 run "embed/chat interleave" bash tests/test_server_embed_chat_interleave.sh 15
 run "0-token battery (#710)" env N=8 LOAD=80 FAIL_THRESHOLD=0.10 python3 tests/test_server_0token_battery.py
+# #1573: tools/analysis/degen_suite.py had ZERO invocation sites - 41 checks
+# that exit non-zero correctly and that nothing ever ran. The pre-push gate's
+# degeneration half is one smoke prompt against one model; this is the deep
+# battery, and this script already has the running server it needs.
+#
+# Categories, not --corpus: the corpus battery is ~250 prompts and belongs in a
+# longer lane. These are the server-protocol failure classes the C-API GTests
+# structurally cannot see (think-leak, special tokens, stream consistency).
+run "degeneration suite (#1573)" python3 tools/analysis/degen_suite.py --url "http://localhost:$PORT"
 
 echo
 if [ "${#fails[@]}" -ne 0 ]; then

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -705,8 +705,13 @@ section "smoke prompts (degeneration check)"
 # Greedy decode on a known-deterministic prompt.
 # Quality gate: output must contain expected substring AND last 32 tokens must
 # have at least 8 distinct tokens (catches "own own own" stuck-token failures).
+# $5 (optional): minimum generated tokens. The skill's figure is 10, with its
+# own exception for "single-word factual" prompts - and this gate's own prompt
+# is one: "The capital of France is" answers in 11 tokens on the 4B model, so a
+# flat 10 would sit one token from a false red. Per-prompt, with the default
+# where the skill put it.
 smoke_prompt() {
-    local label="$1" model="$2" prompt="$3" expect="$4"
+    local label="$1" model="$2" prompt="$3" expect="$4" min_toks="${5:-10}"
     if [ ! -f "$MODELS/$model" ]; then
         skip "$label ($model not present)"
         return
@@ -720,7 +725,17 @@ smoke_prompt() {
     DISTINCT=$(echo "$TOKS" | sort -u | wc -l)
     # Generated word stream (stripped of token id prefix) for NaN/Inf scan
     WORDS=$(grep -oP "\[tok=[0-9]+ '\K[^']*" "$ERR" | tr '\n' ' ')
+    # The repetition and early-abort checks below read the WHOLE run, not the
+    # trailing window. Derived here so the temp file is gone before any of the
+    # early returns below - they used to be the only `rm` and adding checks in
+    # front of it would have leaked one file per failed smoke run.
+    ALL_TOKS=$(grep -oP '\[tok=\K[0-9]+' "$ERR")
     rm -f "$ERR"
+    N_TOKS=$(printf '%s\n' "$ALL_TOKS" | grep -c .)
+    RUNMAX=$(printf '%s\n' "$ALL_TOKS" | uniq -c | awk '{if($1>m)m=$1}END{print m+0}')
+    GRAMMAX=$(printf '%s\n' "$ALL_TOKS" | awk '{a[NR]=$0} END{
+        for(i=1;i+2<=NR;i++){k=a[i]" "a[i+1]" "a[i+2]; c[k]++; if(c[k]>m)m=c[k]}
+        print m+0}')
 
     # Herestrings, not `echo ... | grep -q`: grep -q leaves at the first match and
     # closes the pipe, echo dies of EPIPE, and `set -o pipefail` (:40) turns that
@@ -738,25 +753,54 @@ smoke_prompt() {
         echo "  tokens: $(echo "$TOKS" | tr '\n' ' ')"
         return
     fi
+    # The distinct-token count is one shape of degeneration, and the skill this
+    # gate stands in for names three more (#1573). Two of them are checkable
+    # here, from output this gate already collects, with the skill's own
+    # thresholds:
+    #
+    #   1. verbatim repetition — no token more than 4 times in a row, no 3-gram
+    #      more than 3 times. "a b c a b c a b c a b c" has 3 distinct tokens
+    #      per window and passes the count above; it is the shape #1248 had.
+    #   2. early abort — at least 10 generated tokens. A 3-token answer to a
+    #      sentence-completion prompt is a stop-condition defect, and it also
+    #      makes every check above vacuous: 3 tokens cannot fail a 32-token
+    #      window.
+    if [ "$RUNMAX" -gt 4 ]; then
+        fail "$label — a token repeats $RUNMAX times in a row (skill limit: 4)"
+        echo "  tokens: $(printf '%s ' $ALL_TOKS)"
+        return
+    fi
+    if [ "$GRAMMAX" -gt 3 ]; then
+        fail "$label — a 3-gram repeats $GRAMMAX times (skill limit: 3)"
+        echo "  tokens: $(printf '%s ' $ALL_TOKS)"
+        return
+    fi
+    if [ "$N_TOKS" -lt "$min_toks" ]; then
+        fail "$label — stopped after $N_TOKS tokens (limit: $min_toks)"
+        echo "  words: $WORDS"
+        return
+    fi
     # Generated text appears interleaved with logs on stdout — substring match works
     if ! grep -q "$expect" <<< "$OUT$WORDS"; then
         fail "$label — expected '$expect' in output"
         echo "  words: $WORDS"
         return
     fi
-    pass "$label (distinct=$DISTINCT, contains '$expect')"
+    pass "$label (distinct=$DISTINCT, tokens=$N_TOKS, max-run=$RUNMAX, max-3gram=$GRAMMAX, contains '$expect')"
 }
 
 smoke_prompt "Qwen3-4B Q8_0 (dense)" \
     "Qwen3-4B-Instruct-2507-Q8_0.gguf" \
     "The capital of France is" \
-    "Paris"
+    "Paris" \
+    5
 
 if [ "$MODE" = "full" ]; then
     smoke_prompt "Qwen3.5-4B MXFP4 (GDN)" \
         "Qwen3.5-4B-mxfp4.gguf" \
         "The capital of France is" \
-        "Paris"
+        "Paris" \
+        5
 fi
 
 # ------------------------------------------------------------------- summary


### PR DESCRIPTION
The repo's stated last line of defence against wrong output was a skill
document plus one distinct-token count. Both halves get wired up.

## The battery had zero call sites

`tools/analysis/degen_suite.py` is 41 checks that exit non-zero correctly and
that **nothing ever ran**. `scripts/test_server.sh` already boots the server it
needs, so that is where it goes.

First run in its life, `Qwen3-4B-Instruct-2507-Q8_0` over FP16 KV:

```
degen_suite: 35 checks, 0 FAIL, 1 skipped (5s)
```

**It earned the wiring on its second invocation.** Same binary, `--kv-nvfp4
--set kv_cache.bitdecoding_residual_tokens=64`:

```
degen_suite: 46 checks, 1 FAIL, 1 skipped (22s)
  FAIL [stream] stream == non-stream at temp=0
    stream='1, 2, 3, 4, 5, 6, 7, 8, 9, 10'
    nonstream='1,2,3,4,5,6,7,8,9,10'
```

Control, `--kv-nvfp4` **without** the residual knob: both transports return
`'1, 2, 3, 4, 5, 6, '` - identical. Added to #1708, which is the same path.

Categories rather than `--corpus`: the corpus battery is ~250 prompts and
belongs in a longer lane than a server battery that already takes minutes.

## The stand-in gate saw one shape

The pre-push smoke check asserted one thing about output: at least 8 distinct
tokens in the last 32. That catches `own own own` and nothing else in the
skill's own table. Two of the remaining shapes are checkable from output this
gate already collects, with the skill's own thresholds - no token more than 4
times in a row, no 3-gram more than 3 times.

**Why the 3-gram check is not redundant with the count.** Measured on synthetic
streams:

| stream | n | max run | max 3-gram | verdict |
|---|---|---|---|---|
| healthy sentence | 14 | 1 | 1 | pass |
| stuck token | 14 | 8 | 6 | FAIL |
| 3-gram loop | 14 | 1 | 4 | FAIL |
| early abort | 3 | - | - | FAIL |
| exactly at the limits | 14 | 4 | 3 | pass |

And the case the old gate lets through: a stream with **15 distinct tokens** in
its last 32 - comfortably past the 8 it wants - while repeating a 3-gram four
times.

**The token floor is per-prompt.** The skill says 10, with its own exception
for "single-word factual" prompts, and this gate's own prompt is one: "The
capital of France is" answers in **11 tokens** on the 4B model. A flat 10 would
sit one token from a false red, so both smoke prompts pass 5 and the default
stays where the skill put it.

Real run after the change, from this PR's own push:

```
PASS Qwen3-4B Q8_0 (dense) (distinct=11, tokens=11, max-run=1, max-3gram=1, contains 'Paris')
```

## One thing that is not a feature

The temp file is cleaned before the early returns rather than after them.
Adding checks in front of what used to be the only `rm` would have leaked one
file per failed smoke run.

## Not in this PR

#1571 (KL / PPL-drift / tool-conformance gates, NIAH), #1572 (chat-template
goldens for 9 of 10 families) and #1642 (no soak test) are each their own piece
of work rather than wiring.
