### PR TITLE
docs(plan): in-situ stage/stripe retune refuted - shipped 6/1 beats every override by 7-13%

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -1018,5 +1018,14 @@ GDN scan (188.8 vs vLLM's 158) and the launch-coupled idle (roadmap 0(c)),
 not this kernel. No bimodality per shape: p10-p90 spans are tight; the
 5120 bucket's spread is the o/down shape mix, not variance.
 
+REFUTED follow-up (2026-08-25, night): in-situ stage/stripe retune. The v1
+lesson (isolated optimum != step optimum) does NOT repeat on v2 - a global
+override sweep in the real 32-stream step (temporary config knobs, fresh
+server per config, 3 waves each, same harness) ranks exactly like the
+isolated sweep, and every deviation from the shipped stages=6/stripes=1
+loses 7-13%: base 1169.9 tok/s aggregate vs s6p2 1082.1, s4p2 1092.6,
+s4p4 1080.5, s3p4 1040.0, s6p3 1020.3. The 68-86%-of-floor residual is not
+reachable through grid geometry; the knobs were not merged.
+
 [PROV: commit=15857dff+wiring date=2026-08-25 hw=RTX5090 cuda=13.3
        model=Qwen3.8-27B-NVFP4 harness=scratchpad ab_conc.sh md5=63a8dfd73060a44f2e7a17bf3a32f5e4 n=3/arm]


### PR DESCRIPTION
## Refutation record for the v2 follow-up

In-situ stage/stripe override sweep (32 streams, Qwen3.8-27B-NVFP4, fresh server per config, 3 waves each, same harness as #1766):

| config | aggregate tok/s (median) |
|---|---:|
| shipped (stages=6, stripes=1) | 1169.9 |
| 6/2 | 1082.1 |
| 4/2 | 1092.6 |
| 4/4 | 1080.5 |
| 3/4 | 1040.0 |
| 6/3 | 1020.3 |

- The v1 lesson (isolated optimum != step optimum) does not repeat on v2: in-situ ranks exactly like the isolated sweep.
- The 68-86%-of-floor in-situ residual is not reachable through grid geometry; the temporary knobs were not merged (no flag for a refuted lever).

Not in here: code changes. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
