### PR TITLE
ci: own check name for the test-lane pin, static gates in pre-push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,20 @@ jobs:
       - name: File-size gates (blocking)
         run: bash scripts/ci_static_gates.sh filesize
 
+  # The unlaned-GTest pin (tools/check_test_lanes.py). Its own check name:
+  # it fires on every added GPU test, and inside the "File size" job its
+  # failures read as file-size problems (twice on 2026-08-25).
+  testlanes:
+    name: Test lanes
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Test-lane gate (blocking)
+        run: bash scripts/ci_static_gates.sh lanes
+
   # Documentation layer contract (docs/audit/docs-rewrite/). Seven checks, all
   # of which map to a defect this repo actually shipped: a datacenter-Blackwell
   # feature named as an imp feature, a throughput number that outlived its

--- a/scripts/ci_static_gates.sh
+++ b/scripts/ci_static_gates.sh
@@ -66,10 +66,17 @@ SELECT_ALL=0
 if want filesize; then
     echo "== File size =="
     run "hard-review gate + allowlist ceilings" python3 tools/check_filesize.py
-    run "tests that run in no CI lane"          python3 tools/check_test_lanes.py --report
     run "deterministic-mode sites vs the doc"   python3 tools/check_determinism_sites.py
     run "header-inline definitions with no caller" python3 tools/check_dead_inline_accessors.py
     run "FATAL logs that do not stop"           python3 tools/check_log_fatal.py --list
+fi
+
+# Own group so its failure carries its own CI check name: both 2026-08-25
+# "File size" reds were THIS pin (a new GPU test bumps the unlaned count),
+# and the job name sent two readers to the wrong mechanism.
+if want lanes; then
+    echo "== Test lanes =="
+    run "tests that run in no CI lane"          python3 tools/check_test_lanes.py --report
 fi
 
 if want alloc; then

--- a/scripts/pre-push.hook
+++ b/scripts/pre-push.hook
@@ -66,6 +66,16 @@ if [ "$NEEDS_VERIFY" -eq 0 ]; then
     exit 0
 fi
 
+# Cheap static gates first (seconds, no GPU, no build): the test-lane pin and
+# the file-size ceilings otherwise surface only in CI, one full roundtrip
+# after the push (both 2026-08-25 "File size" reds were the pin, found in CI).
+if [ -x "$ROOT/scripts/ci_static_gates.sh" ] || [ -f "$ROOT/scripts/ci_static_gates.sh" ]; then
+    if ! bash "$ROOT/scripts/ci_static_gates.sh" filesize lanes; then
+        echo "pre-push: static gates failed (see above) - fix or push --no-verify"
+        exit 1
+    fi
+fi
+
 # Both tiers below run kernels, so neither can judge anything on a busy card.
 # Checked after the "no source changes" exit above: a docs-only push must not
 # wait for a card it never touches.


### PR DESCRIPTION
## Static-gate visibility (the two fixes from the 2026-08-25 gate assessment)

Both "File size" reds that day were the unlaned-GTest pin (`tools/check_test_lanes.py`), not file size, and the pin only ever fired in CI - one full roundtrip after the push.

1. **Own check name.** `test-lanes` moves out of the `filesize` gate group into its own group `lanes` + CI job `Test lanes`. The `Build` job still runs every gate (no-filter invocation unchanged), so blocking behavior is identical - only the name a failure carries changes.
2. **Pre-push runs the cheap gates first.** `scripts/pre-push.hook` runs `ci_static_gates.sh filesize lanes` before any GPU work (seconds, no build, no network). A forgotten pin re-pin now trips locally instead of in CI. Guarded like the existing `require_free_gpu.sh` block for old checkouts; dogfooded on this very push.

Not in here: un-bundling determinism-sites / dead-inline / log-fatal from the "File size" job (never fired; churn without a symptom), and a ratchet on the advisory warn tier (44 files, drifting - recorded in the assessment, not built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
