### PR TITLE
docs(qwen38): GEMM survey closed for good - seven approaches, one verdict

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -853,6 +853,32 @@ stalls of 26-42 ms). Gap total 422 us/token: GEMM 145, idle 143, small
 launch-coupled classes ~135. Both engine-side posts closed bounds imp at
 ~1195 tok/s aggregate, within 19% of vLLM, before touching the scan.
 
+## The GEMM survey, closed for good (2026-08-25, late evening)
+
+Two final variants after the correction above, both measured e2e at 32
+streams against the 936-990 baseline:
+
+- **CUTLASS 128x64 COOPERATIVE small-M instance** (isolating tile width
+  from the pingpong schedule the earlier experiment conflated): 785.8
+  tok/s. Every narrower-N tile loses on these shapes regardless of
+  schedule.
+- **v8: a cp.async-pipelined rewrite of the own W4A16 kernel** (both
+  tiles streamed through 3 shared-memory stages, evict-first policy on
+  the weight copies, copies issued before the MMAs): 42-47 us isolated
+  (v7 reads 23.9 with an L2 window), 744.2 tok/s e2e. Kilobytes-in-flight
+  alone do not reproduce what the full TMA warp-specialised machinery
+  does at 4 warps per block.
+
+That makes SEVEN independent approaches agreeing on one statement: on
+M<=32 x N=5120-class shapes, nothing below a full Marlin/CUTLASS-grade
+warp-specialised kernel beats the shipping 128x128 cooperative tile IN
+THE REAL STEP. vLLM's Marlin proves the prize exists (468 vs 613
+us/token for the class). Closing the GEMM post therefore means porting
+the actual Marlin kernel (Apache-2.0, several kLOC, its own scale
+format, W4A16): a standalone project, not a session. Until then the
+class is at its practical local optimum; `gemm.nvfp4_smallm` stays OFF
+and documents the verdict in its config comment.
+
 ## Notes for whoever picks this up
 
 - The GPU must be checked free before every job, not once


### PR DESCRIPTION
Two final e2e-measured variants close the M<=32 GEMM survey.

| variant | isolated | e2e @32 (baseline 936-990) |
|---|---|---|
| CUTLASS 128x64 cooperative small-M | built ok | 785.8 tok/s |
| v8 cp.async 3-stage pipeline (W4A16, evict-first weights, issue-before-MMA) | 42-47 us (v7: 23.9 w/ L2 window) | 744.2 tok/s |

Verdict (7th independent refutation): below a full Marlin/CUTLASS-grade warp-specialised kernel nothing beats the shipping 128x128 cooperative tile in the real step on these shapes. Closing the GEMM post = porting actual Marlin (Apache-2.0, W4A16, own scale format) - standalone project. `gemm.nvfp4_smallm` stays OFF.

Doc-only: docs/plans/2026-08-24-qwen38-port.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu