### PR TITLE
perf(diag): host-time instrumentation end to end, and the wave-ramp attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The decode loop's host time is now instrumented end to end**
+  (`diagnostics.step_timing`: engine phases + step_impl blocks;
+  `IMP_WORKER_TIMING=1`: server worker phases). It settled the last idle
+  question with numbers: the steady-state loop is clean (resume/constrained/
+  schedule at 0/0/1 us) and the residual "outside" time is the WAVE RAMP -
+  prefills plus one CUDA-graph capture per never-seen batch size (75 captures
+  across a 4-wave run; wave 1 reads 704 tok/s against 953-976 for waves 2-4).
+  Batch-size bucketing with padded rows (the vLLM answer) is the priced
+  follow-up in `docs/roadmap.md`.
+
 - **Token delivery no longer preempts the GPU driver loop.** Each step's
   `push_token` woke its SSE handler immediately, and at 32 streams ~6.4 ms of
   handler work (detokenise + socket write) ran per step BEFORE the worker

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,9 +74,16 @@ Ranked by what an agent workload notices first.
    token — plus a handful of 26-42 ms host stalls), and ~135 across small
    classes mostly coupled to the launch count. Closing the two engine-side
    posts alone bounds imp at ~1195 tok/s, within 19% of vLLM. Levers, in
