### PR TITLE
fix(obs): the server's request id and the engine's never met (#1582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **No engine log line could be attributed to an HTTP request** (#1582, second
+  half). The server's `imp-N` and the engine's own request counter are disjoint
+  counters, and under concurrency they do not even run in step - three requests
+  sent at once mapped `imp-3 -> req 3`, `imp-2 -> req 4`, `imp-1 -> req 5`, so
+  the mapping cannot be inferred by arithmetic. `add_request()` now publishes it
+  once per request (`request imp-0 -> engine req 2`), which is what the eleven
+  engine sites printing `req %d` need: several of them hold only the integer and
+  have no `Request` to reach a string through. The two id spaces are joined, not
+  merged. Embeddings and rerank carry no client-facing id and are unaffected.
+
 - **The pre-commit GPU gate ran the full suite for Markdown and Python edits.**
   Its filter selected on the path prefix alone, and `tools/` and `tests/` also
   hold the `CLAUDE.md` tree and the gate/generator scripts - so editing

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -1017,6 +1017,13 @@ std::string Engine::generate(const std::string& prompt, int max_tokens, float te
 void Engine::add_request(std::shared_ptr<Request> req) {
     if (scheduler_) {
         req->id = next_request_id_++;
+        // The join between the two id spaces (#1582). Several engine log sites
+        // print `req %d` from the counter above, and some of them (the
+        // recurrent-slot and MTP ones) hold the integer without a Request to
+        // reach a string through - so the mapping is published once here
+        // instead of rewriting each site.
+        if (!req->trace_id.empty())
+            IMP_LOG_INFO("request %s -> engine req %d", req->trace_id.c_str(), req->id);
         // Initialize in_think_block from the prompt tail. Chat templates for
         // Qwen3 / Qwen3.5 / Qwen3.6 / DeepSeek-R1 inject `<think>\n` via
         // add_generation_prompt by default — without seeding the flag here,

--- a/src/runtime/request.h
+++ b/src/runtime/request.h
@@ -39,6 +39,12 @@ const char* request_status_name(RequestStatus status);
 
 struct Request {
     int id = 0;
+    // The id the CALLER knows this request by - the server's `imp-N`, which is
+    // also what the HTTP response carries. `id` above is the engine's own
+    // counter and the two never met, so no engine log line could be attributed
+    // to an HTTP request (#1582). Empty for direct API users; add_request()
+    // emits the join line when it is set.
+    std::string trace_id;
     RequestStatus status = RequestStatus::PENDING;
 
     std::vector<int32_t> input_tokens;

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -278,6 +278,7 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
     // Create an imp::Request and submit to batching engine (/v1/completions is
     // text-only — no vision).
     auto imp_req = std::make_shared<imp::Request>();
+    imp_req->trace_id = req_id;  // #1582: join the engine's log lines to this request
     imp_req->input_tokens = std::move(tokens);
     imp_req->max_tokens = max_tokens;
     imp_req->temperature = temperature;

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -693,6 +693,10 @@ std::shared_ptr<imp::Request> build_imp_request_(const ChatRequestContext& ctx,
                                                  const std::vector<int32_t>& input_tokens, int completion_idx,
                                                  bool stream) {
     auto req = std::make_shared<imp::Request>();
+    // The id the client sees, carried into the engine so its log lines can be
+    // joined to this HTTP request (#1582). With n>1 several engine requests
+    // share one completion id, which is what the response says too.
+    req->trace_id = ctx.req_id;
     req->image = ctx.snap.vision_image;         // per-request vision (null for text)
     req->qwen_patches = ctx.snap.qwen_patches;  // dynamic-resolution route (empty otherwise)
     req->vision_content_hash = ctx.snap.vision_content_hash;


### PR DESCRIPTION
Closes #1582. Second half; the first (eleven `fprintf(stderr, ...)` sites onto
`IMP_LOG_*`) shipped in #1713.

## The problem, measured

`imp-N` is the id the client sees and the response carries. The engine has its
own counter, and every engine log line printing `req %d` uses that one.

Three concurrent requests, Qwen3-8B-Q8_0:

```
request imp-3 -> engine req 3
request imp-2 -> engine req 4
request imp-1 -> engine req 5
```

The counters do not run in step, so the mapping cannot be derived by arithmetic
even when both ids are known. That is the reason to publish it rather than
document a convention.

## Joined, not merged

Merging would mean carrying a string where the engine carries an int - `req->id`
also keys `block_table(req->id)`, the recurrent-slot map and the MTP binding.
And of the eleven engine sites that print the id, several hold only the integer:

| site | what it has |
|---|---|
| `engine_sampling_stop.cpp` x3 (recurrent slot) | `int req_id` parameter, no `Request` |
| `engine_spec_mtp.cpp` | `mtp_bound_req_`, an int member |
| `engine_scheduler.cpp`, `engine_spec_ngram.cpp` | a `Request`, so a string would reach |

So `Request` gains a `trace_id` the server fills, and `add_request()` publishes
the mapping once:

```
[15:22:41][INFO] engine.cpp:1026: request imp-0 -> engine req 2
```

`engine req 2` for the first HTTP request, because warmup already advanced the
counter - the case you cannot resolve without the line.

## Coverage

| endpoint | how |
|---|---|
| `/v1/chat/completions`, `/v1/messages`, `/v1/responses` | shared `build_imp_request_` |
| `/v1/completions` | its own construction site |
| embeddings, rerank | **not** set: they build a `Request` with `max_tokens=1` and have no client-facing id, so there is nothing to join to |

## Gates

| check | result |
|---|---|
| live server, 4 requests | join line present for every one, ids as above |
| `make dev-test` (CI lane) | 8/8 in 7.65 s |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| pre-commit GPU suite | passed |
| `verify-fast` | PASS, degeneration smoke PASS |

No automated test: `build_imp_request_` lives in `handlers_chat_core.cpp`, which
`test-core` does not link, and `add_request()` needs a loaded model. The
evidence above is a real server run.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
