### PR TITLE
perf(norms): row-block batched-decode RMSNorm, +6.8% aggregate at 32 streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,16 @@ there instead of retelling it.
 
 ### Added
 
+- **Batched-decode RMSNorm: one register-resident CTA per row (+6.8%
+  aggregate at 32 streams).** The FP16 norm at 2-64 rows ran the warp-per-row
+  prefill kernel: 4 CTAs on 170 SMs, every row read twice - 6.3 us median
+  for 0.65 MB (6% of DRAM bandwidth) and 36.2 us/token of critical-path norm
+  time in the concurrency-gap attribution (vLLM: 10). The row-block kernel
+  reads each row once into registers, one block reduce, writes once.
+  Qwen3.8-27B-NVFP4, 32 streams, alternating two-image A/B, 3 trials:
+  1115.5 -> 1191.1 tok/s aggregate median. degen_suite 50/0. M=1 and
+  large-row prefill paths unchanged.
+
 - **Native mxf4nvf4 small-M GEMM (v2) for batched decode, default ON.** The
   M<=32 decode projections on NVFP4 checkpoints now run a block-scaled
   `mma.sync.kind::mxf4nvf4` kernel with a producer/consumer cp.async+mbarrier

--- a/src/compute/layernorm.cu
+++ b/src/compute/layernorm.cu
@@ -210,6 +210,82 @@ __global__ void rmsnorm_fp16_warp_kernel(const __half* __restrict__ x,
 }
 
 // --------------------------------------------------------------------------
+// Row-block FP16 RMSNorm — the batched-decode variant (2 <= rows <= 64).
+//
+// At mbs<=32 the warp-per-row kernel above launches 4 CTAs on 170 SMs and
+// walks every row TWICE through DRAM (sum-of-squares pass + normalize
+// pass): measured 6.3 us median for 0.65 MB of traffic at rows=32 d=5120,
+// ~6% of DRAM bandwidth, pure latency (nsys 2026-08-25, the norms row of
+// the concurrency-gap attribution). One CTA per row keeps the row
+// REGISTER-resident across the reduction: read once, one block reduce,
+// write once — and rows x 1 CTA puts every row's loads in flight at once.
+// --------------------------------------------------------------------------
+template <int kVecs>
+__global__ void rmsnorm_fp16_rowblock_kernel(const __half* __restrict__ x, const __half* __restrict__ weight,
+                                             __half* __restrict__ out, int d_model, float eps,
+                                             float weight_offset) {
+    const int d_vec = d_model >> 3;
+    const float4* x_vec = reinterpret_cast<const float4*>(x + static_cast<int64_t>(blockIdx.x) * d_model);
+    const float4* w_vec = reinterpret_cast<const float4*>(weight);
+    float4* out_vec = reinterpret_cast<float4*>(out + static_cast<int64_t>(blockIdx.x) * d_model);
+
+    float4 v[kVecs];
+    float sum_sq = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kVecs; ++j) {
+        const int i = threadIdx.x + j * static_cast<int>(blockDim.x);
+        if (i < d_vec) {
+            v[j] = x_vec[i];
+            const half2* h = reinterpret_cast<const half2*>(&v[j]);
+#pragma unroll
+            for (int k = 0; k < 4; ++k) {
+                const float2 f = __half22float2(h[k]);
+                sum_sq += f.x * f.x + f.y * f.y;
+            }
+        }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+        sum_sq += __shfl_xor_sync(0xFFFFFFFFu, sum_sq, off);
+    __shared__ float s_part[32];
+    __shared__ float s_inv;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    if (lane == 0)
+        s_part[warp] = sum_sq;
+    __syncthreads();
+    if (warp == 0) {
+        float t = (lane < (static_cast<int>(blockDim.x) >> 5)) ? s_part[lane] : 0.0f;
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+            t += __shfl_xor_sync(0xFFFFFFFFu, t, off);
+        if (lane == 0)
+            s_inv = rsqrtf(t / static_cast<float>(d_model) + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_inv;
+#pragma unroll
+    for (int j = 0; j < kVecs; ++j) {
+        const int i = threadIdx.x + j * static_cast<int>(blockDim.x);
+        if (i < d_vec) {
+            const float4 wv = w_vec[i];
+            const half2* xh = reinterpret_cast<const half2*>(&v[j]);
+            const half2* wh = reinterpret_cast<const half2*>(&wv);
+            float4 result;
+            half2* rh = reinterpret_cast<half2*>(&result);
+#pragma unroll
+            for (int k = 0; k < 4; ++k) {
+                const float2 xf = __half22float2(xh[k]);
+                const float2 wf = __half22float2(wh[k]);
+                rh[k] = __float22half2_rn(make_float2(xf.x * inv_rms * (wf.x + weight_offset),
+                                                      xf.y * inv_rms * (wf.y + weight_offset)));
+            }
+            out_vec[i] = result;
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
 // Fused RMSNorm + residual for FP32
 // out = rmsnorm(x + residual) * weight
 // x is updated in-place to (x + residual)
@@ -356,6 +432,20 @@ void rmsnorm(const Tensor& x, const Tensor& weight, Tensor& out, float eps, cuda
                         static_cast<float*>(out.data), d_model, eps, weight_offset);
             break;
         case QType::F16:
+            // Batched decode (2..64 rows): row-block kernel, register-
+            // resident single DRAM pass — the warp kernel reads every row
+            // twice and fields 4 CTAs at rows=32 (see its comment).
+            if (rows >= 2 && rows <= 64 && (d_model & 7) == 0 && (d_model >> 3) <= 1024) {
+                if ((d_model >> 3) <= 512)
+                    pdl::launch(rmsnorm_fp16_rowblock_kernel<1>, dim3(rows), dim3(512), 0, stream,
+                                static_cast<const __half*>(x.data), static_cast<const __half*>(weight.data),
+                                static_cast<__half*>(out.data), d_model, eps, weight_offset);
+                else
+                    pdl::launch(rmsnorm_fp16_rowblock_kernel<2>, dim3(rows), dim3(512), 0, stream,
+                                static_cast<const __half*>(x.data), static_cast<const __half*>(weight.data),
+                                static_cast<__half*>(out.data), d_model, eps, weight_offset);
+                break;
+            }
             // Batch prefill (#602): warp-per-row — no barriers/smem; the
             // block-per-row kernel was latency-bound at 8-10% BW.
             if (rows >= 16 && (d_model & 7) == 0) {

--- a/tests/test_layernorm.cu
+++ b/tests/test_layernorm.cu
@@ -375,5 +375,43 @@ TEST(LayerNormTest, EpsilonEffect) {
     free_gpu_tensor(d_out_l);
 }
 
+// ===========================================================================
+// RMSNormRowBlockDecodeShapes -- the batched-decode row-block kernel
+// (2 <= rows <= 64): real decode shapes incl. the kVecs=2 instantiation
+// (d_vec > 512) and both edges of the row gate.
+// ===========================================================================
+TEST(LayerNormTest, RMSNormRowBlockDecodeShapes) {
+    constexpr float eps = 1e-5f;
+    const int shapes[][2] = {{2, 2048}, {32, 5120}, {64, 8192}};
+    for (auto& sh : shapes) {
+        const int rows = sh[0], cols = sh[1];
+        std::vector<float> h_x((size_t)rows * cols), h_w(cols);
+        for (size_t i = 0; i < h_x.size(); i++)
+            h_x[i] = 0.02f * static_cast<float>((i * 37) % 101) - 1.0f;
+        for (int c = 0; c < cols; c++)
+            h_w[c] = 0.5f + 0.001f * static_cast<float>(c % 500);
+        std::vector<float> h_x_fp16(h_x.size()), h_w_fp16(cols), h_ref(h_x.size());
+        for (size_t i = 0; i < h_x.size(); i++)
+            h_x_fp16[i] = __half2float(__float2half(h_x[i]));
+        for (int c = 0; c < cols; c++)
+            h_w_fp16[c] = __half2float(__float2half(h_w[c]));
+        cpu_rmsnorm(h_x_fp16.data(), h_w_fp16.data(), h_ref.data(), rows, cols, eps);
+
+        Tensor d_x = make_gpu_tensor(h_x.data(), QType::F16, {rows, cols});
+        Tensor d_w = make_gpu_tensor(h_w.data(), QType::F16, {cols});
+        Tensor d_out = alloc_gpu_tensor(QType::F16, {rows, cols});
+        rmsnorm(d_x, d_w, d_out, eps, nullptr);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        auto h_out = read_gpu_tensor(d_out);
+        double max_err = 0.0;
+        for (size_t i = 0; i < h_x.size(); i++)
+            max_err = std::max(max_err, (double)std::abs(h_out[i] - h_ref[i]));
+        EXPECT_LT(max_err, 1e-2) << "rows=" << rows << " cols=" << cols;
+        free_gpu_tensor(d_x);
+        free_gpu_tensor(d_w);
+        free_gpu_tensor(d_out);
+    }
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -141,7 +141,10 @@ def main():
     # GEMM v2 (host-reference correctness incl. accumulate + multi-stripe,
     # shape-precondition rejects, bandwidth floor, tuning sweep) - GPU-only
     # by nature, run via make test-gpu / verify-fast.
-    PINNED = 1007
+    # 1007 -> 1008 (#1769): LayerNormTest.RMSNormRowBlockDecodeShapes, the
+    # row-block batched-decode RMSNorm against the CPU reference on three
+    # decode shapes - needs a GPU.
+    PINNED = 1008
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
## Batched-decode RMSNorm: one register-resident CTA per row

The FP16 norm at 2-64 rows ran the warp-per-row prefill kernel: 4 CTAs on 170 SMs at rows=32, every row read TWICE from DRAM (sum-of-squares pass + normalize pass) - 6.3 us median for 0.65 MB = 6% of DRAM bandwidth, and 36.2 us/token of critical-path norm time in the concurrency-gap attribution (vLLM: 10). `rmsnorm_fp16_rowblock_kernel` (src/compute/layernorm.cu): one CTA per row, row register-resident across the block reduce, single DRAM pass. Gate: F16, 2 <= rows <= 64, d_model % 8 == 0, d_vec <= 1024; M=1 and large-row prefill keep their paths.

## Measured (Qwen3.8-27B-NVFP4, 32 streams, mbs=32/seq4096 pinned, alternating two-image A/B, 3 trials/arm)

| | main | row-block | delta |
|---|---:|---:|---:|
| aggregate tok/s (median of trial medians) | 1115.5 | 1191.1 | +6.8% |

B over A in 8 of 9 waves. The gain exceeds the norm class's own kernel time (~3.4% of wall): the 4-CTA launch sat as a serial link in the decode chain, so its latency also showed up as GPU idle. degen_suite: 50 checks, 0 FAIL. Correctness: LayerNormTest.RMSNormRowBlockDecodeShapes covers {2,2048}, {32,5120} and {64,8192} (both kVecs instantiations + gate edges) against the CPU reference.

## Gate

verify-fast on the pushed tree (Qwen3-8B-Q8_0, RTX 5090): decode tg128 278.61 vs 287.19 baseline (-2.99%), pp512 -2.67%, pp4096 -1.56%, peak VRAM within 10%, graphs ON 2.30x, degen probe green. The ~3% depression is a host-side GPU consumer (1.2 GiB / 2-8% util, Windows tenant, visible only in memory.used) present during the run; baseline not refreshed (M=1 paths untouched). Pre-commit full GPU suite ran twice: all functional tests green both rounds; the two marginal bandwidth-floor bench thresholds (40%) flaked at 39.5% under the same consumer.

Not in here: gdn_rmsnorm_gated_silu and the norm->NVFP4-quantize fusion (next candidates in the same class, recorded in the plan doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
