### PR TITLE
docs(qwen38): the SIMT small-M kernel prototyped to its ceiling

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -806,9 +806,29 @@ GEMV family is already measured out of contention — MR is capped at 4
 because MR=16 spills (91 us/row at MR=4 vs 118 at MR=16, comment in
 `nvfp4_gemv_batched.cu`), and MR=4 tiling at M=32 costs 8 weight
 re-reads (~75 us on the N=5120 shape against CUTLASS's 41.4). A winning
-kernel must stage the 32 activation rows in shared memory (327 KB total,
-L2-hot) and stream each weight row exactly once; that is a new kernel,
-not an instantiation. Expected: GEMM 14.8 ->
+kernel must stage the 32 activation rows in shared memory and stream each
+weight row exactly once — and that kernel was PROTOTYPED and measured to
+its ceiling (2026-08-25, five iterations on M=32 N=5120 K=5120, correct
+against a host dequant reference at every step):
+
+| iteration | us | what changed |
+|---|---:|---|
+| v1 naive smem tiles | 536.5 | 32-way bank conflict (256-half rows, all threads one bank) |
+| v2 bank-free mapping | 138.7 | consecutive threads share m (x broadcast), w rows padded to odd words |
+| v3 2x2 register tile + hfma2 | 85.6 | smem loads halved per output |
+| v4 register-prefetch double buffer | 74.0 | global latency overlapped with FMA stream |
+| v5 4x2 tile, 128 threads | 67.8 | smem loads at 0.75/output |
+
+The curve flattens at ~1.6x ABOVE the CUTLASS baseline (41.4 us). The
+starvation reading was incomplete: CUTLASS at 40 CTAs is latency-bound
+but still runs tensor-core MMA behind TMA; a SIMT hfma2 kernel hits its
+own smem+ALU wall near 55-60 us before ever reaching the weight floor.
+Beating 41.4 needs the block-scaled mma.sync path with a genuine 32-row
+M-tile — which the 128-row SF atom forbids in stock CUTLASS — i.e. a
+hand-written mxf4nvf4 kernel with its own scale layout. That is the
+campaign's true cost, now priced by measurement. Prototype + bench test
+preserved in the session scratchpad (nvfp4_gemm_smallm.cu); not merged —
+an uncalled kernel is exactly the stub class `find-stubs` exists for. Expected: GEMM 14.8 ->
 ~9-10 ms/step, aggregate ~1050+ against vLLM's 1475. The scan is near
 its own state-bandwidth floor (9.7 GB/step at 32 seqs); the 292
 per-step activation-quantize launches are the secondary item.


### PR DESCRIPTION
Fourth refutation for the M=32 GEMM lever, this one with a built prototype: five measured iterations (536.5 -> 138.7 -> 85.6 -> 74.0 -> 67.8 us on M=32 N=5120 K=5120, correct against a host dequant reference at every step) flatten 1.6x above the CUTLASS 41.4 us baseline. CUTLASS at 40 CTAs is latency-bound but still tensor-core MMA behind TMA; a SIMT hfma2 kernel hits its smem+ALU wall first. True cost of the lever, now priced: a hand-written mxf4nvf4 kernel with a 32-row M-tile and its own scale layout. Prototype preserved in the session scratchpad, not merged (uncalled kernel = the find-stubs class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu