### PR TITLE
fix(graph): the conditional decode graph was recaptured every second or third burst (#1647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,20 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Every second or third decode burst recaptured the conditional graph** (#1647).
+  `rearm()` refuses when `context_len + step_limit` passes the captured ceiling
+  `initial_context_len + max_steps`, and since #1636 `max_steps` was the KV
+  reservation for the *current* burst - so the ceiling was two or three bursts
+  wide by construction. The block-table buffer had the same shape: sized to the
+  table as it stood, outgrown by the next burst. Both had to move; each one alone
+  leaves the other gate refusing. Measured, `imp-cli --bench --bench-pp 16
+  --bench-reps 3 --max-tokens 128` on Qwen3-8B-Q8_0, three alternating rounds:
+
+  | | graph captures | tg128 tok/s (median) |
+  |---|---|---|
+  | before | 36 | 280.56 |
+  | after | 8 | 288.66 (+2.89%) |
+
 - **Jinja: `trim_blocks`, `lstrip_blocks` and the `safe` filter** (#1572). transformers
   renders every chat template with both whitespace flags on; imp had neither, so a
   template written against HF leaked one newline per block tag and every tag line's

--- a/src/runtime/engine_graph_decode.cpp
+++ b/src/runtime/engine_graph_decode.cpp
@@ -318,19 +318,42 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     const auto& full_bt = kv_manager_->block_table(req->id);
     int max_blocks_per_seq = static_cast<int>(full_bt.size());
 
+    // Size the buffer for everything this request can still reach, not for the
+    // table it happens to have now (#1647). Both this allocation and the
+    // `max_blocks_per_seq` baked into the graph below are what the rearm fast
+    // path checks against, and since #1636 the KV reservation is clamped to the
+    // current burst - so the table grows by a block every kv_bs tokens and a
+    // capacity sized to today's table is outgrown by the NEXT burst, by
+    // construction. That is the 8 `cudaGraphInstantiate` at 8.35 ms mean
+    // against a single `cudaGraphExecUpdate` the issue measured. It costs one
+    // int per block: an 8192-token ceiling is 2 KiB.
+    const int bt_kv_bs = kv_cache_raw_ ? kv_cache_raw_->block_size() : kKVBlockSize;
+    int bt_ctx_ceiling = req->context_len() +
+                         std::max(0, req->max_tokens - static_cast<int>(req->output_tokens.size()));
+    if (max_seq_len() > 0)
+        bt_ctx_ceiling = std::min(bt_ctx_ceiling, max_seq_len());
+    const int bt_capacity = std::max(max_blocks_per_seq, (bt_ctx_ceiling + bt_kv_bs - 1) / bt_kv_bs);
+
     int* d_bt = nullptr;
-    if (cudaMalloc(&d_bt, max_blocks_per_seq * sizeof(int)) != cudaSuccess)
+    if (cudaMalloc(&d_bt, static_cast<size_t>(bt_capacity) * sizeof(int)) != cudaSuccess)
         return false;
+    // The tail past the live table is never read (the kernels iterate over
+    // max_context_len and use max_blocks_per_seq as the row stride), but a
+    // zeroed tail keeps a stray index pointing at block 0 rather than at
+    // whatever the allocator returned.
+    IMP_CUDA_CHECK_LOG(cudaMemsetAsync(d_bt, 0, static_cast<size_t>(bt_capacity) * sizeof(int), stream));
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_bt, full_bt.data(), max_blocks_per_seq * sizeof(int),
                                        cudaMemcpyHostToDevice, stream));
     int* d_bt_swa = nullptr;
     if (swa_sizing_active_) {
         const auto& swa_bt = kv_manager_->swa_block_table(req->id);
         if (static_cast<int>(swa_bt.size()) != max_blocks_per_seq ||
-            cudaMalloc(&d_bt_swa, max_blocks_per_seq * sizeof(int)) != cudaSuccess) {
+            cudaMalloc(&d_bt_swa, static_cast<size_t>(bt_capacity) * sizeof(int)) != cudaSuccess) {
             IMP_CUDA_CHECK_LOG(cudaFree(d_bt));
             return false;
         }
+        IMP_CUDA_CHECK_LOG(
+            cudaMemsetAsync(d_bt_swa, 0, static_cast<size_t>(bt_capacity) * sizeof(int), stream));
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(d_bt_swa, swa_bt.data(), max_blocks_per_seq * sizeof(int),
                                            cudaMemcpyHostToDevice, stream));
     }
@@ -342,7 +365,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     state_template.block_tables = d_bt;
     state_template.block_tables_swa = d_bt_swa;
     state_template.n_sequences = 1;
-    state_template.max_blocks_per_seq = max_blocks_per_seq;
+    state_template.max_blocks_per_seq = bt_capacity;
     state_template.is_prefill = false;
 
     // Recurrent state for SSM/GDN layers — pointers are constant for
