### PR TITLE
fix(sampling): the CUB top-k regime dropped the whole batch onto synchronous sampling (#1654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,26 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A `top_k` one candidate over the batching limit cost 14.5% of throughput,
+  and changed what the model sampled from** (#1654). `sample_topk_topp_async`
+  refused the CUB regime (`top_k > 128`), so the whole batch fell back to
+  per-sequence synchronous sampling - one host round trip per sequence per step
+  instead of one pinned gather for the batch. The CUB path was already all-async
+  internally; only its trailing readback forced the sync, so it enqueues now.
+  Qwen3-8B Q8, six concurrent sequences, `top_k=128` against `top_k=129` (one
+  candidate of 151k apart, so the path is the only variable), median of three
+  rounds:
+
+  | | top_k=128 | top_k=129 | delta |
+  |---|---|---|---|
+  | before | 555.4 tok/s | 475.0 tok/s | **-14.5%** |
+  | after | 546.5 tok/s | 544.6 tok/s | -0.3% |
+
+  `sample_topk_topp_device` also **clamped** `top_k` to 128 with a warning, so a
+  request with `top_k=200` sampled from 128 candidates alone in the batch and
+  from 200 sharing it - the same request, two distributions, decided by its
+  neighbours. Both honour the request now.
+
 - **Multi-sequence decode on the residual path faulted with an illegal memory
   access when CUDA graphs were on** (#1708). Silent wrong output, then a sticky
   context: the first fault took every later request in the process with it, and

--- a/src/compute/sampling_topk_topp.cu
+++ b/src/compute/sampling_topk_topp.cu
@@ -557,13 +557,33 @@ struct CubSortScratch {
 
 static CubSortScratch s_cub_scratch;
 
-// CUB-based top-k sampling for k > MAX_TOP_K.
-static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int top_k, float top_p,
-                                    float inv_temperature, unsigned int seed, int32_t* d_result,
-                                    cudaStream_t stream) {
+// Initialise the softmax accumulators on the device (#1654). They used to be
+// two `cudaMemcpyAsync` from function-local `int`/`float`, which is only safe
+// because the enclosing function synchronised before returning. The enqueue
+// form below does not, and a stack address that outlives its frame is the kind
+// of bug that reproduces once a month.
+__global__ void init_cub_max_sum_kernel(float* __restrict__ d_max_sum) {
+    if (threadIdx.x == 0) {
+        d_max_sum[0] = -FLT_MAX;
+        d_max_sum[1] = 0.0f;
+    }
+}
+
+// CUB-based top-k sampling for k > MAX_TOP_K. ENQUEUE ONLY: everything below
+// runs on `stream`, nothing reads back and nothing synchronises, so a caller can
+// queue one of these per sequence and gather every token with a single pinned
+// D2H at the end (#1654). Returns false when the scratch is unavailable.
+//
+// It was already all-async internally; only the trailing readback forced the
+// sync, and that one readback is why crossing MAX_TOP_K dropped aggregate
+// throughput 14.5% at six concurrent sequences - one host round trip per
+// sequence per step instead of one for the batch.
+static bool sample_topk_topp_cub_enqueue(const float* d_logits, int vocab_size, int top_k, float top_p,
+                                         float inv_temperature, unsigned int seed, int32_t* d_result,
+                                         cudaStream_t stream) {
     if (!s_cub_scratch.ensure(vocab_size, stream)) {
         IMP_LOG_ERROR("CUB sort scratch allocation failed for vocab_size=%d", vocab_size);
-        return 0;
+        return false;
     }
 
     auto& sc = s_cub_scratch;
@@ -571,14 +591,8 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     // Step 1: Compute softmax stats (max, then sum) entirely on device.
     // All intermediate values stay in d_max_sum — no D2H syncs needed.
     // d_max_sum[0] = global max, d_max_sum[1] = sum of exp.
-    float neg_inf_val = -FLT_MAX;
-    int neg_inf_bits;
-    std::memcpy(&neg_inf_bits, &neg_inf_val, sizeof(int));
-    IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(sc.d_max_sum, &neg_inf_bits, sizeof(int), cudaMemcpyHostToDevice, stream));
-    float zero = 0.0f;
-    IMP_CUDA_CHECK_LOG(
-        cudaMemcpyAsync(sc.d_max_sum + 1, &zero, sizeof(float), cudaMemcpyHostToDevice, stream));
+    init_cub_max_sum_kernel<<<1, 1, 0, stream>>>(sc.d_max_sum);
+    IMP_CUDA_CHECK_LAUNCH();
 
     int stats_blocks = std::min((vocab_size + BLOCK_SIZE - 1) / BLOCK_SIZE, 128);
 
@@ -639,7 +653,7 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
                 "sample_topk_topp_cub: CUB sort failed (%s) for vocab=%d top_k=%d — no token "
                 "sampled",
                 cudaGetErrorString(rc), vocab_size, top_k);
-            return 0;
+            return false;
         }
     }
 
@@ -647,11 +661,19 @@ static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int t
     topp_sample_from_sorted_kernel<<<1, 1, 0, stream>>>(sc.d_keys_out, sc.d_vals_out, top_k, top_p, seed,
                                                         d_result);
     IMP_CUDA_CHECK_LAUNCH();
+    return true;
+}
 
+// Synchronous wrapper, for the callers that want the token in hand.
+static int32_t sample_topk_topp_cub(const float* d_logits, int vocab_size, int top_k, float top_p,
+                                    float inv_temperature, unsigned int seed, int32_t* d_result,
+                                    cudaStream_t stream) {
+    if (!sample_topk_topp_cub_enqueue(d_logits, vocab_size, top_k, top_p, inv_temperature, seed, d_result,
+                                      stream))
+        return 0;
     int32_t h_result = 0;
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(&h_result, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));
     cudaStreamSynchronize(stream);
-
     return h_result;
 }
 
@@ -725,11 +747,17 @@ bool sample_topk_topp_async(const Tensor& logits, int top_k, float top_p, float 
     // tokens for the same logits/seed).
     if (top_k <= 0 || top_k > vocab_size)
         top_k = vocab_size;
-    if (top_k > MAX_TOP_K)
-        return false;  // CUB regime syncs internally — caller uses the sync variant
     if (temperature <= 0.0f)
         temperature = 1.0f;
     float inv_temperature = 1.0f / temperature;
+
+    // The CUB regime enqueues like any other now (#1654). It used to return
+    // false here and send the caller to the synchronous variant, which cost one
+    // host round trip per sequence per step: 14.5% of aggregate throughput at
+    // six concurrent sequences, for a top_k one candidate over the limit.
+    if (top_k > MAX_TOP_K)
+        return sample_topk_topp_cub_enqueue(d_logits, vocab_size, top_k, top_p, inv_temperature, seed,
+                                            d_result, stream);
 
     launch_topk_topp_multiblock(d_logits, vocab_size, top_k, top_p, inv_temperature, seed, d_result, stream);
     return true;
@@ -742,15 +770,23 @@ void sample_topk_topp_device(const Tensor& logits, int top_k, float top_p, float
 
     if (top_k <= 0 || top_k > vocab_size)
         top_k = vocab_size;
-    if (top_k > MAX_TOP_K) {
-        IMP_LOG_WARN("top_k=%d exceeds MAX_TOP_K=%d, clamping", top_k, MAX_TOP_K);
-        top_k = MAX_TOP_K;
-    }
     if (temperature <= 0.0f)
         temperature = 1.0f;
     float inv_temperature = 1.0f / temperature;
 
-    launch_topk_topp_multiblock(d_logits, vocab_size, top_k, top_p, inv_temperature, seed, d_result, stream);
+    // No clamp (#1654). This used to cut top_k down to MAX_TOP_K with a warning,
+    // so a request with top_k=200 sampled from 128 candidates when it was alone
+    // in the batch and from 200 when it shared the batch with another sequence -
+    // the same request, two distributions, decided by its neighbours. The CUB
+    // path enqueues now, so both honour what was asked.
+    if (top_k > MAX_TOP_K) {
+        if (!sample_topk_topp_cub_enqueue(d_logits, vocab_size, top_k, top_p, inv_temperature, seed, d_result,
+                                          stream))
+            return;
+    } else {
+        launch_topk_topp_multiblock(d_logits, vocab_size, top_k, top_p, inv_temperature, seed, d_result,
+                                    stream);
+    }
 
     // Async copy to mapped pinned memory — no sync needed.
     IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h_mapped, d_result, sizeof(int32_t), cudaMemcpyDeviceToHost, stream));

--- a/src/exec/executor.cu
+++ b/src/exec/executor.cu
@@ -312,13 +312,13 @@ std::vector<int32_t> GraphExecutor::sample_from_logits(const Tensor& logits, con
         const float top_p = state.top_p > 0.0f ? state.top_p : 1.0f;
         // Eligibility is batch-uniform (depends only on shared sampling params
         // and vocab), so decide BEFORE applying any penalties — no sequence is
-        // ever half-processed across the two paths. top_k <= 0 / > vocab
-        // normalizes to vocab inside the samplers, which lands in the CUB
-        // regime (> SAMPLE_MAX_TOP_K) that syncs internally.
-        const int vocab = static_cast<int>(logits.shape[logits.ndim - 1]);
-        const int eff_top_k = (top_k <= 0 || top_k > vocab) ? vocab : top_k;
-        const bool can_batch = d_sample_result_ && h_sample_pinned_.as<int32_t>() && n_seq <= sample_slots_ &&
-                               (greedy || eff_top_k <= SAMPLE_MAX_TOP_K);
+        // ever half-processed across the two paths.
+        //
+        // No top_k term any more (#1654): sample_topk_topp_async enqueues the
+        // CUB regime too, so a top_k over SAMPLE_MAX_TOP_K no longer drops the
+        // whole batch onto the per-sequence synchronous path. It used to, and
+        // that cost 14.5% of aggregate throughput at six sequences.
+        const bool can_batch = d_sample_result_ && h_sample_pinned_.as<int32_t>() && n_seq <= sample_slots_;
         if (can_batch) {
             for (int i = 0; i < n_seq; i++) {
                 Tensor seq_logits = flatten_logits(logits.slice(i, i + 1));
@@ -505,9 +505,11 @@ bool GraphExecutor::sample_single_from_logits_async(const Tensor& logits, const 
     const bool greedy = (state.temperature <= 0.0f || state.top_k == 1);
     const int top_k = state.top_k > 0 ? state.top_k : 50;
     const int eff_top_k = (top_k <= 0 || top_k > vocab) ? vocab : top_k;
-    if (!greedy && eff_top_k > SAMPLE_MAX_TOP_K)
-        return false;  // CUB regime syncs internally
-
+    // No blanket CUB-regime refusal any more (#1654): sample_topk_topp_async
+    // enqueues that regime now. Only the ROW-PARALLEL stash below is still
+    // limited to SAMPLE_MAX_TOP_K - launch_topk_topp_rows takes top_k in
+    // [1, SAMPLE_MAX_TOP_K] by contract - so a larger k skips the stash and
+    // enqueues per row instead of dropping the caller onto a synchronous path.
     apply_row_filters_(lp, vocab, state, stream);
 
     auto* slot = reinterpret_cast<int32_t*>(reinterpret_cast<char*>(d_sample_result_) +
@@ -518,7 +520,7 @@ bool GraphExecutor::sample_single_from_logits_async(const Tensor& logits, const 
     }
     unsigned int seed = state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u;
     float temperature = state.temperature <= 0.0f ? 1.0f : state.temperature;
-    if (h_row_args_.as<TopkRowArgs>() && d_row_args_) {
+    if (h_row_args_.as<TopkRowArgs>() && d_row_args_ && eff_top_k <= SAMPLE_MAX_TOP_K) {
         // STASH the row for the row-parallel batched launch in
         // collect_sampled_tokens — n serialized <<<64>>>+<<<1>>> launch pairs
         // become ONE partial + ONE finalize launch for the whole batch.

--- a/tests/test_sampling.cu
+++ b/tests/test_sampling.cu
@@ -441,12 +441,24 @@ TEST(SamplingTest, AsyncBatchedSlotsMatchSynchronousPerSequence) {
     for (int i = 0; i < n_seq; i++)
         EXPECT_EQ(h_pinned[i], ref_greedy[i]) << "greedy token diverged for sequence " << i;
 
-    // The CUB regime (top_k > SAMPLE_MAX_TOP_K) must decline the async path.
-    EXPECT_FALSE(sample_topk_topp_async(logits[0], SAMPLE_MAX_TOP_K + 1, top_p, temperature, 42u,
-                                        reinterpret_cast<int32_t*>(d_slots), nullptr));
-    EXPECT_FALSE(sample_topk_topp_async(logits[0], /*top_k=*/0, top_p, temperature, 42u,
-                                        reinterpret_cast<int32_t*>(d_slots), nullptr))
-        << "top_k<=0 normalizes to vocab and must take the CUB path";
+    // The CUB regime (top_k > SAMPLE_MAX_TOP_K) enqueues like any other k
+    // (#1654), and must produce the SAME token the synchronous CUB path does.
+    // This used to assert the async form DECLINED - which is what sent the
+    // whole batch to per-sequence synchronous sampling, at -14.5% aggregate
+    // throughput for a top_k one candidate over the limit. Declining is no
+    // longer the contract, so asserting the tokens match is the property left
+    // to guard.
+    for (int cub_k : {SAMPLE_MAX_TOP_K + 1, 0}) {
+        const int32_t want = sample_topk_topp(logits[0], cub_k, top_p, temperature, 42u, d_ref, nullptr);
+        auto* slot = reinterpret_cast<int32_t*>(d_slots);
+        ASSERT_TRUE(sample_topk_topp_async(logits[0], cub_k, top_p, temperature, 42u, slot, nullptr))
+            << "the CUB regime must enqueue, not decline (top_k=" << cub_k << ")";
+        int32_t got = -1;
+        ASSERT_EQ(cudaMemcpyAsync(&got, slot, sizeof(int32_t), cudaMemcpyDeviceToHost, nullptr), cudaSuccess);
+        ASSERT_EQ(cudaStreamSynchronize(nullptr), cudaSuccess);
+        EXPECT_EQ(got, want) << "enqueued CUB token diverged from the synchronous one (top_k=" << cub_k
+                             << "); top_k=0 normalises to vocab, which is the CUB path too";
+    }
 
     cudaFreeHost(h_pinned);
     cudaFree(d_slots);


### PR DESCRIPTION
Closes #1654.

## What it cost

`sample_topk_topp_async` returned false for `top_k > SAMPLE_MAX_TOP_K`, so
`can_batch` was false **for the whole step** and every sequence went through the
per-sequence synchronous sampler - a 4-byte pageable D2H plus a stream sync
each, the pattern the batched path exists to replace.

Qwen3-8B Q8, six concurrent requests, temperature 0.8, **`top_k=128` against
`top_k=129`**: one candidate out of 151k apart, so the sampling path is the only
variable. Median of three rounds:

| | top_k=128 | top_k=129 | delta |
|---|---|---|---|
| before | 555.4 tok/s | 475.0 tok/s | **-14.5%** |
| after | 546.5 tok/s | 544.6 tok/s | -0.3% |

The batched arm itself is unchanged within noise (555.4 → 546.5, -1.6%, against
a round-to-round spread of ~18% on this workload).

## Fix

The CUB path was already all-async internally - only its trailing readback
forced the sync. It is split into `sample_topk_topp_cub_enqueue` and a
synchronous wrapper, and `sample_topk_topp_async` enqueues it like any other k.

`launch_topk_topp_rows` keeps its `SAMPLE_MAX_TOP_K` guard: its contract is
`top_k ∈ [1, SAMPLE_MAX_TOP_K]`. A larger k skips that stash and enqueues per
row, instead of dropping the caller onto a synchronous path.

## Two things found on the way

**`sample_topk_topp_device` clamped.** The pinned single-sequence path cut
`top_k` down to 128 with a warning, while the multi-seq fallback used the CUB
path and honoured it. A request with `top_k=200` sampled from 128 candidates
alone in the batch and from 200 sharing it - the same request, two
distributions, decided by its neighbours. Both honour it now; the warning no
longer appears for `top_k=200`.

**A stack address that was about to outlive its frame.** The CUB path seeded its
softmax accumulators with two `cudaMemcpyAsync` from function-local `int`/`float`.
That is only safe because the enclosing function synchronised before returning -
which the enqueue form does not. A one-thread `init_cub_max_sum_kernel` replaces
them.

## The test

`SamplingTest.AsyncBatchedSlotsMatchSynchronousPerSequence` asserted that the
async form **declined** the CUB regime - the refusal that caused all of this.
Declining is no longer the contract, so it asserts the property that is left:
the enqueued CUB token equals the synchronous CUB token, for `top_k = MAX+1` and
for `top_k = 0`.

## A note on the first measurement, since it was wrong

`top_k=40` against `top_k=0` showed no difference, because the executor
normalises `state.top_k <= 0` to **50** before the samplers see it - both arms
were the batched path, i.e. the control and the case were the same code.
`top_k=1000` showed -16% but changes the sampler's workload as well as its path.
128 vs 129 is the pair that isolates it.

## Gates

| check | result |
|---|---|
| pre-commit GPU suite | passed (caught the test above first) |
| `SamplingTest.*` | 19/19 |
| `make dev-test` (CI lane) | 8/8 in 7.69 s |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| `verify-fast` | PASS, degeneration smoke PASS |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
