### PR TITLE
perf(serving): decode-graph prewarm at init - wave-1 p50 -3-12%, capture attribution corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **Decode-graph prewarm at init** (`runtime.graph_prewarm`, default on,
+  no-op at `max_batch_size` 1): one staggered dummy batch walks every batch
+  size once before the engine goes ready, so all per-size decode graphs
+  (32/32 in 2.3 s on Qwen3.8-27B) capture at startup instead of during the
+  first wave of real traffic. Wave-1 median request latency -3-12% at 32
+  streams; aggregate throughput unchanged - which retires the "captures
+  cost wave-1 throughput" attribution, see
+  `docs/plans/2026-08-24-qwen38-port.md`.
+
 ### Fixed
 
 - **The decode loop's host time is now instrumented end to end**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,6 @@ there instead of retelling it.
 
 ## [Unreleased]
 
-### Added
-
-- **Decode-graph prewarm at init** (`runtime.graph_prewarm`, default on,
-  no-op at `max_batch_size` 1): one staggered dummy batch walks every batch
-  size once before the engine goes ready, so all per-size decode graphs
-  (32/32 in 2.3 s on Qwen3.8-27B) capture at startup instead of during the
-  first wave of real traffic. Wave-1 median request latency -3-12% at 32
-  streams; aggregate throughput unchanged - which retires the "captures
-  cost wave-1 throughput" attribution, see
-  `docs/plans/2026-08-24-qwen38-port.md`.
-
 ### Fixed
 
 - **The decode loop's host time is now instrumented end to end**
@@ -161,6 +150,14 @@ there instead of retelling it.
 
 ### Added
 
+- **Decode-graph prewarm at init** (`runtime.graph_prewarm`, default on,
+  no-op at `max_batch_size` 1): one staggered dummy batch walks every batch
+  size once before the engine goes ready, so all per-size decode graphs
+  (32/32 in 2.3 s on Qwen3.8-27B) capture at startup instead of during the
+  first wave of real traffic. Wave-1 median request latency -3-12% at 32
+  streams; aggregate throughput unchanged - which retires the "captures
+  cost wave-1 throughput" attribution, see
+  `docs/plans/2026-08-24-qwen38-port.md`.
 - **NVFP4 KV is now the default for QWEN35 (Qwen3.8-27B and its Qwen3.5
   siblings), taking `max_model_len` from 48 512 to 131 072 tokens.** The KV cache
   holds K and V for the 16 attention layers only — 64 KiB/token at FP16 — and on

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -879,6 +879,25 @@ format, W4A16): a standalone project, not a session. Until then the
 class is at its practical local optimum; `gemm.nvfp4_smallm` stays OFF
 and documents the verdict in its config comment.
 
+## Wave-ramp attribution corrected by intervention (2026-08-25)
+
+The per-batch-size graph captures were named the wave-1 cost (75 captures
+over a 4-wave run, wave 1 at 704). The direct intervention refutes the
+throughput half: a graph prewarm at init (one staggered dummy batch,
+anchor request with a ~1000-token prompt to bake the 1024 context bucket,
+32/32 sizes captured in 2.3 s) leaves wave-1 aggregate EXACTLY where it
+was (629-650 tok/s prewarmed against 627 without; steady 953-991 both).
+The captures overlap into the wave's existing host slack.
+
+What moves is latency: wave-1 p50 lands at 6.15-6.26 s across four
+prewarmed trials against 6.40-7.11 s without, p90 6.5 against 7.2-10.3.
+A ~9.9 s straggler cluster at p99 appears in BOTH arms, so it is not
+capture-related and remains unattributed (admission order is the
+suspect). Shipped as `runtime.graph_prewarm`, default on; imp-cli pins
+`max_batch_size=1` and is untouched. Lever (b) of the gap attribution
+(batch-size buckets with padded rows) is retired with the same
+measurement - it would remove work that does not bind.
+
 ## Notes for whoever picks this up
 
 - The GPU must be checked free before every job, not once

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,11 +78,16 @@ Ranked by what an agent workload notices first.
    #1758, and the wave-ramp attribution): (a) a GENUINE Marlin port for the
    M<=32 GEMM class - the split-K wmma kernel built in #1756/#1757 beats
    CUTLASS 42% in isolation but loses e2e without TMA/cp.async pipelining;
