### PR TITLE
docs(refs): two generators had drifted out of the tests/refs index, and nothing noticed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,13 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Two generators had drifted out of the `tests/refs/` index** — the table that
+  says which golden each one writes and which test consumes it, and the only way
+  rule 1 of that README ("every golden value traces to a committed generator")
+  can be checked at all. `gen_chat_goldens.py` and `gen_tokenizer_golden.py` are
+  listed now, and `scripts/docs_lint.py` fails when a `tests/refs/gen_*.py` has
+  no row, so the index cannot go stale again.
+
 - **A cuBLASLt matmul failure discarded the benchmarked algo without saying so**
   (#1545). `reselect_algo_for_entry` replaced the timed probe's pick with
   heuristic `results[0]` for the rest of the process and logged nothing; only a

--- a/scripts/docs_lint.py
+++ b/scripts/docs_lint.py
@@ -319,6 +319,30 @@ def check_generated_blocks(errors: list) -> None:
             )
 
 
+def check_refs_generators_listed(errors: list) -> None:
+    """7. Every generator in tests/refs/ has a row in tests/refs/README.md.
+
+    That table is the only index of which golden a generator writes and which
+    test consumes it, and rule 1 of that README ("every golden value traces to a
+    committed generator") is only checkable through it. Two generators had
+    drifted out of it - gen_tokenizer_golden.py and gen_chat_goldens.py - which
+    is the repo's recurring shape: the artefact exists, nothing references it,
+    and its absence reads like absence of the thing itself.
+    """
+    refs = ROOT / "tests" / "refs"
+    readme = refs / "README.md"
+    if not refs.is_dir() or not readme.exists():
+        return
+    text = readme.read_text(encoding="utf-8")
+    missing = sorted(p.name for p in refs.glob("gen_*.py") if p.name not in text)
+    if missing:
+        errors.append(
+            "tests/refs/README.md: generator(s) with no row in the table: "
+            + ", ".join(missing)
+            + " — add one naming the golden it writes and the test that consumes it"
+        )
+
+
 def check_budgets(errors: list) -> None:
     """6. README and CLAUDE.md size budgets."""
     readme = ROOT / "README.md"
@@ -355,6 +379,7 @@ def main() -> int:
         check_file(ROOT / rel, rel, errors, warnings)
 
     check_generated_blocks(errors)
+    check_refs_generators_listed(errors)
     check_budgets(errors)
 
     if warnings:

--- a/tests/refs/README.md
+++ b/tests/refs/README.md
@@ -1,8 +1,8 @@
 <!--
 layer: L2
 audience: kernel-devs
-verified: 2026-08-13
-commit: 81ffa573
+verified: 2026-08-23
+commit: 36a5a4fb
 -->
 
 # tests/refs/ — independent reference goldens
@@ -53,6 +53,8 @@ Generators:
 | `gen_nvfp4_outlier_golden.py` | `nvfp4_outlier_golden.h` | `tests/test_nvfp4_outlier_ref.cu` |
 | `gen_yarn_rope_golden.py` | `yarn_rope_golden.h` | `tests/test_gpt_oss_yarn_ref.cu` |
 | `gen_harmony_golden.py` | `harmony_golden.h` | `tests/test_gpt_oss_harmony_golden.cpp` |
+| `gen_chat_goldens.py` | `chat_template_goldens.h` | `tests/test_chat_template_goldens.cpp` |
+| `gen_tokenizer_golden.py` | `tokenizer_golden_qwen3.h` | `tests/test_tokenizer_compat.cpp` |
 | `tests/test_vision_golden.cu` (dump mode = its own generator) | `vision_encoder_golden.h` | `tests/test_vision_golden.cu` |
 | `gen_reference.py` | — (none committed) | **dormant** (TEST_AUDIT (retired) §7) — HF layer-by-layer dump infra for future use; no test consumes it |
 
@@ -74,6 +76,19 @@ date:` line is normalized in both — documented in the test). Needs
 `transformers`, only the tokenizer/template (no weights):
 `docker run --rm -v $PWD:/work -v $HOME/models:/models -w /work
 python:3.12-slim sh -c "pip install -q transformers jinja2 && MODEL=/models/gpt-oss-20b python3 tests/refs/gen_harmony_golden.py"`.
+
+Chat-template goldens (#1572): the RENDERED PROMPT for nine families, taken from
+each family's upstream template and rendered in the Jinja configuration
+transformers uses. The golden is the rendered string rather than token IDs, so
+it needs no vocabulary and the whole set runs in the CPU lane with no skips —
+pinning IDs would have made every case a model-gated skip. Six of the nine
+families have no local checkpoint, so their templates are fetched by repo id;
+that replication is not assumed faithful but CHECKED, by re-rendering through
+the real `AutoTokenizer.apply_chat_template` for every family that does have one
+(`--verify` refuses to write the header if that number is 0). The family under
+test comes from imp's own `detect_family()`, not from a label chosen by hand:
+Nemotron-3-Nano and Phi-4-reasoning both ship ChatML templates.
+Regenerate with `make chat-goldens` (needs network).
 
 Vision encoder golden (R9 / #583) is the one exception to rule 1's "independent
 generator": there is no fp64 oracle for the SigLIP / gemma4v encoder + projector


### PR DESCRIPTION
`tests/refs/README.md` carries the table mapping each generator to the golden it
writes and the test that consumes it. Rule 1 of that same README — *"every
golden value in a test traces to a committed generator in this directory"* — is
only checkable through that table, so a generator missing from it is a golden
with no stated provenance.

Two were missing. Consumers verified by grep, not assumed:

| generator | golden | consumed by |
|---|---|---|
| `gen_chat_goldens.py` | `chat_template_goldens.h` | `tests/test_chat_template_goldens.cpp` |
| `gen_tokenizer_golden.py` | `tokenizer_golden_qwen3.h` | `tests/test_tokenizer_compat.cpp` |

The first is mine, from #1572 this morning: I added the generator and the golden
and did not touch the index.

## The gate

`docs_lint.py` gains `check_refs_generators_listed()` — every
`tests/refs/gen_*.py` must appear in that README or the `Docs` job fails, naming
the file.

Verified it has teeth rather than assuming:

| | result |
|---|---|
| unmodified | `docs_lint: OK (51 warnings)` |
| `gen_chat_goldens.py` row removed | `FAIL tests/refs/README.md: generator(s) with no row in the table: gen_chat_goldens.py` |

## Also

The chat-template goldens get the paragraph the other golden families have: what
is pinned (the rendered prompt, not token IDs, which is why all 27 cases run in
the CPU lane with no skips), where six of the nine families' templates come
from, and that the replication of transformers' Jinja environment is
cross-checked against real `AutoTokenizer` output rather than trusted. The
`verified:` stamp is refreshed with it — docs_lint warnings 52 → 51.

## Gates

| check | result |
|---|---|
| `scripts/docs_lint.py` | OK, 51 warnings |
| pre-commit | `no buildable source changes staged, skipping GPU tests` |
| pre-push | `no source changes, skipping verify` |

Both hooks skipped by design: the diff is one Markdown file and one Python lint
function, and `scripts/verify.sh` invokes no Python at all. Note the pre-push
skip used the `.py` strip from #1600, which is still in review — under `main`'s
current hook this push would have run `verify-fast` instead.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