-   value order: (a) a Marlin-class small-M GEMM (port or split-K CUTLASS
-   with persistent, graph-safe reduction), (b) launch-density and the
-   large host gaps, (c) kernel fusion across the small classes. The
+   value order (updated 2026-08-25 evening after the deferred-delivery win,
+   #1758, and the wave-ramp attribution): (a) a GENUINE Marlin port for the
+   M<=32 GEMM class - the split-K wmma kernel built in #1756/#1757 beats
+   CUTLASS 42% in isolation but loses e2e without TMA/cp.async pipelining;
+   three measured dead ends bound the design. (b) decode-graph batch-size
+   BUCKETS with padded rows: today every never-seen batch size captures a
+   fresh graph (75 captures over a 4-wave run; wave 1 reads 704 tok/s
+   against 953-976 steady), which is also what production batch fluctuation
+   pays. (c) kernel fusion across the small launch-coupled classes
+   (norms 26 us/token, act-quantize 15, elementwise). The
    630-vs-936 delta between auto=28 and pinned=32 on this bench is NOT a
    rotation cost (scheduler admits 28, the last 4 drain as a near-empty
    batch; auto=28 sustains full rate under continuous arrival); raising

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -75,7 +75,19 @@ bool Engine::step() {
     return more;
 }
 
+namespace {
+struct OutsideTiming {
+    double resume = 0, cp = 0, sched = 0, prefill = 0, decode_wrap = 0;
+    int n = 0;
+};
+OutsideTiming g_ot;
+}  // namespace
+
 bool Engine::step_impl_() {
+    const bool s_ot = runtime_config_.diagnostics.step_timing;
+    std::chrono::steady_clock::time_point o0, o1, o2, o3, o4;
+    if (s_ot)
+        o0 = std::chrono::steady_clock::now();
     // Fast path: async conditional graph loop completed on GPU.
     int async_result = step_async_graph_resume();
     if (async_result == 1)
@@ -85,6 +97,8 @@ bool Engine::step_impl_() {
     }
 
     // Fast path: pipelined constrained decode (json/schema) — one token/tick.
+    if (s_ot)
+        o1 = std::chrono::steady_clock::now();
     int cp_result = step_constrained_pipeline();
     if (cp_result == 1)
         return true;
@@ -93,6 +107,8 @@ bool Engine::step_impl_() {
     }
 
     // Schedule prefill/decode batches and reconfigure green contexts.
+    if (s_ot)
+        o2 = std::chrono::steady_clock::now();
     if (!step_schedule()) {
         // No schedulable work — but an in-flight pipelined step may still
         // hold tokens + deferred KV (all rows finished last step). Drain so
@@ -109,12 +125,30 @@ bool Engine::step_impl_() {
         drain_decode_pipeline();
 
     // Process prefill requests.
+    if (s_ot)
+        o3 = std::chrono::steady_clock::now();
     if (!sched_prefill_batch_.empty()) {
         step_prefill(prefill_stream());
         ensure_prefill_workspace(executor_.get());
     }
 
     // Process decode requests (batched).
+    if (s_ot)
+        o4 = std::chrono::steady_clock::now();
+    if (s_ot) {
+        auto us = [](auto a, auto b) { return std::chrono::duration<double, std::micro>(b - a).count(); };
+        g_ot.resume += us(o0, o1);
+        g_ot.cp += us(o1, o2);
+        g_ot.sched += us(o2, o3);
+        g_ot.prefill += us(o3, o4);
+        if (++g_ot.n >= 256) {
+            const double inv = 1.0 / g_ot.n;
+            IMP_LOG_INFO("outside-timing (n=%d): resume %.0f us, constrained %.0f, schedule %.0f, "
+                         "prefill-block %.0f",
+                         g_ot.n, g_ot.resume * inv, g_ot.cp * inv, g_ot.sched * inv, g_ot.prefill * inv);
+            g_ot = {};
+        }
+    }
     if (!sched_decode_batch_.empty()) {
         step_decode(decode_stream());
         ensure_prefill_workspace(executor_.get());

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 2159, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 2192, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }

--- a/tools/imp-server/batching_engine.cpp
+++ b/tools/imp-server/batching_engine.cpp
@@ -144,6 +144,19 @@ void BatchingEngine::notify_loop_() {
     }
 }
 
+namespace {
+// Worker-side phase attribution (companion to diagnostics.step_timing, which
+// covers the engine's step): admission (steps 0-2), engine->step(), delivery
+// staging (step 4). Enabled by IMP_WORKER_TIMING=1; logs every 256 loops.
+struct WorkerTiming {
+    double admit = 0, step = 0, stage = 0;
+    int n = 0;
+    bool enabled = false;
+    bool init_done = false;
+};
+WorkerTiming g_wt;
+}  // namespace
+
 void BatchingEngine::worker_loop() {
     // Best-effort scheduling boost for the ONE thread that drives the GPU.
     // Step-phase timing at 32 streams put 6.4 ms per step OUTSIDE the engine
@@ -164,8 +177,14 @@ void BatchingEngine::worker_loop() {
     }
     imp::Engine* engine = ctx_->engine.get();
     imp::KVCacheManager* kv_mgr = engine->kv_manager();
+    if (!g_wt.init_done) {
+        const char* e = getenv("IMP_WORKER_TIMING");
+        g_wt.enabled = (e && e[0] == '1');
+        g_wt.init_done = true;
+    }
 
     while (!stop_requested_.load(std::memory_order_relaxed)) {
+        auto wt0 = std::chrono::steady_clock::now();
         // 0. Graceful pause handshake. When a caller wants exclusive engine
         //    access (embeddings / blocking vision), it calls pause(). We must
         //    NOT cancel in-flight generations — instead we keep stepping until
@@ -283,6 +302,7 @@ void BatchingEngine::worker_loop() {
                        !decode_batch_max.compare_exchange_weak(prev, rows, std::memory_order_relaxed)) {}
             }
         }
+        auto wt1 = std::chrono::steady_clock::now();
         try {
             (void)engine->step();
         } catch (const std::exception& e) {
@@ -347,6 +367,7 @@ void BatchingEngine::worker_loop() {
             continue;
         }
 
+        auto wt2 = std::chrono::steady_clock::now();
         // 4. Deliver new tokens and check for completion. Events are staged
         // and handed to notify_loop_ in ONE batch (see the header note): a
         // direct push_token here wakes the SSE handler before the worker can
@@ -449,6 +470,23 @@ void BatchingEngine::worker_loop() {
                            std::make_move_iterator(staged.end()));
             }
             nq_cv_.notify_one();
+        }
+        if (g_wt.enabled) {
+            auto wt3 = std::chrono::steady_clock::now();
+            auto us = [](auto a, auto b) {
+                return std::chrono::duration<double, std::micro>(b - a).count();
+            };
+            g_wt.admit += us(wt0, wt1);
+            g_wt.step += us(wt1, wt2);
+            g_wt.stage += us(wt2, wt3);
+            if (++g_wt.n >= 256) {
+                const double inv = 1.0 / g_wt.n;
+                IMP_LOG_INFO("worker-timing (n=%d): admit %.0f us, engine-step %.0f, stage %.0f",
+                             g_wt.n, g_wt.admit * inv, g_wt.step * inv, g_wt.stage * inv);
+                g_wt = {};
+                g_wt.enabled = true;
+                g_wt.init_done = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes the last open attribution question from #1754 with numbers instead of a suspicion:

- `diagnostics.step_timing` now decomposes engine phases AND step_impl blocks; the server worker gains `IMP_WORKER_TIMING=1` (admit/step/stage).
- Steady state is clean: resume/constrained/schedule at 0/0/1 us, worker admit+stage 37+21 us.
- The residual "outside" time is the wave ramp: prefills + one decode-graph capture per never-seen batch size. 75 captures over a 4-wave run; wave 1 reads 704 tok/s vs 953-976 steady (waves 2-4).

Roadmap item 0 re-ordered with the new knowledge: (a) genuine Marlin port, (b) decode-graph batch-size buckets with padded rows (the vLLM answer; also what production batch fluctuation pays today), (c) small-class fusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu