### PR TITLE
fix(mem): two diagnostics that named a number the code does not use (#1746 #1747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ there instead of retelling it.
   green in both arms. Both recipes mount it now and the quickstart says what
   the second half of the volume is for.
 
+- **The library-reserve warning recommended a value the server does not charge**
+  (#1746). It named the forward window while the plan, the cache and the next
+  start all use `max(forward_window, whole-init)`, which on the NVFP4 path is
+  three orders of magnitude larger: an operator pinning the recommended 4 MiB on
+  a model that charges 3060 got exactly the under-reserve the same warning
+  describes in its other branch. The report now runs after the charge is decided
+  and names that number, prints both figures so the gap is visible, and cites
+  AUDIT B79 rather than the B41 stability claim B79 superseded. Verified on
+  Qwen3.8-27B-NVFP4: the warning recommends 3060 MiB, which is what the line
+  above it records.
+
+- **`live pass would have said N` printed a rescue floor, not a reading**
+  (#1747). It logged `kv_max_blocks` after `min_kv_tokens` had raised it, so a
+  start that hit the floor reported a lower bound of the configuration as if it
+  were the live pass's own figure, and a reader nearly concluded a pool held 512
+  blocks where it held 3639. Both numbers are named when they differ: `KV
+  blocks: plan 3628 (live pass sized 197, raised to 512 by min_kv_tokens)`.
+
 ## [0.30.0] - 2026-08-24
 
 ### Added

--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -282,8 +282,20 @@ bool Engine::init_kv_cache() {
                 // Not a failure — the two are allowed to differ, and the plan is
                 // the one that charges what the live read cannot see. Logged
                 // because a silent divergence is how the old pass drifted.
-                IMP_LOG_INFO("KV blocks: plan %d (live pass would have said %d)", max_blocks,
-                             vram_budget.kv_max_blocks);
+                // The live figure is the pre-floor one: kv_max_blocks may have
+                // been raised by min_kv_tokens, and printing that under "live
+                // pass would have said" reported a lower bound of the
+                // configuration as a reading (#1747). Both are named when they
+                // differ, so a rescued pass is distinguishable from one that
+                // disagreed.
+                const int live_raw = vram_budget.kv_blocks_pre_floor > 0 ? vram_budget.kv_blocks_pre_floor
+                                                                         : vram_budget.kv_max_blocks;
+                if (live_raw != vram_budget.kv_max_blocks) {
+                    IMP_LOG_INFO("KV blocks: plan %d (live pass sized %d, raised to %d by min_kv_tokens)",
+                                 max_blocks, live_raw, vram_budget.kv_max_blocks);
+                } else {
+                    IMP_LOG_INFO("KV blocks: plan %d (live pass sized %d)", max_blocks, live_raw);
+                }
             }
         } else {
             // The plan refuses this configuration. D8 argues that should fail

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -308,38 +308,57 @@ void Engine::build_banned_token_list() {
 // it out of the class keeps engine.h (a god-header already at its size limit)
 // from growing for a diagnostic. Returns the measured claim, SIZE_MAX if it
 // could not be measured.
-static size_t report_library_reserve(size_t free_before, int library_reserve_mb) {
+static size_t measure_library_forward_window(size_t free_before) {
     if (free_before == 0)
         return SIZE_MAX;
     size_t free_after = 0;
     if (!vram_budget_mem_get_info(&free_after, nullptr))
         return SIZE_MAX;
-    const size_t measured = free_before > free_after ? free_before - free_after : 0;
+    return free_before > free_after ? free_before - free_after : 0;
+}
+
+// Report the charge against what the plan assumed, and name the value to pin.
+//
+// This used to live inside the measurement and recommend the FORWARD WINDOW,
+// which is not what anything charges: the caller takes
+// max(forward_window, whole_init) and caches that. On the NVFP4 path the two
+// are three orders of magnitude apart, because CUTLASS claims during the
+// phase-02 cache build and the window only opens at the warmup forward (AUDIT
+// B79). An operator following the old advice pinned 4 MiB on a model that
+// charges 3292, and got the under-reserve the same warning describes in its
+// other branch (#1746).
+//
+// So it runs here, after the charge is decided, and recommends that number.
+static void report_library_reserve(size_t charge, size_t forward_window, size_t whole_init,
+                                   int library_reserve_mb) {
+    if (charge == SIZE_MAX)
+        return;
     const size_t charged = engine_internal::library_reserve_charge(library_reserve_mb);
-    const double meas_mib = measured / (1024.0 * 1024.0);
     const double chg_mib = charged / (1024.0 * 1024.0);
-    // 20 % of the charge, floored at 256 MiB: below that the difference cannot
-    // move a plan decision and the line would be noise on every start.
+    const double use_mib = charge / (1024.0 * 1024.0);
     const size_t tol = std::max<size_t>(charged / 5, 256ull * 1024 * 1024);
-    const size_t diff = measured > charged ? measured - charged : charged - measured;
+    const size_t diff = charge > charged ? charge - charged : charged - charge;
     if (diff <= tol) {
-        IMP_LOG_INFO("library reserve: charged %.0f MiB, first forward claimed %.0f MiB (within "
-                     "tolerance)",
-                     chg_mib, meas_mib);
-        return measured;
+        IMP_LOG_INFO(
+            "library reserve: charged %.0f MiB, this start measured %.0f MiB (within "
+            "tolerance)",
+            chg_mib, use_mib);
+        return;
     }
-    IMP_LOG_WARN("library reserve MISMATCH: the plan charged %.0f MiB, the first forward actually "
-                 "claimed %.0f MiB (%+.0f MiB). %s Pin it for this model with "
-                 "'vram.library_reserve_mb = %.0f' in imp.conf — it is stable per model and quant "
-                 "path, and invariant to batch and context (AUDIT B41).",
-                 chg_mib, meas_mib, meas_mib - chg_mib,
-                 measured > charged
-                     ? "The plan therefore under-reserved: caches and the KV pool were sized "
-                       "against VRAM that the libraries then took."
-                     : "The plan therefore over-reserved: that much KV pool was set aside for "
-                       "nothing.",
-                 meas_mib);
-    return measured;
+    IMP_LOG_WARN(
+        "library reserve MISMATCH: the plan charged %.0f MiB, this start measured %.0f MiB "
+        "(%+.0f MiB, forward window %.0f MiB / whole-init %.0f MiB). %s Pin it for this "
+        "model with 'vram.library_reserve_mb = %.0f' in imp.conf: that is the number the "
+        "plan and the measurement cache both use. The charge is stable per model and "
+        "quant path; the forward WINDOW is not, which is why the two figures above can "
+        "differ by orders of magnitude (AUDIT B79).",
+        chg_mib, use_mib, use_mib - chg_mib,
+        forward_window == SIZE_MAX ? 0.0 : forward_window / (1024.0 * 1024.0), whole_init / (1024.0 * 1024.0),
+        charge > charged ? "The plan therefore under-reserved: caches and the KV pool were sized "
+                           "against VRAM that the libraries then took."
+                         : "The plan therefore over-reserved: that much KV pool was set aside for "
+                           "nothing.",
+        use_mib);
 }
 
 void Engine::warmup() {
@@ -399,7 +418,7 @@ void Engine::warmup() {
         req->status = RequestStatus::CANCELLED;
     }
     MemAccount::instance().checkpoint("05b_post_warmup_forward");
-    const size_t forward_window = report_library_reserve(warm_free_before, config_.library_reserve_mb);
+    const size_t forward_window = measure_library_forward_window(warm_free_before);
 
     // Which library claims WHEN depends on the model's execution path, so the
     // forward window only ever sees part of the charge: Q8_0 first touches
@@ -426,6 +445,9 @@ void Engine::warmup() {
             forward_window / (1024.0 * 1024.0), whole_init / (1024.0 * 1024.0),
             measured_library_reserve_ / (1024.0 * 1024.0));
     }
+    // Only now is there a number to recommend: everything above decides it, and
+    // the warning that names it has to come after, not before (#1746).
+    report_library_reserve(measured_library_reserve_, forward_window, whole_init, config_.library_reserve_mb);
     // Remember it, so the NEXT start on this model charges the measured value
     // instead of the constant (AUDIT B49). A write failure is a warning, never a
     // load failure — refusing to serve a model over a cache file would be absurd.

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -572,6 +572,7 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
     // budget in exchange for more context.
     int cap = user_requested_min ? max_affordable : static_cast<int>(max_affordable * kv_fraction);
     min_kv_blocks = std::min(min_kv_blocks, cap);
+    budget.kv_blocks_pre_floor = budget.kv_max_blocks;
     if (budget.kv_max_blocks < min_kv_blocks) {
         IMP_LOG_INFO("VRAM budget: raising KV from %d to %d blocks (min_kv_tokens=%d)", budget.kv_max_blocks,
                      min_kv_blocks, min_kv_tok);

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -42,6 +42,13 @@ struct VRAMBudget {
     size_t nvfp4_cache_bytes = 0;
     size_t reserve_bytes = 1024ULL * 1024 * 1024;  // 1 GiB safety
     int kv_max_blocks = 0;
+    // What the sizing arrived at BEFORE the min_kv_tokens rescue floor raised
+    // it (vram_budget.cpp, "raising KV from N to M blocks"). Kept because the
+    // divergence log in engine_kv_cache_init.cpp printed the floored figure
+    // under "live pass would have said", so a start that hit the floor
+    // reported a lower bound of the configuration as if it were a reading
+    // (#1747). Equal to kv_max_blocks when no floor was applied.
+    int kv_blocks_pre_floor = 0;
     // SWA-aware sizing (kv_cache.swa_sizing): capacity of the dedicated
     // sliding-window block group (0 = feature off). Sized batch-shaped:
     // ceil(swa_live_tokens / block_size) + 1 blocks per sequence slot.

--- a/tests/test_vram_budget_reserve.cpp
+++ b/tests/test_vram_budget_reserve.cpp
@@ -660,3 +660,42 @@ TEST(VramBudgetReserve, KvBlockBytesPerLayerIsPackingAndScaleAware) {
     EXPECT_EQ(kv_block_bytes_per_layer(QType::MXFP4_KV, bs, nkv, hd), packed4);
     EXPECT_GT(kv_block_bytes_per_layer(QType::NVFP4, bs, nkv, hd), 0u);
 }
+
+// #1747: the divergence log printed kv_max_blocks under "live pass would have
+// said", and kv_max_blocks may already have been raised by the min_kv_tokens
+// rescue floor. A start that hit the floor therefore reported a lower bound of
+// the CONFIGURATION as if it were a reading of what the live pass sized. The
+// pre-floor figure is kept so the log can name both; this pins that it is the
+// unfloored one, which is what the mutation "assign after the raise" breaks.
+TEST(VramBudgetReserve, PreFloorBlocksSurviveTheMinKvTokensRaise) {
+    SKIP_IF_NO_CUDA();
+
+    Model m;
+    fill_model(m, QType::Q8_0, QType::Q8_0);
+
+    EngineConfig config;
+    config.max_seq_len = 32768;
+    config.max_batch_size = 1;
+    config.use_cuda_graphs = false;
+    config.kv_cache_dtype = QType::F16;
+    config.min_kv_tokens = 16384;  // 1024 blocks at block size 16
+
+    // 8 GiB is chosen, not arbitrary: the sizing lands at 618 blocks there and
+    // the floor raises it to 1024. At 9 GiB and above the floor never fires and
+    // this test would pass while proving nothing, which is why the assertion
+    // below is an ASSERT on the floor having fired at all.
+    const size_t tight = 8ull * 1024 * 1024 * 1024;
+    VRAMBudget b = compute_vram_budget(m, config, 36, 128, tight);
+
+    ASSERT_LT(b.kv_blocks_pre_floor, b.kv_max_blocks)
+        << "the floor did not fire at this shape, so nothing here is being tested: pre="
+        << b.kv_blocks_pre_floor << " final=" << b.kv_max_blocks;
+    EXPECT_EQ(b.kv_max_blocks, config.min_kv_tokens / 16)
+        << "the raise should land exactly on the configured floor";
+    EXPECT_GT(b.kv_blocks_pre_floor, 0) << "pre-floor figure was never recorded";
+
+    // The point of the field. Assigning it after the raise instead of before
+    // makes these two equal, which is the state the divergence log used to
+    // report as "live pass would have said" (#1747).
+    EXPECT_NE(b.kv_blocks_pre_floor, b.kv_max_blocks);
+}

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -132,7 +132,10 @@ def main():
     # 979 -> 982 (#1548): three more, running the expert-imbalance kernel that
     # ships against the host reference beside it. The reference's own four
     # tests went into the CPU lane, which is why this only moved by three.
-    PINNED = 982
+    # 982 -> 983 (#1747): one GPU test pinning that the pre-floor KV figure
+    # survives the min_kv_tokens raise. VramBudget* is SKIP_IF_NO_CUDA by
+    # construction (AUDIT B64), so it cannot be anywhere else.
+    PINNED = 983
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
Both lines tell the reader what to do, and both print the wrong figure for it.

## #1746 the warning recommended a value nothing charges

It named the forward window. The plan, the measurement cache and the next start
all use `max(forward_window, whole_init)`, and on the NVFP4 path those differ by
three orders of magnitude: CUTLASS claims during the phase-02 cache build while
the window only opens at the warmup forward (AUDIT B79). Pinning the recommended
number produced the under-reserve the same warning describes in its other
branch.

Measurement and reporting are now separate: `measure_library_forward_window()`
measures, `report_library_reserve()` runs after the charge is decided and names
that number.

Verified on Qwen3.8-27B-NVFP4, two consecutive starts:

| | before | after |
|---|---|---|
| empty cache, charge 3060 MiB | recommends 4 | recommends 3060 |
| warm cache, 3059 MiB read back | mismatch on a 84 vs 3291 gap | tolerance branch, no warning |

The warning also prints both figures now (`forward window 4 MiB / whole-init
3060 MiB`) and cites B79 rather than the B41 stability claim B79 superseded.

## #1747 the divergence log printed a rescue floor

`live pass would have said N` logged `kv_max_blocks` after `min_kv_tokens` had
raised it, so a start that hit the floor reported a lower bound of the
configuration as the live pass's own reading. A reader almost concluded a pool
held 512 blocks where it held 3639.

```
before: KV blocks: plan 3628 (live pass would have said 512)
after:  KV blocks: plan 3628 (live pass sized 197, raised to 512 by min_kv_tokens)
after:  KV blocks: plan 4096 (live pass sized 1038)          # no floor, one number
```

## The test, and why the first one was worthless

One GPU test, `PreFloorBlocksSurviveTheMinKvTokensRaise`. The first version
passed against its own mutation (assign `kv_blocks_pre_floor` after the raise
instead of before), because at the shape it used the floor never fired and the
tolerant branch waved it through.

It now pins 8 GiB, where sizing lands at 618 blocks and the floor raises to
1024, and it ASSERTs the floor fired at all, so a shape that stops exercising
the path fails loudly instead of passing empty.

| | |
|---|---|
| clean | PASSED |
| mutant (assign after the raise) | FAILED, "the floor did not fire at this shape: pre=1024 final=1024" |

`VramBudget*` is `SKIP_IF_NO_CUDA` by construction (AUDIT B64), so
`check_test_lanes` moves 982 -> 983.

## Gates

| | |
|---|---|
| `VramBudget*` | 16/16 |
| `scripts/ci_static_gates.sh` | exit 0 |
| format on changed lines | 0 violations |

Both defects were found in a peer session's logs while it ran v0.30.0. Neither
mis-sizes anything on its own: the applied plan wins in both cases. They mislead
whoever follows them, which is what a diagnostic cannot afford to do.