### PR TITLE
perf(gemm): native mxf4nvf4 small-M GEMM v2, batched decode +16% at 32 streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- **Native mxf4nvf4 small-M GEMM (v2) for batched decode, default ON.** The
+  M<=32 decode projections on NVFP4 checkpoints now run a block-scaled
+  `mma.sync.kind::mxf4nvf4` kernel with a producer/consumer cp.async+mbarrier
+  pipeline on the plain weight layout (no dequant, no second weight copy —
+  the route the discarded Marlin W4A16 sidecar PR #1764 approximated with
+  12.8 GiB of repack). Qwen3.8-27B-NVFP4, alternating A/B, 3 trials:
+  32 streams 992.5 -> 1151.7 tok/s aggregate (+16.0%), 8 streams 363.8 ->
+  494.6 (+36.0%); isolated M=32 N=5120 K=5120 10.4 us vs CUTLASS's 41.4
+  in-situ (weight floor 8.2). degen_suite 50/0. `gemm.nvfp4_smallm_impl=1`
+  keeps the refuted W4A16 kernel for A/B. Design + kill-gates:
+  `docs/plans/2026-08-24-qwen38-port.md`.
+
 ### Fixed
 
 - **A 32-stream burst no longer starves its own tail.** Three defects, one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,6 @@ there instead of retelling it.
 
 ## [Unreleased]
 
-### Added
-
-- **Native mxf4nvf4 small-M GEMM (v2) for batched decode, default ON.** The
-  M<=32 decode projections on NVFP4 checkpoints now run a block-scaled
-  `mma.sync.kind::mxf4nvf4` kernel with a producer/consumer cp.async+mbarrier
-  pipeline on the plain weight layout (no dequant, no second weight copy —
-  the route the discarded Marlin W4A16 sidecar PR #1764 approximated with
-  12.8 GiB of repack). Qwen3.8-27B-NVFP4, alternating A/B, 3 trials:
-  32 streams 992.5 -> 1151.7 tok/s aggregate (+16.0%), 8 streams 363.8 ->
-  494.6 (+36.0%); isolated M=32 N=5120 K=5120 10.4 us vs CUTLASS's 41.4
-  in-situ (weight floor 8.2). degen_suite 50/0. `gemm.nvfp4_smallm_impl=1`
-  keeps the refuted W4A16 kernel for A/B. Design + kill-gates:
-  `docs/plans/2026-08-24-qwen38-port.md`.
-
 ### Fixed
 
 - **A 32-stream burst no longer starves its own tail.** Three defects, one
@@ -178,6 +164,18 @@ there instead of retelling it.
   reasoning-effort preamble. `is not undefined` added alongside.
 
 ### Added
+
+- **Native mxf4nvf4 small-M GEMM (v2) for batched decode, default ON.** The
+  M<=32 decode projections on NVFP4 checkpoints now run a block-scaled
+  `mma.sync.kind::mxf4nvf4` kernel with a producer/consumer cp.async+mbarrier
+  pipeline on the plain weight layout (no dequant, no second weight copy —
+  the route the discarded Marlin W4A16 sidecar PR #1764 approximated with
+  12.8 GiB of repack). Qwen3.8-27B-NVFP4, alternating A/B, 3 trials:
+  32 streams 992.5 -> 1151.7 tok/s aggregate (+16.0%), 8 streams 363.8 ->
+  494.6 (+36.0%); isolated M=32 N=5120 K=5120 10.4 us vs CUTLASS's 41.4
+  in-situ (weight floor 8.2). degen_suite 50/0. `gemm.nvfp4_smallm_impl=1`
+  keeps the refuted W4A16 kernel for A/B. Design + kill-gates:
+  `docs/plans/2026-08-24-qwen38-port.md`.
 
 - **Decode-graph prewarm at init** (`runtime.graph_prewarm`, default on,
   no-op at `max_batch_size` 1): one staggered dummy batch walks every batch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(IMP_QUANT_SOURCES
     src/quant/nvfp4_gemv_dense.cu
     src/quant/nvfp4_gemv_batched.cu
     src/quant/nvfp4_gemm_smallm.cu
+    src/quant/nvfp4_gemm_smallm_v2.cu
     src/quant/nvfp4_gemv_fused.cu
     src/quant/nvfp4_gemv_moe.cu
     src/quant/mxfp4_gemm.cu
@@ -895,6 +896,7 @@ if(IMP_BUILD_TESTS)
         tests/test_cutlass_grouped_ref.cu
         tests/test_cutlass_nvfp4_alpha.cu
         tests/test_nvfp4_smallm.cu
+        tests/test_nvfp4_smallm_v2.cu
         tests/test_smallm_dense_bench.cu
         tests/test_gemm_grouped_nvfp4_smallM.cu
         tests/test_nvfp4_batched_smallm_equiv.cu

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -961,3 +961,42 @@ follow-up in the roadmap.
 - `imp:test` is the `make build` image; `make dev` does not rebuild it.
 - Reproduce the concurrency numbers with `runtime.max_batch_size` pinned — free
   VRAM before the weight upload swings by ~1.6 GB between runs.
+
+## Small-M GEMM v2 - the native mxf4nvf4 pipeline pays (2026-08-25, night)
+
+The route the smallm postmortem priced ("a real Marlin port ... not another
+dispatch or load-hint variant") shipped as a native block-scaled kernel
+instead of a W4A16 port, and it holds e2e where v1 and the A4 variant died:
+
+- Kernel: `src/quant/nvfp4_gemm_smallm_v2.cu`. M32xN64xK256 stages, 6-deep
+  smem ring, 1 producer warp (cp.async.cg 16B + mbarrier, consumers never
+  issue a global load), 4 consumer warps on
+  `mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64`, both sides
+  plain NVFP4 (weights read in place - zero extra VRAM; activations from the
+  existing per-step quantize scratch). Direct FP16 epilogue at stripes=1;
+  deterministic split-K reduce otherwise. Fragment/SF mappings are the
+  CUTLASS `SM120_16x8x64_TN_VS` layouts; the plain nibble order IS the
+  fragment register order, so operands are plain u32 smem loads.
+- Isolated (M=32 N=5120 K=5120, warm clocks): 10.4 us vs CUTLASS 41.4
+  in-situ / 21-24 isolated, v1 23.9, Marlin sidecar 14.4; weight floor 8.2.
+  Stage/stripe sweep: stripes=1 beats every split-K config (deltas track
+  reduce traffic, not CTA count); stages 6 > 4 > 3 > 2.
+- The real step (Qwen3.8-27B-NVFP4, mbs=32/seq4096 pinned, unique short
+  prompts, 300-tok gens, 3 waves/trial, fresh server, alternating, 3
+  trials/arm): 32 streams 992.5 -> 1151.7 tok/s aggregate (+16.0%), 8
+  streams 363.8 -> 494.6 (+36.0%). All 9 ON waves above all 9 OFF waves at
+  both concurrencies - no bimodality. degen_suite 50/0 ON.
+- The GDN-scan L2 interaction that killed v1 (45.8 us in-situ vs 23.9
+  isolated) does not reappear: the pipeline's latency tolerance was the
+  missing property, as the postmortem predicted.
+- PPL was NOT re-measured for this change: teacher-forced perplexity runs
+  prefill (M=2048 -> CUTLASS), which cannot reach the batched-decode-only
+  path; the numerics family (quantized activations x plain-NVFP4 weights)
+  matches the CUTLASS path it replaces. Quality evidence is the server-level
+  degen battery.
+- Follow-ups recorded, not smuggled in: gate|up fusion (one N=34816 stripe
+  set), in-kernel activation quantize (the 292-launch post), per-shape
+  stage/stripe table beyond the measured N=5120 reference.
+
+[PROV: commit=15857dff+wiring date=2026-08-25 hw=RTX5090 cuda=13.3
+       model=Qwen3.8-27B-NVFP4 harness=scratchpad ab_conc.sh md5=63a8dfd73060a44f2e7a17bf3a32f5e4 n=3/arm]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,10 +75,12 @@ Ranked by what an agent workload notices first.
    classes mostly coupled to the launch count. Closing the two engine-side
    posts alone bounds imp at ~1195 tok/s, within 19% of vLLM. Levers, in
    value order (updated 2026-08-25 evening after the deferred-delivery win,
-   #1758, and the wave-ramp attribution): (a) a GENUINE Marlin port for the
-   M<=32 GEMM class - the split-K wmma kernel built in #1756/#1757 beats
-   CUTLASS 42% in isolation but loses e2e without TMA/cp.async pipelining;
-   three measured dead ends bound the design. (b) RETIRED as a
+   #1758, and the wave-ramp attribution): (a) CLOSED 2026-08-25 night: the
+   native mxf4nvf4 small-M v2 kernel (producer/consumer cp.async pipeline on
+   the plain layout, `gemm.nvfp4_smallm` default ON) measures +16.0%
+   aggregate at 32 streams (992.5 -> 1151.7) and +36.0% at 8 (363.8 ->
+   494.6) on Qwen3.8-27B-NVFP4 - the GEMM-class post is paid without the
+   Marlin sidecar's repacked weight copy (PR #1764 closed unmerged). (b) RETIRED as a
    throughput lever, shipped as a latency one: the graph prewarm (walks one
    staggered dummy batch at init, 32/32 sizes captured in 2.3 s,
    `runtime.graph_prewarm`) is the direct intervention - wave-1 aggregate

--- a/src/core/config/gemm.h
+++ b/src/core/config/gemm.h
@@ -117,23 +117,28 @@ struct GEMM {
     // LM head (for_each_lm_head_batch_ allow_cutlass=false) never take
     // this path. Set false for maximum batched-serving coherence.
     bool nvfp4_lm_head_cutlass = true;
-    // Small-M (<=32) NVFP4 GEMM for batched decode: W4A16 dequant-to-FP16 +
-    // HMMA + split-K on the plain weight layout. Isolated it beats the
-    // grid-starved CUTLASS 128x128 block-scaled tile 41.4 -> 23.9 us on the
-    // N=5120 decode shape — but only with an L2 access-policy window pinning
-    // the x tile; in the real batched step (GDN scan streaming 9.7 GB/step
-    // through L2) it runs at 45.8 us and costs ~11% aggregate (measured
-    // 824-836 vs 933-935 tok/s at 32 streams, alternating A/B, 2026-08-25).
-    // Default OFF. BOTH priced routes are now measured: the A4 variant
-    // (quantized activations, x 327 KB -> ~92 KB) reads 742-747 tok/s
-    // aggregate at 32 streams against 955-963 OFF — worse than the FP16
-    // variant's 824-836, the per-GEMM quantize launch included. The x
-    // working set was not the main driver: the split-K kernel is bimodal
-    // even at 92 KB. What the shipping CUTLASS path has that these SIMT-load
-    // kernels lack under real step pressure is TMA + a cp.async pipeline —
-    // i.e. the remaining route is a real Marlin port (ldmatrix/mma pipeline,
-    // stripe partitioning), not another dispatch or load-hint variant.
-    bool nvfp4_smallm = false;
+    // Small-M (<=32) NVFP4 GEMM for batched decode (impl selected below).
+    // History: the W4A16 dequant+HMMA v1 won isolated (23.9 vs CUTLASS's
+    // 41.4 us in-situ on N=5120) and LOST the real 32-stream step (45.8 us,
+    // -11% aggregate) — its synchronous SIMT loads are exposed to the GDN
+    // scan's L2 pressure, and the A4 variant proved footprint was not the
+    // driver (742-747 vs 955-963 tok/s). The v2 kernel closes exactly that
+    // hole: native block-scaled mxf4nvf4 MMA fed by a producer/consumer
+    // cp.async+mbarrier pipeline on the SAME plain weight bytes the M=1
+    // GEMVs read — zero extra VRAM (unlike the discarded Marlin W4A16
+    // sidecar, PR #1764, which needed a repacked second weight copy and
+    // capped out at 13% coverage on the 27B). Measured 2026-08-25,
+    // Qwen3.8-27B-NVFP4, mbs=32/seq4096, alternating A/B, 3 trials each:
+    // 32 streams 992.5 -> 1151.7 tok/s aggregate (+16.0%, all 9 ON waves
+    // above all 9 OFF waves), 8 streams 363.8 -> 494.6 (+36.0%); isolated
+    // M=32 N=5120 K=5120: 10.4 us vs CUTLASS 41.4 in-situ (weight floor
+    // 8.2). degen_suite 50/0 ON. Default ON since the v2 A/B.
+    bool nvfp4_smallm = true;
+    // Which small-M implementation the gate above dispatches: 1 = the W4A16
+    // dequant+HMMA kernel (kept for A/B), 2 = the native mxf4nvf4
+    // producer/consumer pipeline (nvfp4_gemm_smallm_v2.cu; isolated 10.4 us
+    // on M=32 N=5120 K=5120 vs v1's 23.9 and CUTLASS's 41.4 in-situ).
+    int nvfp4_smallm_impl = 2;
     // (gemm.nvfp4_ssm_proj — the 2026-05-30 opt-in that forced GGUF-hybrid
     // GDN projections into the NVFP4 decode cache — was REMOVED 2026-07-11:
     // it had bit-rotted in the tier refactors (measured 71 tok/s vs its

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -334,20 +334,17 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             return;
         }
 
-        // Small-M NVFP4 GEMM (gemm.nvfp4_smallm, default on): batched decode
-        // at n_seq <= 32 used to run these through the CUTLASS 128x128
-        // block-scaled tile — 40 CTAs on the N=5120 shapes, 41.4 us for a
-        // 14 MB weight read (19% of the floor; the cross-engine profile in
-        // BENCHMARKS.md). gemm_nvfp4_smallm is the Marlin recipe (W4A16:
-        // dequant-to-FP16 in smem + HMMA + split-K) on the SAME plain weight
-        // bytes the M=1 decode GEMVs read: 23.9 us median on that shape.
-        // W4A16 vs the CUTLASS path's quantized activations is a numerics
-        // upgrade, not a match. Default OFF: in the real step the GDN scan's
-        // L2 traffic evicts the x tile and the kernel runs at 45.8 us
-        // (isolated: 23.9 with a policy window), costing ~11% aggregate —
-        // see the gemm.h comment for the numbers and the two routes that
-        // would flip the sign. Spec-verify chunks keep their documented
-        // paths (argmax parity, #1055).
+        // Small-M NVFP4 GEMM (gemm.nvfp4_smallm, default ON since v2):
+        // batched decode at n_seq <= 32 used to run these through the
+        // CUTLASS 128x128 block-scaled tile — 40 CTAs on the N=5120 shapes,
+        // 41.4 us for a 14 MB weight read (19% of the floor). impl 2 (the
+        // default) is the native mxf4nvf4 producer/consumer pipeline on the
+        // SAME plain weight bytes the M=1 decode GEMVs read — measured
+        // +16.0% aggregate at 32 streams / +36.0% at 8 on Qwen3.8-27B-NVFP4
+        // (gemm.h has the numbers); impl 1 keeps the refuted W4A16
+        // dequant+HMMA kernel for A/B. Both read quantized activations
+        // (same numerics family as the CUTLASS path). Spec-verify chunks
+        // keep their documented paths (argmax parity, #1055).
         if (runtime_config().gemm.nvfp4_smallm && !ctx.spec_verify_small_m && M <= 32 &&
             (ctx.beta == 0.0f || ctx.beta == 1.0f) && input.qtype == QType::F16 &&
             output.qtype == QType::F16 && h.primary_tier == StorageTier::CUTLASS_NVFP4 &&
@@ -355,7 +352,11 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
             !dequant_gpu_supported(h.source_qtype) && (h.shape[1] * 2) % 128 == 0) {
             const int N = static_cast<int>(h.shape[0]);
             const int K = static_cast<int>(h.shape[1] * 2);
-            const size_t need = gemm_nvfp4_smallm_workspace_bytes(N);
+            // impl 2 = the native mxf4nvf4 pipeline kernel (v2), impl 1 = the
+            // W4A16 dequant+HMMA kernel; unaligned shapes fall back to v1.
+            const bool v2 = runtime_config().gemm.nvfp4_smallm_impl == 2 && (K % 256) == 0 && (N % 64) == 0;
+            const size_t need = v2 ? gemm_nvfp4_smallm_v2_workspace_bytes(N, K)
+                                   : gemm_nvfp4_smallm_workspace_bytes(N);
             if (need > smallm_ws_bytes_) {
                 cudaStreamCaptureStatus cap = cudaStreamCaptureStatusNone;
                 if (cudaStreamIsCapturing(ctx.stream, &cap) != cudaSuccess)
@@ -411,8 +412,13 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                 xq.tensor_scale = 1.0f;
                 xq.N = M;
                 xq.K = K;
-                if (gemm_nvfp4_smallm_a4(nv, xq, reinterpret_cast<half*>(output.data), M, N, K,
-                                         smallm_ws_, ctx.stream, /*accumulate=*/ctx.beta == 1.0f))
+                const bool ok = v2 ? gemm_nvfp4_smallm_v2_a4(nv, xq, reinterpret_cast<half*>(output.data), M,
+                                                             N, K, smallm_ws_, ctx.stream,
+                                                             /*accumulate=*/ctx.beta == 1.0f)
+                                   : gemm_nvfp4_smallm_a4(nv, xq, reinterpret_cast<half*>(output.data), M, N,
+                                                          K, smallm_ws_, ctx.stream,
+                                                          /*accumulate=*/ctx.beta == 1.0f);
+                if (ok)
                     return;
             }
         }

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -54,6 +54,19 @@ bool gemm_nvfp4_smallm(const NvFP4QuantResult& W, const half* x, half* y, int M,
 bool gemm_nvfp4_smallm_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
                           int N_out, int K, void* d_workspace, cudaStream_t stream,
                           bool accumulate = false);
+// v2: native block-scaled mxf4nvf4 MMA on both plain-NVFP4 sides, fed by a
+// producer/consumer cp.async pipeline (no dequant, no FP16 staging). M <= 32,
+// K % 256 == 0, N % 64 == 0; see nvfp4_gemm_smallm_v2.cu for the design and
+// gemm.h for the v1 postmortem that motivates it.
+int gemm_nvfp4_smallm_v2_stripes(int N_out, int K);
+size_t gemm_nvfp4_smallm_v2_workspace_bytes(int N_out, int K);
+bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
+                             int N_out, int K, void* d_workspace, cudaStream_t stream,
+                             bool accumulate = false);
+// Tuning hook (tests only): explicit stage depth {2,3,4,6} and stripe count.
+bool gemm_nvfp4_smallm_v2_a4_tuned(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
+                                   int N_out, int K, void* d_workspace, cudaStream_t stream,
+                                   bool accumulate, int stages, int stripes);
 
 void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
                         int n_act, cudaStream_t stream);

--- a/src/quant/nvfp4_gemm_smallm_v2.cu
+++ b/src/quant/nvfp4_gemm_smallm_v2.cu
@@ -50,10 +50,10 @@ constexpr int kThreads = 160;  // 4 consumer warps + 1 producer warp
 constexpr int kNibStride = 144;
 constexpr int kSfStride = 16;
 
-constexpr int kWNibBytes = kNR * kNibStride;   // 9216
-constexpr int kXNibBytes = kSmM * kNibStride;  // 4608
-constexpr int kWSfBytes = kNR * kSfStride;     // 1024
-constexpr int kXSfBytes = kSmM * kSfStride;    // 512
+constexpr int kWNibBytes = kNR * kNibStride;                                  // 9216
+constexpr int kXNibBytes = kSmM * kNibStride;                                 // 4608
+constexpr int kWSfBytes = kNR * kSfStride;                                    // 1024
+constexpr int kXSfBytes = kSmM * kSfStride;                                   // 512
 constexpr int kStageBytes = kWNibBytes + kXNibBytes + kWSfBytes + kXSfBytes;  // 15360
 constexpr int kDefaultStages = 6;  // smem ring depth; 6 measured best at stripes=1 (sweep 2026-08-25)
 
@@ -133,9 +133,8 @@ __global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed
                                             const uint8_t* __restrict__ w_scales,
                                             const uint8_t* __restrict__ xq_packed,
                                             const uint8_t* __restrict__ xq_scales,
-                                            float* __restrict__ ws_partials, half* __restrict__ y,
-                                            float ts, int acc_flag, int M, int N_out, int K,
-                                            int stripes) {
+                                            float* __restrict__ ws_partials, half* __restrict__ y, float ts,
+                                            int acc_flag, int M, int N_out, int K, int stripes) {
     extern __shared__ uint8_t smem[];
     __shared__ uint64_t bar_full[kStages];
     __shared__ uint64_t bar_empty[kStages];
@@ -216,7 +215,7 @@ __global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed
         const int warp_n = warp >> 1;
         const int T0 = lane & 3;
         const int T1 = lane >> 2;
-        const int a_row = warp_m * 16 + T1;              // A fragment row (V1=0)
+        const int a_row = warp_m * 16 + T1;  // A fragment row (V1=0)
         const int sfa_row = warp_m * 16 + (lane & 1) * 8 + (lane >> 2);
         float acc[4][4];
 #pragma unroll
@@ -242,16 +241,15 @@ __global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed
                 a[1] = *reinterpret_cast<const uint32_t*>(xr + 8 * kNibStride);
                 a[2] = *reinterpret_cast<const uint32_t*>(xr + 16);
                 a[3] = *reinterpret_cast<const uint32_t*>(xr + 8 * kNibStride + 16);
-                const uint32_t sfa =
-                    *reinterpret_cast<const uint32_t*>(s_xsf + sfa_row * kSfStride + c * 4);
+                const uint32_t sfa = *reinterpret_cast<const uint32_t*>(s_xsf + sfa_row * kSfStride + c * 4);
 #pragma unroll
                 for (int nf = 0; nf < 4; ++nf) {
                     const int n_row = warp_n * 32 + nf * 8 + T1;
                     const uint8_t* wr = s_wn + n_row * kNibStride + T0 * 4 + c * 32;
                     const uint32_t b0 = *reinterpret_cast<const uint32_t*>(wr);
                     const uint32_t b1 = *reinterpret_cast<const uint32_t*>(wr + 16);
-                    const uint32_t sfb =
-                        *reinterpret_cast<const uint32_t*>(s_wsf + n_row * kSfStride + c * 4);
+                    const uint32_t sfb = *reinterpret_cast<const uint32_t*>(s_wsf + n_row * kSfStride +
+                                                                            c * 4);
                     mma_mxf4nvf4(acc[nf], a, b0, b1, sfa, sfb);
                 }
             }
