### PR TITLE
docs(bench): the 1.58x concurrency gap attributed per component

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -442,6 +442,51 @@ Readings:
   card — the Mamba-cache-block startup constraint from 2026-08-16 is handled
   by `--max-num-seqs 32`.
 
+### The 1.58x concurrency gap, attributed (2026-08-25)
+
+Both engines profiled under nsys (`--cuda-graph-trace=node`, host Nsight
+2026.1.3 mounted into each container) serving the identical 32-stream wave
+(6400 tokens, 200 per stream, same checkpoint, same client). Under the
+profiler imp reads 908 tok/s and vLLM 1477 — both within noise of their
+unprofiled numbers, so the windows are representative. Per emitted token,
+steady-state wave only:
+
+[PROV: commit=9ff730db date=2026-08-25 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4-CT cuda=13.3 path=server-api cmd=nsys+load32.py n=1
+       window=wave2 tokens=6400]
+
+| us/token | imp | vLLM 0.27.1 | delta | share of gap |
+|---|---:|---:|---:|---:|
+| GEMM class | 613 | 468 (Marlin 413 + bf16 rest 55) | 145 | 34% |
+| **GPU idle** | 179 | 36 | 143 | 34% |
+| norms | 35 | 10 | 26 | 6% |
+| GDN scan | 181 | 158 | 23 | 6% |
+| M=1 GEMV (wave tails) | 22 | — | 22 | 5% |
+| activation quantize | 15 | — | 15 | 4% |
+| conv1d | 17 | 5 | 11 | 3% |
+| attention decode | 22 | 11 | 10 | 2% |
+| cuBLAS fp16 + other | 38 | 18 | 25 | 6% |
+| **wall** | **1125** | **703** | **422** | 100% |
+
+Three readings, one of them a correction:
+
+- **The "structural FP4 trade" framing was wrong.** imp's GEMM class costs
+  MORE than vLLM's despite native FP4: Marlin (W4A16, split-K with atomic
+  reduction, built for small M) beats the CUTLASS block-scaled cooperative
+  tile by ~24% on the same shapes and the same card. The ~41 us "ceiling"
+  the five-approach survey established holds only for no-K-split designs —
+  Marlin is the running existence proof for the split-K route.
+- **Idle is as large as the GEMM deficit.** imp leaves the GPU empty 15.9%
+  of the steady-state window (vLLM: 5.2%): 415k inter-kernel gaps, 687 ms
+  of them under 100 us (launch/replay density — imp issues 438k kernels in
+  the window against vLLM's 200k, 2.2x per token) and 484 ms above 100 us
+  (host moments; the largest single gaps are 42/39/26 ms).
+- The remaining ~135 us/token is a sum of small classes, mostly coupled to
+  the launch count.
+
+Ceiling if both engine-side posts closed: ~1125 - 288 = ~837 us/token,
+i.e. ~1195 tok/s aggregate — within 19% of vLLM without touching the scan.
+
 ## Long context (pp8192 / tg512 @ 16k ctx)
 
 First tracked long-context table (the GOAL benchmarking discipline asks for

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -833,6 +833,26 @@ an uncalled kernel is exactly the stub class `find-stubs` exists for. Expected: 
 its own state-bandwidth floor (9.7 GB/step at 32 seqs); the 292
 per-step activation-quantize launches are the secondary item.
 
+### CORRECTION (2026-08-25 evening): the survey's ceiling holds, its pricing did not
+
+The cross-engine nsys attribution (BENCHMARKS.md, "The 1.58x concurrency
+gap, attributed") retracts two conclusions above:
+
+- The "~41 us is close to what is reachable" reading holds only for
+  no-K-split designs. **vLLM's Marlin executes the same GEMM class on the
+  same card at 468 us/token where imp's CUTLASS path costs 613** — W4A16,
+  split-K, atomic reduction, built for small M. Split-K is not a ~5%
+  lever; it is the production design one engine over, running.
+- The "structural FP4 trade" framing from the first comparison is wrong
+  in the measured direction: imp pays MORE GEMM time despite native FP4.
+
+The same profile adds an equal post the survey never looked at: **143
+us/token of GPU idle** (imp 15.9% of the steady window against vLLM's
+5.2%; 438k kernel launches per window against 200k, plus single host
+stalls of 26-42 ms). Gap total 422 us/token: GEMM 145, idle 143, small
+launch-coupled classes ~135. Both engine-side posts closed bounds imp at
+~1195 tok/s aggregate, within 19% of vLLM, before touching the scan.
+
 ## Notes for whoever picks this up
 
 - The GPU must be checked free before every job, not once

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,21 +60,28 @@ neighbour, publishes no 2026 roadmap.
 
 Ranked by what an agent workload notices first.
 
-0. **Concurrency scaling on the GDN hybrid trails vLLM 1.58x at 32 streams**
-   (measured 2026-08-25, same compressed-tensors NVFP4 checkpoint, same
-   client: imp 935.7 vs vLLM 1475.2 tok/s aggregate; imp per-stream falls
-   85 -> 29 tok/s across 1 -> 32 where vLLM falls 69 -> 46 — see
-   [`BENCHMARKS.md`](BENCHMARKS.md), "imp vs vLLM at concurrency"). Single
-   stream imp leads by 22%. The batched-GDN decode in #1750 closed the gap
-   from ~6.5x; what remains is (a) the batch-decode step cost (scan + attention at
-   n>1: ~34 ms/step at 32 where vLLM's equivalent is ~22, against a
-   ~11 ms weight-read floor both share). The 630-vs-936 delta between
-   auto=28 and pinned=32 on this bench is NOT a rotation cost: the
-   scheduler admits 28 and the last 4 requests drain as a near-empty
-   batch (predicted 667 from the two phases, measured 630) — under
-   continuous arrival auto=28 sustains the full-batch rate. Raising
-   slots per GiB is still what the plan's item 6 (recurrent-state
-   paging) would buy.
+0. **Concurrency scaling on the GDN hybrid trails vLLM 1.58x at 32 streams —
+   now ATTRIBUTED per component** (nsys on both engines, same checkpoint,
+   same 32-stream wave; full table with PROV in
+   [`BENCHMARKS.md`](BENCHMARKS.md), "The 1.58x concurrency gap,
+   attributed"). Of the 422 us/token wall delta: **GEMM class 145** (imp's
+   CUTLASS block-scaled at M=32 loses ~24% to vLLM's Marlin — W4A16
+   split-K with atomic reduction; the five-approach "no-split ceiling"
+   survey in `docs/plans/2026-08-24-qwen38-port.md` holds only for
+   no-K-split designs, and Marlin is the running existence proof for the
+   split-K route on this very card), **GPU idle 143** (imp 15.9% idle vs
+   vLLM 5.2%: 438k kernel launches per window against 200k — 2.2x per
+   token — plus a handful of 26-42 ms host stalls), and ~135 across small
+   classes mostly coupled to the launch count. Closing the two engine-side
+   posts alone bounds imp at ~1195 tok/s, within 19% of vLLM. Levers, in
+   value order: (a) a Marlin-class small-M GEMM (port or split-K CUTLASS
+   with persistent, graph-safe reduction), (b) launch-density and the
+   large host gaps, (c) kernel fusion across the small classes. The
+   630-vs-936 delta between auto=28 and pinned=32 on this bench is NOT a
+   rotation cost (scheduler admits 28, the last 4 drain as a near-empty
+   batch; auto=28 sustains full rate under continuous arrival); raising
+   slots per GiB is still what the plan's item 6 (recurrent-state paging)
+   would buy.
 
 1. **Scheduling has no per-request priority.** Nothing in the scheduler reads
    one, so a caller cannot say which request matters. `max_concurrent` bounds


### PR DESCRIPTION
The remaining imp-vs-vLLM concurrency difference is no longer a framing, it is a measured decomposition: both engines profiled under nsys (host Nsight 2026.1.3 mounted, --cuda-graph-trace=node) serving the identical 32-stream wave on the same checkpoint. Under the profiler: imp 908, vLLM 1477 tok/s (both representative).

Per emitted token, steady-state wave (full table + PROV in BENCHMARKS.md):

| us/token | imp | vLLM | delta |
|---|---:|---:|---:|
| GEMM class | 613 | 468 | 145 (34%) |
| GPU idle | 179 | 36 | 143 (34%) |
| small classes (norms/GEMV-tails/quant/conv/attn) | ~150 | ~45 | ~135 (32%) |
| wall | 1125 | 703 | 422 |

Two corrections to earlier records, stated as such in the docs:
- The "structural FP4 trade" framing is retracted: imp pays MORE GEMM time despite native FP4. Marlin (W4A16, split-K, atomic reduction) beats the CUTLASS block-scaled path ~24% at M=32 on this very card - the five-approach "no-split ceiling" survey holds only for no-split designs.
- An equal-sized post the survey never examined: 143 us/token GPU idle (imp 15.9% vs 5.2%; 438k launches/window vs 200k; single host stalls up to 42 ms).

Roadmap item 0 now carries the lever list in value order: Marlin-class small-M GEMM, launch density + host stalls, fusion of the small classes. Ceiling with the two engine posts closed: ~1195 tok/s (within 19% of vLLM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu