### PR TITLE
test(degen): the suite asserted the thinking contract #1560 replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The degeneration suite asserted the thinking contract #1560 replaced.** Its
+  `anthropic-thinking` category, written 2026-06-06, required a `thinking` block
+  on a `/v1/messages` request that never asked for one. Extended thinking is
+  opt-in upstream and imp matches that since #1560, so the check failed the
+  release gate against correct behaviour. Both sides are pinned now, and the
+  opt-in path (`thinking.type=enabled` on either transport, plus
+  `display: "omitted"`) gained the four checks that nothing covered while the
+  default was asserted to think.
+
+
 - **The CUTLASS NVFP4 GEMM handler accepted a `beta` and dropped it** (#1547).
   `GemmKernelArgs::beta` reached it and the epilogue is built with a literal 0,
   so a `beta = 1` call would have written the product over the residual instead

--- a/tools/analysis/degen_suite.py
+++ b/tools/analysis/degen_suite.py
@@ -801,11 +801,14 @@ class Suite:
                         f"text={r['text'][:80]!r}")
             return
 
-        # 1. Non-stream default: reasoning must arrive as a `thinking` content
-        #    block, the answer as a `text` block — with NO request flags.
+        # 1. Non-stream DEFAULT: extended thinking is opt-in upstream, so a
+        #    request that does not ask for it gets a text block and no thinking
+        #    block. imp returned one until #1560 made the surface match, which
+        #    is the behaviour this pair now pins from both sides.
         r = self.srv.messages(q, max_tokens=n)
-        self.record("anthropic-thinking", "default non-stream: thinking block present",
-                    bool(r["thinking"].strip()), f"blocks={[b.get('type') for b in r['raw'].get('content', [])]}")
+        self.record("anthropic-thinking", "default non-stream: no thinking block (opt-in)",
+                    not r["thinking"].strip(),
+                    f"blocks={[b.get('type') for b in r['raw'].get('content', [])]}")
         self.record("anthropic-thinking", "default non-stream: text block is the answer",
                     bool(r["text"].strip()) and reasoning_opener(r["text"]) is None,
                     f"text={r['text'][:100]!r}")
@@ -816,14 +819,39 @@ class Suite:
                     r["usage"].get("input_tokens", 0) > 0 and r["usage"].get("output_tokens", 0) > 0,
                     str(r["usage"]))
 
-        # 2. Streaming default: thinking_delta blocks, then text_delta.
+        # 2. Streaming default: text deltas only, same reason as above.
         r = self.srv.messages_stream(q, max_tokens=n)
-        self.record("anthropic-thinking", "default stream: thinking_delta events",
-                    bool(r["thinking"].strip()), f"events={sorted(r['events'])}")
+        self.record("anthropic-thinking", "default stream: no thinking_delta (opt-in)",
+                    not r["thinking"].strip(), f"events={sorted(r['events'])}")
         self.record("anthropic-thinking", "default stream: text deltas are answer",
                     bool(r["text"].strip()) and reasoning_opener(r["text"]) is None
                     and "<think>" not in r["text"],
                     f"text={r['text'][:100]!r}")
+
+        # 3. Asked for: `thinking.type=enabled` is the on-switch, and it has to
+        #    produce the block on both transports. Nothing covered this before:
+        #    the default path was asserted to think, so the opt-in was never
+        #    distinguished from it.
+        think_on = {"type": "enabled", "budget_tokens": max(1024, n // 2)}
+        r = self.srv.messages(q, max_tokens=n, thinking=think_on)
+        self.record("anthropic-thinking", "thinking=enabled non-stream: thinking block present",
+                    bool(r["thinking"].strip()),
+                    f"blocks={[b.get('type') for b in r['raw'].get('content', [])]}")
+        self.record("anthropic-thinking", "thinking=enabled non-stream: text is still the answer",
+                    bool(r["text"].strip()) and reasoning_opener(r["text"]) is None,
+                    f"text={r['text'][:100]!r}")
+        r = self.srv.messages_stream(q, max_tokens=n, thinking=think_on)
+        self.record("anthropic-thinking", "thinking=enabled stream: thinking_delta events",
+                    bool(r["thinking"].strip()), f"events={sorted(r['events'])}")
+
+        # 4. display=omitted: the model still reasons, the block is withheld
+        #    (#1560). Distinct from the default, where it does not reason.
+        r = self.srv.messages(q, max_tokens=n,
+                              thinking={"type": "enabled", "budget_tokens": max(1024, n // 2),
+                                        "display": "omitted"})
+        self.record("anthropic-thinking", "display=omitted: no thinking block, answer intact",
+                    not r["thinking"].strip() and bool(r["text"].strip()),
+                    f"blocks={[b.get('type') for b in r['raw'].get('content', [])]}")
 
 
     # -- data-driven corpus -------------------------------------------------


### PR DESCRIPTION
`check-release.sh` exited 1 on the v0.30.0 tree. The only fault was that this
test is older than the contract it asserts.

## What failed

```
[FAIL] default non-stream: thinking block present - blocks=['text']
[FAIL] default stream: thinking_delta events - events=[content_block_delta, ...]
```

Reproduced directly against Qwen3-8B-NVFP4-cortecs:

| endpoint | reasoning present? |
|---|---|
| `/v1/chat/completions` | yes, 488 chars of `reasoning_content` |
| `/v1/messages`, no `thinking` field | no thinking block, `['text']` only |

That is correct. Extended thinking is opt-in upstream, and imp has matched it
since #1560: a `/v1/messages` request with no `thinking` field sets
`enable_thinking=false` (`anthropic.cpp:390-397`).

| | date |
|---|---|
| `anthropic-thinking` category written | 2026-06-06 (`546454b6`) |
| default-off behaviour landed | 2026-08-23 (`9061fde4`, this release) |

## What changed

The default now asserts the absence, from both sides, and the opt-in path gets
the coverage it never had while the default was asserted to think:

| check | pins |
|---|---|
| `default non-stream: no thinking block (opt-in)` | Anthropic's default |
| `default stream: no thinking_delta (opt-in)` | same, streaming |
| `thinking=enabled non-stream: thinking block present` | the on-switch works |
| `thinking=enabled non-stream: text is still the answer` | it does not eat the answer |
| `thinking=enabled stream: thinking_delta events` | on-switch, streaming |
| `display=omitted: no thinking block, answer intact` | #1560's third case |

Four of those six are new. Nothing distinguished "off by default" from "cannot
turn on" before, because the default was asserted to be on.

```
degen_suite: 10 checks, 0 FAIL, 0 skipped (3s)
```

## Gate

```
```

Qwen3-8B-Q8_0 on one RTX 5090, median of 3 processes. Python-only diff, so the
perf gate is untouched by it; the CHANGELOG entry is the reason it ran at all.

Not in here: no server change. The behaviour under test is #1560 and is correct.
