### PR TITLE
diag(spec): name the gate that refused, and record what both gates are worth (#1538 #1539)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,23 @@ there instead of retelling it.
 
 ### Changed
 
+- **The "speculation is off" diagnosis names the gate that refused** (#1538,
+  #1539). It printed eighteen request fields and marked none of them, so
+  answering "why is speculation off for my request" meant re-deriving
+  `spec_verify_gates_ok_` by hand against a log line. Both issues were filed
+  against that line. It now reads `refused by 'sampling_not_greedy'`, from the
+  same function that makes the decision, and the field dump stays because the
+  neighbouring values are usually wanted too.
+
+- **Both gates that keep speculation off a default server request were measured
+  and both stay** (#1538, #1539), recorded in `docs/DESIGN_DECISIONS.md`.
+  Qwen3-14B-Q6_K on one RTX 5090, arms alternated: enabling speculation by
+  dropping `temperature` to 0 is not faster (157.6 against 157.8 tok/s), and
+  relaxing the think-block gate doubles verify steps for 3.0 % less throughput
+  (157.9 against 162.7). A verify there costs eight to ten decode steps and
+  returns 5.83 tokens.
+
+
 - **`docs/LIMITATIONS.md` gains a "Gates that do not exist" section** (#1571,
   #1642), for absent instruments rather than untested features: no KL / PPL
   drift gate against a reference forward, and no soak or endurance test. Both

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -96,3 +96,47 @@ step there costs about four decode steps and returns 1.7 tokens.
 
 **Reopens if:** the draft path becomes capturable, or a model's verify ratio
 drops far enough that the arithmetic changes.
+
+## The two gates that keep speculation off a default server request
+
+**Decision:** speculation stays refused for non-greedy sampling and inside a
+budgeted think block. Both were filed as defects (#1538, #1539); both were
+measured and both stay.
+
+**Why:** on this hardware a verify chunk has to earn back what it costs, and on
+the model measured it does not. Qwen3-14B-Q6_K, one RTX 5090, 400-token
+completions, same prompt, arms alternated:
+
+| arm | tok/s | verify steps |
+|---|---|---|
+| `temperature: 0.7` (server default) | 157.79, 158.46 | 0 |
+| `temperature: 0` (speculation eligible) | 157.61, 157.87 | 6 |
+
+Turning speculation ON is not faster. The log says why: 18.6 % acceptance, 5.83
+tokens emitted per verify, 51-68 ms per verify against a 6.3 ms decode step. A
+verify costs eight to ten decode steps and returns under six tokens.
+
+The think-block gate was A/B'd the same way, two images, arms alternated, by
+relaxing it to fire only when a chunk could overshoot the budget rather than for
+the whole block:
+
+| arm | tok/s | verify steps |
+|---|---|---|
+| gate as shipped | 162.43, 162.96 | 12 |
+| gate relaxed | 157.92, 157.85 | 24 |
+
+Twice the verify steps, 3.0 % less throughput. The gate is not an oversight
+keeping speculation out of most of a reasoning answer; it is what keeps that
+part of the answer from paying for chunks that lose.
+
+Relaxing the think gate alone is also not enough to be coherent: the acceptance
+loop breaks on `in_think_block` too (`engine_spec_ngram.cpp`), so a relaxed gate
+without a matching loop change accepts one token per chunk, which is strictly
+worse than refusing.
+
+**Reopens if:** a model's verify ratio clears its verify cost, which is the same
+condition the entry above names. Removing the greedy restriction additionally
+needs the verify to accept with min(1, p/q) and resample from the corrected
+distribution instead of comparing argmax; that is a feature, and the measurement
+above says what it would currently buy.
+

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -1020,6 +1020,9 @@ private:
         const int n = runtime_config_.speculative.min_history;
         return n > 0 && static_cast<int>(req.output_tokens.size()) < n;
     }
+    // Which gate refuses, or nullptr when none does. See the definition in
+    // engine_spec_ngram.cpp for why the reason is a string and not a bool.
+    const char* spec_verify_gate_refusal_(const Request& req, bool ignore_think = false) const;
     bool spec_verify_gates_ok_(const Request& req, bool ignore_think = false) const;
     bool spec_burst_launch_ok_(const Request& req) const;
     int spec_effective_miss_burst_(const Request& req) const;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -1428,12 +1428,17 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             if (!s_gate_logged && !decode_batch[0]->spec_ngram_given_up) {
                 s_gate_logged = true;
                 const auto& r = *decode_batch[0];
+                // Name the gate. The field dump below stays because a reader
+                // usually wants the neighbouring values too, but it is no
+                // longer the only thing to go on (#1538, #1539).
+                const char* why = spec_verify_gate_refusal_(r);
                 IMP_LOG_INFO(
-                    "spec-ngram: gates failed (temp=%.2f top_k=%d rep_pen=%.2f freq=%.2f "
+                    "spec-ngram: gates failed, refused by '%s' (temp=%.2f top_k=%d rep_pen=%.2f freq=%.2f "
                     "pres=%.2f dry=%.2f mirostat=%d bias=%zu logprobs=%d json=%d schema=%d "
                     "think_budget=%.2f ssm=%d moe=%d moe_nvfp4=%d spec_moe=%d mtp=%d "
                     "chunked_prefill=%d)",
-                    r.temperature, r.top_k, r.repetition_penalty, r.frequency_penalty,
+                    why ? why : "nothing (raced)", r.temperature, r.top_k, r.repetition_penalty,
+                    r.frequency_penalty,
                     r.presence_penalty, r.dry_multiplier, r.mirostat, r.logit_bias.size(),
                     (int)r.logprobs, (int)r.json_mode, (int)!r.json_schema.empty(), r.think_budget,
                     (int)(ssm_state_ != nullptr),

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -140,29 +140,38 @@ bool Engine::spec_burst_launch_ok_(const Request& req) const {
     return true;
 }
 
-bool Engine::spec_verify_gates_ok_(const Request& req, bool ignore_think) const {
-    if (req.spec_ngram_given_up) return false;
+// Which gate refuses this request, or nullptr when none does.
+//
+// Split out of spec_verify_gates_ok_ because the one-time diagnosis in
+// engine_scheduler.cpp printed eighteen request fields and named none of them
+// as the cause, so "why is speculation off" was a manual re-derivation of this
+// function against a log line. #1538 and #1539 were both filed against that
+// line; answering either took reading this file. The strings are the gate
+// names, stable enough to grep for.
+const char* Engine::spec_verify_gate_refusal_(const Request& req, bool ignore_think) const {
+    if (req.spec_ngram_given_up) return "given_up";
     // Greedy sampling only: verify compares argmax tokens.
     const bool greedy = (req.temperature <= 0.0f || req.top_k == 1);
-    if (!greedy) return false;
+    if (!greedy) return "sampling_not_greedy";
     // rep/freq/presence penalties are replicated in the verify
     // (greedy_argmax_all) for the unbounded window; a bounded repeat_last_n
     // window slides per chunk row and is not replicated — stay eager there.
     const bool penalties = req.repetition_penalty != 1.0f || req.frequency_penalty != 0.0f ||
                            req.presence_penalty != 0.0f;
-    if (penalties && req.repeat_last_n != 0) return false;
+    if (penalties && req.repeat_last_n != 0) return "bounded_repeat_window";
     // Logit-shaping the verify chunk does not replicate disqualifies.
     if (req.dry_multiplier != 0.0f || req.mirostat != 0 || !req.logit_bias.empty())
-        return false;
+        return "logit_shaping";
     if (req.logprobs || req.json_mode || !req.json_schema.empty() ||
         !req.regex_pattern.empty() || !req.grammar.empty() || !req.tool_constraint_tools.empty())
-        return false;  // constrained decode: verify replicates no FSM masks (#1002)
+        return "constrained_decode";  // verify replicates no FSM masks (#1002)
     // Think budget forces tokens INSIDE the think block (loop/host-side) —
     // verify only outside it; the think interior runs loop bursts, which
     // handle the budget device-side.
-    if (!ignore_think && req.think_budget > 0.0f && req.in_think_block) return false;
-    if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return false;
-    if (spec_history_too_short_(req)) return false;  // cold start, see min_history
+    if (!ignore_think && req.think_budget > 0.0f && req.in_think_block)
+        return "think_budget_in_block";
+    if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return "not_decoding";
+    if (spec_history_too_short_(req)) return "cold_start";  // see speculative.min_history
     // Long-context economics on the DENSE path (#964): the captured chunk
     // verify runs the FA2 tile + paged-KV gather over the ctx TIER (pow2,
     // floor 4096, clamped to max_seq_len) — its cost follows the tier, not
@@ -180,12 +189,12 @@ bool Engine::spec_verify_gates_ok_(const Request& req, bool ignore_think) const 
                                     model_->profile().moe_experts_nvfp4;
         const bool hybrid_path = ssm_state_ != nullptr;  // only reachable with speculative.hybrid
         if (!moe_nvfp4_path && !hybrid_path && cap > 0 && req.context_len() > cap)
-            return false;
+            return "draft_ctx_cap";
     }
     // Recurrent state (SSM/GDN) advances on every forwarded token. The
     // hybrid verify path (speculative.hybrid) rides SSMState's contiguous
     // per-sequence slab for snapshot/restore.
-    if (ssm_state_ && !runtime_config_.speculative.hybrid) return false;
+    if (ssm_state_ && !runtime_config_.speculative.hybrid) return "recurrent_without_hybrid";
     // MoE speculation engages only for native-NVFP4 experts: the batched
     // verify forward reads the NVFP4 expert cache directly and nets +49-81%
     // on draft-rich code-edit (Qwen3-Coder-30B-FP4, 2026-07-02) with a -3-7%
@@ -193,8 +202,12 @@ bool Engine::spec_verify_gates_ok_(const Request& req, bool ignore_think) const 
     // activated expert per step and measured -22% — those stay on the async
     // conditional-graph loop (as does everything when speculative.moe=false).
     if (!spec_ngram_model_capable_())
-        return false;
-    return true;
+        return "model_not_capable";
+    return nullptr;
+}
+
+bool Engine::spec_verify_gates_ok_(const Request& req, bool ignore_think) const {
+    return spec_verify_gate_refusal_(req, ignore_think) == nullptr;
 }
 
 // Model-level gates, split out of spec_verify_gates_ok_ so spec_ngram_enabled_

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1995, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1997, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
Both issues were filed against the same log line, and neither could be answered
from it. This PR makes the line answer them, then records what the two gates are
actually worth.

## The diagnosis named nothing

`spec-ngram: gates failed (temp=... top_k=... rep_pen=... 18 fields ...)` printed
the request and marked none of the fields as the cause, so "why is speculation
off" meant re-deriving `spec_verify_gates_ok_` by hand against a log line.

It reads `refused by 'sampling_not_greedy'` now, from the function that makes the
decision: `spec_verify_gate_refusal_` returns the gate's name or nullptr, and
`spec_verify_gates_ok_` is "is that null". Ten gates, ten names. No behaviour
change; the field dump stays, because a reader usually wants the neighbouring
values too.

## Both gates were measured, and both stay

Qwen3-14B-Q6_K, one RTX 5090, 400-token completions, same prompt, arms
alternated, 3 requests per arm after a warmup.

**#1538, the greedy restriction.** `verify_steps` is read from the server log per
request, so the control proves which arm actually speculated rather than assuming
it:

| arm | tok/s | verify steps in that request |
|---|---|---|
| `temperature: 0.7` (server default) | 157.79, 158.46 | 0 |
| `temperature: 0` (eligible) | 157.61, 157.87 | 6 |

Speculation ON is not faster. Why, from the same log: 18.6 % acceptance, 5.83
tokens emitted per verify, 51-68 ms per verify against a 6.3 ms decode step. A
verify costs eight to ten decode steps and returns under six tokens.

**#1539, the think-block gate.** Relaxed to fire only when a chunk could overshoot
the budget, rather than for the whole block. Two images, arms alternated:

| arm | tok/s | verify steps |
|---|---|---|
| gate as shipped | 162.43, 162.96 | 12 |
| gate relaxed | 157.92, 157.85 | 24 |

Twice the verify steps, 3.0 % less throughput. That code is in no commit: it was
written, tested (6 CPU tests on the new predicate), built, measured and dropped.

Relaxing that gate alone would also have been incoherent: the acceptance loop
breaks on `in_think_block` too, so a relaxed gate without a matching loop change
accepts one token per chunk, which is worse than refusing. Both were relaxed for
the measurement.

Recorded in `docs/DESIGN_DECISIONS.md` next to the existing speculation entry,
which already said the economics are per-model.

## A measurement that was wrong first

The first #1539 A/B read 157.67 / 157.67 / 157.93 / 157.81, four arms within
0.2 %, which looks like "no effect". It was one effect: port 8099 still held the
previous container, every `docker run -d` failed, and all four arms hit the same
stale server. The failure was invisible because the start was redirected to
/dev/null.

The harness now refuses to measure a container it did not start:
`docker inspect -f '{{.Config.Image}}'` has to match the image asked for, and the
start is no longer silenced. The real numbers are the table above.

## Gates

```
== perf vs baseline ==
  pin: 2026-07-26T01:48:33Z (28 days old), model Qwen3-8B-Q8_0.gguf
  perf gate: median of 3 independent runs (spread 0.13%)
  decode  tg128 =  285.38 tok/s  (baseline  287.19, delta -0.63%)
  prefill pp512 = 12553.28 tok/s  (baseline 12406.87, delta 1.18%)
  GPU during bench: sm=2865MHz(med) mem=13801MHz(med) power=500W(max) n=13
PASS decode within 8% threshold
PASS prefill within 8% threshold
  prefill pp4096 = 15490.84 tok/s  (baseline 15324.70, delta 1.08%, FA2)
PASS long-ctx prefill (pp4096/FA2) within 8% threshold

== peak VRAM vs baseline ==
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
PASS peak VRAM within 10% of baseline

== graphs ON vs OFF decode gate ==
  graphs OFF tg256 =  186.49 tok/s
  graphs ON  tg256 =  454.48 tok/s   (2.44x, threshold 1.3x)
PASS graphs ON delivers ≥1.3x decode speedup

== smoke prompts (degeneration check) ==
PASS Qwen3-4B Q8_0 (dense) (distinct=11, tokens=11, max-run=1, max-3gram=1, contains 'Paris')

=== verify fast: OK === (started 00:36:07Z, ended 00:36:46Z)
```

Qwen3-8B-Q8_0 on one RTX 5090, median of 3 processes. `filesize_thresholds.toml`
re-pinned for engine_scheduler.cpp, 1995 -> 1997, for the two lines that name
the gate.

Not in here: speculative sampling for temperature > 0 (accept with min(1, p/q),
resample from the corrected distribution). That is the feature #1538 would need,
and the first table is what it would currently buy on this model.
