### PR TITLE
docs(limitations): the gates that do not exist, named as absent instruments (#1571 #1642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,14 @@ there instead of retelling it.
 
 ### Changed
 
+- **`docs/LIMITATIONS.md` gains a "Gates that do not exist" section** (#1571,
+  #1642), for absent instruments rather than untested features: no KL / PPL
+  drift gate against a reference forward, and no soak or endurance test. Both
+  need a card, and CI has no GPU runner, so a reader deciding against imp sees
+  the gap without reading the issue tracker. The bullet on the generation half
+  of the HTTP contract now also cites #1559, which is the same wall.
+
+
 - **The tree is C++23 where the build said it already was.** `bool f(...,
   std::string& err)` is gone from `src/`, `tools/` and `include/` (36 sites, 15
   of them header declarations), replaced by `std::expected`; host pointer+length

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -49,7 +49,7 @@ These have a code path and no gate. They may work; nothing proves it.
 - **The generation half of the HTTP contract**: SSE frame structure, usage
   accounting, `finish_reason` and tool-call streaming. CI's `Real API contract
   (model-less)` job deselects every test that produces a token, because
-  generation needs a GPU and there is no GPU runner (#1600). They run in
+  generation needs a GPU and there is no GPU runner (#1600, #1559). They run in
   `make test-server` on a machine with a card, and in no CI job. The job prints
   the collected-here vs collected-total counts so the gap is visible in its own
   log rather than inferred from a job name.
@@ -63,6 +63,33 @@ These have a code path and no gate. They may work; nothing proves it.
 
 All seven were green in `FEATURES.md` without a gate until #1680, which makes
 them invisible here - the legend's whole point.
+
+## Gates that do not exist
+
+These are absent instruments, not untested features: nothing in the tree
+produces the number, so no threshold can be set on it.
+
+- **No correctness gate against a reference implementation** (#1571). There is
+  no KL divergence against an fp16/bf16 forward, no perplexity-drift baseline
+  and no tool-schema conformance rate. `scripts/validate_safetensors.py:11-14`
+  lists the phases it cannot run, and why: no BF16 checkpoint is on disk, and
+  imp consumes pre-quantised weights. `make test-niah` exists
+  (`Makefile:315`) and no workflow invokes it, because like every target with
+  `check-gpu` among its prerequisites it needs a card. Quantisation quality is
+  therefore judged by the degeneration smoke prompts and by hand, not against a
+  reference with a threshold.
+
+- **No soak or endurance test** (#1642). The largest request count any test
+  drives is 10 concurrent requests (`tests/api/test_concurrency.py:37`). Three
+  shipped comments describe what a soak would assert and no soak exists to
+  assert it: `tools/imp-server/metrics_memory.cpp:56`,
+  `tests/test_memory_backend.cpp:223` and `src/memory/alloc_interpose.cpp:129`,
+  the last of which describes an instrument meant "to be run once under a soak
+  and read afterwards". A leak, a fragmenting KV pool or a slow handle
+  exhaustion surfaces in production rather than in a gate.
+
+Both need a GPU runner or a long-running machine with a card, and CI has
+neither.
 
 ## Known-bad and known-limited behaviour
 


### PR DESCRIPTION
#1571, #1642 and #1685 are one class: a gate that cannot exist here. #1685 was
already in `docs/LIMITATIONS.md`; the other two were not, so the file said less
about imp's test coverage than the issue tracker did.

## What is recorded

New section `## Gates that do not exist`, for absent instruments rather than
untested features. Nothing in the tree produces the number, so no threshold can
be set on it.

| gap | why it cannot be a CI job | issue |
|---|---|---|
| KL divergence / PPL drift vs a reference forward | needs a BF16 reference; none on disk, and imp consumes pre-quantised weights (`scripts/validate_safetensors.py:11-14`) | #1571 |
| NIAH | `make test-niah` exists (`Makefile:315`), nothing invokes it: it carries `check-gpu`, so the job would boot a model | #1571 |
| soak / endurance | needs a long run on a card | #1642 |

The bullet on the generation half of the HTTP contract now cites #1559 as well.
It already named #1600 and describes exactly #1559's subject (SSE frame
structure, usage accounting).

## Two corrections to #1642, made while recording it

| | issue says | measured |
|---|---|---|
| soak comments in the tree | 2 | 3 (`src/memory/alloc_interpose.cpp:129` was missed) |
| `test_memory_backend.cpp` | line 163 | line 223 |

`tests/api/test_concurrency.py:37` still caps at 10 concurrent requests, as
reported.

## Gates

| | |
|---|---|
| `scripts/docs_lint.py` | exit 0, 52 pre-existing warnings |
| `scripts/sync_docs.py --check` | up to date |
| `scripts/ci_static_gates.sh` | exit 0 |

No GPU gate: the pre-push hook drops `.md` and `.py` from its file list before
deciding, so a docs-only push runs neither verify nor perf.

Not in here: no `verified:` / `commit:` frontmatter bump on `LIMITATIONS.md`.
Bumping it would claim the whole file was re-checked against this commit, and
only the two new entries were.
