### PR TITLE
fix(kv,sched): admission reserved the prompt only, and the graph loop reserved the whole generation (#1635 #1636 #1662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,55 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Admission reserved for the prompt and the graph loop reserved for the
+  whole generation** (#1635, #1636, #1662). Three ways the KV pool promised
+  what it could not keep.
+
+  `Scheduler::schedule` tested `can_allocate(prompt)` and ignored `max_tokens`,
+  so a batch whose prompts all fit could run the pool dry mid-generation and
+  the loser was cancelled after the client had already received part of the
+  answer. It admits on prompt + `max_tokens` now, and the promise is **held**
+  (`imp_kv_blocks_reserved`, new gauge) until the blocks are written - a test
+  that is not held admits the next request against the same memory one round
+  later. On a pool too small to ever hold prompt + `max_tokens` the reserve is
+  clamped to the pool, which is the old behaviour: no admission rule can
+  promise memory that does not exist.
+
+  The trade, measured on `Qwen3-8B-Q8_0.gguf` with 8 concurrent
+  `max_tokens: 1024` requests: at the default pool it costs nothing (551.3
+  against 519.2 tok/s, inside the run spread). On a 150-block pool `main`
+  truncates one to two of the eight answers per run and reports them as
+  `finish_reason: "length"`, indistinguishable from a spent budget; this PR
+  finishes all eight at **228.5 against 526.3 tok/s**. The reserve is sized by
+  `max_tokens`, so the lever is `max_tokens`, and the server default of 8192 is
+  its worst case.
+
+  `can_allocate` also stopped counting live sequences as reclaimable. Its slow
+  path summed the LRU list on the assumption that `evict_lru()` could hand
+  those blocks back, while `evict_lru()` has had no production caller for
+  exactly the reason that freeing a live sequence's KV corrupts it.
+
+  `prepare_graph_loop` booked KV for the entire remaining generation before a
+  burst that is bounded to `speculative.miss_burst`, `runtime.decode_burst` or
+  16. Measured on `Qwen3-8B-Q8_0.gguf`, `max_tokens: 8192`, same 355-token
+  answer both ways:
+
+  | reservation | peak `imp_kv_blocks_live` |
+  |---|---|
+  | whole generation (before) | 514 |
+  | the burst (after) | **26** |
+
+  It was paid for out of the prefix cache, because `append_block` reclaims
+  cached blocks when the free pool is empty. On a 600-block pool with a warm
+  prefix, same 344-token answer: `imp_kv_blocks_cached` **176 -> 108** before,
+  **176 -> 198** after.
+
+  Third: a KV pool that does not fit halves and retries down to the 16-block
+  floor instead of failing the load, with a WARN per attempt naming planned,
+  retried and the shortfall in MiB. Everything that sizes that pool runs before
+  the allocation, so all of it is a projection - #1631 fixed one wrong one, and
+  #1662 shows that even a correct projection is not sufficient on its own.
+
 - **Two binaries returned exit 0 after doing no work** (#1584). `imp-bench`
   counted invocations rather than measurements, so a host with no CUDA device
   printed "Benchmarks run: 4" and exited 0 with nothing measured; every bench

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,6 +96,12 @@ the server log (#1640, #1641):
 
 `imp_requests_cancelled_total` remains client-disconnect only.
 
+`imp_kv_blocks_reserved` (gauge) is what admission has promised to running
+requests for the rest of their generation and not yet written (#1635). Free
+blocks minus this gauge is what the next request is admitted against, so a
+queue in front of a pool with free blocks is explained by this number and by
+nothing else in `/metrics`.
+
 ## Constrained decoding
 
 Four flavours, all enforced by masking at decode time rather than by

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -82,6 +82,25 @@ Also check `kv_cache.swa_snapshot_mb`: a value **below one snapshot size**
 silently disables prefix caching, which is worse than setting it to zero. It
 warns since #1092.
 
+## Requests queue while `/metrics` shows free KV blocks
+
+`imp_kv_blocks_reserved` is the answer, and it is a gauge since v0.29.0.
+
+Admission reserves prompt **plus `max_tokens`** (#1635). A request admitted on
+its prompt alone can run the pool dry halfway through its own answer, and the
+loser is whichever request needs the next block - a truncated answer after the
+client has already received part of it. Queueing is the better failure, so the
+promise is held from admission until the blocks are written.
+
+The visible cost is concurrency against a client that does not set `max_tokens`:
+the server default is 8192, so each such request reserves
+`ceil(8192/block_size) + 1` blocks whatever it ends up emitting. Set `max_tokens`
+to what the answer actually needs.
+
+On a pool too small to ever hold prompt + `max_tokens` the reserve is clamped to
+the pool, which is the pre-#1635 behaviour - there the mid-stream cancel is still
+possible, because no admission rule can promise memory that does not exist.
+
 ## After a restart, every prompt is cancelled
 
 Restarting the server while the previous process still holds the card gives you

--- a/scripts/check_e2e_lane_split.sh
+++ b/scripts/check_e2e_lane_split.sh
@@ -47,6 +47,8 @@ RequestTest.DefaultState
 RequestTest.StatusTransitions
 SchedulerTest.ACancelledQueueSchedulesNothing
 SchedulerTest.AddRemoveRapidly
+SchedulerTest.AdmissionClampsReserveToPoolSize
+SchedulerTest.AdmissionReservesGeneration
 SchedulerTest.AgingStopsALongPromptFromStarving
 SchedulerTest.AllRequestsTooLargeForMemory
 SchedulerTest.BasicPrefillThenDecode

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -289,6 +289,10 @@ int KVCacheManager::append_block(int seq_id) {
 }
 
 void KVCacheManager::free_sequence(int seq_id) {
+    // Before the early return: a reservation outlives the block table it was
+    // taken against, and an orphan keeps subtracting from can_allocate().
+    decode_reservations_.erase(seq_id);
+
     auto it = seq_blocks_.find(seq_id);
     if (it == seq_blocks_.end())
         return;
@@ -412,27 +416,41 @@ int KVCacheManager::evict_lru() {
     return -1;  // All sequences are pinned.
 }
 
+void KVCacheManager::set_decode_reservation(int seq_id, int total_blocks) {
+    if (total_blocks <= 0) {
+        decode_reservations_.erase(seq_id);
+        return;
+    }
+    decode_reservations_[seq_id] = total_blocks;
+}
+
+int KVCacheManager::outstanding_reserved_blocks() const {
+    int outstanding = 0;
+    for (const auto& [seq_id, promised] : decode_reservations_) {
+        auto it = seq_blocks_.find(seq_id);
+        const int held = it == seq_blocks_.end() ? 0 : static_cast<int>(it->second.size());
+        if (promised > held)
+            outstanding += promised - held;
+    }
+    return outstanding;
+}
+
 bool KVCacheManager::can_allocate(int num_blocks) const {
     if (num_blocks <= 0)
         return true;
 
-    // Fast path: free pool + reclaimable cached blocks (O(1) via counter)
-    int reclaimable = cache_->num_free_blocks() + reclaimable_cached_count_;
-    if (reclaimable >= num_blocks)
-        return true;
-
-    // Slow path: count blocks from evictable LRU sequences
-    for (auto it = lru_order_.begin(); it != lru_order_.end(); ++it) {
-        if (pinned_seq_blocks_.find(*it) != pinned_seq_blocks_.end())
-            continue;
-        auto seq_it = seq_blocks_.find(*it);
-        if (seq_it != seq_blocks_.end()) {
-            reclaimable += static_cast<int>(seq_it->second.size());
-        }
-        if (reclaimable >= num_blocks)
-            return true;
-    }
-    return false;
+    // Free pool + reclaimable cached blocks (O(1) via counter), minus what
+    // running sequences have already been promised and not yet written.
+    //
+    // There is deliberately no second source. The old slow path added the
+    // blocks of live LRU sequences, which evict_lru() would have to free —
+    // and evict_lru() has no production caller precisely because freeing a
+    // live sequence's KV corrupts it (no recompute path). The predicate
+    // therefore answered "there is room" with memory that never comes back,
+    // which is the over-admission half of #1635.
+    const int available = cache_->num_free_blocks() + reclaimable_cached_count_ -
+                          outstanding_reserved_blocks();
+    return available >= num_blocks;
 }
 
 // ─── Content-addressed prefix caching ────────────────────────────────

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -67,10 +67,26 @@ public:
     // pressure (it reject-newests instead). Manager primitive only.
     int evict_lru();
 
-    // Check whether `num_blocks` blocks are available.  Returns true if
-    // the free pool already has enough blocks *or* if evicting LRU
-    // sequences could free enough.
+    // Check whether `num_blocks` blocks are available, i.e. whether the free
+    // pool plus the reclaimable cached blocks cover them, minus what live
+    // sequences have already been promised (see set_decode_reservation).
+    //
+    // It used to answer "yes" off a second source as well: the blocks of live
+    // LRU sequences, on the assumption that evict_lru() could hand them back.
+    // It cannot — every lru_order_ entry is LIVE and there is no recompute
+    // path, so the engine stopped calling evict_lru() and the predicate was
+    // counting memory that will never be freed (#1635).
     [[nodiscard]] bool can_allocate(int num_blocks) const;
+
+    // Promise `total_blocks` (prompt + decode) to a sequence at admission.
+    // The unwritten part is subtracted from can_allocate() until the blocks
+    // are actually appended, so a later request queues instead of being
+    // admitted against memory the running one is going to need (#1635).
+    // Cleared by free_sequence().
+    void set_decode_reservation(int seq_id, int total_blocks);
+
+    // Promised-but-not-yet-held blocks, summed over live sequences.
+    [[nodiscard]] int outstanding_reserved_blocks() const;
 
     // ── Content-addressed prefix caching ─────────────────────────────
 
@@ -483,6 +499,10 @@ private:
     std::list<int> pin_fifo_;
     // Cap on unique pinned blocks (0 = unlimited).
     int pin_budget_blocks_ = 0;
+
+    // seq_id -> total blocks promised at admission (prompt + max_tokens).
+    // Only the part not yet held counts against can_allocate().
+    std::unordered_map<int, int> decode_reservations_;
 
     // Incrementally maintained count of reclaimable cached blocks
     // (cached_blocks_lru_.size() minus pinned cached blocks).

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -1341,7 +1341,9 @@ private:
     // ── CUDA graph helpers ───────────────────────────────────────────
     // Pre-allocate KV blocks and check preconditions for graph loop.
     // Returns remaining tokens (>0 = ok, <=0 = cannot use graph).
-    int prepare_graph_loop(std::shared_ptr<Request>& req);
+    // step_limit > 0 books KV for that burst only; 0 books the whole
+    // remaining generation (the synchronous generate() loop, which runs it).
+    int prepare_graph_loop(std::shared_ptr<Request>& req, int step_limit = 0);
 
     // Build InferenceState + CudaGraphConditionalRunner::Config for graph loop.
     CudaGraphConditionalRunner::Config build_graph_config(const Request& req, int remaining) const;

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -36,12 +36,24 @@ const int32_t* Engine::banned_tokens_device_(cudaStream_t stream) {
     return d_banned_tokens_.get();
 }
 
-int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
+int Engine::prepare_graph_loop(std::shared_ptr<Request>& req, int step_limit) {
     const int kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
 
     int remaining = req->max_tokens - static_cast<int>(req->output_tokens.size());
     if (remaining <= 0)
         return 0;
+
+    // Book for the burst that is about to run, not for the whole generation
+    // (#1636). The caller clamps the launch to runtime.decode_burst (128), to
+    // 16 while another request waits, or to speculative.miss_burst (8); the
+    // reservation was not clamped with it, so an 8192-token default booked 512
+    // blocks on the first decode step of an answer that may emit 40 tokens.
+    // append_block reclaims cached prefix blocks when the free pool is empty,
+    // so that reservation was paid for out of the prefix cache the next turn
+    // was going to hit. The loop relaunches per burst anyway.
+    int reserve_tokens = remaining;
+    if (step_limit > 0)
+        reserve_tokens = std::min(reserve_tokens, step_limit);
 
     constexpr int kMaxLayersForConditionalGraph = 128;
     if (model_->config().n_layers > kMaxLayersForConditionalGraph)
@@ -56,7 +68,7 @@ int Engine::prepare_graph_loop(std::shared_ptr<Request>& req) {
 
     // Pre-allocate KV blocks
     int ctx_len = req->context_len();
-    int final_ctx = ctx_len + remaining;
+    int final_ctx = ctx_len + reserve_tokens;
     int blocks_needed = (final_ctx + kv_bs - 1) / kv_bs;
     int blocks_have = static_cast<int>(kv_manager_->block_table(req->id).size());
 
@@ -232,7 +244,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
         !req->regex_pattern.empty() || !req->grammar.empty() || !req->tool_constraint_tools.empty())
         return false;
 
-    int remaining = prepare_graph_loop(req);
+    int remaining = prepare_graph_loop(req, step_limit);
     if (remaining <= 0)
         return false;
 

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -471,6 +471,8 @@ bool Engine::init_kv_cache() {
     // reading that is wrong most often — free VRAM while another process is
     // still letting go of the card — stops being final.
     const int kv_ceiling_blocks = runtime_config_.kv_cache.growable ? kv_blocks_planned : 0;
+    // What the pool was actually built with; the retry loop below may lower it.
+    int kv_ceiling_effective = kv_ceiling_blocks;
     if (kv_ceiling_blocks > 0) {
         // Commit a fraction on purpose, where the operator asked for it. The
         // clamp above answers "what fits" from a reading that is wrong in both
@@ -509,35 +511,96 @@ bool Engine::init_kv_cache() {
     // Per-layer KV shape path (Gemma 4 dual attention geometry): build per-layer
     // nkv/hd arrays restricted to attention layers (hybrid models may have non-attn layers).
     // SWA sizing also requires the per-layer path (per-layer region capacities).
-    std::unique_ptr<KVCache> kv_cache;
-    if ((!mcfg.head_dim_per_layer.empty() || swa_sizing_active_) &&
-        config_.kv_cache_dtype != QType::INT8 && config_.kv_cache_dtype != QType::INT4) {
-        std::vector<int> per_layer_nkv(n_kv_layers, 0);
-        std::vector<int> per_layer_hd(n_kv_layers, 0);
-        std::vector<char> per_layer_swa(swa_sizing_active_ ? n_kv_layers : 0, 0);
-        for (int l = 0, k = 0; l < mcfg.n_layers && k < n_kv_layers; l++) {
-            // Only attention layers get KV cache entries
-            int attn_nkv = (l < (int)mcfg.n_kv_heads_per_layer.size()) ? mcfg.n_kv_heads_per_layer[l]
-                                                                       : mcfg.n_kv_heads;
-            if (kv_layer_map[l] < 0)
-                continue;  // non-attention layer (SSM/GDN)
-            if (attn_nkv <= 0)
-                attn_nkv = mcfg.n_kv_heads;
-            per_layer_nkv[k] = attn_nkv;
-            per_layer_hd[k] = (l < (int)mcfg.head_dim_per_layer.size() && mcfg.head_dim_per_layer[l] > 0)
-                                  ? mcfg.head_dim_per_layer[l]
-                                  : head_dim;
-            if (swa_sizing_active_)
-                per_layer_swa[k] = layer_swa_window(mcfg, model_->profile(), l) > 0 ? 1 : 0;
-            k++;
+    auto make_kv_cache = [&](int blocks, int ceiling) -> std::unique_ptr<KVCache> {
+        std::unique_ptr<KVCache> kv_cache;
+        if ((!mcfg.head_dim_per_layer.empty() || swa_sizing_active_) &&
+            config_.kv_cache_dtype != QType::INT8 && config_.kv_cache_dtype != QType::INT4) {
+            std::vector<int> per_layer_nkv(n_kv_layers, 0);
+            std::vector<int> per_layer_hd(n_kv_layers, 0);
+            std::vector<char> per_layer_swa(swa_sizing_active_ ? n_kv_layers : 0, 0);
+            for (int l = 0, k = 0; l < mcfg.n_layers && k < n_kv_layers; l++) {
+                // Only attention layers get KV cache entries
+                int attn_nkv = (l < (int)mcfg.n_kv_heads_per_layer.size()) ? mcfg.n_kv_heads_per_layer[l]
+                                                                           : mcfg.n_kv_heads;
+                if (kv_layer_map[l] < 0)
+                    continue;  // non-attention layer (SSM/GDN)
+                if (attn_nkv <= 0)
+                    attn_nkv = mcfg.n_kv_heads;
+                per_layer_nkv[k] = attn_nkv;
+                per_layer_hd[k] = (l < (int)mcfg.head_dim_per_layer.size() && mcfg.head_dim_per_layer[l] > 0)
+                                      ? mcfg.head_dim_per_layer[l]
+                                      : head_dim;
+                if (swa_sizing_active_)
+                    per_layer_swa[k] = layer_swa_window(mcfg, model_->profile(), l) > 0 ? 1 : 0;
+                k++;
+            }
+            kv_cache = std::make_unique<KVCache>(n_kv_layers, per_layer_nkv, per_layer_hd,
+                                                 config_.kv_cache_dtype, blocks, kv_bs, &vram_alloc_,
+                                                 per_layer_swa,
+                                                 swa_sizing_active_ ? vram_budget.swa_max_blocks : 0,
+                                                 ceiling);
+        } else {
+            kv_cache = std::make_unique<KVCache>(n_kv_layers, mcfg.n_kv_heads, head_dim,
+                                                 config_.kv_cache_dtype, blocks, kv_bs, &vram_alloc_,
+                                                 ceiling);
         }
-        kv_cache = std::make_unique<KVCache>(n_kv_layers, per_layer_nkv, per_layer_hd, config_.kv_cache_dtype,
-                                             max_blocks, kv_bs, &vram_alloc_, per_layer_swa,
-                                             swa_sizing_active_ ? vram_budget.swa_max_blocks : 0,
-                                             kv_ceiling_blocks);
-    } else {
-        kv_cache = std::make_unique<KVCache>(n_kv_layers, mcfg.n_kv_heads, head_dim, config_.kv_cache_dtype,
-                                             max_blocks, kv_bs, &vram_alloc_, kv_ceiling_blocks);
+        return kv_cache;
+    };
+
+    // #1662: a pool that does not fit is a smaller pool, not a dead process.
+    //
+    // Everything that sizes this pool runs BEFORE the allocation - the planner,
+    // the clamp, the residual re-sizing - so all of it is working from a
+    // projection. #1631 fixed one wrong projection; the arms in #1662 show that
+    // even the planner's own correct projection is not sufficient on its own
+    // (library_reserve_mb=6100 plans 9977 blocks and OOMs, 7460 plans 7079 and
+    // serves). Halving down to the 16-block floor is the backstop for the next
+    // one: the operator gets a smaller KV pool instead of 537 error lines.
+    //
+    // Only the pool retries. The weight caches are already built at this point
+    // and the model's source tensors may be consumed, so a retry one level up
+    // (imp_context_create) cannot rebuild this engine at all.
+    std::unique_ptr<KVCache> kv_cache;
+    {
+        constexpr int kKVFloorBlocks = 16;
+        const int planned = max_blocks;
+        int attempt_blocks = max_blocks;
+        int attempt_ceiling = kv_ceiling_blocks;
+        for (;;) {
+            try {
+                kv_cache = make_kv_cache(attempt_blocks, attempt_ceiling);
+                break;
+            } catch (const std::exception& e) {
+                if (attempt_blocks <= kKVFloorBlocks) {
+                    IMP_LOG_ERROR(
+                        "KV cache: %d blocks is the %d-block floor and it still does not "
+                        "fit - giving up (%s)",
+                        attempt_blocks, kKVFloorBlocks, e.what());
+                    throw;
+                }
+                const int next = std::max(kKVFloorBlocks, attempt_blocks / 2);
+                const double short_mib = static_cast<double>(n_kv_layers) * (attempt_blocks - next) *
+                                         kv_block_bytes_per_layer(config_.kv_cache_dtype, kv_bs,
+                                                                  mcfg.n_kv_heads, head_dim) /
+                                         (1024.0 * 1024.0);
+                IMP_LOG_WARN(
+                    "KV cache: %d blocks did not fit (planned %d), retrying at %d blocks "
+                    "- %.1f MiB less (%s)",
+                    attempt_blocks, planned, next, short_mib, e.what());
+                attempt_blocks = next;
+                // The ceiling is a reservation of the same pool, so a retry
+                // that only halves the committed part reserves the same
+                // address space again and fails the same way.
+                if (attempt_ceiling > 0)
+                    attempt_ceiling = std::max(next, attempt_ceiling / 2);
+            }
+        }
+        if (attempt_blocks != max_blocks) {
+            max_blocks = attempt_blocks;
+            kv_ceiling_effective = attempt_ceiling;
+            IMP_LOG_WARN("KV cache: serving %d blocks (%.0f tokens) instead of the planned %d", max_blocks,
+                         static_cast<double>(max_blocks) * kv_bs, planned);
+        }
     }
     kv_cache_raw_ = kv_cache.get();
     kv_manager_ = std::make_unique<KVCacheManager>(std::move(kv_cache));
@@ -789,7 +852,7 @@ bool Engine::init_kv_cache() {
         // grew to serve a 25 222-token prompt and the upload then failed with
         // `prefill memcpy block_tables failed: invalid argument`. It is four
         // bytes per block of a pool that may never exist, which is nothing.
-        size_t bt_bytes = static_cast<size_t>(std::max(max_blocks, kv_ceiling_blocks)) * sizeof(int);
+        size_t bt_bytes = static_cast<size_t>(std::max(max_blocks, kv_ceiling_effective)) * sizeof(int);
         size_t swa_bt_bytes = swa_sizing_active_ ? bt_bytes : 0;
         size_t cl_bytes = sizeof(int);
         prefill_pool_size_ = tok_bytes + pos_bytes + bt_bytes + swa_bt_bytes + cl_bytes;

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -76,7 +76,26 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                 int ctx_len = req->context_len();
                 const int bs = kv_manager_->kv_cache()->block_size();
                 int blocks_needed = (ctx_len + bs - 1) / bs;
-                if (!kv_manager_->can_allocate(blocks_needed)) {
+
+                // Admit on prompt + generation, not on the prompt alone
+                // (#1635). context_len() counts what exists NOW, so a batch
+                // whose prompts all fit could still run the pool dry mid-
+                // generation, and the loser is cancelled after the client has
+                // already received part of the answer. The grow branch below
+                // has computed the decode half correctly since it was written;
+                // the admission test above it did not read it.
+                //
+                // Clamped to the pool: on a cache too small to ever hold
+                // prompt + max_tokens (the 16-block floor case) the full
+                // reserve would queue every request forever. There the
+                // guarantee degrades to the old prompt-only admission rather
+                // than to a refusal, and the mid-stream cancel stays possible.
+                const int decode_blocks = (req->max_tokens + bs - 1) / bs + 1;
+                const int pool_blocks = kv_manager_->kv_cache()->total_blocks();
+                const int admit_blocks = std::min(blocks_needed + decode_blocks,
+                                                  std::max(blocks_needed, pool_blocks));
+
+                if (!kv_manager_->can_allocate(admit_blocks)) {
                     // If the request needs more blocks than the KV cache can
                     // ever hold, no eviction will free enough — leaving the
                     // request in pending_ would busy-loop the worker forever
@@ -106,7 +125,6 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                         // block short, after paying for the growth. Measured on
                         // a 25 222-token prompt: grew 810 -> 1577 blocks, then
                         // refused.
-                        const int decode_blocks = (req->max_tokens + bs - 1) / bs + 1;
                         cap = kv_manager_->kv_cache()->try_grow_to(blocks_needed + decode_blocks);
                     }
                     if (blocks_needed > cap) {
@@ -199,6 +217,20 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
                         continue;
                     }
                 }
+            }
+
+            if (kv_manager_) {
+                // Hold the promise, do not just test it. Without this the next
+                // request is admitted against the blocks this one has not
+                // written yet, which is the same over-admission one round
+                // later (#1635). It decays as the blocks are appended and is
+                // dropped by free_sequence().
+                const int bs = kv_manager_->kv_cache()->block_size();
+                const int prompt_blocks = (req->context_len() + bs - 1) / bs;
+                const int decode_blocks = (req->max_tokens + bs - 1) / bs + 1;
+                const int pool_blocks = kv_manager_->kv_cache()->total_blocks();
+                kv_manager_->set_decode_reservation(req->id, std::min(prompt_blocks + decode_blocks,
+                                                                      std::max(prompt_blocks, pool_blocks)));
             }
 
             auto r = *it;

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -477,6 +477,13 @@ TEST(KVCacheManagerTest, AllocationNeverEvictsLiveSequenceUnderPressure) {
 }
 
 // 18. ManagerCanAllocate
+//
+// The contract changed with #1635: a LIVE sequence's blocks are not a source
+// of memory. They used to be - can_allocate() summed the LRU list on the
+// assumption that evict_lru() could hand them back, while evict_lru() has had
+// no production caller for exactly the reason that freeing a live sequence's
+// KV corrupts it. So this test used to assert that a full pool could still
+// allocate 8 more blocks.
 TEST(KVCacheManagerTest, ManagerCanAllocate) {
     SKIP_IF_NO_CUDA();
 
@@ -486,19 +493,52 @@ TEST(KVCacheManagerTest, ManagerCanAllocate) {
     (void)mgr->allocate_blocks(1, 4);
     EXPECT_EQ(mgr->num_free_blocks(), 0);
 
-    // We have 0 free blocks, but can evict 4+4 = 8 blocks total.
-    // So can_allocate(4) should be true (eviction can recover enough).
-    EXPECT_TRUE(mgr->can_allocate(4));
-
-    // can_allocate(8) should also be true (evict everything).
-    EXPECT_TRUE(mgr->can_allocate(8));
-
-    // can_allocate(9) should be false -- even evicting all sequences only
-    // frees 8 blocks, which is less than 9.
-    EXPECT_FALSE(mgr->can_allocate(9));
+    // Nothing is free and nothing is cached: the answer is no, at any size.
+    EXPECT_FALSE(mgr->can_allocate(1));
+    EXPECT_FALSE(mgr->can_allocate(4));
+    EXPECT_FALSE(mgr->can_allocate(8));
 
     // Edge case: can_allocate(0) is trivially true.
     EXPECT_TRUE(mgr->can_allocate(0));
+
+    // Finishing a sequence is what returns its blocks.
+    mgr->free_sequence(0);
+    EXPECT_TRUE(mgr->can_allocate(4));
+    EXPECT_FALSE(mgr->can_allocate(5));
+}
+
+// 18b. A reservation is subtracted until the blocks are actually written.
+TEST(KVCacheManagerTest, DecodeReservationHoldsUnwrittenBlocks) {
+    SKIP_IF_NO_CUDA();
+
+    auto mgr = MakeManager(8);
+
+    ASSERT_TRUE(mgr->allocate_blocks(0, 2));
+    EXPECT_EQ(mgr->num_free_blocks(), 6);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 0);
+
+    // Promise 6 blocks total; 2 are held, so 4 are outstanding.
+    mgr->set_decode_reservation(0, 6);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 4);
+    EXPECT_TRUE(mgr->can_allocate(2));
+    EXPECT_FALSE(mgr->can_allocate(3));
+
+    // Writing a promised block converts reserve into use - the total
+    // available to a second sequence does not move.
+    EXPECT_GE(mgr->append_block(0), 0);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 3);
+    EXPECT_TRUE(mgr->can_allocate(2));
+    EXPECT_FALSE(mgr->can_allocate(3));
+
+    // Overshooting the promise does not go negative.
+    for (int i = 0; i < 5; i++)
+        (void)mgr->append_block(0);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 0);
+
+    // free_sequence drops the reservation with the blocks.
+    mgr->free_sequence(0);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 0);
+    EXPECT_TRUE(mgr->can_allocate(8));
 }
 
 // 19. ManagerPrefixCaching -- legacy register/find/share_prefix removed.
@@ -876,17 +916,22 @@ TEST(KVCacheManagerTest, PinPrefixCanAllocateAccuracy) {
     (void)mgr->allocate_blocks(1, 4);
     EXPECT_EQ(mgr->num_free_blocks(), 0);
 
-    // Pin seq 0. Now only seq 1's 4 blocks are reclaimable via eviction.
+    // Pinning changes nothing here: neither sequence's blocks were ever a
+    // source can_allocate() may draw on while they are live (#1635).
     mgr->pin_prefix(0, 4);
 
-    EXPECT_TRUE(mgr->can_allocate(4));   // Can evict seq 1.
-    EXPECT_FALSE(mgr->can_allocate(5));  // Seq 0 is pinned, can't reclaim its blocks.
+    EXPECT_FALSE(mgr->can_allocate(1));
+    EXPECT_FALSE(mgr->can_allocate(4));
 
     mgr->unpin_prefix(0);
-    EXPECT_TRUE(mgr->can_allocate(8));  // Both sequences reclaimable now.
+    EXPECT_FALSE(mgr->can_allocate(1));
+
+    // A pin does survive free_sequence, so seq 0's blocks stay held while
+    // seq 1's come back.
+    mgr->free_sequence(1);
+    EXPECT_TRUE(mgr->can_allocate(4));
 
     mgr->free_sequence(0);
-    mgr->free_sequence(1);
 }
 
 // ============================================================================

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -103,28 +103,117 @@ TEST(SchedulerTest, RemovesFinishedRequests) {
 TEST(SchedulerTest, MemoryAwareScheduling) {
     SKIP_IF_NO_CUDA();
 
-    // Create a small KV cache with limited blocks
+    // Pool of 8 blocks = 128 tokens. Each request is a 32-token prompt
+    // (2 blocks) plus max_tokens=16 (1 block + the partial-block spare), so
+    // one reservation is 4 blocks and exactly two fit.
     auto cache = std::make_unique<KVCache>(
-        /*n_layers=*/2, /*n_kv_heads=*/4, /*head_dim=*/64, QType::F16, /*max_blocks=*/4);
+        /*n_layers=*/2, /*n_kv_heads=*/4, /*head_dim=*/64, QType::F16, /*max_blocks=*/8);
 
     auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
 
     Scheduler sched(16);  // high batch size, but limited by memory
     sched.set_kv_manager(mgr.get());
 
-    // Each request with 32 tokens needs 2 blocks (kKVBlockSize=16)
     for (int i = 0; i < 5; i++) {
         auto req = std::make_shared<Request>();
+        req->id = i;                      // distinct KV sequences
         req->input_tokens.resize(32, i);  // 32 tokens = 2 blocks
+        req->max_tokens = 16;             // + 1 block + 1 spare
         sched.add_request(req);
     }
 
     std::vector<std::shared_ptr<Request>> prefill, decode;
     sched.schedule(prefill, decode);
 
-    // Only 2 requests should be admitted (2 blocks each = 4 blocks total)
     EXPECT_EQ(prefill.size(), 2u);
     EXPECT_TRUE(sched.has_pending());
+}
+
+// 10b. Admission reserves the generation, not just the prompt (#1635).
+//
+// Before the fix this admitted both requests: the test is `prompt fits`, and
+// four 2-block prompts fit an 8-block pool. The generation then ran the pool
+// dry and the loser was cancelled mid-stream, after the client had already
+// received part of the answer.
+TEST(SchedulerTest, AdmissionReservesGeneration) {
+    SKIP_IF_NO_CUDA();
+
+    // 16 blocks = 256 tokens. Each request: 32-token prompt (2 blocks) +
+    // max_tokens=64 (4 blocks + 1 spare) = 7 blocks reserved, so two fit and
+    // the third must queue.
+    //
+    // Three requests, not two: with two, the first request's reservation
+    // alone already starves the second, and the test would pass with the
+    // admission quantity mutated back to the prompt. The third is what the
+    // admission test has to see - free blocks say yes (10 left), the
+    // outstanding reservations say no.
+    auto cache = std::make_unique<KVCache>(
+        /*n_layers=*/2, /*n_kv_heads=*/4, /*head_dim=*/64, QType::F16, /*max_blocks=*/16);
+    auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
+
+    Scheduler sched(16);
+    sched.set_kv_manager(mgr.get());
+
+    std::vector<std::shared_ptr<Request>> reqs;
+    for (int i = 0; i < 3; i++) {
+        auto req = std::make_shared<Request>();
+        req->id = i;
+        req->input_tokens.resize(32, i);
+        req->max_tokens = 64;
+        reqs.push_back(req);
+        sched.add_request(req);
+    }
+
+    std::vector<std::shared_ptr<Request>> prefill, decode;
+    sched.schedule(prefill, decode);
+
+    // Two admitted, one still queued - and none cancelled.
+    EXPECT_EQ(prefill.size(), 2u);
+    EXPECT_TRUE(sched.has_pending());
+    for (const auto& r : reqs)
+        EXPECT_NE(r->status, RequestStatus::CANCELLED);
+
+    // 12 blocks are free and 10 are promised: the free count on its own
+    // would have admitted the third.
+    EXPECT_EQ(mgr->num_free_blocks(), 12);
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 10);
+
+    // When one finishes, its reservation goes with it.
+    mgr->free_sequence(reqs[0]->id);
+    reqs[0]->status = RequestStatus::FINISHED;
+    EXPECT_EQ(mgr->outstanding_reserved_blocks(), 5);
+
+    sched.schedule(prefill, decode);
+    EXPECT_EQ(prefill.size(), 1u);
+    EXPECT_FALSE(sched.has_pending());
+}
+
+// 10c. A pool too small to ever hold prompt + max_tokens degrades to
+// prompt-only admission instead of queueing the request forever (#1635).
+TEST(SchedulerTest, AdmissionClampsReserveToPoolSize) {
+    SKIP_IF_NO_CUDA();
+
+    // 4 blocks = 64 tokens, against a 32-token prompt + max_tokens=256.
+    // The full reserve (2 + 17) never fits, so the clamp is what keeps this
+    // request servable at all.
+    auto cache = std::make_unique<KVCache>(
+        /*n_layers=*/2, /*n_kv_heads=*/4, /*head_dim=*/64, QType::F16, /*max_blocks=*/4);
+    auto mgr = std::make_unique<KVCacheManager>(std::move(cache));
+
+    Scheduler sched(16);
+    sched.set_kv_manager(mgr.get());
+
+    auto req = std::make_shared<Request>();
+    req->id = 0;
+    req->input_tokens.resize(32, 7);
+    req->max_tokens = 256;
+    sched.add_request(req);
+
+    std::vector<std::shared_ptr<Request>> prefill, decode;
+    sched.schedule(prefill, decode);
+
+    EXPECT_EQ(prefill.size(), 1u);
+    EXPECT_NE(req->status, RequestStatus::CANCELLED);
 }
 // 11. Continuous batching: prefill priority over decode
 TEST(SchedulerTest, PrefillPriorityOverDecode) {

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -78,7 +78,7 @@ roots = ["src", "tools", "tests"]
 "src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1061, reason = "(c) one path: batched-MoE forward dispatch (host-only)" }
 "src/exec/executor_workspace_buffers.cu" = { code_loc = 1350, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
-"src/memory/kv_cache_manager.cpp" = { code_loc = 1200, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
+"src/memory/kv_cache_manager.cpp" = { code_loc = 1207, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
 "src/model/gguf_loader.cpp" = { code_loc = 820, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
 "src/model/jinja.cpp" = { code_loc = 2366, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
@@ -90,6 +90,6 @@ roots = ["src", "tools", "tests"]
 "src/runtime/engine_scheduler.cpp" = { code_loc = 1985, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
-"tests/test_kv_cache.cpp" = { code_loc = 1159, reason = "(c) 59 tests across KV allocator/cache/manager - one test target" }
+"tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }
 "tests/test_paged_attention.cu" = { code_loc = 1202, reason = "(c) 26 tests of the paged-attention kernel - one test target" }
 "tests/test_quant_integration.cu" = { code_loc = 1470, reason = "(c) 25 tests, all exercising the quant_gemm/dequant unit - one test target" }

--- a/tools/imp-server/metrics_memory.cpp
+++ b/tools/imp-server/metrics_memory.cpp
@@ -73,6 +73,14 @@ if (state.ctx && state.ctx->engine) {
             out += "# TYPE imp_kv_blocks_live gauge\n";
             out += "imp_kv_blocks_live " + std::to_string(total_blocks - free_blocks - cached) +
                    "\n";
+            // Promised at admission and not yet written (#1635). Free blocks
+            // minus this is what the next request is admitted against, and
+            // without it a queue behind a full-looking pool reads as a bug.
+            out +=
+                "# HELP imp_kv_blocks_reserved KV blocks promised to admitted requests for "
+                "their remaining generation, not yet written\n";
+            out += "# TYPE imp_kv_blocks_reserved gauge\n";
+            out += "imp_kv_blocks_reserved " + std::to_string(mgr->outstanding_reserved_blocks()) + "\n";
         }
 
         // Speculative decoding (#1321). Without these a spec-decoding test


### PR DESCRIPTION
Three ways the KV pool promised what it could not keep. Two are admission
arithmetic, one is a backstop for a projection that was wrong before and will
be wrong again.

## #1635 - admission tested the prompt, the run needs prompt + generation

`Scheduler::schedule` called `can_allocate(prompt_blocks)`. `context_len()`
counts what exists NOW, so a batch whose prompts all fit could run the pool dry
halfway through its own generation, and the loser is whichever request needs the
next block - a truncated answer after the client has already received part of it.
The grow branch 30 lines below had computed the decode half correctly since it
was written; the admission test above it never read it.

Two halves, and the second is the load-bearing one:

- **Admit on prompt + `max_tokens`.** Clamped to the pool: on a cache too small
  to ever hold that (the 16-block floor case) the full reserve would queue every
  request forever, so there the guarantee degrades to the old prompt-only
  admission rather than to a refusal.
- **Hold the promise.** A test that is not held admits the next request against
  the same memory one round later. `set_decode_reservation` records it and
  `can_allocate` subtracts what is promised and not yet written; it decays per
  appended block and `free_sequence` drops it.

`can_allocate` also lost its slow path, which summed the blocks of live LRU
sequences on the assumption that `evict_lru()` could hand them back.
`evict_lru()` has had no production caller since its own comment explained why -
freeing a live sequence's KV corrupts it, and there is no recompute path. The
predicate was answering "there is room" with memory that never comes back.

**Measured** (`Qwen3-8B-Q8_0.gguf`, 8 concurrent requests, `max_tokens: 1024`,
answers ~300 tokens, arms alternating, three rounds each). The pool size decides
whether the reserve binds at all:

| pool | arm | tok/s (median of 3) | `finish_reason` | `imp_kv_pressure_rejections_total` |
|---|---|---|---|---|
| default (6571 blocks) | this PR | **551.3** | 8x `stop` | 0 |
| default | `main` | 519.2 | 8x `stop` | 0 |
| 300 blocks | this PR | **350.0** | 8x `stop` | 0 |
| 300 blocks | `main` | 517.4 | 8x `stop` | 0 |
| 150 blocks | this PR | **228.5** | 8x `stop` | **0** |
| 150 blocks | `main` | 526.3 | 6x `stop`, **2x `length`** | **2** |

Read bottom-up. At 150 blocks `main` is faster because it truncates: one to two
of the eight answers are cut off mid-generation in every run, and the client
sees `finish_reason: "length"` - the same value a spent token budget produces.
Only `imp_kv_pressure_rejections_total` distinguishes them.

At 300 blocks the guarantee costs **-32.4 %** throughput and buys nothing
visible: `main` does not run out either, because the answers are a third of the
`max_tokens` they reserved against. That is the shape of the trade - the reserve
is sized by `max_tokens`, not by the answer.

At the default pool there is no cost (the arms are 6.2 % apart, inside a branch
spread of 16 % over three runs).

**The lever for an operator is `max_tokens`**, and the server default of 8192 is
the worst case for it. Documented in `docs/TROUBLESHOOTING.md`.

**Two existing tests asserted the old contract** and are rewritten rather than
deleted: `ManagerCanAllocate` asserted that a full pool could still allocate 8
more blocks, and `PinPrefixCanAllocateAccuracy` asserted the same for one pinned
and one unpinned sequence.

## #1636 - the graph loop booked for the whole generation before a bounded burst

`prepare_graph_loop` walked `blocks_have -> blocks_needed(ctx_len + max_tokens -
emitted)` and took whatever the pool would give. The burst it prepares is
bounded to `speculative.miss_burst`, `runtime.decode_burst` (128) or 16 while
another request waits. The reservation was not bounded with it, and nothing
trims an over-booked table.

`Qwen3-8B-Q8_0.gguf`, `max_tokens: 8192`, `speculative.ngram=false` so
`runtime.decode_burst` is what sets the burst (with n-gram on, `spec_limit`
wins and the knob is dead). Same 355-token answer in every arm:

| arm | peak `imp_kv_blocks_live` | first burst |
|---|---|---|
| `decode_burst=16384` (= the old reservation) | 514 | 8190 |
| default `decode_burst=128` | **26** | 141 |
| `decode_burst=16384`, repeat | 514 | 8190 |
| default, repeat | **26** | 141 |

**It was paid for out of the prefix cache.** `append_block` reclaims cached
blocks when the free pool is empty, so the speculative reservation evicted the
warm prefix the next turn was going to hit. Pool pinned to 600 blocks, warm
system prompt, same 344-token answer:

| arm | `imp_kv_blocks_cached` before -> after |
|---|---|
| whole generation | 176 -> **108** |
| the burst | 176 -> **198** |

The synchronous `generate()` loop and the constrained pipeline keep the full
reservation (`step_limit = 0`): they run the whole remaining generation, so
there the booking is not speculative.

## #1662 - a pool that does not fit is a smaller pool, not a dead process

On an allocation failure the KV pool halves and retries down to the 16-block
floor, one WARN per attempt naming planned blocks, retried blocks and the
shortfall in MiB.

The retry is at the pool, not at `imp_context_create` where the issue puts it:
the weight caches are already built by then and the model's source tensors may
be consumed (`Engine::init` refuses a second bind on such a handle, #830), so a
retry one level up cannot rebuild the engine at all.

The growable ceiling halves with the committed part - it is a reservation of the
same pool, so a retry that only halves what is committed reserves the same
address space again and fails identically.

**Not verified end to end.** The #1662 arms (`library_reserve_mb` 6100 plans
9977 blocks and OOMs, 7460 plans 7079 and serves) come from the #1631 session
and reproducing the OOM on demand needs that model. What is verified is the
structure: the retry exists, the floor terminates it, and the sizing path it
guards is unchanged on the success path.

## Mutation

Each of the three new scheduler tests dies against exactly the change it
measures:

| mutant | red |
|---|---|
| `admit_blocks = blocks_needed` (prompt only) | `AdmissionReservesGeneration` |
| no `set_decode_reservation` call | `AdmissionReservesGeneration`, `MemoryAwareScheduling` |
| no pool clamp on the reserve | `AdmissionClampsReserveToPoolSize`, `MemoryAwareSkipsLargeAdmitsSmall` |

`AdmissionReservesGeneration` uses **three** requests, not two: with two, the
first request's held reservation alone starves the second and the test passes
against the prompt-only mutant.

## Pins

`src/memory/kv_cache_manager.cpp` code_loc 1200 -> 1207,
`tests/test_kv_cache.cpp` 1159 -> 1184.

New gauge `imp_kv_blocks_reserved`, documented in `docs/API.md`; the queue-in-
front-of-free-blocks symptom in `docs/TROUBLESHOOTING.md`.

CPU lane 7/7, KVCacheManagerTest 50/50, SchedulerTest 25/25, full GPU suite
green (no `[  FAILED  ]` line), static gates green.

Perf gate: decode **-1.14 %**, prefill **+0.65 %**, pp4096 **+0.68 %**, peak
VRAM **+0.01 %** (median of 3 processes, spread 0.20 %).
