### PR TITLE
perf(serving): a 32-stream burst no longer starves its own tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ there instead of retelling it.
 
 ### Fixed
 
+- **A 32-stream burst no longer starves its own tail.** Three defects, one
+  per layer, found by tracing per-request arrival and first-prefill times:
+  the HTTP worker pool was sized to cores (cpp-httplib default max(8,
+  cores-1) = 15 here) while a streamed completion holds its worker for the
+  whole generation, so late requests ARRIVED 4-7 s late; the prefill
+  scheduler ran one forward per step while anyone decoded
+  (`prefill_batch_decode_cap` 1 -> 0, replaced by a token-charged budget:
+  one full `prefill_chunk_decode_cap` chunk per step as before, several
+  small prompts together, each charged a 256-token launch-cost floor); and
+  the prefill round-robin rotor drifted over the shrinking batch (now
+  rotates by last-served request id). At 32 streams: TTFT max 6.8-8.0 s ->
+  2.2-3.7 s, stragglers 1-10 -> 0, and the 4-wave bench reads 1047-1073
+  tok/s on EVERY wave against 629/954-991 before - the wave-1 "ramp" was
+  these defects. Details: `docs/plans/2026-08-24-qwen38-port.md`.
+
 - **The decode loop's host time is now instrumented end to end**
   (`diagnostics.step_timing`: engine phases + step_impl blocks;
   `IMP_WORKER_TIMING=1`: server worker phases). It settled the last idle

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -898,6 +898,62 @@ suspect). Shipped as `runtime.graph_prewarm`, default on; imp-cli pins
 (batch-size buckets with padded rows) is retired with the same
 measurement - it would remove work that does not bind.
 