@@ -359,7 +382,26 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     if (runtime_config_.diagnostics.spec_trace)
         IMP_LOG_INFO("[burst-launch] FRESH seed=%d ctx=%d limit=%d remaining=%d", (int)first_token,
                      req->context_len(), step_limit, remaining);
-    auto gcfg = build_graph_config(*req, remaining);
+    // Capture a ceiling for the whole generation, not for this burst (#1647).
+    // `rearm()` refuses when `context_len + step_limit` passes
+    // `initial_context_len + max_steps`, and since #1636 `remaining` is the
+    // KV reservation for the CURRENT burst - so the captured ceiling is two or
+    // three bursts wide and the loop recaptures forever. Measured on
+    // `imp-cli --bench --bench-pp 16 --bench-reps 3 --max-tokens 128`: 44 rearm
+    // attempts, 36 of them refused here and rebuilt.
+    //
+    // Only when the launch is bounded. With `step_limit == 0` the on-device
+    // loop runs to `max_steps` with no host in between, and the KV blocks are
+    // reserved per burst - raising the ceiling there would let it decode past
+    // the blocks it has.
+    int capture_steps = remaining;
+    if (step_limit > 0) {
+        int span = req->max_tokens - static_cast<int>(req->output_tokens.size());
+        if (max_seq_len() > 0)
+            span = std::min(span, max_seq_len() - req->context_len());
+        capture_steps = std::max(remaining, span);
+    }
+    auto gcfg = build_graph_config(*req, capture_steps);
     gcfg.step_limit = step_limit;
 
     if (!async_graph_runner_.setup(executor_.get(), state_template, first_token, gcfg, stream)) {
@@ -379,7 +421,7 @@ bool Engine::try_launch_async_graph_loop(std::shared_ptr<Request> req, int32_t f
     async_graph_req_ = req;
     async_d_block_tables_ = d_bt;
     async_d_block_tables_swa_ = d_bt_swa;
-    async_bt_capacity_ = max_blocks_per_seq;
+    async_bt_capacity_ = bt_capacity;
     async_parked_req_id_ = -1;
     IMP_LOG_DEBUG("AsyncGraphLoop: launched with %d banned tokens", state_template.n_d_banned_tokens);
     async_pending_tokens_.clear();


### PR DESCRIPTION
Closes #1647.

## Cause

`rearm()` refuses when `context_len + step_limit` passes the captured ceiling
`initial_context_len + max_steps` (`src/runtime/cuda_graph.cu:1166`). Since #1636
clamped the KV reservation to the current burst, the `max_steps` handed to
`build_graph_config` **was that burst** - so the ceiling was two or three bursts
wide by construction.

The block-table buffer had the same shape: `cudaMalloc`'d at exactly the table
size of the moment, and both that buffer and the `max_blocks_per_seq` baked into
the graph are what the rearm capacity check reads. The table grows a block every
`kv_bs` tokens, so the next burst outgrew it.

Trace of the old behaviour (`diagnostics.spec_trace=true`), ceiling 17+15=32:

```
FRESH seed=16 ctx=17 limit=8 remaining=15
REARM ctx=25 limit=8      -> 25+8 = 33 > 32, refused
FRESH ctx=25 remaining=23                    ceiling 48
REARM ctx=33 limit=8      -> 41 <= 48, ok
REARM ctx=41 limit=8      -> 49 > 48, refused
FRESH ctx=41 remaining=23                    ceiling 64
```

## Both gates are load-bearing

Each change alone leaves the other gate refusing, so neither is measurable on its
own. Same command, counting `ConditionalRunner: graph built`:

| arm | captures |
|---|---|
| block-table capacity only | 36 |
| capture ceiling only | 36 |
| both | **8** |

The ceiling is raised only for a bounded launch. With `step_limit == 0` the
on-device loop runs to `max_steps` with no host in between and KV blocks are
reserved per burst, so raising it there would decode past the blocks it has.

## Measured

`imp-cli --bench --bench-pp 16 --bench-reps 3 --max-tokens 128`, Qwen3-8B-Q8_0,
two binaries from the same tree, runs alternated:

| round | fix tg128 | main tg128 |
|---|---|---|
| 1 | 288.66 | 280.32 |
| 2 | 288.48 | 281.06 |
| 3 | 289.03 | 280.56 |

median **288.66 vs 280.56 = +2.89%**, captures **36 -> 8**. Within-arm spread
0.19% (fix) and 0.26% (main), so the gap is well outside the noise.

## Gates

| check | result |
|---|---|
| pre-commit GPU suite | 6/6 DetEval e2e passed |
| `make dev-test` (CI lane) | 7/7 in 7.41 s |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| `verify-fast` perf gate | decode -1.34%, prefill +0.73%, pp4096 +0.23%, peak VRAM +0.01%, all PASS |
| degeneration smoke | PASS (distinct=11, max-run=1) |

The perf gate benches with speculation off and does not exercise the burst path,
so it reads as unchanged - it is here as a no-regression check, not as the
measurement of this fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
