### PR TITLE
fix(kv,graph): the multi-sequence residual KV write was not graph-safe (#1708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,28 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Multi-sequence decode on the residual path faulted with an illegal memory
+  access when CUDA graphs were on** (#1708). Silent wrong output, then a sticky
+  context: the first fault took every later request in the process with it, and
+  the client saw `finish_reason: length` with a degenerate string, not an error.
+  Three things on that path were resolved on the host at capture time - a
+  device pointer array `cudaMallocAsync`'d per call and per layer inside the
+  captured region and freed right after it, the ring index baked into those
+  pointers, and a host-side ring advance that a replay never runs (the
+  device-side advance was gated on `kv_seq_id`, which only the single-sequence
+  path sets). All three are computed on the device now. Qwen3-8B-Q8_0,
+  `kv_cache.bitdecoding_residual_tokens=64`, six concurrent requests:
+
+  | | before | after |
+  |---|---|---|
+  | answers | 6/6 empty | 6/6 correct |
+  | `illegal memory access` in the log | 15 | 0 |
+
+  One request was clean before and stays clean; graphs off was clean before and
+  stays clean. `ResidualKvWriteMulti.ReplayFollowsTheRingInsteadOfTheCapturedIndex`
+  captures a graph, advances the ring on the device only, and asserts the replay
+  followed it - it fails on a frozen index, which is what the old path had.
+
 - **The prefill latency guard capped chunk size, never chunk count** (#1643).
   One engine step ran a chunk for *every* prefilling request, so k concurrent
   ingests inserted k chunk forwards between two decode steps of every decoder -

--- a/src/exec/executor_forward.cu
+++ b/src/exec/executor_forward.cu
@@ -598,6 +598,16 @@ void GraphExecutor::forward_logits(const InferenceState& state, Tensor& logits_o
                 state.kv_manager->residual_n_tokens());
             IMP_CUDA_CHECK_LAUNCH();
         }
+    } else if (!state.is_prefill && state.kv_manager != nullptr && state.kv_manager->residual_enabled() &&
+               state.d_residual_seq_slots != nullptr && state.n_sequences > 1) {
+        // Multi-seq: `kv_seq_id` is only set on the N==1 path, so the branch
+        // above never fired here and the ring was advanced on the host instead
+        // - which a graph replay does not run (#1708). Slots come from the
+        // engine's per-step upload, so this is correct across replays.
+        advance_residual_state_multi_kernel<<<1, state.n_sequences, 0, stream>>>(
+            state.kv_manager->d_residual_widx_ptr(), state.kv_manager->d_residual_fc_ptr(),
+            state.d_residual_seq_slots, state.n_sequences, state.kv_manager->residual_n_tokens());
+        IMP_CUDA_CHECK_LAUNCH();
     }
 
     // Final FP32→FP16 conversion for the tokens that need LM head projection.

--- a/src/exec/executor_kernels.h
+++ b/src/exec/executor_kernels.h
@@ -133,6 +133,23 @@ __global__ void residual_kv_write_indirect_kernel(
     int seq_slot,                                     // index into d_residual_widx_ptr
     int slot_elems);
 
+// Graph-capture-safe MULTI-seq variant of the above. The per-batch-index
+// destination is computed on the device from the layer base, the residual
+// per-seq stride and the ring index, so nothing about it is frozen at capture
+// time (#1708). The old form took a device ARRAY of destination pointers that
+// the host built and `cudaMallocAsync`'d per call, per layer - inside the
+// captured region, freed again right after, so a replay wrote to memory the
+// allocator had handed to someone else.
+__global__ void residual_kv_write_multi_indirect_kernel(
+    const half* __restrict__ k_in,                // [n_tokens, slot_elems]
+    const half* __restrict__ v_in,                // [n_tokens, slot_elems]
+    half* __restrict__ residual_k_layer_base,     // slot 0 of this layer, K
+    half* __restrict__ residual_v_layer_base,     // slot 0 of this layer, V
+    int64_t seq_stride_elems,                     // half-elements between seq slots
+    const int* __restrict__ d_seq_slots,          // [n_tokens] residual slot per batch idx
+    const int* __restrict__ d_residual_widx_ptr,  // [max_seqs] device array
+    int slot_elems);
+
 // Advance the residual ring state for one slot. Single-thread kernel:
 //   d_widx[slot] = (d_widx[slot] + 1) % residual_n_tokens
 //   d_fc[slot]   = min(d_fc[slot] + 1, residual_n_tokens)
@@ -141,6 +158,14 @@ __global__ void advance_residual_state_kernel(
     int* __restrict__ d_fc,
     int slot,
     int residual_n_tokens);
+
+// Same, for every sequence in a multi-seq decode step (#1708). The single-slot
+// form above is reached only when `state.kv_seq_id >= 0`, which only the N==1
+// path sets - so a multi-seq step advanced the ring on the HOST, and a graph
+// replay never ran that.
+__global__ void advance_residual_state_multi_kernel(int* __restrict__ d_widx, int* __restrict__ d_fc,
+                                                    const int* __restrict__ d_seq_slots, int n_seqs,
+                                                    int residual_n_tokens);
 
 __global__ __launch_bounds__(256) void write_kv_cache_rope_fused_kernel(
     const half* __restrict__ k_in, const half* __restrict__ v_in, const int* __restrict__ positions,

--- a/src/exec/executor_kv_write.cu
+++ b/src/exec/executor_kv_write.cu
@@ -266,40 +266,39 @@ void GraphExecutor::write_kv_cache(int layer, const InferenceState& state, cudaS
                         // once per step by advance_residual_state_kernel in forward_logits.
                     }
                 }
-            } else if (state.h_residual_seq_ids != nullptr) {
-                // Multi-seq: build device pointer arrays per layer (host-side,
-                // upload via the per-step residual_meta buffer is left to the
-                // engine to pre-upload — we fall back to per-call upload here
-                // for simplicity; n_sequences > 1 is rare so this is OK).
-                std::vector<half*> k_ptrs(n, nullptr), v_ptrs(n, nullptr);
-                for (int s = 0; s < n; s++) {
-                    int seq_id = state.h_residual_seq_ids[s];
-                    if (seq_id < 0) continue;
-                    void* dst_k = state.kv_manager->residual_k_ptr(seq_id, kv_layer);
-                    void* dst_v = state.kv_manager->residual_v_ptr(seq_id, kv_layer);
-                    if (dst_k == nullptr || dst_v == nullptr) continue;
-                    auto rs = state.kv_manager->residual_state(seq_id);
-                    k_ptrs[s] = static_cast<half*>(dst_k) + rs.write_idx * slot_elems;
-                    v_ptrs[s] = static_cast<half*>(dst_v) + rs.write_idx * slot_elems;
+            } else if (state.d_residual_seq_slots != nullptr) {
+                // Multi-seq, graph-safe (#1708). Everything the destination
+                // depends on is resolved on the DEVICE at execution time: the
+                // layer base plus the per-seq stride, the residual slot from
+                // the engine's per-step upload, and the ring index from the
+                // manager's device array.
+                //
+                // What this replaces built a device array of destination
+                // pointers per call and per layer, with `cudaMallocAsync` and a
+                // matching `cudaFreeAsync` around the launch - inside the
+                // captured region. A replay wrote through the captured address
+                // after it had been freed and reused ("an illegal memory
+                // access"), with the ring index frozen at capture time on top.
+                // It was written when `n_sequences > 1` was rare; the comment
+                // said so.
+                void* k_layer_base = state.kv_manager->residual_k_layer_base(kv_layer);
+                void* v_layer_base = state.kv_manager->residual_v_layer_base(kv_layer);
+                const int* d_widx = state.kv_manager->d_residual_widx_ptr();
+                if (k_layer_base != nullptr && v_layer_base != nullptr && d_widx != nullptr) {
+                    const int64_t seq_stride_elems = static_cast<int64_t>(
+                        state.kv_manager->residual_seq_stride_bytes() / sizeof(half));
+                    dim3 grid_multi(n, 2);
+                    residual_kv_write_multi_indirect_kernel<<<grid_multi, kThreads, 0, stream>>>(
+                        src_k_base, src_v_base, static_cast<half*>(k_layer_base),
+                        static_cast<half*>(v_layer_base), seq_stride_elems, state.d_residual_seq_slots,
+                        d_widx, slot_elems);
+                    IMP_CUDA_CHECK_LAUNCH();
                 }
-                half** d_k_ptrs = nullptr;
-                half** d_v_ptrs = nullptr;
-                cudaMallocAsync(&d_k_ptrs, n * sizeof(half*), stream);
-                cudaMallocAsync(&d_v_ptrs, n * sizeof(half*), stream);
-                cudaMemcpyAsync(d_k_ptrs, k_ptrs.data(), n * sizeof(half*),
-                                cudaMemcpyHostToDevice, stream);
-                cudaMemcpyAsync(d_v_ptrs, v_ptrs.data(), n * sizeof(half*),
-                                cudaMemcpyHostToDevice, stream);
-                dim3 grid_multi(n, 2);
-                residual_kv_write_multi_kernel<<<grid_multi, kThreads, 0, stream>>>(
-                    src_k_base, src_v_base, d_k_ptrs, d_v_ptrs, slot_elems);
-                IMP_CUDA_CHECK_LAUNCH();
-                cudaFreeAsync(d_k_ptrs, stream);
-                cudaFreeAsync(d_v_ptrs, stream);
-                for (int s = 0; s < n; s++) {
-                    int seq_id = state.h_residual_seq_ids[s];
-                    if (seq_id >= 0) state.kv_manager->advance_residual(seq_id);
-                }
+                // No host advance_residual: the ring is advanced on device once
+                // per step by advance_residual_state_multi_kernel, inside the
+                // captured graph. The host call this replaces ran at capture
+                // time only, so replays left the ring where the capture found
+                // it.
             }
         }
     }