+## The burst tail, traced to three defects (2026-08-25, night)
+
+The ~9.9 s p99 straggler both prewarm arms showed was pulled apart with
+per-request TTFT tracing (streamed completions, arrival logged at
+`Scheduler::add_request`, first prefill logged in the prefill loop). At
+32 concurrent requests the tail was 6-10 requests whose FIRST token
+waited until the wave drained, and the engine was innocent for most of
+it: their HTTP requests ARRIVED at the scheduler 4-7 s late.
+
+Three defects, one per layer:
+
+1. **HTTP worker pool sized to cores, not streams** (tools/imp-server/
+   main.cpp). cpp-httplib's default task queue is max(8, cores-1) = 15
+   threads on this box; a streamed completion holds its worker for the
+   whole generation, so requests 16..32 of a burst queued behind
+   finished streams. Fix: `svr.new_task_queue` sized to
+   `max_concurrent + 8`. This was the whole arrival delay.
+2. **Prefill throttled to one forward per step while anyone decodes**
+   (`prefill_batch_decode_cap = 1`, #1643). Correct for its measured
+   case (a 5.2k-token ingest beside streaming decoders) but it
+   serialised 31 short prompts to one per engine step - the decoders it
+   protected were the burst's own first finishers. Fix: token-charged
+   budget (`prefill_chunk_decode_cap` per step, each forward charged at
+   least 256 tokens for its launch-bound floor) - one full-sized chunk
+   per step as before, several small prompts together. Count cap
+   default 0, still available on top.
+3. **The prefill round-robin rotor drifted under membership churn**
+   (index-based; requests leave the list as they finish prefill, so the
+   rotor jumped a moving cohort). Fix: rotate by last-served request id.
+
+During the fix a fourth bug appeared and was caught by the same logs:
+the budget's break condition `token_budget > 0 && charge > token_budget`
+DISARMED itself once the budget hit exactly 0 and ran the whole batch -
+`budgeted` flag separated "feature on" from "budget left".
+
+Measured (32 streams, fresh server per run):
+
+| pattern | before | after |
+|---|---|---|
+| 32x identical short | wall 9.8 s, 3 stragglers | wall 6.0 s, 0 |
+| 32x unique short | wall 8.3 s, 1 straggler | wall 6.2 s, 0 |
+| 32x unique ~130 tok | wall 9.5-11.0 s, TTFT max 6.8-7.3 | wall 6.9-7.6 s, TTFT max 2.2-2.8 (3 trials) |
+| 32x shared prefix + unique tail | wall 9.8 s, TTFT max 8.0 | wall 6.1 s, TTFT max 3.7 |
+| waves3 (4 waves x 32) | wave1 629, steady 954-991 | ALL waves 1047-1073 |
+
+The steady-state waves gain ~8-10% because every wave START was paying
+the same three defects. Aggregate at 32 streams is now ~1070 tok/s
+against vLLM's ~1450: the 1.58x gap of the original attribution, after
+deferred delivery (#1758) and this, stands at ~1.35x.
+
+Remaining in this area: all 32 first tokens still take 2-3.5 s when 32
+long-ish prompts land at once - burst prefill runs one sequence per
+forward at ~1700 tok/s effective (launch-bound, 64 layers), where
+cross-sequence prefill batching (M>1) would amortise it. Priced as the
+follow-up in the roadmap.
+
 ## Notes for whoever picks this up
 
 - The GPU must be checked free before every job, not once

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,7 +88,15 @@ Ranked by what an agent workload notices first.
    prewarm does buy: wave-1 median request latency -3-12% (p50 6.2 s tight
    across trials vs 6.4-7.1 s) and a tail that no longer pays first-capture
    stalls. (c) kernel fusion across the small launch-coupled classes
-   (norms 26 us/token, act-quantize 15, elementwise). The
+   (norms 26 us/token, act-quantize 15, elementwise). (d) cross-sequence
+   prefill batching: a 32-prompt burst prefills one sequence per forward
+   at ~1700 tok/s effective (launch-bound, 64 layers), so every first
+   token waits 2-3.5 s; batching prefill rows the way decode batches
+   would amortise the fixed cost. UPDATE 2026-08-25 night: after the
+   burst-serving fixes (HTTP pool sized to streams, token-charged prefill
+   budget, id-based rotor - see the plan doc) the 4-wave bench reads
+   1047-1073 tok/s on every wave; the measured gap to vLLM stands at
+   ~1.35x. The
    630-vs-936 delta between auto=28 and pinned=32 on this bench is NOT a
    rotation cost (scheduler admits 28, the last 4 drain as a near-empty
    batch; auto=28 sustains full rate under continuous arrival); raising

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -165,7 +165,16 @@ struct RuntimeConfig {
         // ones. Same trade the chunk cap above already takes (+27% TTFT for
         // bounded latency), so the default follows it. The cap does not apply
         // when nobody is decoding, so batch ingest throughput is untouched.
-        int prefill_batch_decode_cap = 1;
+        // Default 0 since the token-charged budget (engine_scheduler.cpp,
+        // prefill loop) took over the protective role: the budget admits
+        // exactly one FULL-sized chunk per step (the #1643 schedule for
+        // large ingests, unchanged by construction) but lets several small
+        // prompts through together, each charged a 256-token launch-cost
+        // floor. The count cap of 1 serialised 31 concurrent ~110-token
+        // prompts to one per engine step: burst-arrival TTFT reached 8 s at
+        // 32 streams while the pool sat idle. Set a positive value to
+        // reimpose a hard forward-count cap on top of the token budget.
+        int prefill_batch_decode_cap = 0;
         // Hybrid (SSM/GDN) decode fairness: the recurrent scan kernels are
         // single-sequence, so concurrent sessions time-slice the decode.
         // This is the slice length in tokens — after it, the engine rotates

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -432,7 +432,7 @@ private:
     // Round-robin cursor for runtime.prefill_batch_decode_cap (#1643): taking a
     // fixed prefix of the batch would starve every later ingest, which is the
     // failure #1634/#1637 came from.
-    size_t sched_prefill_rr_ = 0;
+    int sched_prefill_last_id_ = -1;
     std::vector<std::shared_ptr<Request>> sched_decode_batch_;
     std::vector<std::shared_ptr<Request>> valid_decode_;
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -614,25 +614,65 @@ void Engine::step_prefill(cudaStream_t stream) {
         effective_chunk = capped;
     }
 
-    // Decode-aware batching: the cap above bounds the SIZE of one chunk, this
-    // one bounds how MANY of them run before the decoders get their step
-    // (#1643). Starting index rotates so the ingests that do not run this step
-    // are the ones that ran last step.
+    // Decode-aware batching: the size cap above bounds ONE chunk, this bounds
+    // how much prefill runs per step before the decoders get their turn
+    // (#1643). The budget is TOKEN-charged, not forward-counted: the old
+    // count cap of 1 was measured on ~5.2k-token ingests, where one forward
+    // IS the whole latency story - but it also serialised 31 concurrent
+    // ~110-token prompts to one per engine step, which starved a burst
+    // arrival for seconds (TTFT up to 8 s at 32 streams; the decoders being
+    // protected were the burst's own first finishers). Each forward charges
+    // at least kPrefillForwardFloorTokens, because a short forward's cost is
+    // launch-bound (64 layers), not token-bound - so a 1024 budget admits at
+    // most 4 small forwards (~100 ms stall, the same bound the size cap
+    // targets) and exactly 1 full-sized chunk (the #1643 schedule,
+    // unchanged). Starting index rotates so the ingests that do not run this
+    // step are the ones that ran last step.
     const size_t n_prefill = sched_prefill_batch_.size();
     size_t budget = n_prefill;
     const int batch_cap = runtime_config_.runtime.prefill_batch_decode_cap;
     if (batch_cap > 0 && !sched_decode_batch_.empty() && n_prefill > static_cast<size_t>(batch_cap))
         budget = static_cast<size_t>(batch_cap);
+    constexpr int kPrefillForwardFloorTokens = 256;
+    const bool budgeted = decode_cap > 0 && !sched_decode_batch_.empty();
+    int token_budget = budgeted ? std::max(decode_cap, kPrefillForwardFloorTokens) : 0;
 
+    // Rotation is by request ID, not by index: requests LEAVE the batch as
+    // their prefill completes, so an index-based rotor drifts over the
+    // shrunken list and systematically jumps a moving cohort (measured as
+    // 5 of 32 burst requests starved to wave-end TTFT while the budget had
+    // room). The rotor remembers the last-served id and starts just past
+    // it; ids are admission-ordered, so this is a clean round-robin under
+    // membership churn.
+    size_t start = 0;
+    for (size_t i = 0; i < n_prefill; i++) {
+        if (sched_prefill_batch_[i]->id > sched_prefill_last_id_) {
+            start = i;
+            break;
+        }
+    }
+    size_t ran = 0;
     for (size_t i = 0; i < budget; i++) {
-        auto& req = sched_prefill_batch_[(sched_prefill_rr_ + i) % n_prefill];
+        auto& req = sched_prefill_batch_[(start + i) % n_prefill];
+        // Charge from the PRE-call remaining: step_prefill_one advances
+        // prefill_offset, so reading it afterwards undercharges any chunk
+        // that does not finish the prompt.
+        const int remaining = static_cast<int>(req->input_tokens.size()) - req->prefill_offset;
+        const int charge = std::max(kPrefillForwardFloorTokens,
+                                    std::min(std::max(remaining, 0), effective_chunk));
+        // `budgeted`, not `token_budget > 0`: an exhausted budget must break,
+        // not disarm the check (that bug ran the whole batch after charge 4).
+        if (budgeted && ran > 0 && charge > token_budget)
+            break;
         step_prefill_one(req, effective_chunk, stream);
         kv_manager_->touch(req->id);
+        ran++;
+        sched_prefill_last_id_ = req->id;
+        if (budgeted)
+            token_budget -= charge;
     }
-    if (budget < n_prefill)
-        sched_prefill_rr_ = (sched_prefill_rr_ + budget) % n_prefill;
-    else
-        sched_prefill_rr_ = 0;
+    if (ran >= n_prefill)
+        sched_prefill_last_id_ = -1;
 }
 
 // =====================================================================

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 2192, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 2210, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }

--- a/tools/imp-server/main.cpp
+++ b/tools/imp-server/main.cpp
@@ -170,6 +170,16 @@ int main(int argc, char** argv) {
     svr.set_read_timeout(args.read_timeout, 0);
     svr.set_write_timeout(args.write_timeout, 0);
     svr.set_keep_alive_max_count(args.keep_alive_max);
+    // Worker threads must cover the CONCURRENT STREAMS, not the cores: a
+    // streamed completion holds its worker for the whole generation, and the
+    // library default (max(8, cores-1) = 15 here) silently queued the tail
+    // of a 32-stream burst behind finished streams - measured as 6-10
+    // requests arriving at the scheduler 4-7 s late with TTFT at wave-end
+    // while the engine sat ready (2026-08-25). +8 covers health checks and
+    // admin routes while every stream slot is held.
+    svr.new_task_queue = [&args] {
+        return new httplib::ThreadPool(static_cast<size_t>(args.max_concurrent) + 8);
+    };
 
     // Store API key and limits in state
     state.api_key = args.api_key;


### PR DESCRIPTION
## What

Three defects, one per layer, found by tracing per-request arrival (`Scheduler::add_request`) and first-prefill times at 32 concurrent streams:

| layer | defect | fix |
|---|---|---|
| HTTP ingress | cpp-httplib default pool = max(8, cores-1) = 15 threads; a streamed completion holds its worker for the whole generation - burst requests 16..32 ARRIVED 4-7 s late | `svr.new_task_queue` sized to `max_concurrent + 8` |
| prefill scheduling | `prefill_batch_decode_cap=1` (#1643) ran ONE prefill forward per step while anyone decoded - 31 short prompts serialised behind the burst's own first finishers | token-charged budget: one full `prefill_chunk_decode_cap` chunk per step (the #1643 schedule for large ingests, unchanged by construction), several small prompts together, each charged a 256-token launch-cost floor; count cap default 1 -> 0, still available on top |
| prefill rotor | index-based round-robin over a list requests leave as they finish - drifted and starved a moving cohort | rotates by last-served request id |

En route: the budget's break guard (`token_budget > 0 && ...`) disarmed itself at exactly 0 remaining and ran the whole batch - separated into a `budgeted` flag.

## Measured (32 streams, Qwen3.8-27B-NVFP4, fresh server per run)

| pattern | before | after |
|---|---|---|
| 32x unique ~130-token prompts | TTFT max 6.8-7.3 s, 1-10 stragglers | TTFT max 2.2-2.8 s, 0 stragglers (3/3 trials) |
| 32x shared prefix + unique tail | wall 9.8 s, TTFT max 8.0 | wall 6.1 s, TTFT max 3.7 |
| 32x identical short | wall 9.8 s | wall 6.0 s |
| 4-wave bench (4x 32 x 200 tok) | wave1 629, steady 954-991 | 1047-1073 on EVERY wave |

The wave-1 "ramp" was these defects; steady waves gain ~8-10% because every wave START paid them. Gap to vLLM at 32 streams: ~1.35x (was 1.58x at attribution time). Follow-up priced in roadmap: cross-sequence prefill batching (burst prefill is launch-bound at ~1700 tok/s effective).

Coherence probe green, `make dev-test` 8/8, pre-push verify-fast green (decode/prefill/VRAM/graphs/smoke all PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu