### PR TITLE
perf(exec): shared-activation quantize for batched decode, +4.6% aggregate at 32 streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,28 +48,6 @@ there instead of retelling it.
   (median 987, three runs), per-request event order preserved, SSE and
   finish_reason verified, degen_suite 50/50.
 
-- **The small-M GEMM's A4 variant exists and is measured** (`gemm_nvfp4_smallm_a4`
-  + graph-safe `quantize_fp16_to_nvfp4_into`): both sides packed NVFP4. E2e it
-  reads 742-747 tok/s aggregate at 32 streams against 955-963 with the CUTLASS
-  path - worse than the FP16 variant - and its microbench stays bimodal at a
-  92 KiB activation working set, retiring L2 eviction as the main driver. The
-  route to Marlin-class small-M economics is a genuine Marlin port (cp.async
-  pipeline, stripe partitioning); the config comment carries the numbers.
-  Default stays OFF.
-
-- **A Marlin-class small-M NVFP4 GEMM exists now** (`gemm_nvfp4_smallm`,
-  `gemm.nvfp4_smallm`, default OFF): W4A16 dequant-to-FP16 in smem + HMMA +
-  split-K on the plain weight layout. Isolated on the batched-decode shape
-  (M=32 N=5120 K=5120) it reads 23.9 us median against the shipping CUTLASS
-  tile's 41.4 - the "no-split ceiling" from the five-approach survey falls.
-  In the real step the GDN scan's 9.7 GB/step of L2 traffic evicts the
-  activation tile and it runs at 45.8 us, costing ~11% aggregate, hence the
-  default. The two routes that flip the sign are priced in the config
-  comment. Kernel-level and host-reference tests ship with it; the eight
-  measurement iterations (536.5 -> 23.9 us, including a 32-way smem bank
-  conflict, a warmup-ramp trap and an L2 set-conflict bimodality) are in
-  `docs/plans/2026-08-24-qwen38-port.md`.
-
 - **The n>1 decode loop no longer re-uploads each row's whole output history
   from pageable memory every step.** With the server's repetition-penalty
   default every batched row paid one pageable H2D per step (8.5k per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,16 @@ there instead of retelling it.
 
 ### Added
 
+- **Shared-activation quantize for batched decode (+4.6% aggregate at 32
+  streams).** gate/up, q/k/v and GDN in/z read the same normed input, and the
+  small-M dispatch quantized it once PER GEMM - 1:1 quantize launches on the
+  decode critical path. The dispatch now honors the existing act-quant hint
+  (the CUTLASS prefill sharing mechanism) plus a scratch tag, skipping the
+  re-quantize for the second and third member of a pair: quantize:GEMM launch
+  ratio 1.0 -> 0.64 (nsys), bit-identical xq. Qwen3.8-27B-NVFP4, 32 streams,
+  alternating two-image A/B, 3 trials: 1132.2 -> 1183.8 tok/s median, +3.6
+  to +4.6% pairwise in 3 of 3 pairs. degen_suite 50/0.
+
 - **Batched-decode RMSNorm: one register-resident CTA per row (+6.8%
   aggregate at 32 streams).** The FP16 norm at 2-64 rows ran the warp-per-row
   prefill kernel: 4 CTAs on 170 SMs, every row read twice - 6.3 us median

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -260,6 +260,13 @@ public:
     size_t smallm_ws_bytes_ = 0;
     void* smallm_xq_ = nullptr;   // A4 activation quantize scratch [32, Kmax]
     size_t smallm_xq_bytes_ = 0;
+    // What smallm_xq_ currently holds (source pointer + shape of the last
+    // activation quantize). Lets a dispatch with a matching act-quant hint
+    // skip the re-quantize when two GEMMs share one normed input (gate/up,
+    // q/k/v, GDN in/z). The triple self-invalidates on every fresh quantize.
+    const void* smallm_xq_src_ = nullptr;
+    int smallm_xq_src_m_ = 0;
+    int smallm_xq_src_k_ = 0;
     // NVFP4 view of the LM head for the MTP draft chain's M=1 logits GEMV.
     // Fills `out` from the secondary decode cache (wcache_.nvfp4) or the
     // native-NVFP4 registry tier — the same sources the decode-path LM head

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -393,13 +393,29 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                         smallm_xq_ = nullptr;
                         smallm_xq_bytes_ = 0;
                     }
+                    smallm_xq_src_ = nullptr;  // fresh scratch holds nothing
                 }
             }
             if (smallm_ws_bytes_ >= need && smallm_xq_bytes_ >= xq_need) {
                 uint8_t* xq_packed = static_cast<uint8_t*>(smallm_xq_);
                 uint8_t* xq_scales = xq_packed + (size_t)32 * (K / 2);
-                quantize_fp16_to_nvfp4_into(input.data, M, K, xq_packed, xq_scales,
-                                            /*tensor_scale=*/1.0f, ctx.stream);
+                // Shared-activation skip: the call site marked this input as
+                // already quantized by the PREVIOUS dispatch (act-quant hint,
+                // same mechanism the CUTLASS prefill block uses), and the
+                // scratch tag confirms the scratch still holds exactly that
+                // quantize. Saves one quantize launch + a [M,K] FP16 read per
+                // second member of a gate/up, q/k/v or GDN in/z pair.
+                const bool prequant = ctx.act_quant_hint_data != nullptr &&
+                                      ctx.act_quant_hint_data == input.data && ctx.act_quant_hint_m == M &&
+                                      ctx.act_quant_hint_k == K && smallm_xq_src_ == input.data &&
+                                      smallm_xq_src_m_ == M && smallm_xq_src_k_ == K;
+                if (!prequant) {
+                    quantize_fp16_to_nvfp4_into(input.data, M, K, xq_packed, xq_scales,
+                                                /*tensor_scale=*/1.0f, ctx.stream);
+                    smallm_xq_src_ = input.data;
+                    smallm_xq_src_m_ = M;
+                    smallm_xq_src_k_ = K;
+                }
                 NvFP4QuantResult nv;
                 nv.packed_data = const_cast<void*>(h.source_data);
                 nv.micro_scales = h.source_scales;

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -482,7 +482,14 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         gate_out = Tensor(gate_ptr, compute_dtype_, 2, gate_shape, true);
     } else {
         gate_out = Tensor(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
-        gemm_via_handle_(ly.gdn_gate_id, no, gate_out, ctx);
+        // ssm_in (above) quantized the same normed input into the activation
+        // scratch and no GEMM dispatches in between — mark it shared (the
+        // dispatch verifies against its scratch tag before skipping).
+        GemmContext gate_ctx = ctx;
+        if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.ssm_in_id, n) &&
+            prefill_routes_cutlass_nvfp4_(ly.gdn_gate_id, n))
+            gate_ctx = ctx.with_act_quant_hint(no.data, n, static_cast<int>(no.shape[1]));
+        gemm_via_handle_(ly.gdn_gate_id, no, gate_out, gate_ctx);
     }
 
     const bool use_fp32_scan = runtime_config().gdn.fp32_scan;


### PR DESCRIPTION
## Shared-activation quantize (batched decode)

gate/up, q/k/v and GDN in/z read the same normed input, and the small-M dispatch quantized it once PER GEMM - 1:1 quantize launches on the decode critical path (471600 in the 3-wave window, 19.4 us/token). The dispatch now honors the existing act-quant hint (the mechanism the CUTLASS prefill block already uses for gate/up and q/k/v sharing) guarded by a scratch tag (`smallm_xq_src_/m_/k_`), and skips the re-quantize for the second/third member of a pair. The GDN site (`gdn_gate` after `ssm_in`, no GEMM in between) gains the hint; FFN and attention already set it. xq is bit-identical either way (same input, same bytes) - no numerics change.

## Measured (Qwen3.8-27B-NVFP4, 32 streams, mbs=32/seq4096 pinned, alternating two-image A/B, 3 trials/arm)

| | main | shared | delta |
|---|---:|---:|---:|
| aggregate tok/s (median of trial medians) | 1132.2 | 1183.8 | +4.6% |

Pairwise +3.6 / +3.6 / +4.6% in 3 of 3 pairs. Mechanism proof (nsys, one 32-stream wave): quantize:GEMM launch ratio 1.0 -> 0.64 - exactly the predicted 36% shared members (64 gate/up + 32 k/v + 48 GDN of ~400/step). degen_suite: 50 checks, 0 FAIL.

## Gate

Pre-commit full GPU suite: 0 FAILED. verify-fast on the pushed tree: green (the change is decode-dispatch-only; M=1 and prefill paths keep their behavior - prefill's own hint consumer is untouched).

Not in here: the second half of the launch-idle campaign (norm -> NVFP4-quantize fusion in the producer kernels) - recorded in the plan doc. Also drops the two [Unreleased] CHANGELOG entries for the v1 W4A16 kernel and its A4 variant: superseded by v2 in the same release cycle, their measurement history lives in `docs/plans/2026-08-24-qwen38-port.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVa519mPrhx5E7rZDSkCu
