### PR TITLE
build(gates): the pre-commit GPU gate fired on Markdown and Python edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The pre-commit GPU gate ran the full suite for Markdown and Python edits.**
+  Its filter selected on the path prefix alone, and `tools/` and `tests/` also
+  hold the `CLAUDE.md` tree and the gate/generator scripts - so editing
+  `tests/CLAUDE.md` paid an image build plus the whole GTest suite for a result
+  that cannot move. `.html` and `.txt` still gate (`cmake/embed_webui.cmake`
+  compiles the web UI into `imp-server`; tests read corpora from `tests/refs` at
+  runtime). New CPU-lane guard `guard_precommit_filter` pins 19 cases on both
+  sides - over-excluding fails it too, because CI has no GPU runner and a C++
+  change that skips this hook is gated nowhere.
+
 - **Every second or third decode burst recaptured the conditional graph** (#1647).
   `rearm()` refuses when `context_len + step_limit` passes the captured ceiling
   `initial_context_len + max_steps`, and since #1636 `max_steps` was the KV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1023,9 +1023,16 @@ if(IMP_BUILD_TESTS)
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_verify_filter.sh
                 ${CMAKE_CURRENT_BINARY_DIR}/imp-tests ${CMAKE_CURRENT_SOURCE_DIR}/scripts/verify.sh)
 
+    # The pre-commit hook runs the FULL GPU suite, so its path filter decides
+    # minutes of a shared card per commit - and CI has no GPU runner, so a C++
+    # change that slips past it is gated nowhere. Pins both directions.
+    add_test(NAME guard_precommit_filter
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_precommit_filter.sh
+                ${CMAKE_CURRENT_SOURCE_DIR})
+
     set_tests_properties(unit_core unit_text unit_e2e_subset guard_e2e_lane_split
                          guard_det_suite_filter guard_cancel_teardown
-                         guard_verify_filter
+                         guard_verify_filter guard_precommit_filter
         PROPERTIES LABELS "unit")
 
     add_test(NAME gpu_compute   COMMAND test-compute)

--- a/scripts/check_precommit_filter.sh
+++ b/scripts/check_precommit_filter.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Guard the pre-commit hook's path filter against over- and under-gating.
+#
+# The hook runs the FULL GPU suite, so its filter decides minutes of a shared
+# card per commit. It used to select on the path prefix alone, and `tools/` and
+# `tests/` also hold the CLAUDE.md tree and the gate/generator scripts - so a
+# Markdown edit paid an image build plus the whole suite for a result that
+# cannot move. Excluding too much is the worse failure: a C++ change that skips
+# the suite is gated nowhere, because CI has no GPU runner.
+#
+# The filter is READ OUT OF the hook rather than copied here. A guard with its
+# own copy of the expression guards the copy.
+#
+# Usage: check_precommit_filter.sh <repo-root>
+# Exit 0 = every case below lands on the expected side.
+
+set -eu
+
+ROOT="${1:?usage: check_precommit_filter.sh <repo-root>}"
+HOOK="$ROOT/scripts/pre-commit.hook"
+
+if [ ! -f "$HOOK" ]; then
+    echo "check_precommit_filter: $HOOK not found" >&2
+    exit 2
+fi
+
+# The two grep expressions the hook chains, pulled from the hook itself.
+KEEP=$(grep -m1 -- "| grep -E '\^(src/" "$HOOK" | sed "s/.*grep -E '//; s/' *\\\\*$//")
+DROP=$(grep -m1 -- "| grep -vE" "$HOOK" | sed "s/.*grep -vE '//; s/' *\\\\*$//")
+
+if [ -z "$KEEP" ] || [ -z "$DROP" ]; then
+    echo "check_precommit_filter: could not read both filter expressions out of $HOOK" >&2
+    echo "  keep='$KEEP' drop='$DROP'" >&2
+    exit 1
+fi
+
+# Left column: does the hook run the GPU suite for this staged set?
+#   gate = must run it. skip = must not.
+cases='gate|src/model/jinja.cpp
+gate|include/core/logging.h
+gate|tools/imp-server/handlers_chat.cpp
+gate|tests/test_jinja.cpp
+gate|CMakeLists.txt
+gate|cmake/imp-deps.cmake
+gate|tools/imp-server/webui/index.html
+gate|tests/refs/ppl_corpus.txt
+gate|tests/refs/chat_template_goldens.h
+gate|tests/CLAUDE.md src/model/jinja.cpp
+skip|tests/CLAUDE.md
+skip|tools/imp-server/CLAUDE.md
+skip|src/compute/CLAUDE.md
+skip|tools/kernel_resources.py
+skip|tests/refs/gen_chat_goldens.py
+skip|tools/kernel_resources.py tests/CLAUDE.md
+skip|README.md
+skip|docs/internals/SM120.md
+skip|CHANGELOG.md'
+
+# The loop runs in a subshell, so it cannot set a variable the parent reads:
+# it prints one line per mismatch and the count IS the verdict.
+bad=$(echo "$cases" | while IFS='|' read -r want files; do
+    [ -z "$want" ] && continue
+    got=$(printf '%s\n' $files | grep -E "$KEEP" | grep -vE "$DROP" || true)
+    if [ -n "$got" ]; then have=gate; else have=skip; fi
+    if [ "$have" != "$want" ]; then
+        echo "check_precommit_filter: '$files' -> $have, expected $want" >&2
+        echo x
+    fi
+done | wc -l)
+
+if [ "$bad" -ne 0 ]; then
+    echo "check_precommit_filter: $bad case(s) on the wrong side of the pre-commit filter" >&2
+    exit 1
+fi
+
+echo "check_precommit_filter: $(echo "$cases" | wc -l) case(s) match the pre-commit filter"
+exit 0

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -7,7 +7,8 @@
 # only local gate — the pre-push hook runs `verify-fast`, a filtered subset plus
 # the perf and smoke gates — but it is the only one that runs the FULL suite. It
 # fires only when staged changes touch buildable sources (src/, include/, tools/,
-# tests/, CMakeLists, *.cmake) — doc/config-only commits are not gated.
+# tests/, CMakeLists, *.cmake) — doc/config-only commits are not gated, and
+# neither are the .md and .py files that live inside those directories.
 #
 # Runs `make test-gpu` (Docker build + the full GTest suite via imp-tests; this
 # includes the CPU binaries too, so a commit that passes here has run everything).
@@ -17,8 +18,18 @@ set -uo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# The path prefix says WHERE, not WHETHER: `tools/` and `tests/` also hold
+# Markdown (the CLAUDE.md tree) and Python (the gates and generators), and
+# neither reaches the compiler or the suite - no test in tests/ shells out to a
+# script, and no CMake target embeds one. Editing tests/CLAUDE.md used to pay a
+# full image build plus the whole GTest suite for a result that could not move.
+#
+# Deliberately NOT excluded: .html, because cmake/embed_webui.cmake compiles
+# tools/imp-server/webui/index.html into imp-server, and .txt, because tests
+# read reference corpora from tests/refs at runtime.
 CHANGED=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null \
           | grep -E '^(src/|include/|tools/|tests/|CMakeLists\.txt|cmake/|.*\.cmake$)' \
+          | grep -vE '\.(md|py)$' \
           || true)
 
 if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
The pre-commit hook runs the **full GPU suite**, and it selected its input on the
path prefix alone:

```
grep -E '^(src/|include/|tools/|tests/|CMakeLists\.txt|cmake/|.*\.cmake$)'
```

`tools/` and `tests/` also hold the `CLAUDE.md` tree and the gate/generator
scripts, so editing `tests/CLAUDE.md` paid a Docker image build plus the whole
GTest suite for a result that cannot move.

## Why these two extensions are safe to drop

| claim | check |
|---|---|
| no test shells out to a script | `grep -rn "system(\|popen(\|execv\|fork()" tests/*.cpp tests/*.cu` -> three hits, all inside comments |
| no CMake target embeds one | `.py`/`.md` appear in `CMakeLists.txt` and `cmake/*.cmake` only in comments |

## Deliberately still gating

| extension | why |
|---|---|
| `.html` | `cmake/embed_webui.cmake` compiles `tools/imp-server/webui/index.html` into `imp-server` |
| `.txt` | tests read reference corpora from `tests/refs` at runtime |

## The guard

Over-excluding is the worse failure: CI has no GPU runner, so a C++ change that
skips this hook is gated **nowhere**. `scripts/check_precommit_filter.sh` pins
19 cases on both sides and reads the two expressions out of the hook rather than
keeping a copy, then runs in the CPU lane as `guard_precommit_filter`.

Verified it fails in both directions rather than assuming it would:

| mutation | result |
|---|---|
| add `.html` to the exclusion | `'tools/imp-server/webui/index.html' -> skip, expected gate`, exit 1 |
| delete the exclusion line | `could not read both filter expressions out of the hook`, exit 1 |
| unmodified | `19 case(s) match the pre-commit filter`, exit 0 |

## Gates

| check | result |
|---|---|
| `make dev-test` (CI lane) | 8/8 in 7.82 s (was 7 tests) |
| pre-commit GPU suite | passed |
| `verify-fast` | PASS, degeneration smoke PASS |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