@@ -303,16 +301,16 @@ __global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed
 // Reduce the stripe partial planes into FP16 y, applying the combined tensor
 // scale. kAcc adds onto the existing y (o/down residual call sites, beta=1).
 template <bool kAcc>
-__global__ void smallm_v2_reduce_kernel(const float* __restrict__ ws_partials, half* __restrict__ y,
-                                        int M, int N_out, int stripes, float ts) {
+__global__ void smallm_v2_reduce_kernel(const float* __restrict__ ws_partials, half* __restrict__ y, int M,
+                                        int N_out, int stripes, float ts) {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= M * N_out)
         return;
     const int m = i / N_out, n = i % N_out;
     float acc = 0.0f;
     for (int sp = 0; sp < stripes; ++sp)
-        acc += __ldcs(&ws_partials[static_cast<size_t>(sp) * kSmM * N_out +
-                                   static_cast<int64_t>(m) * N_out + n]);
+        acc += __ldcs(
+            &ws_partials[static_cast<size_t>(sp) * kSmM * N_out + static_cast<int64_t>(m) * N_out + n]);
     const int64_t o = static_cast<int64_t>(m) * N_out + n;
     y[o] = __float2half(ts * acc + (kAcc ? __half2float(y[o]) : 0.0f));
 }
@@ -349,8 +347,8 @@ size_t gemm_nvfp4_smallm_v2_workspace_bytes(int N_out, int K) {
 namespace {
 
 template <int kStages>
-bool launch_smallm_v2(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M, int N_out,
-                      int K, void* d_workspace, cudaStream_t stream, bool accumulate, int stripes) {
+bool launch_smallm_v2(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M, int N_out, int K,
+                      void* d_workspace, cudaStream_t stream, bool accumulate, int stripes) {
     static const bool smem_ok = [] {
         return cudaFuncSetAttribute(gemm_nvfp4_smallm_v2_kernel<kStages>,
                                     cudaFuncAttributeMaxDynamicSharedMemorySize,
@@ -362,19 +360,20 @@ bool launch_smallm_v2(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, hal
     const float ts = W.tensor_scale * Xq.tensor_scale;
     gemm_nvfp4_smallm_v2_kernel<kStages><<<grid, kThreads, kStages * kStageBytes, stream>>>(
         reinterpret_cast<const uint8_t*>(W.packed_data), reinterpret_cast<const uint8_t*>(W.micro_scales),
-        reinterpret_cast<const uint8_t*>(Xq.packed_data),
-        reinterpret_cast<const uint8_t*>(Xq.micro_scales), static_cast<float*>(d_workspace), y, ts,
-        accumulate ? 1 : 0, M, N_out, K, stripes);
+        reinterpret_cast<const uint8_t*>(Xq.packed_data), reinterpret_cast<const uint8_t*>(Xq.micro_scales),
+        static_cast<float*>(d_workspace), y, ts, accumulate ? 1 : 0, M, N_out, K, stripes);
     IMP_CUDA_CHECK_LAUNCH();
     if (stripes == 1)
         return true;
     const int total = M * N_out;
     if (accumulate)
-        smallm_v2_reduce_kernel<true><<<(total + 255) / 256, 256, 0, stream>>>(
-            static_cast<const float*>(d_workspace), y, M, N_out, stripes, ts);
+        smallm_v2_reduce_kernel<true>
+            <<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const float*>(d_workspace), y, M, N_out,
+                                                      stripes, ts);
     else
-        smallm_v2_reduce_kernel<false><<<(total + 255) / 256, 256, 0, stream>>>(
-            static_cast<const float*>(d_workspace), y, M, N_out, stripes, ts);
+        smallm_v2_reduce_kernel<false>
+            <<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const float*>(d_workspace), y, M, N_out,
+                                                      stripes, ts);
     IMP_CUDA_CHECK_LAUNCH();
     return true;
 }
@@ -391,20 +390,19 @@ bool smallm_v2_args_ok(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, in
 
 }  // namespace
 
-bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
-                             int N_out, int K, void* d_workspace, cudaStream_t stream, bool accumulate) {
+bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M, int N_out,
+                             int K, void* d_workspace, cudaStream_t stream, bool accumulate) {
     const int stripes = gemm_nvfp4_smallm_v2_stripes(N_out, K);
     if (!smallm_v2_args_ok(W, Xq, M, N_out, K, d_workspace, stripes))
         return false;
-    return launch_smallm_v2<kDefaultStages>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate,
-                                            stripes);
+    return launch_smallm_v2<kDefaultStages>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
 }
 
 // Tuning hook for the isolated sweep (tests only): explicit stage depth and
 // stripe count. Workspace must hold `stripes` planes.
 bool gemm_nvfp4_smallm_v2_a4_tuned(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
-                                   int N_out, int K, void* d_workspace, cudaStream_t stream,
-                                   bool accumulate, int stages, int stripes) {
+                                   int N_out, int K, void* d_workspace, cudaStream_t stream, bool accumulate,
+                                   int stages, int stripes) {
     if (!smallm_v2_args_ok(W, Xq, M, N_out, K, d_workspace, stripes))
         return false;
     if (stripes < 1 || stripes > K / kKT)

--- a/src/quant/nvfp4_gemm_smallm_v2.cu
+++ b/src/quant/nvfp4_gemm_smallm_v2.cu
@@ -366,15 +366,17 @@ bool launch_smallm_v2(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, hal
     if (stripes == 1)
         return true;
     const int total = M * N_out;
-    if (accumulate)
+    if (accumulate) {
         smallm_v2_reduce_kernel<true>
             <<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const float*>(d_workspace), y, M, N_out,
                                                       stripes, ts);
-    else
+        IMP_CUDA_CHECK_LAUNCH();
+    } else {
         smallm_v2_reduce_kernel<false>
             <<<(total + 255) / 256, 256, 0, stream>>>(static_cast<const float*>(d_workspace), y, M, N_out,
                                                       stripes, ts);
-    IMP_CUDA_CHECK_LAUNCH();
+        IMP_CUDA_CHECK_LAUNCH();
+    }
     return true;
 }
 

--- a/src/quant/nvfp4_gemm_smallm_v2.cu
+++ b/src/quant/nvfp4_gemm_smallm_v2.cu
@@ -1,0 +1,426 @@
+// nvfp4_gemm_smallm_v2.cu — small-M NVFP4 GEMM v2: y[m, n] = W[n, :] @ x[m, :]
+// for M <= 32 activation rows, both sides packed NVFP4 in the PLAIN layout
+// (nibbles + linear FP8-UE4M3 micro-scales), computed with the native
+// block-scaled mma.sync.kind::mxf4nvf4 — no dequant anywhere, weights and
+// scales stream through an asynchronous multi-stage smem pipeline with one
+// producer warp (cp.async + mbarrier) and four consumer warps.
+//
+// Why v2 (docs/plans/2026-08-24-qwen38-port.md; gemm.h postmortem): the
+// W4A16 v1 kernel wins isolated (23.9 vs CUTLASS 41.4 us on M=32 N=5120
+// K=5120) and loses the real 32-stream step (45.8 us, -11% aggregate): its
+// synchronous SIMT loads are exposed to the GDN scan's L2 pressure. What
+// the shipping CUTLASS tile has that v1 lacks is an async pipeline; what
+// CUTLASS cannot give us is a CTA_M < 128 block-scaled tile (SF atom
+// static-asserts at 128 rows). v2 owns an M=32 tile natively:
+//   - block tile M32 x N64 x K256 per stage, 4-6 stage ring, ~15 KiB/stage
+//   - producer warp: cp.async.cg 16B chunks + cp.async.mbarrier.arrive;
+//     consumers never issue a global load
+//   - data stays 4-bit until the MMA; smem traffic is 4-bit + SF bytes
+//   - Marlin-style striped K-partitioning, fixed per shape, deterministic
+//     two-kernel split-K reduce (no atomics)
+//
+// Fragment/SF mappings are the CUTLASS SM120_16x8x64_TN_VS layouts,
+// cross-checked in-tree against src/compute/mxf4nvf4_qkt_validate.cu:
+//   A   (T32,V32)->(M16,K64): m = T1 + V1*8, k = T0*8 + V0 + V2*32
+//   B   (T32,V16)->(N8, K64): n = T1,        k = T0*8 + V0 + V1*32
+//   SFA lane t supplies the 4 K-group scales of row m = (t%2)*8 + t/4
+//   SFB lane t supplies the 4 K-group scales of row n = t/4
+// with T0 = t%4, T1 = t/4. The nibble order of the plain packed layout is
+// exactly the fragment register order, so operands are plain u32 loads.
+
+#include "quant/nvfp4_gemm.h"
+#include "quant/nvfp4_gemm_internal.cuh"
+#include "core/logging.h"
+
+#include <cuda_fp16.h>
+
+namespace imp {
+namespace {
+
+constexpr int kSmM = 32;       // M tile (activation rows, padded with zeros)
+constexpr int kNR = 64;        // N rows per CTA
+constexpr int kKT = 256;       // K elements per pipeline stage
+constexpr int kThreads = 160;  // 4 consumer warps + 1 producer warp
+
+// Row strides in smem. Nibble rows are padded 128 -> 144 bytes so the
+// consumers' u32 fragment loads hit 32 distinct banks (bank = (36r + off/4)
+// % 32 walks all banks across a warp); 144 = 9*16 keeps cp.async 16B
+// alignment. SF rows stay at 16 bytes — the only conflict there is a 2-way
+// on the SFA rows, one extra cycle on a 4-byte load.
+constexpr int kNibStride = 144;
+constexpr int kSfStride = 16;
+
+constexpr int kWNibBytes = kNR * kNibStride;   // 9216
+constexpr int kXNibBytes = kSmM * kNibStride;  // 4608
+constexpr int kWSfBytes = kNR * kSfStride;     // 1024
+constexpr int kXSfBytes = kSmM * kSfStride;    // 512
+constexpr int kStageBytes = kWNibBytes + kXNibBytes + kWSfBytes + kXSfBytes;  // 15360
+constexpr int kDefaultStages = 6;  // smem ring depth; 6 measured best at stripes=1 (sweep 2026-08-25)
+
+// ---- mbarrier / cp.async primitives -----------------------------------------
+
+__device__ __forceinline__ void mbar_init(uint64_t* bar, uint32_t count) {
+    const uint32_t a = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    asm volatile("mbarrier.init.shared.b64 [%0], %1;" ::"r"(a), "r"(count));
+}
+
+__device__ __forceinline__ void mbar_arrive(uint64_t* bar) {
+    const uint32_t a = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    uint64_t st;
+    asm volatile("mbarrier.arrive.shared.b64 %0, [%1];" : "=l"(st) : "r"(a) : "memory");
+}
+
+// Spin until the phase with the given parity completes.
+__device__ __forceinline__ void mbar_wait(uint64_t* bar, uint32_t parity) {
+    const uint32_t a = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P;\n"
+        "SMALLM_V2_WAIT_%=:\n\t"
+        "mbarrier.try_wait.parity.shared.b64 P, [%0], %1;\n\t"
+        "@!P bra SMALLM_V2_WAIT_%=;\n\t"
+        "}" ::"r"(a),
+        "r"(parity)
+        : "memory");
+}
+
+// Async-arrive: one arrive on the mbarrier once all prior cp.async of this
+// thread have completed. .noinc consumes one of the pre-initialized expected
+// arrivals (the memcpy_async pattern: full-barrier expected count = 32
+// producer lanes).
+__device__ __forceinline__ void cp_async_mbar_arrive(uint64_t* bar) {
+    const uint32_t a = static_cast<uint32_t>(__cvta_generic_to_shared(bar));
+    asm volatile("cp.async.mbarrier.arrive.noinc.shared.b64 [%0];" ::"r"(a));
+}
+
+// 16-byte global->shared async copy, zero-filling when src_bytes == 0
+// (activation rows >= M: nibbles AND scales land as 0, so the padded rows
+// contribute exactly nothing).
+__device__ __forceinline__ void cp_async16(void* dst, const void* src, int src_bytes) {
+    const uint32_t d = static_cast<uint32_t>(__cvta_generic_to_shared(dst));
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16, %2;" ::"r"(d), "l"(src), "r"(src_bytes));
+}
+
+// ---- the MMA ----------------------------------------------------------------
+
+__device__ __forceinline__ void mma_mxf4nvf4(float acc[4], const uint32_t a[4], uint32_t b0, uint32_t b1,
+                                             uint32_t sfa, uint32_t sfb) {
+#if __CUDA_ARCH__ >= 1200
+    asm volatile(
+        "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col.f32.e2m1.e2m1.f32.ue4m3 "
+        "{%0, %1, %2, %3},"
+        "{%4, %5, %6, %7},"
+        "{%8, %9},"
+        "{%0, %1, %2, %3},"
+        "{%10},"
+        "{%11, %12},"
+        "{%13},"
+        "{%14, %15};\n"
+        : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1), "r"(sfa),
+          "h"(static_cast<uint16_t>(0)), "h"(static_cast<uint16_t>(0)), "r"(sfb),
+          "h"(static_cast<uint16_t>(0)), "h"(static_cast<uint16_t>(0)));
+#endif
+}
+
+// ---- kernel -----------------------------------------------------------------
+
+// grid = (N/kNR, stripes). Each CTA walks a contiguous stripe of K-tiles for
+// its n-tile and writes one FP32 partial plane per stripe (stripe-exclusive
+// -> deterministic reduce). Dynamic smem: kStages * kStageBytes.
+template <int kStages>
+__global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed,
+                                            const uint8_t* __restrict__ w_scales,
+                                            const uint8_t* __restrict__ xq_packed,
+                                            const uint8_t* __restrict__ xq_scales,
+                                            float* __restrict__ ws_partials, half* __restrict__ y,
+                                            float ts, int acc_flag, int M, int N_out, int K,
+                                            int stripes) {
+    extern __shared__ uint8_t smem[];
+    __shared__ uint64_t bar_full[kStages];
+    __shared__ uint64_t bar_empty[kStages];
+
+    const int tid = threadIdx.x;
+    const int warp = tid / 32;
+    const int lane = tid & 31;
+    const int n_base = blockIdx.x * kNR;
+    const int stripe = blockIdx.y;
+
+    if (tid == 0) {
+#pragma unroll
+        for (int s = 0; s < kStages; ++s) {
+            mbar_init(&bar_full[s], 32);    // producer lanes async-arrive
+            mbar_init(&bar_empty[s], 128);  // consumer lanes arrive
+        }
+    }
+    __syncthreads();
+
+    // Stripe of K-tiles owned by this CTA.
+    const int k_tiles = K / kKT;
+    const int per_stripe = (k_tiles + stripes - 1) / stripes;
+    const int kt0 = stripe * per_stripe;
+    const int kt1 = min(k_tiles, kt0 + per_stripe);
+    const int iters = kt1 - kt0;
+
+    auto stage_base = [&](int s) { return smem + s * kStageBytes; };
+
+    if (warp == 4) {
+        // ---- producer warp: fill the ring, never compute ----
+        // Per-lane chunk assignments are fixed; only the K offset advances.
+        // w nibbles: 64 rows x 8 16B-chunks = 512 -> 16/lane
+        // x nibbles: 32 rows x 8         = 256 -> 8/lane
+        // w scales:  64 rows x 1 16B     = 64  -> 2/lane
+        // x scales:  32 rows x 1         = 32  -> 1/lane
+        const int64_t w_row_bytes = static_cast<int64_t>(K) / 2;
+        const int64_t sf_row_bytes = static_cast<int64_t>(K) / kMicroBlockSize;
+        for (int i = 0; i < iters; ++i) {
+            const int s = i % kStages;
+            const int use = i / kStages;
+            if (i >= kStages)
+                mbar_wait(&bar_empty[s], (use - 1) & 1);
+            uint8_t* base = stage_base(s);
+            uint8_t* s_wn = base;
+            uint8_t* s_xn = base + kWNibBytes;
+            uint8_t* s_wsf = base + kWNibBytes + kXNibBytes;
+            uint8_t* s_xsf = s_wsf + kWSfBytes;
+            const int kt = kt0 + i;
+            const int64_t k_nib_off = static_cast<int64_t>(kt) * (kKT / 2);
+            const int64_t k_sf_off = static_cast<int64_t>(kt) * (kKT / kMicroBlockSize);
+#pragma unroll
+            for (int v = 0; v < 16; ++v) {
+                const int c = lane + v * 32;
+                const int r = c / 8, j = c % 8;
+                cp_async16(s_wn + r * kNibStride + j * 16,
+                           w_packed + (n_base + r) * w_row_bytes + k_nib_off + j * 16, 16);
+            }
+#pragma unroll
+            for (int v = 0; v < 8; ++v) {
+                const int c = lane + v * 32;
+                const int r = c / 8, j = c % 8;
+                cp_async16(s_xn + r * kNibStride + j * 16, xq_packed + r * w_row_bytes + k_nib_off + j * 16,
+                           r < M ? 16 : 0);
+            }
+#pragma unroll
+            for (int v = 0; v < 2; ++v) {
+                const int r = lane + v * 32;
+                cp_async16(s_wsf + r * kSfStride, w_scales + (n_base + r) * sf_row_bytes + k_sf_off, 16);
+            }
+            cp_async16(s_xsf + lane * kSfStride, xq_scales + lane * sf_row_bytes + k_sf_off,
+                       lane < M ? 16 : 0);
+            cp_async_mbar_arrive(&bar_full[s]);
+        }
+    } else {
+        // ---- consumer warps: wait, MMA, release ----
+        // Warp tile: M16 x N32. warp_m in {0,1}, warp_n in {0,1}.
+        const int warp_m = warp & 1;
+        const int warp_n = warp >> 1;
+        const int T0 = lane & 3;
+        const int T1 = lane >> 2;
+        const int a_row = warp_m * 16 + T1;              // A fragment row (V1=0)
+        const int sfa_row = warp_m * 16 + (lane & 1) * 8 + (lane >> 2);
+        float acc[4][4];
+#pragma unroll
+        for (int nf = 0; nf < 4; ++nf)
+#pragma unroll
+            for (int r = 0; r < 4; ++r)
+                acc[nf][r] = 0.0f;
+
+        for (int i = 0; i < iters; ++i) {
+            const int s = i % kStages;
+            const int use = i / kStages;
+            mbar_wait(&bar_full[s], use & 1);
+            const uint8_t* base = stage_base(s);
+            const uint8_t* s_wn = base;
+            const uint8_t* s_xn = base + kWNibBytes;
+            const uint8_t* s_wsf = base + kWNibBytes + kXNibBytes;
+            const uint8_t* s_xsf = s_wsf + kWSfBytes;
+#pragma unroll
+            for (int c = 0; c < kKT / 64; ++c) {
+                uint32_t a[4];
+                const uint8_t* xr = s_xn + a_row * kNibStride + T0 * 4 + c * 32;
+                a[0] = *reinterpret_cast<const uint32_t*>(xr);
+                a[1] = *reinterpret_cast<const uint32_t*>(xr + 8 * kNibStride);
+                a[2] = *reinterpret_cast<const uint32_t*>(xr + 16);
+                a[3] = *reinterpret_cast<const uint32_t*>(xr + 8 * kNibStride + 16);
+                const uint32_t sfa =
+                    *reinterpret_cast<const uint32_t*>(s_xsf + sfa_row * kSfStride + c * 4);
+#pragma unroll
+                for (int nf = 0; nf < 4; ++nf) {
+                    const int n_row = warp_n * 32 + nf * 8 + T1;
+                    const uint8_t* wr = s_wn + n_row * kNibStride + T0 * 4 + c * 32;
+                    const uint32_t b0 = *reinterpret_cast<const uint32_t*>(wr);
+                    const uint32_t b1 = *reinterpret_cast<const uint32_t*>(wr + 16);
+                    const uint32_t sfb =
+                        *reinterpret_cast<const uint32_t*>(s_wsf + n_row * kSfStride + c * 4);
+                    mma_mxf4nvf4(acc[nf], a, b0, b1, sfa, sfb);
+                }
+            }
+            mbar_arrive(&bar_empty[s]);
+        }
+
+        // Stage the FP32 accumulators for coalesced plane stores. Ring smem
+        // is dead after the loop; the __syncthreads below fences the reuse.
+        __syncthreads();
+        float* s_out = reinterpret_cast<float*>(smem);  // [kSmM][kNR]
+#pragma unroll
+        for (int nf = 0; nf < 4; ++nf) {
+            const int n0 = warp_n * 32 + nf * 8 + T0 * 2;
+            s_out[(warp_m * 16 + T1) * kNR + n0] = acc[nf][0];
+            s_out[(warp_m * 16 + T1) * kNR + n0 + 1] = acc[nf][1];
+            s_out[(warp_m * 16 + T1 + 8) * kNR + n0] = acc[nf][2];
+            s_out[(warp_m * 16 + T1 + 8) * kNR + n0 + 1] = acc[nf][3];
+        }
+    }
+    if (warp == 4)
+        __syncthreads();  // producer joins the consumers' staging barrier
+    __syncthreads();
+
+    const float* s_out = reinterpret_cast<const float*>(smem);
+    if (stripes == 1) {
+        // Single stripe owns the full K range: write FP16 y directly, tensor
+        // scale applied — no reduce launch, no partial-plane round-trip.
+        for (int i = tid; i < kSmM * kNR; i += kThreads) {
+            const int m = i / kNR;
+            if (m >= M)
+                continue;
+            const int n = i % kNR;
+            const int64_t o = static_cast<int64_t>(m) * N_out + n_base + n;
+            y[o] = __float2half(ts * s_out[i] + (acc_flag ? __half2float(y[o]) : 0.0f));
+        }
+        return;
+    }
+    // Streaming stores: each partial is written once and read once by the
+    // reduce kernel (v1 lesson — un-hinted partials knocked L2 sets out from
+    // under the weight stream).
+    float* plane = ws_partials + static_cast<size_t>(stripe) * kSmM * N_out;
+    for (int i = tid; i < kSmM * kNR; i += kThreads) {
+        const int m = i / kNR;
+        const int n = i % kNR;
+        __stcs(&plane[static_cast<int64_t>(m) * N_out + n_base + n], s_out[i]);
+    }
+}
+
+// Reduce the stripe partial planes into FP16 y, applying the combined tensor
+// scale. kAcc adds onto the existing y (o/down residual call sites, beta=1).
+template <bool kAcc>
+__global__ void smallm_v2_reduce_kernel(const float* __restrict__ ws_partials, half* __restrict__ y,
+                                        int M, int N_out, int stripes, float ts) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= M * N_out)
+        return;
+    const int m = i / N_out, n = i % N_out;
+    float acc = 0.0f;
+    for (int sp = 0; sp < stripes; ++sp)
+        acc += __ldcs(&ws_partials[static_cast<size_t>(sp) * kSmM * N_out +
+                                   static_cast<int64_t>(m) * N_out + n]);
+    const int64_t o = static_cast<int64_t>(m) * N_out + n;
+    y[o] = __float2half(ts * acc + (kAcc ? __half2float(y[o]) : 0.0f));
+}
+
+}  // namespace
+
+// K-stripe count per shape: enough CTAs to cover the SMs about twice, capped
+// by the K-tile count. Fixed per (N, K) — no per-launch scheduler state, so
+// launches are graph-safe and the reduce is deterministic.
+int gemm_nvfp4_smallm_v2_stripes(int N_out, int K) {
+    const int n_tiles = N_out / kNR;
+    const int k_tiles = K / kKT;
+    // Measured (M=32 N=5120 K=5120 sweep, 2026-08-25): one stripe beats every
+    // split-K config — the deltas track the extra reduce traffic, not the CTA
+    // count. Split K only when the n-grid alone leaves most of the card idle.
+    if (n_tiles >= 80)
+        return 1;
+    int s = (160 + n_tiles - 1) / n_tiles;
+    if (s < 1)
+        s = 1;
+    if (s > k_tiles)
+        s = k_tiles;
+    return s;
+}
+
+size_t gemm_nvfp4_smallm_v2_workspace_bytes(int N_out, int K) {
+    return static_cast<size_t>(gemm_nvfp4_smallm_v2_stripes(N_out, K)) * kSmM * N_out * sizeof(float);
+}
+
+// y[m, n] = W[n, :] @ x[m, :], both sides plain NVFP4. M <= 32; K % 256 == 0;
+// N % 64 == 0. d_workspace: gemm_nvfp4_smallm_v2_workspace_bytes(N_out, K).
+// Xq rows >= M are never read (zero-filled in the pipeline), so Xq buffers
+// only need M rows.
+namespace {
+
+template <int kStages>
+bool launch_smallm_v2(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M, int N_out,
+                      int K, void* d_workspace, cudaStream_t stream, bool accumulate, int stripes) {
+    static const bool smem_ok = [] {
+        return cudaFuncSetAttribute(gemm_nvfp4_smallm_v2_kernel<kStages>,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                    kStages * kStageBytes) == cudaSuccess;
+    }();
+    if (!smem_ok)
+        return false;
+    const dim3 grid(N_out / kNR, stripes);
+    const float ts = W.tensor_scale * Xq.tensor_scale;
+    gemm_nvfp4_smallm_v2_kernel<kStages><<<grid, kThreads, kStages * kStageBytes, stream>>>(
+        reinterpret_cast<const uint8_t*>(W.packed_data), reinterpret_cast<const uint8_t*>(W.micro_scales),
+        reinterpret_cast<const uint8_t*>(Xq.packed_data),
+        reinterpret_cast<const uint8_t*>(Xq.micro_scales), static_cast<float*>(d_workspace), y, ts,
+        accumulate ? 1 : 0, M, N_out, K, stripes);
+    IMP_CUDA_CHECK_LAUNCH();
+    if (stripes == 1)
+        return true;
+    const int total = M * N_out;
+    if (accumulate)
+        smallm_v2_reduce_kernel<true><<<(total + 255) / 256, 256, 0, stream>>>(
+            static_cast<const float*>(d_workspace), y, M, N_out, stripes, ts);
+    else
+        smallm_v2_reduce_kernel<false><<<(total + 255) / 256, 256, 0, stream>>>(
+            static_cast<const float*>(d_workspace), y, M, N_out, stripes, ts);
+    IMP_CUDA_CHECK_LAUNCH();
+    return true;
+}
+
+bool smallm_v2_args_ok(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, int M, int N_out, int K,
+                       void* d_workspace, int stripes) {
+    if (M <= 0 || M > kSmM || (K % kKT) != 0 || (N_out % kNR) != 0)
+        return false;
+    if (stripes > 1 && d_workspace == nullptr)
+        return false;
+    return W.packed_data != nullptr && W.micro_scales != nullptr && Xq.packed_data != nullptr &&
+           Xq.micro_scales != nullptr;
+}
+
+}  // namespace
+
+bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
+                             int N_out, int K, void* d_workspace, cudaStream_t stream, bool accumulate) {
+    const int stripes = gemm_nvfp4_smallm_v2_stripes(N_out, K);
+    if (!smallm_v2_args_ok(W, Xq, M, N_out, K, d_workspace, stripes))
+        return false;
+    return launch_smallm_v2<kDefaultStages>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate,
+                                            stripes);
+}
+
+// Tuning hook for the isolated sweep (tests only): explicit stage depth and
+// stripe count. Workspace must hold `stripes` planes.
+bool gemm_nvfp4_smallm_v2_a4_tuned(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
+                                   int N_out, int K, void* d_workspace, cudaStream_t stream,
+                                   bool accumulate, int stages, int stripes) {
+    if (!smallm_v2_args_ok(W, Xq, M, N_out, K, d_workspace, stripes))
+        return false;
+    if (stripes < 1 || stripes > K / kKT)
+        return false;
+    switch (stages) {
+        case 2:
+            return launch_smallm_v2<2>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
+        case 3:
+            return launch_smallm_v2<3>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
+        case 4:
+            return launch_smallm_v2<4>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
+        case 6:
+            return launch_smallm_v2<6>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
+        default:
+            return false;
+    }
+}
+
+}  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -285,6 +285,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gemm.nvfp4_lm_head_gdn", cfg.gemm.nvfp4_lm_head_gdn);
     B("gemm.nvfp4_lm_head_cutlass", cfg.gemm.nvfp4_lm_head_cutlass);
     B("gemm.nvfp4_smallm", cfg.gemm.nvfp4_smallm);