--- a/src/exec/executor_kv_write_kernels.cu
+++ b/src/exec/executor_kv_write_kernels.cu
@@ -473,6 +473,47 @@ __global__ void residual_kv_write_indirect_kernel(
     }
 }
 
+__global__ void residual_kv_write_multi_indirect_kernel(
+    const half* __restrict__ k_in, const half* __restrict__ v_in, half* __restrict__ residual_k_layer_base,
+    half* __restrict__ residual_v_layer_base, int64_t seq_stride_elems, const int* __restrict__ d_seq_slots,
+    const int* __restrict__ d_residual_widx_ptr, int slot_elems) {
+    const int token_idx = blockIdx.x;
+    const bool is_v = (blockIdx.y == 1);
+
+    const int seq_slot = d_seq_slots[token_idx];
+    if (seq_slot < 0)
+        return;
+    half* base = is_v ? residual_v_layer_base : residual_k_layer_base;
+    if (base == nullptr)
+        return;
+    base += static_cast<int64_t>(seq_slot) * seq_stride_elems;
+
+    const int widx = d_residual_widx_ptr[seq_slot];
+    half* dst = base + static_cast<int64_t>(widx) * slot_elems;
+    const half* src = (is_v ? v_in : k_in) + static_cast<int64_t>(token_idx) * slot_elems;
+
+    for (int i = threadIdx.x; i < slot_elems; i += blockDim.x) {
+        dst[i] = src[i];
+    }
+}
+
+__global__ void advance_residual_state_multi_kernel(int* __restrict__ d_widx, int* __restrict__ d_fc,
+                                                    const int* __restrict__ d_seq_slots, int n_seqs,
+                                                    int residual_n_tokens) {
+    const int i = threadIdx.x;
+    if (i >= n_seqs)
+        return;
+    const int slot = d_seq_slots[i];
+    if (slot < 0)
+        return;
+    // One thread per sequence, and two sequences never share a residual slot,
+    // so these are disjoint addresses - no atomics needed.
+    const int w = d_widx[slot];
+    const int f = d_fc[slot];
+    d_widx[slot] = (w + 1) % residual_n_tokens;
+    d_fc[slot] = (f < residual_n_tokens) ? (f + 1) : f;
+}
+
 __global__ void advance_residual_state_kernel(
     int* __restrict__ d_widx,
     int* __restrict__ d_fc,

--- a/tests/test_attention_paged_nvfp4_tc_residual.cu
+++ b/tests/test_attention_paged_nvfp4_tc_residual.cu
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "compute/attention_paged.h"
+#include "exec/executor_kernels.h"
 #include "core/tensor.h"
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
@@ -677,4 +678,120 @@ TEST_F(PagedAttentionNvfp4TCResidualTest, SplitKResidualLaunchSucceeds_HD128) {
 }
 
 }  // namespace
+
+// ---------------------------------------------------------------------------
+// #1708: the multi-seq residual KV write must be graph-safe.
+//
+// The path this guards wrote through a device pointer array the HOST built and
+// `cudaMallocAsync`'d per call, per layer, inside the captured region, freeing
+// it right after the launch. A replay then wrote through an address the
+// allocator had handed to someone else - "an illegal memory access", six
+// concurrent sequences, graphs on, silent wrong output before that.
+//
+// The property that broke is not "the kernel computes the right address once".
+// It is "the address it computes follows the ring across a REPLAY". So the test
+// captures a graph, advances the ring on the device without re-capturing, and
+// asserts the second write landed one slot further on.
+// ---------------------------------------------------------------------------
+
+TEST(ResidualKvWriteMulti, ReplayFollowsTheRingInsteadOfTheCapturedIndex) {
+    int dev = 0;
+    if (cudaGetDeviceCount(&dev) != cudaSuccess || dev == 0)
+        GTEST_SKIP() << "no CUDA device";
+
+    constexpr int kSeqs = 3;       // batch slots
+    constexpr int kSlotElems = 8;  // n_kv_heads * head_dim, tiny on purpose
+    constexpr int kRingSlots = 4;  // residual ring depth
+    constexpr int kMaxSlots = 8;   // residual slots the manager could hand out
+    // Stride between two sequences' residual regions, in halves.
+    constexpr int64_t kSeqStride = kRingSlots * kSlotElems;
+
+    // Batch index i writes for residual slot slots[i] - deliberately not the
+    // identity, because the batch index and the residual slot are exactly the
+    // two things the old code conflated.
+    const int h_slots[kSeqs] = {5, 0, 2};
+
+    half *d_k_in = nullptr, *d_v_in = nullptr, *d_k_base = nullptr, *d_v_base = nullptr;
+    int *d_slots = nullptr, *d_widx = nullptr;
+    const size_t in_bytes = kSeqs * kSlotElems * sizeof(half);
+    const size_t base_bytes = kMaxSlots * kSeqStride * sizeof(half);
+    ASSERT_EQ(cudaMalloc(&d_k_in, in_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_v_in, in_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_k_base, base_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_v_base, base_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_slots, kSeqs * sizeof(int)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_widx, kMaxSlots * sizeof(int)), cudaSuccess);
+
+    std::vector<half> h_in(kSeqs * kSlotElems);
+    for (int s = 0; s < kSeqs; s++)
+        for (int e = 0; e < kSlotElems; e++)
+            h_in[s * kSlotElems + e] = __float2half(static_cast<float>(100 * (s + 1) + e));
+    ASSERT_EQ(cudaMemcpy(d_k_in, h_in.data(), in_bytes, cudaMemcpyHostToDevice), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_v_in, h_in.data(), in_bytes, cudaMemcpyHostToDevice), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_k_base, 0, base_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMemset(d_v_base, 0, base_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_slots, h_slots, sizeof(h_slots), cudaMemcpyHostToDevice), cudaSuccess);
+    std::vector<int> h_widx(kMaxSlots, 0);
+    ASSERT_EQ(cudaMemcpy(d_widx, h_widx.data(), kMaxSlots * sizeof(int), cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    cudaStream_t stream;
+    ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+
+    cudaGraph_t graph = nullptr;
+    cudaGraphExec_t exec = nullptr;
+    ASSERT_EQ(cudaStreamBeginCapture(stream, cudaStreamCaptureModeThreadLocal), cudaSuccess);
+    residual_kv_write_multi_indirect_kernel<<<dim3(kSeqs, 2), 64, 0, stream>>>(d_k_in, d_v_in, d_k_base,
+                                                                               d_v_base, kSeqStride, d_slots,
+                                                                               d_widx, kSlotElems);
+    ASSERT_EQ(cudaStreamEndCapture(stream, &graph), cudaSuccess);
+    ASSERT_EQ(cudaGraphInstantiate(&exec, graph, nullptr, nullptr, 0), cudaSuccess);
+
+    // Ring index 0.
+    ASSERT_EQ(cudaGraphLaunch(exec, stream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    // Advance the ring on the DEVICE only - no re-capture, no host pointer
+    // rebuild. This is what a real decode step does.
+    for (int i = 0; i < kSeqs; i++)
+        h_widx[h_slots[i]] = 1;
+    ASSERT_EQ(cudaMemcpy(d_widx, h_widx.data(), kMaxSlots * sizeof(int), cudaMemcpyHostToDevice),
+              cudaSuccess);
+    ASSERT_EQ(cudaGraphLaunch(exec, stream), cudaSuccess);
+    ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+
+    std::vector<half> got(kMaxSlots * kSeqStride);
+    ASSERT_EQ(cudaMemcpy(got.data(), d_k_base, base_bytes, cudaMemcpyDeviceToHost), cudaSuccess);
+
+    for (int s = 0; s < kSeqs; s++) {
+        const int64_t region = static_cast<int64_t>(h_slots[s]) * kSeqStride;
+        for (int e = 0; e < kSlotElems; e++) {
+            const float want = static_cast<float>(100 * (s + 1) + e);
+            EXPECT_FLOAT_EQ(__half2float(got[region + 0 * kSlotElems + e]), want)
+                << "first launch, seq " << s << " elem " << e;
+            // The replay must have followed d_widx to ring index 1. Frozen at
+            // capture time this stays 0 and the test fails here.
+            EXPECT_FLOAT_EQ(__half2float(got[region + 1 * kSlotElems + e]), want)
+                << "replay did not follow the ring, seq " << s << " elem " << e;
+        }
+        // Nothing outside the two written ring slots.
+        for (int r = 2; r < kRingSlots; r++)
+            for (int e = 0; e < kSlotElems; e++)
+                EXPECT_FLOAT_EQ(__half2float(got[region + r * kSlotElems + e]), 0.0f);
+    }
+    // A slot no batch index named stays untouched.
+    for (int e = 0; e < kSlotElems; e++)
+        EXPECT_FLOAT_EQ(__half2float(got[static_cast<int64_t>(1) * kSeqStride + e]), 0.0f);
+
+    cudaGraphExecDestroy(exec);
+    cudaGraphDestroy(graph);
+    cudaStreamDestroy(stream);
+    cudaFree(d_k_in);
+    cudaFree(d_v_in);
+    cudaFree(d_k_base);
+    cudaFree(d_v_base);
+    cudaFree(d_slots);
+    cudaFree(d_widx);
+}
+
 }  // namespace imp

--- a/tools/alloc_allowlist.txt
+++ b/tools/alloc_allowlist.txt
@@ -38,7 +38,6 @@ src/exec/executor_forward_moe.cu  # 5
 src/exec/executor_forward_moe_batch.cu  # 7
 src/exec/executor_forward_moe_cutlass.cu  # 10
 src/exec/executor_helpers.h  # 3
-src/exec/executor_kv_write.cu  # 4
 src/exec/executor_lora.cu  # 2
 src/exec/executor_perplexity.cu  # 8
 src/exec/executor_ssm_gdn.cu  # 2

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -126,7 +126,7 @@ def main():
                     help="expected unlaned macro count (default: read PINNED below)")
     args = ap.parse_args()
 
-    PINNED = 975
+    PINNED = 976
 
     text = CMAKE.read_text()
     mods = module_sources(text)

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -75,7 +75,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/json_schema.cpp" = { code_loc = 1200, reason = "(c) one module: JSON-schema parser + RegexNfa compiler/executor for constrained decode" }
 "src/compute/mtp_forward.cu" = { code_loc = 856, reason = "(c) MTP forward path: many small fused ops (emb_gather/concat/argmax/attn_kv_scan/mrope) for one feature" }
 "src/compute/schema_constrain.cu" = { code_loc = 1184, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands" }
-"src/exec/executor_forward.cu" = { code_loc = 732, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
+"src/exec/executor_forward.cu" = { code_loc = 738, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1061, reason = "(c) one path: batched-MoE forward dispatch (host-only)" }
 "src/exec/executor_workspace_buffers.cu" = { code_loc = 1350, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
 "src/memory/kv_cache_manager.cpp" = { code_loc = 1207, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }


### PR DESCRIPTION
Closes #1708.

## Cause

Three things on the multi-sequence residual write path were resolved on the host
and frozen at capture time:

| # | what | why a replay breaks |
|---|---|---|
| 1 | a device array of destination pointers, `cudaMallocAsync`'d **per call and per layer** inside the captured region, `cudaFreeAsync`'d right after the launch | the replay writes through an address the allocator has since handed to someone else |
| 2 | the ring index, baked into those pointers | the write never leaves the slot it was captured at |
| 3 | the ring advance, a host call | the device-side advance is gated on `state.kv_seq_id`, which only the N==1 path sets, so a multi-seq step never reached it |

Not #1648: that fixed a per-step `cudaMallocAsync` in `engine_scheduler.cpp`.
This one is in `executor_kv_write.cu` and the fault survived that fix unchanged,
as the issue says.

The old code said what it was:

> upload via the per-step residual_meta buffer is left to the engine to
> pre-upload — we fall back to per-call upload here for simplicity;
> n_sequences > 1 is rare so this is OK

## Fix

`residual_kv_write_multi_indirect_kernel` takes the layer base, the per-seq
stride and the two device arrays the engine already uploads per step, and
resolves slot and ring index on the device - the shape the single-seq path has
used since it was made graph-safe. `KVCacheManager` already exposed
`residual_k_layer_base()` and `residual_seq_stride_bytes()` for exactly this,
with the formula `K_for_slot_s = K_layer_base + s * stride` in its header
comment; the multi-seq path never used them.
`advance_residual_state_multi_kernel` advances every sequence in the step,
inside the captured graph.

## Measured

Qwen3-8B-Q8_0, `--kv-nvfp4 --set kv_cache.bitdecoding_residual_tokens=64`, six
concurrent requests, same tree in both arms:

| arm | answers | `illegal memory access` lines |
|---|---|---|
| before | **6/6 empty content** | 15 |
| after | **6/6 correct** | 0 |

Controls: one request is clean in both arms; the fixed build with
`runtime.cuda_graphs=never` is 6/6 correct with 0 fault lines, so the fix is not
just hiding the path.

## The regression test

`ResidualKvWriteMulti.ReplayFollowsTheRingInsteadOfTheCapturedIndex` captures a
graph, advances the ring on the **device only** - no re-capture, no host pointer
rebuild - and asserts the replay followed it. Batch index and residual slot are
deliberately different (`{5, 0, 2}`), because conflating them is the other half
of what the old code did.

Verified it has teeth rather than assuming: with the ring index frozen to 0 in
the kernel it fails on `replay did not follow the ring, seq 0 elem 0`.

## Gates

| check | result |
|---|---|
| pre-commit GPU suite | passed |
| `make dev-test` (CI lane) | 8/8 in 7.88 s |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| `verify-fast` | PASS, degeneration smoke PASS |

`tools/alloc_allowlist.txt` loses `src/exec/executor_kv_write.cu`: the I1 gate
reports its four allocation sites are gone, which is the change itself. The
unlaned-GTest pin and two code_loc pins move with the new test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
