### PR TITLE
docs(changelog): the reserve number measured the pin, not the mount (#1744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ there instead of retelling it.
   library-reserve constant on every start and that comes out of the KV pool, so
   a copied recipe costs KV capacity rather than startup time. AUDIT B77 measured
   639 MiB per restart on Qwen3-14B-Q6_K; on a model whose first forward claims
-  almost nothing the gap is the whole constant. Measured again on
-  Qwen3.8-27B-NVFP4 while finding this: pinning the reserve to what the model
-  actually claims takes the pool from 1516 to 2811 blocks, +85 %, conformance
-  green in both arms. Both recipes mount it now and the quickstart says what
-  the second half of the volume is for.
+  almost nothing the gap is the whole constant. Measured on Qwen3.8-27B-NVFP4,
+  mounted against not, KV dtype held at FP8: 3030 to 3639 blocks, 96960 to
+  116448 tokens, +20 %, because the second start plans the measured 3291 MiB
+  instead of the 3900 MiB constant. Both recipes mount it now and the
+  quickstart says what the second half of the volume is for.
 
 ## [0.30.0] - 2026-08-24
 


### PR DESCRIPTION
#1744 shipped a figure for the wrong thing. Correcting it, not the recipe.

## What was wrong

| | claimed as | actually measured |
|---|---|---|
| 1516 -> 2811 blocks, +85 % | the effect of mounting the cache volume | the effect of `--set vram.library_reserve_mb=4` by hand, on an FP16 KV run |

Two problems with quoting it: it measures the pin rather than the mount, and
whether that pool is safe or overcommitted was never checked. It reads as a
recommendation for a configuration nobody validated.

## What replaces it

Qwen3.8-27B-NVFP4 on imp@9a655bd1, KV dtype held at FP8, mounted against not,
conformance 26/26 green in both states:

| | blocks | tokens |
|---|---|---|
| cache not mounted | 3030 | 96960 |
| cache mounted, second start | 3639 | 116448 |

+20 %, and the mechanism is in the number: the second start plans the measured
3291 MiB instead of the 3900 MiB constant. That is 609 MiB, next to AUDIT B77's
639 MiB on Qwen3-14B-Q6_K.

Log anchors for both arms:

```
# mounted, second start
kv_cache_init.cpp:215  library reserve: 3291 MiB from the measurement cache
kv_cache_init.cpp:285  KV blocks: plan 3639 (live pass would have said 512)
kv_cache_init.cpp:503  KV cache: 3639 blocks (116448 tokens), 3639.00 MiB,
                       dtype=FP8_E4M3 (layers=16/64, kv_heads=4, head_dim=256,
                       block_size=32)

# not mounted
kv_cache_init.cpp:285  KV blocks: plan 3030 (live pass would have said 5484)
kv_cache_init.cpp:503  KV cache: 3030 blocks (96960 tokens), 3030.00 MiB,
                       dtype=FP8_E4M3
```

## Gates

| | |
|---|---|
| `scripts/docs_lint.py` | exit 0 |
| `scripts/ci_static_gates.sh` | exit 0 |

Not in here: the recipe change from #1744 is untouched, and correct. Only the
figure attached to it moves.

The live-pass figures above swing 5484 -> 512 while the applied plan moves
3030 -> 3639. Resolved since, and filed as #1747: in the mounted arm the 512 is
the `min_kv_tokens` rescue floor and not a live reading (`6093.9 - 5886.2 =
207.7` at `vram_budget.cpp:534`, raised to 512 at `:576`), and the plan's 3639
blocks were allocated and served a full green conformance run. The unmounted
arm's 5484 was never attempted and stays open.
