### PR TITLE
fix(gemm): a matmul failure discarded the benchmarked algo silently (#1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,15 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A cuBLASLt matmul failure discarded the benchmarked algo without saying so**
+  (#1545). `reselect_algo_for_entry` replaced the timed probe's pick with
+  heuristic `results[0]` for the rest of the process and logged nothing; only a
+  *second* failure logged anything, so a shape could run on a different algo
+  than the one the probe chose, differently on each process start. The cache
+  entry now records whether its algo came from the probe or the heuristic, and
+  replacing a benchmarked one logs it once with the shape. The reselection
+  itself is unchanged - the retry is what keeps the matmul alive.
+
 - **Multi-sequence decode on the residual path faulted with an illegal memory
   access when CUDA graphs were on** (#1708). Silent wrong output, then a sticky
   context: the first fault took every later request in the process with it, and

--- a/src/compute/gemm.cu
+++ b/src/compute/gemm.cu
@@ -265,6 +265,11 @@ struct GemmCacheEntry {
     cublasLtMatmulAlgo_t algo;
     size_t workspace_size;
     bool has_algo;
+    // The algo came from the TIMED probe, not from the heuristic. Without this
+    // the reselect path cannot tell which of the two it is about to overwrite,
+    // so discarding a benchmarked pin looked exactly like re-picking a
+    // heuristic one - i.e. like nothing at all (#1545).
+    bool benchmarked = false;
     int64_t desc_M;  // M dimension baked into layout descriptors
 };
 
@@ -316,7 +321,7 @@ static void rebuild_layouts_for_m(GemmCacheEntry& entry, cudaDataType_t dtype_A,
 // that validation silently, mid-run, on the one path that promises
 // reproducibility (#1574). The caller then falls back rather than retrying
 // with an unvalidated algo.
-static bool reselect_algo_for_entry(GemmCacheEntry& entry) {
+static bool reselect_algo_for_entry(GemmCacheEntry& entry, int64_t M, int64_t K, int64_t N) {
     if (imp::process_diag_deterministic_gemm()) {
         IMP_LOG_DEBUG(
             "[gemm-algo] matmul failed and deterministic_gemm is on: not re-picking by "
@@ -336,9 +341,24 @@ static bool reselect_algo_for_entry(GemmCacheEntry& entry) {
     cublasLtMatmulPreferenceDestroy(pref);
 
     if (nresults > 0) {
+        // Say it once, when it happens. The benchmarked pin is being replaced
+        // by heuristic results[0] for the REST OF THE PROCESS, and the old code
+        // logged nothing here - only a second failure, further down, logged
+        // anything at all. So a shape could quietly run on a different algo
+        // than the one the probe chose, differently on each process start
+        // (#1545). `benchmarked` is cleared with it, so this fires once per
+        // pin rather than once per failure.
+        if (entry.benchmarked) {
+            IMP_LOG_WARN(
+                "[gemm-algo] matmul failed with the BENCHMARKED algo for M=%ld K=%ld N=%ld "
+                "(bucket desc_M=%ld) — replacing it with the heuristic pick for the rest of the "
+                "process; the probe's choice is gone until restart",
+                (long)M, (long)K, (long)N, (long)entry.desc_M);
+        }
         entry.algo = results[0].algo;
         entry.workspace_size = (results[0].workspaceSize <= s_workspace_size) ? results[0].workspaceSize : 0;
         entry.has_algo = true;
+        entry.benchmarked = false;
     } else {
         entry.has_algo = false;
         entry.workspace_size = 0;
@@ -504,6 +524,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         entry.workspace_size =
             (results[pick].workspaceSize <= s_workspace_size) ? results[pick].workspaceSize : 0;
         entry.has_algo = true;
+        entry.benchmarked = false;
         if (gemm_algo_log_enabled() && M > 0) {
             IMP_LOG_DEBUG("[gemm-algo]   PICKED cand[%d] (deterministic, warmup-validated)", pick);
         }
@@ -515,6 +536,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
         entry.algo = results[0].algo;
         entry.workspace_size = (results[0].workspaceSize <= s_workspace_size) ? results[0].workspaceSize : 0;
         entry.has_algo = true;
+        entry.benchmarked = false;
         return;
     }
     void* temp_c = s_bench_scratch;
@@ -653,6 +675,7 @@ static void benchmark_and_select_algo(cublasLtHandle_t lt, GemmCacheEntry& entry
     entry.algo = results[best_idx].algo;
     entry.workspace_size = results[best_idx].workspaceSize;
     entry.has_algo = true;
+    entry.benchmarked = true;
     if (gemm_algo_log_enabled() && M > 0) {
         int picked_tile = -1;
         cublasLtMatmulAlgoConfigGetAttribute(&entry.algo, CUBLASLT_ALGO_CONFIG_TILE_ID, &picked_tile,
@@ -867,7 +890,7 @@ static void gemm_cublaslt_generic(const Tensor& A, const Tensor& B, Tensor& C, f
             // what the warmup probe exists to reject (#1574).
             {
                 std::lock_guard<std::mutex> lock(s_gemm_cache_mutex);
-                reselect_algo_for_entry(*entry);
+                reselect_algo_for_entry(*entry, M, K, N);
             }
             st = cublasLtMatmul(lt, entry->opDesc, p_alpha, B.data, entry->Bdesc, A.data, entry->Adesc,
                                 p_beta, C.data, entry->Cdesc, C.data, entry->Cdesc,
@@ -1027,7 +1050,7 @@ void gemm_cublaslt(const Tensor& A, const Tensor& B, Tensor& C, float alpha, flo
         // may be invalid for the current M. Re-select via heuristic and retry.
         {
             std::lock_guard<std::mutex> lock(s_gemm_cache_mutex);
-            reselect_algo_for_entry(*entry);
+            reselect_algo_for_entry(*entry, M, K, N);
         }
         set_gemm_scale_pointers(entry->opDesc, aScale, bScale);
         st = cublasLtMatmul(lt, entry->opDesc, &alpha, B.data, entry->Bdesc, A.data, entry->Adesc, &beta,

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -68,7 +68,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/attention_paged.cu" = { code_loc = 1215, reason = "(c) one paged-attention family: gqa-prefill, decode, splitk, reduce, cluster - shared block/KV layout" }
 "src/compute/attention_paged_nvfp4_tc.cu" = { code_loc = 849, reason = "(c) NVFP4 tensor-core paged-attn family (decode/splitk/reduce) - shared TC path" }
 "src/compute/attention_paged_fp8.cu" = { code_loc = 603, reason = "(c) FP8 paged-attn family (decode/splitk/reduce) - same shape as its FP16 and NVFP4 siblings above; crossed 600 by the three -1 sentinel guards of #1678" }
-"src/compute/gemm.cu" = { code_loc = 734, reason = "(c) one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)" }
+"src/compute/gemm.cu" = { code_loc = 746, reason = "(c) one module: generic cuBLAS GEMM wrapper + algo-reselect/fallback chain + packed-weight leak guards (pushed over 600 by the #925 defense-in-depth guards)" }
 "src/compute/gemm_dp4a.cu" = { code_loc = 601, reason = "(c) one dp4a q8_1 family: activation/rmsnorm quantize kernels + the per-qtype GEMV launcher set (pushed to 601 by the 2026-07-17 post-launch error checks)" }
 "src/compute/gemm_grouped_nvfp4_smallM.cu" = { code_loc = 693, reason = "(c) one small-M grouped-GEMM family (software-ref + prod + smoke variants)" }
 "src/compute/gemv_dp4a_traits.cuh" = { code_loc = 1320, reason = "(b) trait-based template library: 8 DequantTraits<> specializations + 6 template GEMV kernels, consolidating ~33 hand-written kernels (header - wide include blast radius)" }


### PR DESCRIPTION
Closes #1545.

## The silence

`reselect_algo_for_entry` replaced the timed probe's algo with heuristic
`results[0]` **for the remainder of the process** and logged nothing on that
branch. Only a *second* failure logged anything, so the event that actually
drops the pin was invisible - a shape could run on a different algo than the
probe chose, differently on each process start.

The cache entry could not tell the two apart either: it carried `has_algo` and
nothing else, so discarding a benchmarked pin looked identical to re-picking a
heuristic one.

## Change

| | |
|---|---|
| `GemmCacheEntry::benchmarked` | set by the timed probe, cleared by both heuristic paths |
| the reselect | logs once per pin, with `M/K/N` and the bucket's `desc_M`, when the algo it replaces was benchmarked |

Once per **pin**, not once per failure: `benchmarked` is cleared with the
overwrite, so a shape that keeps failing does not keep warning.

## What this does not do

The reselection itself is unchanged - the retry is what keeps the matmul alive,
and the deterministic branch already refuses it (#1574). Whether to *restore*
the pin when the entry returns to the M it was benchmarked for is a behaviour
change on a path this box cannot trigger on demand, so it is not in here: I
would be shipping untested behaviour on a failure path.

## Gates

| check | result |
|---|---|
| pre-commit GPU suite | passed |
| `make dev-test` (CI lane) | 8/8 in 7.43 s |
| `scripts/ci_static_gates.sh` | all selected gates passed (`gemm.cu` re-pinned 734 → 746 code_loc) |
| `verify-fast` | PASS, degeneration smoke PASS |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