+    I("gemm.nvfp4_smallm_impl", cfg.gemm.nvfp4_smallm_impl);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
     B("gemm.fp8_ssm_proj", cfg.gemm.fp8_ssm_proj);
     S("gemm.fp8_attn_proj", cfg.gemm.fp8_attn_proj);

--- a/tests/test_nvfp4_smallm_v2.cu
+++ b/tests/test_nvfp4_smallm_v2.cu
@@ -1,0 +1,272 @@
+// =============================================================================
+// test_nvfp4_smallm_v2.cu — the native mxf4nvf4 small-M GEMM: correctness + bw
+// =============================================================================
+//
+// Correctness: y[m,n] must match a host dequant walk over the ACTUAL packed
+// buffers of BOTH sides (W4A4 — the same numerics family as the CUTLASS
+// batched-decode path). The v2 kernel accumulates in FP32 with exact
+// FP4xUE4M3 products, so the tolerance is tight (1e-3 relative).
+//
+// Bandwidth: on the reference batched-decode shape (M=32, N=5120, K=5120)
+// the kernel exists to beat the grid-starved CUTLASS 128x128 tile (41.4 us /
+// 19% of the weight floor in-situ) AND the refuted W4A16 v1 (23.9 us
+// isolated, lost e2e). The bench asserts >= 40% of the weight floor so a
+// regression back into starvation fails loud; the M2 acceptance gate
+// (<= 15 us isolated) lives in the campaign doc, not here.
+//
+// GPU required — skips cleanly without one.
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "quant/nvfp4_gemm.h"
+#include "quant/nvfp4_quant.h"
+#include "core/tensor.h"
+
+namespace {
+
+bool gpu_available() {
+    int n = 0;
+    return cudaGetDeviceCount(&n) == cudaSuccess && n > 0;
+}
+
+// Host dequant of one element from plain packed buffers (UE4M3 micro-scales).
+float host_dequant(const std::vector<uint8_t>& packed, const std::vector<uint8_t>& scales,
+                   float tensor_scale, int n, int k, int K) {
+    static const float lut[16] = {0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
+                                  -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f};
+    uint8_t byte = packed[(size_t)n * (K / 2) + k / 2];
+    uint8_t nib = (k & 1) ? (byte >> 4) : (byte & 0xF);
+    uint8_t se = scales[(size_t)n * (K / 16) + k / 16];
+    int exp = (se >> 3) & 0xF;
+    int mant = se & 0x7;
+    float sf = (exp == 0) ? (mant / 8.0f) * std::pow(2.0f, -6.0f)
+                          : (1.0f + mant / 8.0f) * std::pow(2.0f, exp - 7);
+    return lut[nib] * sf * tensor_scale;
+}
+
+struct DeviceQuant {
+    imp::NvFP4QuantResult q{};
+    std::vector<uint8_t> packed_h, scales_h;
+    void quantize(const std::vector<__half>& src, int rows, int K) {
+        void* d = nullptr;
+        ASSERT_EQ(cudaMalloc(&d, src.size() * sizeof(__half)), cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(d, src.data(), src.size() * sizeof(__half), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        int64_t shp[2] = {rows, K};
+        imp::Tensor t(d, imp::QType::F16, 2, shp, /*on_device=*/true);
+        imp::quantize_fp16_to_nvfp4(t, q, nullptr);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        ASSERT_NE(q.packed_data, nullptr);
+        cudaFree(d);
+        packed_h.resize((size_t)rows * K / 2);
+        scales_h.resize((size_t)rows * K / 16);
+        ASSERT_EQ(cudaMemcpy(packed_h.data(), q.packed_data, packed_h.size(), cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(scales_h.data(), q.micro_scales, scales_h.size(), cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+    }
+};
+
+class NvFP4SmallMV2Test : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        if (!gpu_available())
+            GTEST_SKIP() << "no CUDA device";
+    }
+};
+
+void run_case(int M, int N, int K, bool accumulate) {
+    std::mt19937 rng(7 + M + N + K);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    std::vector<__half> w_h((size_t)N * K), x_h((size_t)M * K);
+    for (auto& v : w_h)
+        v = __float2half(dist(rng));
+    for (auto& v : x_h)
+        v = __float2half(dist(rng));
+
+    DeviceQuant W, X;
+    W.quantize(w_h, N, K);
+    X.quantize(x_h, M, K);
+
+    std::vector<__half> y0_h((size_t)M * N);
+    for (auto& v : y0_h)
+        v = __float2half(accumulate ? dist(rng) : 0.0f);
+    void *d_y = nullptr, *d_ws = nullptr;
+    const size_t ws_bytes = imp::gemm_nvfp4_smallm_v2_workspace_bytes(N, K);
+    ASSERT_EQ(cudaMalloc(&d_y, (size_t)M * N * sizeof(__half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_ws, ws_bytes), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(d_y, y0_h.data(), (size_t)M * N * sizeof(__half), cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr,
+                                             accumulate));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    std::vector<__half> y_h((size_t)M * N);
+    ASSERT_EQ(cudaMemcpy(y_h.data(), d_y, y_h.size() * sizeof(__half), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+
+    const float ts = W.q.tensor_scale * X.q.tensor_scale;
+    double max_rel = 0.0;
+    for (int m = 0; m < M; ++m) {
+        for (int n = 0; n < N; ++n) {
+            double ref = 0.0;
+            for (int k = 0; k < K; ++k)
+                ref += host_dequant(W.packed_h, W.scales_h, 1.0f, n, k, K) *
+                       host_dequant(X.packed_h, X.scales_h, 1.0f, m, k, K);
+            ref = ref * ts + (accumulate ? __half2float(y0_h[(size_t)m * N + n]) : 0.0);
+            double got = __half2float(y_h[(size_t)m * N + n]);
+            double rel = std::abs(got - ref) / std::max(1.0, std::abs(ref));
+            max_rel = std::max(max_rel, rel);
+        }
+    }
+    // FP32 accumulate over exact FP4xUE4M3 products, then one FP16 round:
+    // the FP16 output quantum on |y|~1 dominates the envelope.
+    EXPECT_LT(max_rel, 2e-3) << "M=" << M << " N=" << N << " K=" << K << " acc=" << accumulate
+                             << " max relative error " << max_rel;
+
+    cudaFree(d_y);
+    cudaFree(d_ws);
+}
+
+TEST_F(NvFP4SmallMV2Test, MatchesHostReference) {
+    run_case(/*M=*/19, /*N=*/192, /*K=*/512, /*accumulate=*/false);
+}
+
+TEST_F(NvFP4SmallMV2Test, MatchesHostReferenceFullTileMultiStripe) {
+    run_case(/*M=*/32, /*N=*/128, /*K=*/2048, /*accumulate=*/false);
+}
+
+TEST_F(NvFP4SmallMV2Test, AccumulateAddsOntoY) {
+    run_case(/*M=*/8, /*N=*/64, /*K=*/256, /*accumulate=*/true);
+}
+
+TEST_F(NvFP4SmallMV2Test, RejectsUnalignedShapes) {
+    imp::NvFP4QuantResult dummy{};
+    dummy.packed_data = reinterpret_cast<void*>(0x10);
+    dummy.micro_scales = reinterpret_cast<void*>(0x20);
+    int probe = 0;
+    EXPECT_FALSE(imp::gemm_nvfp4_smallm_v2_a4(dummy, dummy, nullptr, 33, 64, 256, &probe, nullptr));
+    EXPECT_FALSE(imp::gemm_nvfp4_smallm_v2_a4(dummy, dummy, nullptr, 8, 96, 256, &probe, nullptr));
+    EXPECT_FALSE(imp::gemm_nvfp4_smallm_v2_a4(dummy, dummy, nullptr, 8, 64, 384, &probe, nullptr));
+}
+
+TEST_F(NvFP4SmallMV2Test, BandwidthAboveStarvationFloor) {
+    const int M = 32, N = 5120, K = 5120;
+    std::mt19937 rng(11);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    std::vector<__half> w_h((size_t)N * K), x_h((size_t)M * K);
+    for (auto& v : w_h)
+        v = __float2half(dist(rng));
+    for (auto& v : x_h)
+        v = __float2half(dist(rng));
+    DeviceQuant W, X;
+    W.quantize(w_h, N, K);
+    X.quantize(x_h, M, K);
+
+    void *d_y = nullptr, *d_ws = nullptr;
+    ASSERT_EQ(cudaMalloc(&d_y, (size_t)M * N * sizeof(__half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_ws, imp::gemm_nvfp4_smallm_v2_workspace_bytes(N, K)), cudaSuccess);
+
+    // Warmup >1s of busy time so clocks ramp (the box never throttles; it
+    // DOES idle-downclock, and 20 ms of load measures the idle clocks).
+    cudaEvent_t t0, t1;
+    cudaEventCreate(&t0);
+    cudaEventCreate(&t1);
+    float ms = 0.0f;
+    for (int w = 0; w < 100; ++w) {
+        for (int i = 0; i < 1000; ++i)
+            ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
+                                                     nullptr));
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    }
+    double best_ms = 1e30;
+    for (int r = 0; r < 3; ++r) {
+        cudaEventRecord(t0);
+        for (int i = 0; i < 1000; ++i)
+            ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
+                                                     nullptr));
+        cudaEventRecord(t1);
+        ASSERT_EQ(cudaEventSynchronize(t1), cudaSuccess);
+        cudaEventElapsedTime(&ms, t0, t1);
+        best_ms = std::min(best_ms, (double)ms);
+    }
+    const double us = best_ms;  // 1000 calls -> ms == us/call
+    // Weight bytes dominate: N*K/2 nibbles + N*K/16 scales = 14.75 MB.
+    const double bytes = (double)N * K / 2 + (double)N * K / 16;
+    const double floor_us = bytes / 1792e9 * 1e6;  // 8.2 us
+    const double pct = floor_us / us * 100.0;
+    printf("[ BENCH    ] smallm_v2 M=32 N=5120 K=5120: %.1f us/call, %.0f%% of weight floor (%.1f us)\n",
+           us, pct, floor_us);
+    EXPECT_GT(pct, 40.0) << us << " us — starvation regression (CUTLASS in-situ is 41.4 us)";
+
+    cudaFree(d_y);
+    cudaFree(d_ws);
+    cudaEventDestroy(t0);
+    cudaEventDestroy(t1);
+}
+
+TEST_F(NvFP4SmallMV2Test, SweepTuning) {
+    if (getenv("IMP_SMALLM_V2_SWEEP") == nullptr)
+        GTEST_SKIP() << "set IMP_SMALLM_V2_SWEEP=1 to run the tuning sweep";
+    const int M = 32, N = 5120, K = 5120;
+    std::mt19937 rng(11);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    std::vector<__half> w_h((size_t)N * K), x_h((size_t)M * K);
+    for (auto& v : w_h)
+        v = __float2half(dist(rng));
+    for (auto& v : x_h)
+        v = __float2half(dist(rng));
+    DeviceQuant W, X;
+    W.quantize(w_h, N, K);
+    X.quantize(x_h, M, K);
+    void *d_y = nullptr, *d_ws = nullptr;
+    const int kMaxStripes = 8;
+    ASSERT_EQ(cudaMalloc(&d_y, (size_t)M * N * sizeof(__half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_ws, (size_t)kMaxStripes * 32 * N * sizeof(float)), cudaSuccess);
+    // clock ramp
+    for (int i = 0; i < 20000; ++i)
+        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
+                                                 nullptr));
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    cudaEvent_t t0, t1;
+    cudaEventCreate(&t0);
+    cudaEventCreate(&t1);
+    const int stages_v[] = {2, 3, 4, 6};
+    const int stripes_v[] = {1, 2, 3, 4, 5, 8};
+    for (int st : stages_v) {
+        for (int sp : stripes_v) {
+            float ms = 0.0f;
+            double best = 1e30;
+            if (!imp::gemm_nvfp4_smallm_v2_a4_tuned(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
+                                                    nullptr, false, st, sp))
+                continue;
+            for (int r = 0; r < 3; ++r) {
+                cudaEventRecord(t0);
+                for (int i = 0; i < 1000; ++i)
+                    imp::gemm_nvfp4_smallm_v2_a4_tuned(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
+                                                       nullptr, false, st, sp);
+                cudaEventRecord(t1);
+                ASSERT_EQ(cudaEventSynchronize(t1), cudaSuccess);
+                cudaEventElapsedTime(&ms, t0, t1);
+                best = std::min(best, (double)ms);
+            }
+            printf("[ SWEEP    ] stages=%d stripes=%d ctas=%d: %.2f us/call\n", st, sp, (N / 64) * sp,
+                   best);
+        }
+    }
+    cudaFree(d_y);
+    cudaFree(d_ws);
+    cudaEventDestroy(t0);
+    cudaEventDestroy(t1);
+}
+
+}  // namespace

--- a/tests/test_nvfp4_smallm_v2.cu
+++ b/tests/test_nvfp4_smallm_v2.cu
@@ -36,8 +36,8 @@ bool gpu_available() {
 }
 
 // Host dequant of one element from plain packed buffers (UE4M3 micro-scales).
-float host_dequant(const std::vector<uint8_t>& packed, const std::vector<uint8_t>& scales,
-                   float tensor_scale, int n, int k, int K) {
+float host_dequant(const std::vector<uint8_t>& packed, const std::vector<uint8_t>& scales, float tensor_scale,
+                   int n, int k, int K) {
     static const float lut[16] = {0.0f,  0.5f,  1.0f,  1.5f,  2.0f,  3.0f,  4.0f,  6.0f,
                                   -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f};
     uint8_t byte = packed[(size_t)n * (K / 2) + k / 2];
@@ -74,7 +74,7 @@ struct DeviceQuant {
 };
 
 class NvFP4SmallMV2Test : public ::testing::Test {
-  protected:
+protected:
     void SetUp() override {
         if (!gpu_available())
             GTEST_SKIP() << "no CUDA device";
@@ -105,13 +105,12 @@ void run_case(int M, int N, int K, bool accumulate) {
     ASSERT_EQ(cudaMemcpy(d_y, y0_h.data(), (size_t)M * N * sizeof(__half), cudaMemcpyHostToDevice),
               cudaSuccess);
 
-    ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr,
-                                             accumulate));
+    ASSERT_TRUE(
+        imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr, accumulate));
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
     std::vector<__half> y_h((size_t)M * N);
-    ASSERT_EQ(cudaMemcpy(y_h.data(), d_y, y_h.size() * sizeof(__half), cudaMemcpyDeviceToHost),
-              cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(y_h.data(), d_y, y_h.size() * sizeof(__half), cudaMemcpyDeviceToHost), cudaSuccess);
 
     const float ts = W.q.tensor_scale * X.q.tensor_scale;
     double max_rel = 0.0;
@@ -184,16 +183,16 @@ TEST_F(NvFP4SmallMV2Test, BandwidthAboveStarvationFloor) {
     float ms = 0.0f;
     for (int w = 0; w < 100; ++w) {
         for (int i = 0; i < 1000; ++i)
-            ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
-                                                     nullptr));
+            ASSERT_TRUE(
+                imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr));
         ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     }
     double best_ms = 1e30;
     for (int r = 0; r < 3; ++r) {
         cudaEventRecord(t0);
         for (int i = 0; i < 1000; ++i)
-            ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
-                                                     nullptr));
+            ASSERT_TRUE(
+                imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr));
         cudaEventRecord(t1);
         ASSERT_EQ(cudaEventSynchronize(t1), cudaSuccess);
         cudaEventElapsedTime(&ms, t0, t1);
@@ -204,8 +203,8 @@ TEST_F(NvFP4SmallMV2Test, BandwidthAboveStarvationFloor) {
     const double bytes = (double)N * K / 2 + (double)N * K / 16;
     const double floor_us = bytes / 1792e9 * 1e6;  // 8.2 us
     const double pct = floor_us / us * 100.0;
-    printf("[ BENCH    ] smallm_v2 M=32 N=5120 K=5120: %.1f us/call, %.0f%% of weight floor (%.1f us)\n",
-           us, pct, floor_us);
+    printf("[ BENCH    ] smallm_v2 M=32 N=5120 K=5120: %.1f us/call, %.0f%% of weight floor (%.1f us)\n", us,
+           pct, floor_us);
     EXPECT_GT(pct, 40.0) << us << " us — starvation regression (CUTLASS in-situ is 41.4 us)";
 
     cudaFree(d_y);
@@ -234,8 +233,7 @@ TEST_F(NvFP4SmallMV2Test, SweepTuning) {
     ASSERT_EQ(cudaMalloc(&d_ws, (size_t)kMaxStripes * 32 * N * sizeof(float)), cudaSuccess);
     // clock ramp
     for (int i = 0; i < 20000; ++i)
-        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
-                                                 nullptr));
+        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr));
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     cudaEvent_t t0, t1;
     cudaEventCreate(&t0);
