### PR TITLE
docs(qwen38): two more M=32 GEMM levers measured and refuted

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -771,9 +771,17 @@ CTAs — 24 % of the SMs. Same disease the small-N pingpong variant
 doubles the grid (40 -> 80 CTAs) and still loses — aggregate 358 -> 249
 at 8 streams (-30%) and 936 -> 792 at 32 (-15%); the 64-wide N-tile's
 per-CTA efficiency loss outweighs the extra CTAs, matching the #596
-"loses ~25% on large N" note. What remains is a REAL small-M
-instantiation (64-row M-tile, cooperative schedule) or stream-K over
-the 40 K-tiles — new template instances, not a dispatch change. Expected: GEMM 14.8 ->
+"loses ~25% on large N" note. Two more levers measured
+and REFUTED the same night: (b) a 64-row M-tile instance does not
+build — the sm120 block-scaled SF atom is 128-row, CUTLASS static-asserts
+on any CTA_M below 128; (c) swapping the StreamKScheduler into the
+128x128 kernel builds and passes correctness, and collapses under load:
+181.8 tok/s aggregate at 32 streams against 935.7 baseline (283 vs 358
+at 8) — with 353 GEMM launches per step, stream-K's per-launch workspace
+fixup dwarfs what the extra parallelism buys. What remains is a properly
+configured stream-K (hw_info, DataParallel decomposition, graph-safe
+workspace) or a dedicated M<=32 weight-streaming kernel; both are real
+campaigns, not dispatch flips. Expected: GEMM 14.8 ->
 ~9-10 ms/step, aggregate ~1050+ against vLLM's 1475. The scan is near
 its own state-bandwidth floor (9.7 GB/step at 32 seqs); the 292
 per-step activation-quantize launches are the secondary item.

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -231,7 +231,7 @@ model on this card exist in `docs/BENCHMARKS.md`.
 | # | work | files | acceptance |
 |---|---|---|---|
 | 1 | HF logits-parity harness for GDN hybrids | `tests/` + a pinned-transformers container | max abs diff < 2e-2, top-5 order, 20 prompts × {short, 4k, 32k} |
-| 2 | DeltaNet state-drift check at 32k | same harness, compare `h` tensors not logits | state cosine ≥ 0.999 vs reference |
+| 2 | ~~DeltaNet state-drift check at 32k~~ MEASURED 08-25 (internal bound) | `diagnostics.dump_gdn_state_dir` + chunk-size A/B | see below: 46k prefill is bit-stable across processes; chunk-size variance costs +0.33% PPL |
 | 3 | `reasoning_effort` plumbing (G1) | `chat_template.cpp`, `jinja.cpp`, server request parse, `tests/refs/` | `prompt_tokens` differs across the three efforts; golden matches upstream template |
 | 4 | FP8-as-source limitation documented (G2) | `docs/LIMITATIONS.md`, `docs/MODELS.md` | claim carries the 25.87 GiB figure and the sm_120 FP8-GEMM reason |
 | 5 | ~~Fix the MTP enable-path mismatch~~ DONE 08-25 | `tools/imp-cli/main.cpp` | `--set speculative.mtp_k=2` enables MTP under the CLI |
@@ -738,6 +738,26 @@ norm offsets, lm_head precision, head count):
 What remains is head quality (a 425M single-layer dense head against the
 80B checkpoint's) and the verify price on a GDN hybrid (16 vs 11.6 ms
 per step). Neither is an implementation defect.
+
+## State drift at 46k, bounded (2026-08-25)
+
+The item-2 criterion as written (state cosine >= 0.999 vs an HF reference at
+32k) stays unmeasurable on this card (the BF16 checkpoint is 51.75 GiB), but
+the drift is now bounded internally, with a control:
+
+| comparison (same 46 579-token prompt, final state + final logits) | logits cos | state cos (48 layers) |
+|---|---:|---|
+| control: chunk 2048, two processes | **1.000000**, top-1 = | min 1.000, 0/48 below 0.999 |
+| chunk 2048 vs chunk 512 | 0.945391, top-1 = | min 0.932, mean 0.986, **44/48 below 0.999** |
+
+The control is the load-bearing row: the 46k GDN prefill is **bit-stable
+across processes**, so the chunk-size divergence is a real numerical effect
+of boundary count, not noise. Its quality cost, teacher-forced over
+`ppl_corpus_45k.txt` (13 811 tokens, deterministic_gemm both arms):
+chunk 2048 PPL 4.6259, chunk 512 PPL 4.6412 — **+0.33%**, the same order as
+the accepted FP8-KV trade. Verdict: benign accumulation, no chunk-boundary
+state bug (the #981 class would read like 8.30 -> 15.35 here, not +0.33%).
+Item 1 (HF logits parity at 32k) remains hardware-blocked and open.
 
 ## The concurrency gap, decomposed (2026-08-25, from the existing 32-way profile)
 

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -801,7 +801,14 @@ at 8) — with 353 GEMM launches per step, stream-K's per-launch workspace
 fixup dwarfs what the extra parallelism buys. What remains is a properly
 configured stream-K (hw_info, DataParallel decomposition, graph-safe
 workspace) or a dedicated M<=32 weight-streaming kernel; both are real
-campaigns, not dispatch flips. Expected: GEMM 14.8 ->
+campaigns, not dispatch flips. Scope prior for the kernel route: the
+GEMV family is already measured out of contention — MR is capped at 4
+because MR=16 spills (91 us/row at MR=4 vs 118 at MR=16, comment in
+`nvfp4_gemv_batched.cu`), and MR=4 tiling at M=32 costs 8 weight
+re-reads (~75 us on the N=5120 shape against CUTLASS's 41.4). A winning
+kernel must stage the 32 activation rows in shared memory (327 KB total,
+L2-hot) and stream each weight row exactly once; that is a new kernel,
+not an instantiation. Expected: GEMM 14.8 ->
 ~9-10 ms/step, aggregate ~1050+ against vLLM's 1475. The scan is near
 its own state-bandwidth floor (9.7 GB/step at 32 seqs); the 292
 per-step activation-quantize launches are the secondary item.


### PR DESCRIPTION
Follow-up record to #1750's concurrency-gap decomposition. Both candidate quick levers for the 40-CTA grid starvation measured, both refuted:

| lever | result |
|---|---|
| 64-row M-tile instance | does not build: sm120 block-scaled SF atom is 128-row, CUTLASS static-asserts below CTA_M=128 |
| StreamKScheduler on the 128x128 kernel | builds, tests pass, collapses under load: 181.8 vs 935.7 tok/s aggregate at 32 streams (283 vs 358 at 8) |

(The third, routing M<=64 onto the existing 128x64 pingpong, was refuted in #1750: -15% at 32.) Remaining: properly configured stream-K (hw_info, graph-safe workspace) or a dedicated M<=32 weight-streaming kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu