### PR TITLE
docs(quickstart): the cache volume is not optional, it holds the library reserve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ there instead of retelling it.
   library-reserve constant on every start and that comes out of the KV pool, so
   a copied recipe costs KV capacity rather than startup time. AUDIT B77 measured
   639 MiB per restart on Qwen3-14B-Q6_K; on a model whose first forward claims
-  almost nothing the gap is the whole constant. Both recipes mount it now and
-  the quickstart says what the second half of the volume is for.
+  almost nothing the gap is the whole constant. Measured again on
+  Qwen3.8-27B-NVFP4 while finding this: pinning the reserve to what the model
+  actually claims takes the pool from 1516 to 2811 blocks, +85 %, conformance
+  green in both arms. Both recipes mount it now and the quickstart says what
+  the second half of the volume is for.
 
 ## [0.30.0] - 2026-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The build-from-source docker recipe did not mount the cache volume, and the
+  quickstart called it optional.** Without it the memory plan charges a 3900 MiB
+  library-reserve constant on every start and that comes out of the KV pool, so
+  a copied recipe costs KV capacity rather than startup time. AUDIT B77 measured
+  639 MiB per restart on Qwen3-14B-Q6_K; on a model whose first forward claims
+  almost nothing the gap is the whole constant. Both recipes mount it now and
+  the quickstart says what the second half of the volume is for.
+
 ## [0.30.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Tracks `main` rather than the latest release.
 ```bash
 git clone https://github.com/kekzl/imp.git && cd imp
 docker compose build imp-server
-docker run --gpus all -v ./models:/models -p 127.0.0.1:8080:8080 \
+docker run --gpus all -v ./models:/models -v imp-cache:/home/imp/.cache/imp \
+  -p 127.0.0.1:8080:8080 \
   imp:latest --model /models/your-model.gguf
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -87,9 +87,20 @@ docker run --gpus all \
   ghcr.io/kekzl/imp:latest --model /models/Qwen3.8-27B-NVFP4
 ```
 
-The cache volume is optional and pays for itself immediately: it holds the
-transformed weights, so a second start skips the conversion. On
-Qwen3-14B-NVFP4 that is 7.9 s cold against 2.1 s warm.
+Mount the cache volume. It holds two things, and the second one costs VRAM
+rather than time:
+
+- the transformed weights, so a second start skips the conversion: on
+  Qwen3-14B-NVFP4, 7.9 s cold against 2.1 s warm;
+- the measured library reserve. Without it the memory plan charges a 3900 MiB
+  constant on every start, and that comes out of the KV pool. Measured on
+  Qwen3-14B-Q6_K: 0 MiB planned with the path mounted against 3900 MiB without
+  it, which hands 639 MiB back to the pools on every restart. On a model whose
+  first forward claims almost nothing the gap is the whole constant, and the
+  server says so after its first forward ("library reserve MISMATCH").
+
+A `docker run --rm` without this volume re-measures every start and never uses
+the answer.
 
 Watch for these lines; they tell you the engine picked the fast paths. On
 Qwen3.8-27B:


### PR DESCRIPTION
A peer ran v0.30.0 in a container without the cache mount and reported the
context window as a regression. It was not one. The memory plan charged a
3900 MiB library-reserve constant because the measurement had nowhere to
persist, and that came out of the KV pool.

## What was wrong

| recipe | mounted the cache |
|---|---|
| `README.md:67` (ghcr image) | yes |
| `docs/QUICKSTART.md:83` | yes, but described as "optional" |
| `README.md:223` (build from source) | **no** |

The quickstart named only the weight-transform saving (7.9 s cold against 2.1 s
warm). The other half of that volume costs VRAM, not time.

## The number

AUDIT B77, on Qwen3-14B-Q6_K: 3900 MiB planned without the path, 0 MiB with it,
**639 MiB** handed back to the pools on every restart. On a model whose first
forward claims almost nothing the gap is the whole constant.

The server already says so, but only after the first forward
(`library reserve MISMATCH`), by which time the pool is sized around it. The
plan-time line names the path and the knob since B77; what was missing is that
two of our own three recipes did not follow it.

## Gates

| | |
|---|---|
| `scripts/docs_lint.py` | exit 0 |
| `scripts/ci_static_gates.sh` | exit 0 |

Markdown only, so the pre-push hook drops it before the GPU gate.

Not in here: no code. `vram.library_reserve_cache` and the plan-time warning
both already exist; this is the recipes catching up with them.