@@ -246,8 +244,8 @@ TEST_F(NvFP4SmallMV2Test, SweepTuning) {
         for (int sp : stripes_v) {
             float ms = 0.0f;
             double best = 1e30;
-            if (!imp::gemm_nvfp4_smallm_v2_a4_tuned(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws,
-                                                    nullptr, false, st, sp))
+            if (!imp::gemm_nvfp4_smallm_v2_a4_tuned(W.q, X.q, static_cast<half*>(d_y), M, N, K, d_ws, nullptr,
+                                                    false, st, sp))
                 continue;
             for (int r = 0; r < 3; ++r) {
                 cudaEventRecord(t0);
@@ -259,8 +257,7 @@ TEST_F(NvFP4SmallMV2Test, SweepTuning) {
                 cudaEventElapsedTime(&ms, t0, t1);
                 best = std::min(best, (double)ms);
             }
-            printf("[ SWEEP    ] stages=%d stripes=%d ctas=%d: %.2f us/call\n", st, sp, (N / 64) * sp,
-                   best);
+            printf("[ SWEEP    ] stages=%d stripes=%d ctas=%d: %.2f us/call\n", st, sp, (N / 64) * sp, best);
         }
     }
     cudaFree(d_y);

--- a/tools/analysis/conc_client.py
+++ b/tools/analysis/conc_client.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# conc_client.py - N concurrent unique short prompts against a running
+# imp-server, 300-token greedy gens, aggregate tok/s = sum completion
+# tokens / wall. Usage: conc_client.py PORT CONC WAVES [TAG].
+import sys
+import threading
+import time
+import urllib.request
+
+PORT = int(sys.argv[1])
+CONC = int(sys.argv[2])
+WAVES = int(sys.argv[3])
+TAG = sys.argv[4] if len(sys.argv) > 4 else "x"
+GEN = 300
+
+results = []
+
+
+def one(i, wave, out):
+    prompt = (f"[{TAG}-w{wave}-r{i}] Explain topic {i * 7 + wave}: how a {i}-way set-associative "
+              f"CPU cache interacts with a TLB during a page-crossing load.")
+    body = json.dumps({
+        "model": "Qwen3.8-27B-NVFP4",
+        "prompt": prompt,
+        "max_tokens": GEN,
+        "temperature": 0,
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"http://127.0.0.1:{PORT}/v1/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=600) as r:
+            j = json.loads(r.read())
+        out[i] = (j.get("usage", {}).get("completion_tokens", 0), time.time() - t0)
+    except Exception as e:
+        out[i] = (0, time.time() - t0)
+        print(f"ERR r{i}: {e}", file=sys.stderr)
+
+
+for wave in range(WAVES):
+    out = {}
+    threads = [threading.Thread(target=one, args=(i, wave, out)) for i in range(CONC)]
+    t0 = time.time()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    wall = time.time() - t0
+    toks = sum(v[0] for v in out.values())
+    agg = toks / wall
+    results.append(agg)
+    print(f"wave{wave}: {toks} tok in {wall:.2f}s = {agg:.1f} tok/s aggregate", flush=True)
+
+results.sort()
+print(f"MEDIAN {results[len(results) // 2]:.1f}")

--- a/tools/analysis/smallm_v2_conc_ab.sh
+++ b/tools/analysis/smallm_v2_conc_ab.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# smallm_v2_conc_ab.sh - alternating A/B for gemm.nvfp4_smallm (off vs on)
+# 3 trials/arm, 3 waves/trial at CONC streams. mbs/seq pinned (free-VRAM swing).
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MODEL=/models/Qwen3.8-27B-NVFP4
+PORT=8090
+CONC=${CONC:-32}
+WAVES=3
+TRIALS=${TRIALS:-3}
+LOG="${TMPDIR:-/tmp}/ab_conc_${CONC}.log"
+: > "$LOG"
+
+start_server() {  # $1 = extra --set args
+    docker rm -f imp-ab >/dev/null 2>&1
+    # shellcheck disable=SC2086
+    docker run -d --name imp-ab --gpus all -v /home/kekz/models:/models \
+        -p ${PORT}:${PORT} imp:test imp-server --model $MODEL --port $PORT \
+        --host 0.0.0.0 --max-concurrent $CONC \
+        --set runtime.max_batch_size=32 --set runtime.max_seq_len=4096 $1 >/dev/null
+    for _ in $(seq 1 180); do
+        sleep 2
+        if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ -z "$(docker ps -q -f name=imp-ab)" ]; then
+            echo "server died:" | tee -a "$LOG"
+            docker logs imp-ab 2>&1 | tail -20 | tee -a "$LOG"
+            return 1
+        fi
+    done
+    echo "server never became healthy" | tee -a "$LOG"
+    return 1
+}
+
+run_arm() {  # $1 = arm name, $2 = extra sets
+    ~/.claude/skills/gpu-stats/gpu-busy-check.sh >/dev/null || {
+        echo "GPU BUSY before $1 - aborting" | tee -a "$LOG"; exit 2; }
+    start_server "$2" || exit 3
+    echo "== arm $1 trial $3 ==" | tee -a "$LOG"
+    python3 "$HERE/conc_client.py" $PORT $CONC $WAVES "$1$3" 2>&1 | tee -a "$LOG"
+    docker rm -f imp-ab >/dev/null 2>&1
+    sleep 3
+}
+
+for t in $(seq 1 $TRIALS); do
+    run_arm A "" "$t"
+    run_arm B "--set gemm.nvfp4_smallm=true" "$t"
+done
+echo "=== summary ===" | tee -a "$LOG"
+grep -H "MEDIAN\|== arm" "$LOG" | tail -40

--- a/tools/analysis/smallm_v2_conc_ab.sh
+++ b/tools/analysis/smallm_v2_conc_ab.sh
@@ -2,6 +2,7 @@
 # smallm_v2_conc_ab.sh - alternating A/B for gemm.nvfp4_smallm (off vs on)
 # 3 trials/arm, 3 waves/trial at CONC streams. mbs/seq pinned (free-VRAM swing).
 set -u
+MODELS_DIR=${MODELS_DIR:-$HOME/models}
 HERE="$(cd "$(dirname "$0")" && pwd)"
 MODEL=/models/Qwen3.8-27B-NVFP4
 PORT=8090
@@ -14,7 +15,7 @@ LOG="${TMPDIR:-/tmp}/ab_conc_${CONC}.log"
 start_server() {  # $1 = extra --set args
     docker rm -f imp-ab >/dev/null 2>&1
     # shellcheck disable=SC2086
-    docker run -d --name imp-ab --gpus all -v /home/kekz/models:/models \
+    docker run -d --name imp-ab --gpus all -v ${MODELS_DIR:-$HOME/models}:/models \
         -p ${PORT}:${PORT} imp:test imp-server --model $MODEL --port $PORT \
         --host 0.0.0.0 --max-concurrent $CONC \
         --set runtime.max_batch_size=32 --set runtime.max_seq_len=4096 $1 >/dev/null

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -137,7 +137,11 @@ def main():
     # construction (AUDIT B64), so it cannot be anywhere else.
     # 997 -> 999 (#this): two GPU tests for gemm_nvfp4_smallm (host-reference
     # walk + bandwidth regression bar) — kernel tests, card required.
-    PINNED = 1001
+    # 1001 -> 1007 (#1766): six GPU tests for the native mxf4nvf4 small-M
+    # GEMM v2 (host-reference correctness incl. accumulate + multi-stripe,
+    # shape-precondition rejects, bandwidth floor, tuning sweep) - GPU-only
+    # by nature, run via make test-gpu / verify-fast.
+    PINNED = 1007
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
## Small-M GEMM v2 (native mxf4nvf4, default ON)

The M<=32 batched-decode projections on NVFP4 checkpoints now run a native block-scaled kernel instead of the grid-starved CUTLASS 128x128 tile: `mma.sync.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64` fed by a producer/consumer cp.async+mbarrier pipeline (1 producer warp, 4 consumer warps, M32xN64xK256 stages, 6-deep smem ring), both sides plain NVFP4. Weights are read in place: zero extra VRAM, 100% coverage. This replaces the Marlin W4A16 sidecar route (#1764, closed unmerged: 12.8 GiB repacked copy for 13% coverage).

- Kernel: `src/quant/nvfp4_gemm_smallm_v2.cu`; dispatch: `gemm.nvfp4_smallm` (now default true) + `gemm.nvfp4_smallm_impl` (2 = v2 default, 1 = the refuted W4A16 kernel, kept for A/B).
- Direct FP16 epilogue at stripes=1 (one launch, no reduce); deterministic split-K reduce otherwise. Spec-verify paths unchanged (#1055 argmax parity). M=1 GEMV paths unchanged.
- Fragment/SF mappings are the CUTLASS `SM120_16x8x64_TN_VS` layouts, cross-checked against `mxf4nvf4_qkt_validate.cu`; correctness gated against a host dequant walk of both packed sides (5 GPU tests in `tests/test_nvfp4_smallm_v2.cu`).

## Measured (Qwen3.8-27B-NVFP4, mbs=32/seq4096 pinned, alternating A/B, 3 trials/arm, fresh server each)

| | off | on | delta |
|---|---:|---:|---:|
| 32 streams, aggregate tok/s (median) | 992.5 | 1151.7 | +16.0% |
| 8 streams | 363.8 | 494.6 | +36.0% |
| isolated M=32 N=5120 K=5120 | 41.4 us (CUTLASS in-situ) | 10.4 us | 4.0x (floor 8.2) |

All 9 ON waves above all 9 OFF waves at both concurrencies, no bimodality. degen_suite: 50 checks, 0 FAIL with v2 ON. Harness: `tools/analysis/smallm_v2_conc_ab.sh` (md5 63a8dfd73060a44f2e7a17bf3a32f5e4). Design, sweep and refutation history: `docs/plans/2026-08-24-qwen38-port.md`, `gemm.h`.

## Gate

verify-fast on the pushed tree (Qwen3-8B-Q8_0, RTX 5090): decode tg128 289.05 vs 287.19 baseline (+0.65%), prefill pp512 12499.64 (+0.75%), pp4096 15472.05 (+0.96%), peak VRAM within 10%, graphs ON 3.35x. Baseline NOT refreshed: the gated single-stream paths do not take this kernel (M=1 GEMV; GGUF model). Pre-commit full GPU suite: 0 FAILED.

Not in here: PPL re-measurement. Teacher-forced PPL runs prefill (M=2048, CUTLASS) and cannot reach the batched-decode-only path; the numerics family (quantized activations x plain NVFP4 weights) matches the CUTLASS path this replaces. Quality evidence is the server-level degen battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
