### PR TITLE
fix(sched): the prefill latency guard bounded chunk size, never chunk count (#1643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,30 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The prefill latency guard capped chunk size, never chunk count** (#1643).
+  One engine step ran a chunk for *every* prefilling request, so k concurrent
+  ingests inserted k chunk forwards between two decode steps of every decoder -
+  and the pinned 1024 measurement behind the size cap was taken with a single
+  ingest, so nothing in it depends on k. New `runtime.prefill_batch_decode_cap`
+  (default 1) bounds the count while anyone is decoding, with a rotating start
+  index. Qwen3-8B Q8, one streaming decoder against three ~5.2k-token ingests:
+
+  | | before | after |
+  |---|---|---|
+  | worst inter-token gap | 259 / 254 ms | 112 / 88 ms |
+  | gaps over 100 ms | 6 / 6 | 1 / 0 |
+  | ingest wall time | 2017.7 ms | 2381.4 ms (+18.0%) |
+
+  The stall is spread, not removed: gaps over 50 ms go 6 -> 17. Harness:
+  `scripts/bench_prefill_latency.py`.
+
+- **A promoted request that missed its first chunk was never scheduled again.**
+  `Scheduler::schedule()` re-queued in-flight prefills on `prefill_offset > 0`,
+  so a request promoted but not served in that tick stayed PREFILLING, admitted
+  and holding KV, in no batch ever again. Nothing reached it while every
+  promotion was served immediately; with the cap above, two of three concurrent
+  ingests hung until the 300 s request timeout.
+
 - **The pre-commit GPU gate ran the full suite for Markdown and Python edits.**
   Its filter selected on the path prefix alone, and `tools/` and `tests/` also
   hold the `CLAUDE.md` tree and the gate/generator scripts - so editing

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -61,6 +61,12 @@ prefill_chunk_size   = -1
 # multi-tenant serving; 0 = disable (full chunk). The full chunk returns as
 # soon as nobody is decoding.
 prefill_chunk_decode_cap = 1024
+# How MANY prefill chunks run per engine step while others decode. The cap above
+# bounds one chunk; k concurrent ingests still run k of them between two decode
+# steps. Measured with three concurrent ingests: worst inter-token gap 259 -> 112
+# ms, gaps over 100 ms 6 -> 1, at +18% ingest wall time. 0 = unbounded. The
+# starting index rotates, so no ingest is starved.
+prefill_batch_decode_cap = 1
 # Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are single-
 # sequence, so concurrent sessions time-slice the decode. Slice length in
 # tokens; after it the engine rotates round-robin to the next decoding

--- a/scripts/bench_prefill_latency.py
+++ b/scripts/bench_prefill_latency.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Decoder inter-token latency while k other sessions ingest (#1643).
+
+One streaming decoder, then k concurrent long ingests. Reports the decoder's
+inter-token latency (what the ingests interfere with) and each ingest's wall
+time (what bounding them costs). This is the harness behind the
+`runtime.prefill_batch_decode_cap` numbers in src/runtime/config.h.
+
+It exists because the sibling knob's pinned numbers were taken against ONE
+active decoder and one ingest, and nothing in the tree could re-run them - so
+the k-dependence they miss stayed invisible.
+
+Two traps it already walked into, both of which silently produce a
+"no difference" result:
+
+  - The decoder must still be running when the ingests land. At 120 tokens it
+    finished in 0.4 s, before the ingests started, and every arm looked equal.
+  - Every ingest prompt must be unique per arm AND per run, or the prefix cache
+    serves it: the same prompt came back at 260 ms against 1200 ms cold, i.e.
+    it measured a cache hit and no prefill at all. Hence NONCE.
+
+Usage:  bench_prefill_latency.py [url] [model] [k] [nonce]
+The engine reads the cap at startup, so the two arms are two server runs.
+"""
+import json, statistics, sys, threading, time, urllib.request
+
+URL = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8099"
+MODEL = sys.argv[2] if len(sys.argv) > 2 else "Qwen3-8B-Q8_0.gguf"
+K = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+# Every ingest prompt must be unique across arms AND within a run: the second
+# measurement came back at 260 ms against 1200 ms because the prefix cache had
+# the previous run's prompt, i.e. it measured a cache hit and no prefill at all.
+NONCE = sys.argv[4] if len(sys.argv) > 4 else "0"
+INGEST_WORDS = 5200          # ~7k tokens
+DECODE_TOKENS = 600
+
+def post(path, body, stream=False):
+    req = urllib.request.Request(URL + path, data=json.dumps(body).encode(),
+                                 headers={"content-type": "application/json"})
+    return urllib.request.urlopen(req, timeout=600)
+
+def decoder(out):
+    body = {"model": MODEL, "max_tokens": DECODE_TOKENS, "temperature": 0, "stream": True,
+            "messages": [{"role": "user",
+                          "content": "Count slowly from one to sixty. Nonce %s." % NONCE}]}
+    deltas, last, n = [], None, 0
+    r = post("/v1/chat/completions", body, stream=True)
+    for raw in r:
+        line = raw.decode("utf-8", "replace").strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if payload == "[DONE]":
+            break
+        try:
+            d = json.loads(payload)
+        except Exception:
+            continue
+        delta = d.get("choices", [{}])[0].get("delta", {})
+        if not (delta.get("content") or delta.get("reasoning_content")):
+            continue
+        now = time.perf_counter()
+        if last is not None:
+            deltas.append((now - last) * 1000.0)
+        last = now
+        n += 1
+    out["deltas"] = deltas
+    out["tokens"] = n
+
+def ingest(idx, out):
+    prompt = ("w%s%d " % (NONCE, idx)) + ("token " * INGEST_WORDS) + \
+             "\nSummarise the text above in one word."
+    body = {"model": MODEL, "max_tokens": 4, "temperature": 0,
+            "messages": [{"role": "user", "content": prompt}]}
+    t0 = time.perf_counter()
+    try:
+        post("/v1/chat/completions", body).read()
+        out[idx] = (time.perf_counter() - t0) * 1000.0
+    except Exception as e:
+        out[idx] = float("nan")
+        sys.stderr.write("ingest %d failed: %s\n" % (idx, e))
+
+dec = {}
+t = threading.Thread(target=decoder, args=(dec,))
+t.start()
+time.sleep(0.3)                      # ingests must land while the decoder still runs
+ing = {}
+threads = [threading.Thread(target=ingest, args=(i, ing)) for i in range(K)]
+for th in threads: th.start()
+for th in threads: th.join()
+t.join()
+
+d = sorted(dec.get("deltas") or [0.0])
+def pct(p):
+    if not d: return 0.0
+    return d[min(len(d) - 1, int(round(p / 100.0 * (len(d) - 1))))]
+print(json.dumps({
+    "decode_tokens": dec.get("tokens", 0),
+    # p95 hides this: only a handful of gaps are affected, and those are the
+    # stutter a user sees. The count over 50 ms is the honest signal.
+    "inter_token_ms": {"median": round(statistics.median(d), 1) if d else 0,
+                       "p95": round(pct(95), 1), "p99": round(pct(99), 1),
+                       "max": round(max(d), 1) if d else 0},
+    "gaps_over_50ms": sum(1 for x in d if x > 50.0),
+    "gaps_over_100ms": sum(1 for x in d if x > 100.0),
+    "ingest_ms": [round(ing[i], 1) for i in sorted(ing)],
+}, indent=None))

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -161,6 +161,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("runtime.decode_burst", cfg.runtime.decode_burst);
     I("runtime.prefill_chunk_size", cfg.runtime.prefill_chunk_size);
     I("runtime.prefill_chunk_decode_cap", cfg.runtime.prefill_chunk_decode_cap);
+    I("runtime.prefill_batch_decode_cap", cfg.runtime.prefill_batch_decode_cap);
     I("runtime.hybrid_decode_quantum", cfg.runtime.hybrid_decode_quantum);
     B("runtime.decode_pipeline", cfg.runtime.decode_pipeline);
     I("runtime.vram_budget_mb", cfg.runtime.vram_budget_mb);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -136,6 +136,25 @@ struct RuntimeConfig {
         // a key. A CLI value wins over the file.
         int prefill_chunk_size = -1;
         int prefill_chunk_decode_cap = 1024;
+        // Cap the NUMBER of prefill chunk forwards per engine step while other
+        // sequences are DECODING (#1643). The size cap above bounds ONE chunk;
+        // with k concurrent ingests the step loop still runs k of them between
+        // two decode steps of every decoder, and no term in the size cap
+        // depends on k - the 1024 measurement above was taken with a single
+        // ingest. 0 = unbounded (the pre-#1643 behaviour). The starting index
+        // rotates, so a later ingest is not starved behind an earlier one.
+        //
+        // Measured (Qwen3-8B Q8, one streaming decoder, three concurrent
+        // ~5.2k-token ingests, two alternating rounds per arm):
+        //   worst inter-token gap  259/254 ms -> 112/88 ms
+        //   gaps over 100 ms       6/6        -> 1/0
+        //   gaps over 50 ms        6/6        -> 16/17
+        //   ingest wall time       2017.7 ms  -> 2381.4 ms (+18.0%)
+        // The stall is spread instead of removed: more small gaps, no large
+        // ones. Same trade the chunk cap above already takes (+27% TTFT for
+        // bounded latency), so the default follows it. The cap does not apply
+        // when nobody is decoding, so batch ingest throughput is untouched.
+        int prefill_batch_decode_cap = 1;
         // Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are
         // single-sequence, so concurrent sessions time-slice the decode.
         // This is the slice length in tokens — after it, the engine rotates

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -429,6 +429,10 @@ private:
     std::vector<int> padded_block_table_;
     std::vector<int> padded_swa_block_table_;
     std::vector<std::shared_ptr<Request>> sched_prefill_batch_;
+    // Round-robin cursor for runtime.prefill_batch_decode_cap (#1643): taking a
+    // fixed prefix of the batch would starve every later ingest, which is the
+    // failure #1634/#1637 came from.
+    size_t sched_prefill_rr_ = 0;
     std::vector<std::shared_ptr<Request>> sched_decode_batch_;
     std::vector<std::shared_ptr<Request>> valid_decode_;
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -580,10 +580,25 @@ void Engine::step_prefill(cudaStream_t stream) {
         effective_chunk = capped;
     }
 
-    for (auto& req : sched_prefill_batch_) {
+    // Decode-aware batching: the cap above bounds the SIZE of one chunk, this
+    // one bounds how MANY of them run before the decoders get their step
+    // (#1643). Starting index rotates so the ingests that do not run this step
+    // are the ones that ran last step.
+    const size_t n_prefill = sched_prefill_batch_.size();
+    size_t budget = n_prefill;
+    const int batch_cap = runtime_config_.runtime.prefill_batch_decode_cap;
+    if (batch_cap > 0 && !sched_decode_batch_.empty() && n_prefill > static_cast<size_t>(batch_cap))
+        budget = static_cast<size_t>(batch_cap);
+
+    for (size_t i = 0; i < budget; i++) {
+        auto& req = sched_prefill_batch_[(sched_prefill_rr_ + i) % n_prefill];
         step_prefill_one(req, effective_chunk, stream);
         kv_manager_->touch(req->id);
     }
+    if (budget < n_prefill)
+        sched_prefill_rr_ = (sched_prefill_rr_ + budget) % n_prefill;
+    else
+        sched_prefill_rr_ = 0;
 }
 
 // =====================================================================

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -243,8 +243,17 @@ void Scheduler::schedule(std::vector<std::shared_ptr<Request>>& prefill_batch,
 
     // 3. Re-schedule incomplete PREFILLING requests (chunked prefill).
     //    Skip requests already in prefill_batch (just promoted from pending).
+    //
+    //    `>= 0`, not `> 0` (#1643): a request promoted in step 2 but not served
+    //    that tick still has offset 0, and the old condition dropped it here -
+    //    PREFILLING, admitted, holding KV, and in no batch ever again. Nothing
+    //    hit it while every promoted request was served immediately; the
+    //    per-step prefill cap makes "not served this tick" a normal state, and
+    //    two of three concurrent ingests then hung until the 300 s request
+    //    timeout. The `already_queued` scan below is what keeps the
+    //    just-promoted ones from being added twice.
     for (auto& req : active_) {
-        if (req->status == RequestStatus::PREFILLING && req->prefill_offset > 0 &&
+        if (req->status == RequestStatus::PREFILLING && req->prefill_offset >= 0 &&
             req->prefill_offset < static_cast<int>(req->input_tokens.size())) {
             bool already_queued = false;
             for (const auto& pf : prefill_batch) {

--- a/tests/test_scheduler.cpp
+++ b/tests/test_scheduler.cpp
@@ -11,6 +11,8 @@
 // test NAMES, not files.
 
 #include <gtest/gtest.h>
+
+#include <algorithm>
 #include <cuda_runtime.h>
 
 #include "memory/kv_cache.h"
@@ -184,7 +186,15 @@ TEST(SchedulerTest, AdmissionReservesGeneration) {
     EXPECT_EQ(mgr->outstanding_reserved_blocks(), 5);
 
     sched.schedule(prefill, decode);
-    EXPECT_EQ(prefill.size(), 1u);
+    // Two, not one: the third is admitted now, and reqs[1] is still PREFILLING
+    // at offset 0 (nothing stepped it here) so it is re-queued with it. Before
+    // #1643 the refill required `prefill_offset > 0` and dropped it - in the
+    // engine that never showed, because every promoted request was served in
+    // the same tick it was promoted.
+    EXPECT_EQ(prefill.size(), 2u);
+    EXPECT_NE(std::find(prefill.begin(), prefill.end(), reqs[1]), prefill.end())
+        << "an admitted request that has not been stepped yet must stay schedulable";
+    EXPECT_NE(std::find(prefill.begin(), prefill.end(), reqs[2]), prefill.end());
     EXPECT_FALSE(sched.has_pending());
 }
 

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -87,7 +87,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1985, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1995, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
Closes #1643.

## The gap

One engine step runs a prefill chunk for **every** prefilling request, then one
decode step for everyone else. The only latency guard caps the **size** of a
chunk. With k concurrent ingests the loop still inserts k chunk forwards between
two decode steps of every decoder, and no term in the size cap depends on k -
its pinned numbers were measured against one ingest and one decoder.

`runtime.prefill_batch_decode_cap` (default 1) bounds the count while anyone is
decoding. The starting index rotates; a fixed prefix would starve every later
ingest, which is the failure #1634/#1637 came from.

## Measured

Qwen3-8B Q8, one streaming decoder against three ~5.2k-token ingests, two
alternating rounds per arm (`scripts/bench_prefill_latency.py`):

| | cap=0 (today) | cap=1 |
|---|---|---|
| worst inter-token gap | 259.2 / 254.4 ms | 111.8 / 87.9 ms |
| gaps over 100 ms | 6 / 6 | 1 / 0 |
| gaps over 50 ms | 6 / 6 | 16 / 17 |
| ingest wall time (mean of 6) | 2017.7 ms | 2381.4 ms (**+18.0%**) |
| median inter-token | 3.4 ms | 3.4 ms |

The stall is **spread, not removed**: more small gaps, no large ones. Same trade
the chunk cap already takes (+27% TTFT for bounded latency), so the default
follows it. The cap does not apply when nobody is decoding, so batch ingest
throughput is untouched.

## A second defect, found by the first arm

With the cap on, two of three ingests hung until the **300 s** request timeout:

```
ingest_ms: [300069.9, 300086.1, 1226.5]
```

`Scheduler::schedule()` re-queued in-flight prefills on `prefill_offset > 0`. A
request promoted from pending but not served in that tick still has offset 0, so
it stayed PREFILLING, admitted and holding KV, and in **no batch ever again**.
Nothing reached it while every promoted request was served in the same tick it
was promoted; the cap makes "not served this tick" a normal state. The condition
is `>= 0` now, and the existing `already_queued` scan is what keeps just-promoted
requests from being added twice.

`SchedulerTest.AdmissionReservesGeneration` expected one request from the second
`schedule()` and now gets two - the newly admitted one plus the one admitted
earlier that nothing has stepped yet. That test encoded the assumption this
removes, and it is the only place in the tree that could see it.

## The harness

`scripts/bench_prefill_latency.py` ships with the two measurement traps it
walked into written into its header, because both produce a confident
"no difference":

| trap | what it looked like |
|---|---|
| decoder finished before the ingests landed (120 tokens = 0.4 s) | every arm identical, max gap 17 ms |
| same ingest prompt across arms -> prefix cache hit | ingest 260 ms against 1200 ms cold, i.e. no prefill measured at all |

## Gates

| check | result |
|---|---|
| pre-commit GPU suite | passed (caught the test above first) |
| `make dev-test` (CI lane) | 8/8 in 7.34 s |
| `SchedulerTest.*` | 25/25 |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| `verify-fast` | PASS, degeneration smoke PASS |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
