### PR TITLE
docs(bench): GEMM class with smallm v2 - 613 -> 388.9 us/token, under vLLM's 468

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -502,6 +502,36 @@ project) and cross-sequence prefill batching (`docs/roadmap.md` item
        quant=NVFP4-CT cuda=13.3 path=server-api cmd=bench_conc.py+waves3.py n=3
        flags=max_batch_size=32,max_seq_len=4096]
 
+
+### The GEMM-class lever, shipped (2026-08-25, night)
+
+The native mxf4nvf4 small-M GEMM (v2, #1766, `gemm.nvfp4_smallm` default ON)
+closes the table's largest engine-side post. Same checkpoint, same 32-stream
+wave shape (32x unique short prompts, 300-tok greedy gens), server under nsys
+(`--cuda-graph-trace=node`, Nsight 2026.1.3), kernel-time sums over the
+3-wave window divided by the 28665 emitted tokens:
+
+[PROV: commit=41b9d7e1 date=2026-08-25 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4 cuda=13.3 path=server-api cmd=nsys+conc_client.py n=1
+       window=3-waves tokens=28665 flags=--max-concurrent 32
+       --set runtime.max_batch_size=32 --set runtime.max_seq_len=4096]
+
+| us/token | imp before (steady wave) | imp with v2 (3-wave window) | vLLM 0.27.1 |
+|---|---:|---:|---:|
+| GEMM class | 613 | **388.9** | 468 (Marlin 413 + bf16 rest 55) |
+| activation quantize | 15 | 19.4 | — |
+| GDN scan | 181 | 188.8 | 158 |
+| norms | 35 | 36.2 | 10 |
+
+The v2 kernel is the top GPU kernel of the serving run (51.5% of kernel
+time, med 29.2 us/launch in-situ vs the CUTLASS tile's 41.4) and the CUTLASS
+block-scaled tile disappears from the decode class (remaining instances are
+prefill). Window caveat: this window includes wave boundaries and tails, so
+its wall (953 us/token) and idle are NOT comparable to the steady-state
+wave-2 method above; the like-for-like end-to-end number is the alternating
+A/B: 992.5 -> 1151.7 tok/s aggregate at 32 streams (+16.0%), 363.8 -> 494.6
+at 8 (+36.0%), 3 trials/arm, `tools/analysis/smallm_v2_conc_ab.sh`.
+
 ## Long context (pp8192 / tg512 @ 16k ctx)
 
 First tracked long-context table (the GOAL benchmarking discipline asks for

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -998,5 +998,25 @@ instead of a W4A16 port, and it holds e2e where v1 and the A4 variant died:
   set), in-kernel activation quantize (the 292-launch post), per-shape
   stage/stripe table beyond the measured N=5120 reference.
 
+### In-situ per-shape floors bound the remaining in-class headroom
+
+From the same nsys window (grid.x = N/64 separates the shapes; per-launch
+percentiles over the 3 waves):
+
+| shape (N, launches/step) | p10 | med | p90 | DRAM floor | med % floor |
+|---|---:|---:|---:|---:|---:|
+| gate/up 17408 (128) | 33.3 | 34.4 | 35.2 | 28.0 | 81% |
+| attn q 12288 (16) | 27.9 | 29.2 | 29.9 | 19.8 | 68% |
+| qkv 10240 (48) | 20.9 | 22.3 | 23.0 | 16.5 | 74% |
+| z 6144 (48) | 13.5 | 14.1 | 14.6 | 9.9 | 70% |
+| 5120-mixed: o/out (64, K=6144) + down (64, K=17408) | 13.8 | 32.7 | 35.6 | 9.9 / 28.0 | ~72 / ~86% |
+
+Perfect-floor bound: ~237 us/token for the class against the measured
+388.9, i.e. the OPTIMISTIC in-class residual is ~150 us/token and realistic
+tuning captures a fraction of it. The larger remaining engine posts are the
+GDN scan (188.8 vs vLLM's 158) and the launch-coupled idle (roadmap 0(c)),
+not this kernel. No bimodality per shape: p10-p90 spans are tight; the
+5120 bucket's spread is the o/down shape mix, not variance.
+
 [PROV: commit=15857dff+wiring date=2026-08-25 hw=RTX5090 cuda=13.3
        model=Qwen3.8-27B-NVFP4 harness=scratchpad ab_conc.sh md5=63a8dfd73060a44f2e7a17bf3a32f5e4 n=3/arm]


### PR DESCRIPTION
## BENCHMARKS.md: cross-engine attribution follow-up

New subsection under the 1.58x-gap attribution: the GEMM-class lever shipped (#1766).

| us/token | imp before | imp with v2 | vLLM 0.27.1 |
|---|---:|---:|---:|
| GEMM class | 613 | 388.9 | 468 (Marlin 413 + bf16 rest 55) |

- Method: nsys (`--cuda-graph-trace=node`, Nsight 2026.1.3) on the serving run, kernel-time sums over the 3-wave window / 28665 emitted tokens; PROV inline. Window caveat documented (wave boundaries included, idle/wall not comparable to the steady-wave method).
- Path proof: v2 kernel is the top GPU kernel of the run (51.5% of kernel time, 471600 launches, med 29.2 us in-situ); the CUTLASS block-scaled tile disappears from the decode class (remaining 953 instances are prefill).

Not in here: a fresh two-engine rerun of the aggregate table (needs the vLLM container + its harness; open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
