### PR TITLE
fix(api): a \uXXXX escape that compiled to '?', and a vocabulary re-classified per request (#1563 #1568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,25 @@ there instead of retelling it.
 
 ### Fixed
 
+- **`json_schema`: a `\uXXXX` escape compiled to a literal `?`** (#1563). The
+  schema string parser skipped the four hex digits and appended `?`. That is
+  not an edge case: `json.dumps` defaults to `ensure_ascii=True`, so a schema
+  round-tripped through any Python client arrives with every non-ASCII
+  character escaped - and the same parser reads enum values, property names,
+  `required` entries and `pattern`, so the compiled grammar then *forced* the
+  model to emit `?` where the caller asked for a character. Escapes decode to
+  UTF-8 now, surrogate pairs included; a lone surrogate becomes U+FFFD and a
+  truncated escape ends the string rather than inventing one. Four CPU tests,
+  all four red without the fix.
+
+- **The regex constraint re-classified the whole vocabulary on every request**
+  (#1568). `prepare_grammar` has skipped that work for an unchanged grammar
+  since it was written; `prepare_regex` never had the check, so ~151K tokens
+  were re-classified on the scheduler thread for every request - and a client
+  that pins one pattern sends it on every request. Measured on
+  `Qwen3-4B-Instruct-2507-Q8_0.gguf`, same pattern eight times, median of
+  requests 2-8: **73.0 ms before, 37.0 ms after (-49.3%)**.
+
 - **A growable KV pool zeroed new blocks on stream 0 and published them to a
   non-blocking stream** (#1652). `cudaMemset` runs on the legacy default
   stream; the engine decodes on a `cudaStreamNonBlocking` stream, which by

--- a/src/compute/json_schema.cpp
+++ b/src/compute/json_schema.cpp
@@ -97,6 +97,52 @@ private:
         return false;
     }
 
+    // Four hex digits into `out`. False when fewer than four remain or one is
+    // not hex - a truncated escape is malformed input, not a character.
+    bool read_hex4(uint32_t& out) {
+        if (pos_ + 4 > len_)
+            return false;
+        uint32_t v = 0;
+        for (int i = 0; i < 4; i++) {
+            const char c = data_[pos_ + i];
+            uint32_t d;
+            if (c >= '0' && c <= '9')
+                d = static_cast<uint32_t>(c - '0');
+            else if (c >= 'a' && c <= 'f')
+                d = static_cast<uint32_t>(c - 'a' + 10);
+            else if (c >= 'A' && c <= 'F')
+                d = static_cast<uint32_t>(c - 'A' + 10);
+            else
+                return false;
+            v = (v << 4) | d;
+        }
+        pos_ += 4;
+        out = v;
+        return true;
+    }
+
+    // A lone surrogate is not a legal codepoint; JSON allows one to appear and
+    // the standard replacement character is what every other decoder emits.
+    static void append_utf8(std::string& s, uint32_t cp) {
+        if (cp >= 0xD800 && cp <= 0xDFFF)
+            cp = 0xFFFD;
+        if (cp < 0x80) {
+            s += static_cast<char>(cp);
+        } else if (cp < 0x800) {
+            s += static_cast<char>(0xC0 | (cp >> 6));
+            s += static_cast<char>(0x80 | (cp & 0x3F));
+        } else if (cp < 0x10000) {
+            s += static_cast<char>(0xE0 | (cp >> 12));
+            s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            s += static_cast<char>(0x80 | (cp & 0x3F));
+        } else {
+            s += static_cast<char>(0xF0 | (cp >> 18));
+            s += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+            s += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+            s += static_cast<char>(0x80 | (cp & 0x3F));
+        }
+    }
+
     std::string parse_string() {
         skip_ws();
         if (peek() != '"')
@@ -133,10 +179,33 @@ private:
                         s += '\f';
                         break;
                     case 'u': {
-                        // Skip unicode escape (4 hex digits)
-                        for (int i = 0; i < 4 && !eof(); i++)
-                            pos_++;
-                        s += '?';
+                        // \uXXXX -> UTF-8. This used to skip the four hex
+                        // digits and append a literal '?', which is not a
+                        // near-miss: json.dumps defaults to ensure_ascii=True,
+                        // so a schema round-tripped through any Python client
+                        // arrives with EVERY non-ASCII character escaped - and
+                        // parse_string() is the reader for enum values,
+                        // property names, `required` entries and `pattern`, so
+                        // the grammar then forced the model to emit '?' where
+                        // the caller asked for a character (#1563).
+                        uint32_t cp = 0;
+                        if (!read_hex4(cp))
+                            return s;  // truncated escape: stop, do not invent
+                        // A high surrogate must be followed by \uDC00-\uDFFF;
+                        // the pair encodes one codepoint above the BMP.
+                        if (cp >= 0xD800 && cp <= 0xDBFF) {
+                            if (pos_ + 1 < len_ && data_[pos_] == '\\' && data_[pos_ + 1] == 'u') {
+                                const size_t save = pos_;
+                                pos_ += 2;
+                                uint32_t lo = 0;
+                                if (read_hex4(lo) && lo >= 0xDC00 && lo <= 0xDFFF) {
+                                    cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                                } else {
+                                    pos_ = save;  // not a pair; emit the lone surrogate below
+                                }
+                            }
+                        }
+                        append_utf8(s, cp);
                         break;
                     }
                     default:

--- a/src/runtime/constraint_manager.cpp
+++ b/src/runtime/constraint_manager.cpp
@@ -310,10 +310,17 @@ bool ConstraintManager::prepare_regex(const std::string& pattern, Tokenizer* tok
         return false;
     if (!regex_constrainer_)
         regex_constrainer_ = std::make_unique<RegexConstrainer>();
+    // Same pattern this pooled manager already serves: skip re-compiling and
+    // re-classifying ~151K tokens, and keep the warm mask cache. prepare_grammar
+    // below has carried this check since it was written; the regex path never
+    // had one, so every request paid a full vocabulary classification on the
+    // scheduler thread - and a client that pins one pattern sends it on every
+    // request (#1568).
+    const bool reuse = regex_constrainer_->is_initialized() && regex_constrainer_->pattern() == pattern;
     // vocab_size here is the LOGITS width; the constrainer clamps its own
     // classification to the tokenizer vocab (SafeTensors models pad lm_head
     // past it — indexing to the logits width read out of bounds once).
-    if (!regex_constrainer_->init(pattern, tokenizer)) {
+    if (!reuse && !regex_constrainer_->init(pattern, tokenizer)) {
         IMP_LOG_WARN("ConstraintManager: regex '%s' rejected — not enforcing it", pattern.c_str());
         return false;
     }
@@ -322,7 +329,8 @@ bool ConstraintManager::prepare_regex(const std::string& pattern, Tokenizer* tok
         regex_constrainer_->set_preamble(think_close, 8192, thinking_open);
     regex_constrainer_->reset();
     active_regex_ = true;
-    IMP_LOG_INFO("ConstraintManager: constraining output to regex '%s'", pattern.c_str());
+    IMP_LOG_INFO("ConstraintManager: constraining output to regex '%s'%s", pattern.c_str(),
+                 reuse ? " (reused classification)" : "");
     return true;
 }
 

--- a/tests/test_schema_constrain_property.cpp
+++ b/tests/test_schema_constrain_property.cpp
@@ -315,6 +315,50 @@ TEST(SchemaParserDesync, UnclosedObjectIsAnError) {
     EXPECT_EQ(parse_json_schema(R"({"type":"object","properties":{"a":{"type":"string"})"), nullptr);
 }
 
+// #1563: \uXXXX was skipped and replaced with a literal '?'. That is not an
+// edge case: json.dumps defaults to ensure_ascii=True, so a schema round-tripped
+// through any Python client arrives with every non-ASCII character escaped -
+// and parse_string() reads enum values, property names, `required` entries and
+// `pattern`, so the compiled grammar then forced the model to emit '?'.
+TEST(SchemaUnicodeEscape, BmpEscapeBecomesUtf8) {
+    // "Berlin, Straße" with the sharp s escaped, as json.dumps writes it.
+    auto sc = make_fsm(R"({"type":"object","properties":{"city":{"type":"string",)"
+                       R"("enum":["Stra\u00dfe"]}},"required":["city"]})");
+    ASSERT_NE(sc, nullptr);
+    // "\xc3\x9fe": C++ keeps consuming hex digits after \x, so the trailing 'e'
+    // would join the escape and overflow. Split the literal.
+    EXPECT_TRUE(
+        sc->token_legal("{\"city\": \"Stra\xc3\x9f"
+                        "e\"}"));
+    EXPECT_FALSE(sc->token_legal(R"({"city": "Stra?e"})"));
+}
+
+TEST(SchemaUnicodeEscape, PropertyNamesDecodeToo) {
+    auto sc = make_fsm(R"({"type":"object","properties":{"stra\u00dfe":{"type":"string"}},)"
+                       R"("required":["stra\u00dfe"]})");
+    ASSERT_NE(sc, nullptr);
+    EXPECT_TRUE(
+        sc->token_legal("{\"stra\xc3\x9f"
+                        "e\": \"x\"}"));
+}
+
+// Above the BMP arrives as a surrogate pair and encodes to four bytes.
+TEST(SchemaUnicodeEscape, SurrogatePairsBecomeOneCodepoint) {
+    // U+1F600 GRINNING FACE
+    auto sc = make_fsm(R"({"type":"object","properties":{"e":{"type":"string",)"
+                       R"("enum":["\ud83d\ude00"]}},"required":["e"]})");
+    ASSERT_NE(sc, nullptr);
+    EXPECT_TRUE(sc->token_legal("{\"e\": \"\xf0\x9f\x98\x80\"}"));
+}
+
+// CJK, three bytes, the case a '?' substitution mangles most visibly.
+TEST(SchemaUnicodeEscape, ThreeByteEscapes) {
+    auto sc = make_fsm(R"({"type":"object","properties":{"c":{"type":"string",)"
+                       R"("enum":["\u4e2d\u6587"]}},"required":["c"]})");
+    ASSERT_NE(sc, nullptr);
+    EXPECT_TRUE(sc->token_legal("{\"c\": \"\xe4\xb8\xad\xe6\x96\x87\"}"));
+}
+
 // #1540: an unconstrained `integer` had no digit bound. At the server's default
 // temperature the sampler stayed in the digit state and emitted
 // 1020000000000000000000000000000000000000 for a population field - a value no

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -72,7 +72,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/gemm_dp4a.cu" = { code_loc = 601, reason = "(c) one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)" }
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = { code_loc = 693, reason = "(c) one small-M grouped-GEMM family (software-ref + prod + smoke variants)" }
 "src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }
-"src/compute/json_schema.cpp" = { code_loc = 1147, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
+"src/compute/json_schema.cpp" = { code_loc = 1200, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
 "src/compute/mtp_forward.cu" = { code_loc = 856, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
 "src/compute/schema_constrain.cu" = { code_loc = 1184, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
 "src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }


### PR DESCRIPTION
Two defects on the constrained-decoding path: one that silently rewrote what
the caller asked for, one that paid for the same work on every request.

## #1563 - a `\uXXXX` escape compiled to a literal `?`

The JSON-Schema string parser skipped the four hex digits and appended `?`.

**Not an edge case.** `json.dumps` defaults to `ensure_ascii=True`, so a schema
round-tripped through any Python client arrives with every non-ASCII character
escaped - and `parse_string()` is the reader for enum values, property names,
`required` entries and `pattern`. The compiled grammar then **forced** the
model to emit `?` where the caller asked for a character.

Escapes decode to UTF-8 now, surrogate pairs included. A lone surrogate becomes
U+FFFD, which is what every other decoder emits; a truncated escape ends the
string rather than inventing a character.

Four CPU tests - BMP, property names, surrogate pair, three-byte CJK - and all
four go red against the old branch.

### One test hazard, now carrying a comment

`"\xc3\x9fe"` is **one** character in C++, not three bytes plus `e`: `\x` keeps
consuming hex digits, so the literal overflows. Split into `"\xc3\x9f" "e"`.
Both string tests failed on that before the schema code was reached at all,
which is a fair reminder that a red test is not yet evidence about the thing
under test.

## #1568 - the regex constraint re-classified the vocabulary per request

`prepare_grammar` has skipped re-compiling and re-classifying ~151K tokens for
an unchanged grammar since it was written. `prepare_regex` never had the check,
so every request paid a full vocabulary classification **on the scheduler
thread** - and a client that pins one pattern sends it on every request.

Measured on `Qwen3-4B-Instruct-2507-Q8_0.gguf`, the same pattern eight times:

| arm | first | median 2-8 | mean 2-8 | min | max |
|---|---|---|---|---|---|
| no reuse check | 85 | **73.0** | 65.3 | 49 | 85 |
| with reuse check | 102 | **37.0** | 38.6 | 34 | 52 |

**-49.3 %** on the median of requests 2-8. The first request is noise either
way - model warmup plus the one classification that genuinely has to happen -
so the steady state is the measurement, and the log line says
`(reused classification)` when the path is taken.

## Not in this PR

**#1597** (`strict: true` is all-or-nothing). The uniform `TOOL_CALL` enum is
what forces that behaviour, so serving a mixed strict/loose tool set needs the
constraint FSM to bind arguments **per tool name** - a capability change, not a
condition to relax. Relaxing the condition alone would over-constrain the loose
tool, which is what the current comment says it is avoiding.

**#1559** (the `/v1/messages` SSE schema runs in no CI job) needs a GPU runner
and a model.

## Pins

`json_schema.cpp` code_loc 1147 → 1200.

CPU lane 7/7, GPU suite clean, static gates green.