-   three measured dead ends bound the design. (b) decode-graph batch-size
-   BUCKETS with padded rows: today every never-seen batch size captures a
-   fresh graph (75 captures over a 4-wave run; wave 1 reads 704 tok/s
-   against 953-976 steady), which is also what production batch fluctuation
-   pays. (c) kernel fusion across the small launch-coupled classes
+   three measured dead ends bound the design. (b) RETIRED as a
+   throughput lever, shipped as a latency one: the graph prewarm (walks one
+   staggered dummy batch at init, 32/32 sizes captured in 2.3 s,
+   `runtime.graph_prewarm`) is the direct intervention - wave-1 aggregate
+   throughput did NOT move (629-650 tok/s prewarmed vs 627 not, same
+   953-991 steady), so the per-size captures never were the wave-1 cost and
+   batch-size buckets with padded rows would buy the same nothing. What the
+   prewarm does buy: wave-1 median request latency -3-12% (p50 6.2 s tight
+   across trials vs 6.4-7.1 s) and a tail that no longer pays first-capture
+   stalls. (c) kernel fusion across the small launch-coupled classes
    (norms 26 us/token, act-quantize 15, elementwise). The
    630-vs-936 delta between auto=28 and pinned=32 on this bench is NOT a
    rotation cost (scheduler admits 28, the last 4 drain as a near-empty

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -150,6 +150,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     }
     S("runtime.cuda_graphs", cfg.runtime.cuda_graphs);
     B("runtime.warmup", cfg.runtime.warmup);
+    B("runtime.graph_prewarm", cfg.runtime.graph_prewarm);
     I("runtime.max_seq_len", cfg.runtime.max_seq_len);
     B("runtime.no_pdl", cfg.runtime.no_pdl);
     B("runtime.debug_raw", cfg.runtime.debug_raw);

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -55,6 +55,17 @@ struct RuntimeConfig {
         // trade reproducibility for init time (dev/CI). Gemma-4 and MXFP4
         // models keep their warmup skips (Engine::warmup).
         bool warmup = true;
+        // Pre-capture the per-batch-size decode graph pool at init (server
+        // shapes only: no-op unless max_batch_size > 1 and graphs are on).
+        // Without it every never-seen batch size pays its capture during the
+        // first wave of real traffic: measured 75 captures across a 4-wave
+        // 32-stream run, wave 1 at 704 tok/s against 953-976 steady. The
+        // prewarm walks one staggered dummy batch from max_batch_size down
+        // to 1 so each pool slot captures before the engine goes ready. One
+        // anchor request carries a ~1000-token prompt so the captures bake
+        // the 1024 context bucket, not the 64 one. Costs init time; set
+        // false to trade first-wave throughput for startup.
+        bool graph_prewarm = true;
         // NOTE: full run-to-run determinism additionally needs stable cuBLAS
         // algo selection across processes — see runtime.deterministic_gemm.
         int max_seq_len = 0;               // 0 = use model default

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -35,6 +35,7 @@
 
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -507,6 +508,79 @@ void Engine::warmup() {
     // failure on consumer GPUs — the error propagates to cuBLAS otherwise).
     cudaGetLastError();
     cudaDeviceSynchronize();  // ensure all weight upload/dequant kernels are done
+
+    // Graph prewarm: capture the per-batch-size decode graph pool BEFORE the
+    // engine goes ready. Continuous batching visits every batch size on the
+    // way up and down, and each never-seen size pays its capture in the first
+    // wave of real traffic (measured: 75 captures across a 4-wave 32-stream
+    // run, wave 1 at 704 tok/s against 953-976 steady). One staggered dummy
+    // batch walks max_batch_size -> 1 so each pool slot captures now. The
+    // last request carries a ~1000-token prompt so max_ctx during every
+    // capture sits in the 1024 pow2 bucket - the growth-only re-capture
+    // trigger (see engine_scheduler.cpp) then stays quiet for real requests
+    // up to that context. Runs before reset_kv_calibration below, so the
+    // synthetic tokens never leave a calibration trace either.
+    if (runtime_config_.runtime.graph_prewarm && config_.use_cuda_graphs &&
+        config_.max_batch_size > 1) {
+        const auto t0 = std::chrono::steady_clock::now();
+        const int n = std::min(config_.max_batch_size, (int)kMaxGraphPoolSize);
+        const int anchor_len = std::min(1000, std::max(16, config_.max_seq_len - 64));
+        std::vector<std::shared_ptr<Request>> reqs;
+        reqs.reserve(n);
+        for (int i = 0; i < n; i++) {
+            auto req = std::make_shared<Request>();
+            req->id = next_request_id_++;
+            // The anchor goes FIRST so its long prefill completes before the
+            // short ones start decoding - queued last, the batch peaked at
+            // n-1 because the shortest-budget request finished during the
+            // anchor's prefill (measured: 31/32 captured).
+            const bool is_anchor = (i == 0);
+            req->input_tokens.resize(is_anchor ? anchor_len : 16, warmup_id);
+            // Staggered budgets: the batch passes through every size n..1;
+            // the anchor lives longest. The +4 base keeps the shortest
+            // request alive across the chunked-prefill window in which late
+            // requests still prefill while early ones already decode - with
+            // a base of 2 the first request finished before the batch ever
+            // assembled fully and size n never captured.
+            req->max_tokens = is_anchor ? n + 8 : i + 4;
+            req->temperature = 0.0f;
+            req->ignore_eos = true;
+            scheduler_->add_request(req);
+            reqs.push_back(std::move(req));
+        }
+        // n+2 decode steps finish the whole ladder; prefill takes a few more.
+        const int step_budget = 4 * n + 32;
+        int steps = 0;
+        auto unfinished = [&]() {
+            for (const auto& r : reqs)
+                if (r->status != RequestStatus::FINISHED) return true;
+            return false;
+        };
+        while (unfinished() && steps < step_budget) {
+            (void)step();
+            steps++;
+        }
+        int captured = 0;
+        std::string missing;
+        for (int i = 0; i < n; i++) {
+            if (decode_graph_pool_[i].is_ready())
+                captured++;
+            else
+                missing += " " + std::to_string(i + 1);
+        }
+        for (const auto& r : reqs) {
+            kv_manager_->free_sequence(r->id);
+            reset_ssm_state(r->id);
+            r->status = RequestStatus::CANCELLED;
+        }
+        while (kv_manager_->evict_cached_block()) {}
+        decode_batch_pool_.reset_upload_cache();
+        cudaDeviceSynchronize();
+        const double dt = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+        IMP_LOG_INFO("graph prewarm: %d/%d decode graphs captured (%d steps, %.1f s)%s%s",
+                     captured, n, steps, dt, missing.empty() ? "" : ", missing sizes:",
+                     missing.c_str());
+    }
     // Drop FP8 KV calibrated_ flags so the first real prefill re-runs absmax
     // and promotes the per-layer scale via high-water-mark. Warmup uses
     // synthetic BOS tokens whose K/V absmax is unrepresentative; without this


### PR DESCRIPTION
## What

`runtime.graph_prewarm` (default on, no-op at `max_batch_size` 1): one staggered dummy batch walks every batch size n..1 during `Engine::warmup()`, before the engine goes ready. Anchor request carries a ~1000-token prompt so every capture bakes the 1024 pow2 context bucket (growth-only re-capture trigger stays quiet up to that context). Runs before `reset_kv_calibration`, so the synthetic tokens leave no calibration trace. 32/32 graphs captured in 2.3 s on Qwen3.8-27B-NVFP4 at batch 32.

## Measured (32 streams, alternating fresh servers)

| metric | prewarm on | off |
|---|---|---|
| wave-1 aggregate | 629-650 tok/s | 627 tok/s |
| steady waves 2-4 | 954-991 | 955-987 |
| wave-1 p50 (4 trials) | 6.15-6.26 s | 6.40-7.11 s |
| wave-1 p90 | 6.46-6.51 s | 7.21-10.28 s |
| init cost | +2.3 s | - |

- Wave-1 throughput UNCHANGED: refutes the capture attribution for the wave ramp; roadmap lever (b) batch-size buckets with padded rows retired by the same measurement.
- p99 straggler ~9.9 s exists in BOTH arms, unattributed (admission order suspected).
- Coherence probe green (Paris), `make dev-test` 8/8, pre-push verify-fast green.

## Iterations

31/32 first (anchor queued last: shortest request died during anchor prefill), 31/32 second (base budget 2 died inside the chunked-prefill window), 32/32 with anchor-first + base budget 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu