### PR TITLE
fix(gemm): the CUTLASS NVFP4 handler accepted a beta and dropped it (#1547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,15 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The CUTLASS NVFP4 GEMM handler accepted a `beta` and dropped it** (#1547).
+  `GemmKernelArgs::beta` reached it and the epilogue is built with a literal 0,
+  so a `beta = 1` call would have written the product over the residual instead
+  of adding to it, and answered with quiet garbage. It refuses now, which hands
+  the caller to the dequant path that does honour beta. Unreachable today
+  because both callers that can set beta exclude the tier, which is one edit
+  away from not being true.
+
+
 - **The deterministic MoE combine scanned every expert row per output column,
   not per token** (#1546). The row search sat inside the column loop, so the
   O(total_rows) scan ran once per column chunk rather than once per token: 8

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -140,3 +140,45 @@ needs the verify to accept with min(1, p/q) and resample from the corrected
 distribution instead of comparing argmax; that is a feature, and the measurement
 above says what it would currently buy.
 
+## The NVFP4 residual add stays a separate kernel
+
+**Decision:** the CUTLASS NVFP4 epilogue keeps beta = 0, and `o_proj` /
+`down_proj` on a native-NVFP4 checkpoint keep paying a residual copy plus an
+elementwise add. Filed as #1547; built, measured, and not shipped.
+
+**Why:** three measurements, Qwen3-14B-NVFP4 (281 CUTLASS tensors, so the tier
+is actually exercised), one RTX 5090, arms alternated, 3 rounds each.
+
+Prefill, which is what the fusion targets: the fused arm won all three paired
+rounds, but the within-arm spread of the UNCHANGED arm was 43.8 % (15787,
+22707, 20896 tok/s). A delta inside that is not a result, and the issue's own
+ceiling arithmetic put the prize at ~1.5 %.
+
+  [PROV: commit=4cb36025 date=2026-08-24 hw=RTX5090 model=Qwen3-14B-NVFP4
+         quant=NVFP4 cuda=13.3 path=imp-cli --bench
+         cmd=`imp-cli --bench --bench-pp 512 --bench-reps 3` and the same with
+         `--set speculative.ngram=false`
+         n=3 rounds per arm, arms alternated, one process per round]
+
+Decode with speculation off, which isolates the kernels: 159.97 against 160.00
+tok/s. Neutral, as expected for a change that only fires at M > 1.
+
+Decode with speculation on, which is the default here: 272.2 against 354.4
+tok/s, 23 % down, with the spread under 1 %. The mechanism is not the kernel.
+The fused epilogue rounds once (FP32 accumulate, then one conversion) where the
+copy-plus-add rounds twice, so the token stream changes; n-gram acceptance fell
+from 99.8 % to 98.8 % and tokens per verify from 8.15 to 6.75 on a deliberately
+repetitive bench prompt. On a real request measured the same evening acceptance
+is 18.6 %, where a point of acceptance is noise. So the 23 % is a property of
+the benchmark, not a regression, and it is also not a reason to take a prefill
+change that cannot be measured.
+
+The wiring is also not the two-step the issue describes. With the epilogue
+taking beta and a test exercising it, `AlphaIsActuallyApplied` began leaving a
+sticky `invalid argument` that the next GEMM's own guard reported, three runs
+out of three, against three clean runs of the same pair on the tree without it.
+Opening this needs that understood first.
+
+**Reopens if:** the prefill win can be measured above the host's spread, or a
+workload is found where the changed rounding does not move the token stream.
+

--- a/src/exec/gemm_kernel_cutlass_nvfp4.cu
+++ b/src/exec/gemm_kernel_cutlass_nvfp4.cu
@@ -106,6 +106,18 @@ static GemmDispatchResult cutlass_nvfp4_gemm_kernel(const GemmKernelArgs& args) 
     if (!args.act_prequantized || args.mxfp4_payload != nullptr)
         quantize_fp16_to_nvfp4_cutlass(args.input->data, args.cutlass_act_data, args.cutlass_act_sf, M, K,
                                        args.stream);
+    // GemmKernelArgs carries a beta and this handler cannot honour it: the
+    // CUTLASS NVFP4 epilogue is built with a literal 0, so a beta=1 call would
+    // write the product OVER the residual instead of adding to it and answer
+    // with quiet garbage. Refusing hands the caller to the dequant path, which
+    // does honour beta.
+    //
+    // The two callers that can set beta (o_proj, down_proj) exclude this tier
+    // today, so this is unreachable by construction. It is here because that
+    // is one edit away from not being true, and the failure it would produce
+    // is silent (#1547).
+    if (args.beta != 0.0f)
+        return GemmDispatchResult::PreconditionFail;
     bool ok = gemm_nvfp4_cutlass_sm120(args.cutlass_act_data, args.cutlass_act_sf, payload,
                                        args.output->data, M, N, K, args.cutlass_workspace,
                                        args.cutlass_workspace_size, args.stream);


### PR DESCRIPTION
I built what #1547 asks for, measured it, and am not shipping it. What ships is
the latent defect underneath: the handler accepted a `beta` and dropped it.

## The refusal

`GemmKernelArgs::beta` reached `gemm_kernel_cutlass_nvfp4.cu` and the epilogue
is built with a literal `0`, so a `beta = 1` call would have written the product
OVER the residual instead of adding to it, and answered with quiet garbage.
Three lines refuse it, which hands the caller to the dequant path that does
honour beta.

Unreachable today: `will_fuse_o_beta1` and `will_fuse_down_beta1` both exclude
this tier. That is one edit away from not being true and the failure would be
silent, which is what the refusal is for.

## Why the fusion itself is not here

Qwen3-14B-NVFP4 (281 CUTLASS tensors, so the tier is actually exercised), one
RTX 5090, `imp-cli --bench --bench-pp 512 --bench-reps 3`, arms alternated,
3 rounds each.

| arm | pp512 tok/s | tg8192 tok/s |
|---|---|---|
| unchanged | 23517, 21549, 23880 | 354.4, 354.2, 356.3 |
| fused | 24938, 23454, 23755 | 271.3, 272.2, 273.5 |

Decode looks like a 23 % regression. It is not the kernel. Same benchmark with
`--set speculative.ngram=false`:

| arm | pp512 tok/s | tg8192 tok/s |
|---|---|---|
| unchanged | 15787, 22707, 20896 | 160.13, 159.91, 160.00 |
| fused | 25006, 24316, 21579 | 159.97, 159.95, 159.99 |

Decode is neutral to four significant figures once speculation is out of the
way, exactly as a change that only fires at M > 1 should be. The 23 % is
second-order: the fused epilogue rounds once where copy-plus-add rounds twice,
so the token stream moves, and the n-gram matcher loses its hit rate on a
deliberately repetitive bench prompt.

| | unchanged | fused |
|---|---|---|
| n-gram acceptance | 99.8 % | 98.8 % |
| tokens per verify | 8.15 | 6.75 |
| miss steps | 8 | 166 |

A real request measured the same evening runs at 18.6 % acceptance, where a
point of acceptance is noise. So the 23 % is a property of the benchmark.

And prefill, which is the actual target, cannot be called: the fused arm won all
three paired rounds, but the UNCHANGED arm's own spread is 43.8 % (15787 to
22707 tok/s with speculation off). The issue's ceiling arithmetic put the prize
at ~1.5 %, which is inside that.

## One more reason it is not a two-step change

The issue describes the fix as "pass beta into the epilogue, then widen the
gates". With the epilogue taking beta and a test exercising it,
`AlphaIsActuallyApplied` began leaving a sticky `invalid argument` that the next
GEMM's own guard reported. Reproducible 3 runs of 3, against 3 clean runs of the
same pair on the tree without it, with both builds' exit codes checked. Whatever
that is, it wants understanding before the gates open.

Recorded in `docs/DESIGN_DECISIONS.md` with a PROV block.

## What widening the gates would have needed anyway

Not in the issue and worth writing down: the gates are not the only place the
tier has to be listed. `will_fuse_*_beta1` suppresses the residual copy into
`r`, while the beta=1 arm tests `tier == FP16` separately. A tier added to the
gate alone passes it, falls through to the else arm, and adds a never-populated
`r`. The comment at both sites now says so.

## Gate

```
== perf vs baseline ==
  pin: 2026-07-26T01:48:33Z (29 days old), model Qwen3-8B-Q8_0.gguf
  perf gate: median of 3 independent runs (spread 0.13%)
  decode  tg128 =  285.89 tok/s  (baseline  287.19, delta -0.45%)
  prefill pp512 = 12527.57 tok/s  (baseline 12406.87, delta 0.97%)
  GPU during bench: sm=2895MHz(med) mem=13801MHz(med) power=500W(max) n=13
PASS decode within 8% threshold
PASS prefill within 8% threshold
  prefill pp4096 = 15493.48 tok/s  (baseline 15324.70, delta 1.10%, FA2)
PASS long-ctx prefill (pp4096/FA2) within 8% threshold

== peak VRAM vs baseline ==
  own peak VRAM = 20718 MiB  (baseline 20716, delta 0.01%)
PASS peak VRAM within 10% of baseline

== graphs ON vs OFF decode gate ==
  graphs OFF tg256 =  167.57 tok/s
  graphs ON  tg256 =  454.02 tok/s   (2.71x, threshold 1.3x)
PASS graphs ON delivers ≥1.3x decode speedup

== smoke prompts (degeneration check) ==
PASS Qwen3-4B Q8_0 (dense) (distinct=11, tokens=11, max-run=1, max-3gram=1, contains 'Paris')

=== verify fast: OK === (started 02:19:45Z, ended 02:20:23Z)
```

Qwen3-8B-Q8_0 on one RTX 5090, median of 3 processes. That model has 0 CUTLASS
NVFP4 tensors, so the gate cannot see this tier at all: it says "nothing else
moved", not "the refusal works".
