### PR TITLE
test(api): three contract tests were coverable in CI, two of the five passed on nothing (#1600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,23 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Three API-contract tests could have run in CI all along, and two passed
+  vacuously** (#1600). The `Real API contract` lane selects `-m nomodel`;
+  measured against the same model-less server it runs, 63 of 126 tests pass but
+  only 58 are marked, so five were coverable and deselected. Two of the five
+  pass on *nothing*: `test_sequence_numbers_monotonic` collected an empty SSE
+  list and asserted `[] == sorted([])`, and `test_probes_agree_on_context_length`
+  returned early when `/v1/models` was empty. Those two are fixed rather than
+  marked - the first now fails on an empty stream, which it would also have done
+  with a model - and the other three are marked. **CI lane 58 -> 61 tests.** The
+  generation contract (57 tests) still needs a GPU runner.
+
+- **The pre-push gate ran verify-fast for Python-only pushes.** It already
+  stripped `.md` before deciding; `.py` now goes with it, `scripts/verify.sh`
+  invoking no Python at all (checked). Same class as #1723 in the other hook.
+  `guard_precommit_filter` covers both hooks now, and fails if either starts
+  skipping buildable source.
+
 - **A cuBLASLt matmul failure discarded the benchmarked algo without saying so**
   (#1545). `reselect_algo_for_entry` replaced the timed probe's pick with
   heuristic `results[0]` for the rest of the process and logged nothing; only a

--- a/scripts/check_precommit_filter.sh
+++ b/scripts/check_precommit_filter.sh
@@ -11,6 +11,10 @@
 # The filter is READ OUT OF the hook rather than copied here. A guard with its
 # own copy of the expression guards the copy.
 #
+# Guards the pre-push hook's filter as well: it strips the same extensions before
+# deciding whether to run verify-fast, and it gates on a card shared with another
+# session, so over-gating there is not free either.
+#
 # Usage: check_precommit_filter.sh <repo-root>
 # Exit 0 = every case below lands on the expected side.
 
@@ -73,5 +77,47 @@ if [ "$bad" -ne 0 ]; then
     exit 1
 fi
 
-echo "check_precommit_filter: $(echo "$cases" | wc -l) case(s) match the pre-commit filter"
+# --- the pre-push hook strips the same extensions -------------------------
+PUSH="$ROOT/scripts/pre-push.hook"
+if [ -f "$PUSH" ]; then
+    PDROP=$(grep -m1 -- "grep -vE '\\\\." "$PUSH" | sed "s/.*grep -vE '//; s/' .*//")
+    if [ -z "$PDROP" ]; then
+        echo "check_precommit_filter: could not read the extension filter out of $PUSH" >&2
+        exit 1
+    fi
+    for f in tests/CLAUDE.md tools/kernel_resources.py tests/api/test_chat.py; do
+        if printf '%s\n' "$f" | grep -qE "$PDROP"; then :; else
+            echo "check_precommit_filter: pre-push would gate '$f' (docs/scripts cannot move a number)" >&2
+            exit 1
+        fi
+    done
+    for f in src/model/jinja.cpp tools/imp-server/webui/index.html; do
+        if printf '%s\n' "$f" | grep -qE "$PDROP"; then
+            echo "check_precommit_filter: pre-push would SKIP '$f' — that is buildable source" >&2
+            exit 1
+        fi
+    done
+fi
+
+# --- the INSTALLED hook is a copy -----------------------------------------
+# `make install-hooks` copies scripts/pre-commit.hook into .git/hooks/. Editing
+# the repo copy changes nothing until that runs again, so a shipped hook fix can
+# sit inactive on the machine that shipped it - which is how the #1723 filter
+# was still gating .py locally after it had merged. It also fires while a branch
+# that edits a hook is checked out without installing it - same true statement,
+# same fix. Absent (a fresh clone, CI) is fine; present and different is not.
+for h in pre-commit pre-push; do
+    INSTALLED="$ROOT/.git/hooks/$h"
+    [ -f "$INSTALLED" ] || continue
+    if ! cmp -s "$INSTALLED" "$ROOT/scripts/$h.hook"; then
+        echo "check_precommit_filter: .git/hooks/$h differs from scripts/$h.hook — what runs is" >&2
+        echo "  not what this tree says. Either the installed copy predates a merged hook change" >&2
+        echo "  (the case this exists for: #1723 shipped and kept gating .py locally), or you are" >&2
+        echo "  on a branch whose hook edit is not installed. Both resolve the same way:" >&2
+        echo "    make install-hooks" >&2
+        exit 1
+    fi
+done
+
+echo "check_precommit_filter: $(echo "$cases" | wc -l) pre-commit case(s), 5 pre-push case(s), installed hooks current"
 exit 0

--- a/scripts/pre-push.hook
+++ b/scripts/pre-push.hook
@@ -49,7 +49,13 @@ while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
     # Documentation cannot move a number or break a kernel, wherever it lives.
     # Without this, src/compute/CLAUDE.md matches PERF_RE and a docs-only push
     # pays the full perf gate — which then reports the host, not the change.
-    FILES=$(echo "$FILES" | grep -vE '\.md$' || true)
+    #
+    # Python neither: scripts/verify.sh invokes no .py at all (checked, not
+    # assumed), so nothing a Python edit can touch reaches the tests, the perf
+    # gate or the smoke prompts. tools/ and tests/ are full of it — the gate
+    # scripts and the API contract suite — and SOURCE_RE matches those
+    # directories by prefix. Same reasoning as the pre-commit filter (#1723).
+    FILES=$(echo "$FILES" | grep -vE '\.(md|py)$' || true)
     [ -z "$FILES" ] && continue
     echo "$FILES" | grep -qE "$SOURCE_RE" && NEEDS_VERIFY=1
     echo "$FILES" | grep -qE "$PERF_RE"   && NEEDS_PERF=1

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -91,6 +91,7 @@ def test_temperature_zero_deterministic(client, model):
     assert c1 == c2, f"Non-deterministic at temp=0 seed=42: {c1!r} != {c2!r}"
 
 
+@pytest.mark.nomodel  # /v1/models answers without weights (#1600)
 def test_models_endpoint(client):
     r = client.get("/v1/models")
     assert r.status_code == 200

--- a/tests/api/test_contract.py
+++ b/tests/api/test_contract.py
@@ -97,7 +97,9 @@ class TestContextProbes:
         # All three conventions must report the same window.
         models = client.get("/v1/models").json()["data"]
         if not models:
-            return
+            # `return` here made this a silent pass on a model-less server -
+            # indistinguishable from three probes that agreed (#1600).
+            pytest.skip("no model loaded: nothing to compare the three probes against")
         max_model_len = models[0]["max_model_len"]
         assert client.get("/props").json()["n_ctx"] == max_model_len
         assert client.get("/info").json()["max_total_tokens"] == max_model_len
@@ -140,6 +142,8 @@ class TestChatCompletionsSchema:
         assert usage["completion_tokens"] > 0
         assert usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
 
+    # Holds model-less too: the error envelope is JSON by invariant (#1600).
+    @pytest.mark.nomodel
     def test_content_type_json(self, client, model):
         r = client.post("/v1/chat/completions", json={
             "model": model,

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -69,6 +69,8 @@ class TestResponsesNonStream:
         args = json.loads(fc["arguments"])
         assert isinstance(args, dict)
 
+    # Validation runs before model resolution, so this holds model-less (#1600).
+    @pytest.mark.nomodel
     def test_stateful_fields_rejected(self, model):
         with httpx.Client(base_url=conftest.BASE_URL, timeout=30.0) as c:
             r = c.post("/v1/responses", json={
@@ -114,6 +116,11 @@ class TestResponsesStream:
                 for line in r.iter_lines():
                     if line.startswith("data: "):
                         seqs.append(json.loads(line[6:])["sequence_number"])
+        # Without this the test passes on an EMPTY stream: [] == sorted([]) and
+        # 0 == 0. That is how it "passed" against a model-less server, and it
+        # would pass the same way here if the stream ever came back empty
+        # (#1600).
+        assert seqs, "no SSE data frames arrived — nothing to check monotonicity on"
         assert seqs == sorted(seqs)
         assert len(set(seqs)) == len(seqs)
 


### PR DESCRIPTION
Closes #1600.

## Measured, not assumed

The `Real API contract` lane selects `-m nomodel`. Run against the same
model-less server the job starts (no GPU):

| | tests |
|---|---|
| pass model-less | 63 of 126 |
| selected by the lane | 58 |
| **coverable but deselected** | **5** |

## Two of the five pass on nothing

Which is why marking all five would have been worse than marking none:

| test | why it passes model-less |
|---|---|
| `test_sequence_numbers_monotonic` | collects `sequence_number` from SSE `data:` lines; there are none, so `seqs` is empty and both assertions hold — `[] == sorted([])` and `0 == 0` |
| `test_probes_agree_on_context_length` | `if not models: return` — a silent pass, indistinguishable from three probes that agreed |

Those two are **fixed, not marked**. The streaming one asserts the stream was
non-empty first — which it needed with a model too: an empty stream is exactly
the defect it exists to catch. The probe one skips out loud.

The other three assert something real without weights (`/v1/models` answers,
stateful-field validation runs before model resolution, the JSON envelope holds
on the error path by invariant), so they are marked.

**CI lane 58 → 61.** The generation contract (57 tests) still needs a GPU
runner; the job already prints covered-vs-total from a live collect, so that
number follows on its own.

## Second: the pre-push gate ran verify-fast for Python-only pushes

It already stripped `.md` before deciding. `.py` goes with it —
`scripts/verify.sh` invokes no Python at all (checked, not assumed), so nothing
a Python edit touches reaches the tests, the perf gate or the smoke prompts.
Same class as #1723 in the pre-commit hook, and this very change is the case:
`tests/api/*.py` plus `scripts/`.

## Third: the installed hook is a copy

Found by trying to commit this. `make install-hooks` copies
`scripts/pre-commit.hook` into `.git/hooks/`, so editing the repo copy changes
nothing until that runs again — #1723 merged this morning and was **still
gating `.py` on this machine tonight**. `guard_precommit_filter` now fails when
an installed hook differs from its source, naming `make install-hooks`. Absent
(fresh clone, CI) is skipped; present and different is not.

## The guard

| mutation | result |
|---|---|
| unmodified | `19 pre-commit case(s), 5 pre-push case(s), installed hooks current` |
| add `.html` to the pre-push strip | fails, names `index.html` as buildable source |
| remove `.py` from the strip | fails, names `kernel_resources.py` as over-gated |
| installed hook edited | fails, names `make install-hooks` |

## Gates

| check | result |
|---|---|
| `make dev-test` (CI lane) | 8/8 |
| `scripts/ci_static_gates.sh` | all selected gates passed |
| pre-push `verify-fast` | PASS, degeneration smoke PASS |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Serj13NNkhR5U7Rvp8Hiuq
