### PR TITLE
perf(gdn): BF16 recurrent state for the scan - +12.5% aggregate at 32 streams, opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,19 @@ there instead of retelling it.
 
 ### Added
 
+- **BF16 recurrent state for the GDN scan (`gdn.state_bf16`, opt-in): +12.5%
+  aggregate at 32 streams.** The FP32 scan sits at this box's resident
+  bandwidth ceiling (1527 GB/s measured isolated), so halving the state
+  bytes is the whole win: 132.7 -> 64.9 us/launch isolated (2.04x), e2e
+  1210.5 -> 1362.0 tok/s median at 32 streams (3/3 pairs, KV pinned at 2387
+  blocks in both arms), state pool 4848 -> 2544 MiB. Quality: PPL 4.6259 ->
+  4.6356 (+0.21%) over ppl_corpus_45k, degen_suite 50/0, 256-step decode
+  trajectory 0.18% relative RMS vs FP32 state. Arithmetic stays FP32 in
+  registers; FP16 state remains refuted (subnormal truncation). Not yet the
+  default: an unpinned start trips #1765 (the VRAM plan collapses KV to 128
+  blocks when it formally succeeds) - pin `kv_cache.max_blocks` until that
+  is fixed.
+
 - **Producer-side NVFP4 activation quantize for batched decode (+2.6%
   aggregate at 32 streams).** The fused rmsnorm+quantize and swiglu+quantize
   kernels emit the small-M xq scratch inside the kernel that writes the FP16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/reduce.cu
     src/compute/ssm.cu
     src/compute/gdn.cu
+    src/compute/gdn_gated_norm.cu
     src/compute/hadamard.cu
     src/compute/mmq_q4k_imma_layout.cu
     src/compute/mmq_q4k_imma_tile.cu

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -1029,3 +1029,41 @@ reachable through grid geometry; the knobs were not merged.
 
 [PROV: commit=15857dff+wiring date=2026-08-25 hw=RTX5090 cuda=13.3
        model=Qwen3.8-27B-NVFP4 harness=scratchpad ab_conc.sh md5=63a8dfd73060a44f2e7a17bf3a32f5e4 n=3/arm]
+
+## The GDN scan post is paid: BF16 state (2026-08-26)
+
+The scan was not a kernel problem - the FP32 kernel measures 1527 GB/s
+isolated (48h x 32seq, 8 rotating 100-MB slabs to defeat L2), which IS this
+box's resident ceiling (~1530). Bytes were the only lever. `gdn.state_bf16`
+stores h_state as BF16 (FP32 range kept; FP16 state stays refuted on the
+~6e-5 subnormal truncation), arithmetic FP32 in registers:
+
+| | FP32 state | BF16 state |
+|---|---:|---:|
+| scan us/launch isolated (48h x 32seq) | 132.7 | 64.9 (2.04x) |
+| effective GB/s | 1527 | 1570 |
+| 32-stream aggregate (median of 3, KV pinned 2387) | 1210.5 | 1362.0 (+12.5%) |
+| PPL ppl_corpus_45k | 4.6259 | 4.6356 (+0.21%) |
+| state pool | 4848 MiB | 2544 MiB |
+
+degen 50/0; 256-step decode round-trip trajectory 0.18% relative RMS.
+Against vLLM's 1477 profiled the gap stands at ~1.08x.
+
+Two findings on the way:
+
+- **The "MUST keep FP32" resolver note was a LAYOUT constraint, not a
+  numerics one** (the scan kernels assumed 4 B/element against a pool
+  allocated at dtype size). The Qwen3.6 NaN in the known-issues table has
+  the same signature (state region overflow), not intrinsic BF16
+  instability.
+- **#1765 reproduced from the other side**: freeing 2.3 GB of state made
+  the VRAM plan formally succeed with kv.blocks=128, which is then APPLIED
+  over a live pass that sized 4096 ('KV blocks: plan 128 (live pass sized
+  4096)') - 32-stream aggregate 510 tok/s purely from the starved pool.
+  When the plan REJECTS, the live fallback (2387) rescues it. Default-ON
+  for state_bf16 is blocked on that fix; until then pin
+  `kv_cache.max_blocks`.
+
+[PROV: commit=9862e3b2 date=2026-08-26 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4-CT cuda=13.3 path=server-api cmd=gdn_bf16_ab.sh n=3/arm
+       flags=max_batch_size=32,max_seq_len=4096,kv_cache.max_blocks=2387]

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -1,6 +1,7 @@
 #include "compute/gdn_internal.cuh"
 #include "core/logging.h"
 
+#include <cuda_bf16.h>
 #include <stdexcept>
 #include <string>
 
@@ -34,18 +35,24 @@ __global__ void gdn_scan_decode_kernel(const float*, const float*, const float*,
 // thread owns half a column, the two partners sit in ADJACENT lanes so the two
 // dot products reduce with a single __shfl_xor_sync, and the register pressure
 // halves.
-template <int HD, int SS, typename YOut, int SPLIT = 1>
+// StateT: h_state STORAGE type — float (default) or __nv_bfloat16
+// (gdn.state_bf16: halves the state traffic that dominates batched decode;
+// the microbench reads the FP32 kernel at 1527 GB/s = the box's resident
+// ceiling, so bytes are the only lever). All arithmetic stays FP32 in
+// registers; loads/stores convert. BF16 keeps FP32's range — FP16 state was
+// refuted for GDN (subnormal truncation at ~6e-5 breaks near-zero heads).
+template <int HD, int SS, typename YOut, int SPLIT = 1, typename StateT = float>
 __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     const float* __restrict__ conv_f32,  // [n_tokens, conv_channels] FP32
     const half* __restrict__ alpha_all,  // [n_tokens, n_heads] FP16
     const half* __restrict__ beta_all,   // [n_tokens, n_heads] FP16
     const float* __restrict__ A_log,     // [n_heads] FP32
     const float* __restrict__ dt_bias,   // [n_heads] FP32
-    float* __restrict__ h_state,         // [n_heads, SS, HD] FP32
+    StateT* __restrict__ h_state,        // [n_heads, SS, HD] in StateT
     YOut* __restrict__ y_out,            // [n_tokens, n_heads * HD] FP16 or FP32
     int n_tokens, int n_heads, int n_groups, int conv_channels, int grouped_layout,
     const int* __restrict__ d_real_n,    // device chunk length (padded verify chunk) or nullptr
-    float* __restrict__ h_snap,          // second state output, or nullptr
+    StateT* __restrict__ h_snap,         // second state output, or nullptr
     const int* __restrict__ d_snap_n,    // row count h_snap is taken at
     // --- batched decode over independent sequences (#GDN-batch) ---
     // seq_slots: per-blockIdx.y recurrent-state slot id, or nullptr for the
@@ -104,10 +111,10 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     // Each thread holds SS floats = one column of H[SS, HD].
     float H_reg[SS_PER];
     {
-        const float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+        const StateT* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
 #pragma unroll
         for (int s = 0; s < SS_PER; s++)
-            H_reg[s] = H_col[(s_base + s) * HD];
+            H_reg[s] = static_cast<float>(H_col[(s_base + s) * HD]);
     }
 
     // Shared memory: K_norm[SS] + Q_norm[SS] + reduce_buf[HD]
@@ -246,16 +253,16 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
         // no barrier needed). For the unpadded case real_n == n_tokens and
         // this is the single end-of-scan store the kernel always did.
         if (t + 1 == real_n) {
-            float* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
+            StateT* H_col = h_state + static_cast<size_t>(h) * SS * HD + d;
 #pragma unroll
             for (int s = 0; s < SS_PER; s++)
-                H_col[(s_base + s) * HD] = H_reg[s];
+                H_col[(s_base + s) * HD] = static_cast<StateT>(H_reg[s]);
         }
         if (t + 1 == snap_n) {
-            float* S_col = h_snap + static_cast<size_t>(h) * SS * HD + d;
+            StateT* S_col = h_snap + static_cast<size_t>(h) * SS * HD + d;
 #pragma unroll
             for (int s = 0; s < SS_PER; s++)
-                S_col[(s_base + s) * HD] = H_reg[s];
+                S_col[(s_base + s) * HD] = static_cast<StateT>(H_reg[s]);
         }
 
         // Sync before next token — the next iteration overwrites s_k/s_q in
@@ -266,50 +273,7 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Fused RMSNormGated + SiLU kernel.
-// Computes: y[t,h,:] = rmsnorm(y[t,h,:], weight) * silu(gate[t,h,:])
-//
-// Grid:  (n_tokens, n_heads)
-// Block: (head_dim)
-// ---------------------------------------------------------------------------
-__global__ void gdn_rmsnorm_gated_silu_kernel(
-    half* __restrict__ y,             // [n_tokens, n_heads * head_dim] in/out
-    const half* __restrict__ gate,    // [n_tokens, n_heads * head_dim]
-    const half* __restrict__ weight,  // [head_dim] shared norm weight
-    float eps, int n_heads, int head_dim) {
-    const int t = blockIdx.x;
-    const int h = blockIdx.y;
-    const int d = threadIdx.x;
-    if (d >= head_dim)
-        return;
-
-    const int inner = n_heads * head_dim;
-    const int base = t * inner + h * head_dim;
-
-    // Load y value
-    float val = __half2float(y[base + d]);
-
-    // Parallel sum-of-squares for RMSNorm
-    extern __shared__ float s_buf[];
-    s_buf[d] = val * val;
-    __syncthreads();
-    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
-        if (d < stride)
-            s_buf[d] += s_buf[d + stride];
-        __syncthreads();
-    }
-    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
-
-    // RMSNorm: normalize and scale by weight
-    float normed = val * inv_rms * __half2float(weight[d]);
-
-    // SiLU on gate and multiply
-    float g = __half2float(gate[base + d]);
-    float silu_g = g / (1.0f + expf(-g));
-
-    y[base + d] = __float2half(normed * silu_g);
-}
+// Gated-norm family (FP16/FP32 variants) lives in gdn_gated_norm.cu.
 
 // ---------------------------------------------------------------------------
 // V-head reorder: tiled -> grouped (undo GGUF converter reorder for ssm_out)
@@ -406,18 +370,44 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
         const size_t smem = (2 * 128 + 128 * SPLIT) * sizeof(float);
         gdn_scan_fused_kernel<128, 128, half, SPLIT><<<grid, 128 * SPLIT, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
-            conv_channels, grouped_layout, d_real_n, nullptr, nullptr, seq_slots, h_state_seq_stride);
+            conv_channels, grouped_layout, d_real_n, static_cast<float*>(nullptr), nullptr, seq_slots,
+            h_state_seq_stride);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         const size_t smem = (2 * 64 + 64) * sizeof(float);
         gdn_scan_fused_kernel<64, 64, half><<<grid, 64, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
-            conv_channels, grouped_layout, d_real_n, nullptr, nullptr, seq_slots, h_state_seq_stride);
+            conv_channels, grouped_layout, d_real_n, static_cast<float*>(nullptr), nullptr, seq_slots,
+            h_state_seq_stride);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         IMP_LOG_ERROR("gdn_scan_fused_f32_batched: unsupported head_dim=%d state_size=%d", head_dim_ssm,
                       state_size);
     }
+}
+
+// BF16-state twin (gdn.state_bf16). h_state_seq_stride is in BF16 ELEMENTS.
+// HD=SS=128 only — the init resolver refuses BF16 state for other shapes,
+// so reaching the else here is a wiring bug, not a serving condition.
+void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const half* alpha,
+                                 const half* beta, const float* A_log, const float* dt_bias,
+                                 __nv_bfloat16* h_state_pool, const int* seq_slots,
+                                 int64_t h_state_seq_stride, half* y, int n_seq, int n_tokens, int n_heads,
+                                 int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
+                                 int grouped_layout, const int* d_real_n) {
+    if (n_seq <= 0)
+        return;
+    if (head_dim_ssm != 128 || state_size != 128)
+        throw std::runtime_error("gdn_scan_fused_bf16_batched: no kernel for HD=" +
+                                 std::to_string(head_dim_ssm) + " SS=" + std::to_string(state_size));
+    dim3 grid(n_heads, n_seq);
+    constexpr int SPLIT = 2;
+    const size_t smem = (2 * 128 + 128 * SPLIT) * sizeof(float);
+    gdn_scan_fused_kernel<128, 128, half, SPLIT, __nv_bfloat16><<<grid, 128 * SPLIT, smem, stream>>>(
+        conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups, conv_channels,
+        grouped_layout, d_real_n, static_cast<__nv_bfloat16*>(nullptr), nullptr, seq_slots,
+        h_state_seq_stride);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // Fused scan: processes all tokens in one kernel launch.
@@ -436,13 +426,13 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
         gdn_scan_fused_kernel<128, 128, half>
             <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
                                              n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
-                                             nullptr, nullptr);
+                                             static_cast<float*>(nullptr), nullptr);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         gdn_scan_fused_kernel<64, 64, half>
             <<<n_heads, 64, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
-                                            nullptr, nullptr);
+                                            static_cast<float*>(nullptr), nullptr);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Fallback: per-token loop (for unsupported HD/SS sizes). The host
@@ -463,6 +453,23 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
             IMP_CUDA_CHECK_LAUNCH();
         }
     }
+}
+
+// BF16-state twin of gdn_scan_fused_f32 (prefill / single-sequence path).
+// HD=SS=128 only — see the batched twin's comment.
+void gdn_scan_fused_bf16(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                         const float* A_log, const float* dt_bias, __nv_bfloat16* h_state, half* y,
+                         int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                         cudaStream_t stream, int grouped_layout, const int* d_real_n) {
+    if (head_dim_ssm != 128 || state_size != 128)
+        throw std::runtime_error("gdn_scan_fused_bf16: no kernel for HD=" + std::to_string(head_dim_ssm) +
+                                 " SS=" + std::to_string(state_size));
+    size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
+    gdn_scan_fused_kernel<128, 128, half, 1, __nv_bfloat16>
+        <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
+                                         n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
+                                         static_cast<__nv_bfloat16*>(nullptr), nullptr);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // FP32-output variant — writes scan result as FP32 for downstream
@@ -507,6 +514,25 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
                                  "its FP32 output, so serving this shape would return a scan that did "
                                  "nothing.");
     }
+}
+
+// BF16-state twin of gdn_scan_fused_fp32out (the gdn.fp32_scan combo).
+// HD=SS=128 only — see the batched twin's comment.
+void gdn_scan_fused_fp32out_bf16(const float* conv_f32, int conv_channels, const half* alpha,
+                                 const half* beta, const float* A_log, const float* dt_bias,
+                                 __nv_bfloat16* h_state, float* y_fp32, int n_tokens, int n_heads,
+                                 int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
+                                 int grouped_layout, const int* d_real_n, __nv_bfloat16* h_snap,
+                                 const int* d_snap_n) {
+    if (head_dim_ssm != 128 || state_size != 128)
+        throw std::runtime_error("gdn_scan_fused_fp32out_bf16: no kernel for HD=" +
+                                 std::to_string(head_dim_ssm) + " SS=" + std::to_string(state_size));
+    size_t smem = (2 * state_size + head_dim_ssm) * sizeof(float);
+    gdn_scan_fused_kernel<128, 128, float, 1, __nv_bfloat16>
+        <<<n_heads, 128, smem, stream>>>(conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
+                                         n_heads, n_groups, conv_channels, grouped_layout, d_real_n, h_snap,
+                                         d_snap_n);
+    IMP_CUDA_CHECK_LAUNCH();
 }
 
 // ---------------------------------------------------------------------------
@@ -684,107 +710,6 @@ void gdn_scan_reference_f32(const float* conv_f32, int conv_channels, const half
                                                                        n_groups, head_dim_ssm, state_size,
                                                                        conv_channels, grouped_layout,
                                                                        d_real_n);
-    IMP_CUDA_CHECK_LAUNCH();
-}
-
-// FP32-input variant: reads y as FP32, writes FP16. Used together with
-// `gdn_scan_fused_fp32out` so the RMS reduction sees full-precision scan output
-// (without FP16 subnormal truncation at ~6e-5).
-__global__ void gdn_rmsnorm_gated_silu_fp32in_kernel(
-    half* __restrict__ y_fp16_out,        // [n_tokens, n_heads * head_dim]
-    const float* __restrict__ y_fp32_in,  // [n_tokens, n_heads * head_dim]
-    const half* __restrict__ gate, const half* __restrict__ weight, float eps, int n_heads, int head_dim) {
-    const int t = blockIdx.x;
-    const int h = blockIdx.y;
-    const int d = threadIdx.x;
-    if (d >= head_dim)
-        return;
-
-    const int inner = n_heads * head_dim;
-    const int base = t * inner + h * head_dim;
-
-    float val = y_fp32_in[base + d];
-
-    extern __shared__ float s_buf[];
-    s_buf[d] = val * val;
-    __syncthreads();
-    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
-        if (d < stride)
-            s_buf[d] += s_buf[d + stride];
-        __syncthreads();
-    }
-    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
-
-    float normed = val * inv_rms * __half2float(weight[d]);
-
-    float g = __half2float(gate[base + d]);
-    float silu_g = g / (1.0f + expf(-g));
-
-    y_fp16_out[base + d] = __float2half(normed * silu_g);
-}
-
-void gdn_rmsnorm_gated_silu_fp32in(half* y_fp16_out, const float* y_fp32_in, const half* gate,
-                                   const half* weight, float eps, int n_tokens, int n_heads, int head_dim,
-                                   cudaStream_t stream) {
-    size_t smem = head_dim * sizeof(float);
-    dim3 grid(n_tokens, n_heads);
-    gdn_rmsnorm_gated_silu_fp32in_kernel<<<grid, head_dim, smem, stream>>>(y_fp16_out, y_fp32_in, gate,
-                                                                           weight, eps, n_heads, head_dim);
-    IMP_CUDA_CHECK_LAUNCH();
-}
-
-// FP32-in, FP32-out: keeps full precision through gated norm so ssm_out GEMM
-// sees FP32 input (fixes 6% accumulation drift in FP16-input matmul).
-__global__ void gdn_rmsnorm_gated_silu_fp32inout_kernel(float* __restrict__ y_fp32_out,
-                                                        const float* __restrict__ y_fp32_in,
-                                                        const half* __restrict__ gate,
-                                                        const half* __restrict__ weight, float eps,
-                                                        int n_heads, int head_dim) {
-    const int t = blockIdx.x;
-    const int h = blockIdx.y;
-    const int d = threadIdx.x;
-    if (d >= head_dim)
-        return;
-
-    const int inner = n_heads * head_dim;
-    const int base = t * inner + h * head_dim;
-
-    float val = y_fp32_in[base + d];
-
-    extern __shared__ float s_buf[];
-    s_buf[d] = val * val;
-    __syncthreads();
-    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
-        if (d < stride)
-            s_buf[d] += s_buf[d + stride];
-        __syncthreads();
-    }
-    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
-
-    float normed = val * inv_rms * __half2float(weight[d]);
-
-    float g = __half2float(gate[base + d]);
-    float silu_g = g / (1.0f + expf(-g));
-
-    y_fp32_out[base + d] = normed * silu_g;
-}
-
-void gdn_rmsnorm_gated_silu_fp32inout(float* y_fp32_out, const float* y_fp32_in, const half* gate,
-                                      const half* weight, float eps, int n_tokens, int n_heads, int head_dim,
-                                      cudaStream_t stream) {
-    size_t smem = head_dim * sizeof(float);
-    dim3 grid(n_tokens, n_heads);
-    gdn_rmsnorm_gated_silu_fp32inout_kernel<<<grid, head_dim, smem, stream>>>(y_fp32_out, y_fp32_in, gate,
-                                                                              weight, eps, n_heads, head_dim);
-    IMP_CUDA_CHECK_LAUNCH();
-}
-
-// Fused RMSNormGated + SiLU
-void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float eps, int n_tokens,
-                            int n_heads, int head_dim, cudaStream_t stream) {
-    size_t smem = head_dim * sizeof(float);
-    dim3 grid(n_tokens, n_heads);
-    gdn_rmsnorm_gated_silu_kernel<<<grid, head_dim, smem, stream>>>(y, gate, weight, eps, n_heads, head_dim);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -2,6 +2,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 
 namespace imp {
 
@@ -31,6 +32,29 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
                         const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
                         int n_heads, int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
                         int grouped_layout = 0, const int* d_real_n = nullptr);
+
+// BF16-state twins (gdn.state_bf16): h_state stored as __nv_bfloat16, all
+// arithmetic FP32 in registers — halves the state traffic that dominates
+// batched decode (the FP32 kernel measures 1527 GB/s = this box's resident
+// bandwidth ceiling; bytes are the only lever left). HD=SS=128 only; the
+// init resolver refuses BF16 state for other shapes and for the
+// ref/chunkwise scan routes. Batched stride is in BF16 ELEMENTS.
+void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const half* alpha,
+                                 const half* beta, const float* A_log, const float* dt_bias,
+                                 __nv_bfloat16* h_state_pool, const int* seq_slots,
+                                 int64_t h_state_seq_stride, half* y, int n_seq, int n_tokens, int n_heads,
+                                 int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
+                                 int grouped_layout = 0, const int* d_real_n = nullptr);
+void gdn_scan_fused_bf16(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
+                         const float* A_log, const float* dt_bias, __nv_bfloat16* h_state, half* y,
+                         int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,
+                         cudaStream_t stream, int grouped_layout = 0, const int* d_real_n = nullptr);
+void gdn_scan_fused_fp32out_bf16(const float* conv_f32, int conv_channels, const half* alpha,
+                                 const half* beta, const float* A_log, const float* dt_bias,
+                                 __nv_bfloat16* h_state, float* y_fp32, int n_tokens, int n_heads,
+                                 int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
+                                 int grouped_layout = 0, const int* d_real_n = nullptr,
+                                 __nv_bfloat16* h_snap = nullptr, const int* d_snap_n = nullptr);
 
 // EXPERIMENTAL — Phase 1b scaffolding for chunkwise SSD scan.
 // Same signature as `gdn_scan_fused_f32`. Will eventually implement the

--- a/src/compute/gdn_gated_norm.cu
+++ b/src/compute/gdn_gated_norm.cu
@@ -1,0 +1,157 @@
+// gdn_gated_norm.cu — the RMSNormGated + SiLU family (FP16, FP32-in and
+// FP32-in/out). Split out of gdn.cu (one logical unit per TU; the
+// hard-review size gate was the trigger). Kernels moved VERBATIM.
+#include "compute/gdn.h"
+#include "core/logging.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+namespace imp {
+
+// ---------------------------------------------------------------------------
+// Fused RMSNormGated + SiLU kernel.
+// Computes: y[t,h,:] = rmsnorm(y[t,h,:], weight) * silu(gate[t,h,:])
+//
+// Grid:  (n_tokens, n_heads)
+// Block: (head_dim)
+// ---------------------------------------------------------------------------
+__global__ void gdn_rmsnorm_gated_silu_kernel(
+    half* __restrict__ y,             // [n_tokens, n_heads * head_dim] in/out
+    const half* __restrict__ gate,    // [n_tokens, n_heads * head_dim]
+    const half* __restrict__ weight,  // [head_dim] shared norm weight
+    float eps, int n_heads, int head_dim) {
+    const int t = blockIdx.x;
+    const int h = blockIdx.y;
+    const int d = threadIdx.x;
+    if (d >= head_dim)
+        return;
+
+    const int inner = n_heads * head_dim;
+    const int base = t * inner + h * head_dim;
+
+    // Load y value
+    float val = __half2float(y[base + d]);
+
+    // Parallel sum-of-squares for RMSNorm
+    extern __shared__ float s_buf[];
+    s_buf[d] = val * val;
+    __syncthreads();
+    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
+        if (d < stride)
+            s_buf[d] += s_buf[d + stride];
+        __syncthreads();
+    }
+    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
+
+    // RMSNorm: normalize and scale by weight
+    float normed = val * inv_rms * __half2float(weight[d]);
+
+    // SiLU on gate and multiply
+    float g = __half2float(gate[base + d]);
+    float silu_g = g / (1.0f + expf(-g));
+
+    y[base + d] = __float2half(normed * silu_g);
+}
+
+// FP32-input variant: reads y as FP32, writes FP16. Used together with
+// `gdn_scan_fused_fp32out` so the RMS reduction sees full-precision scan output
+// (without FP16 subnormal truncation at ~6e-5).
+__global__ void gdn_rmsnorm_gated_silu_fp32in_kernel(
+    half* __restrict__ y_fp16_out,        // [n_tokens, n_heads * head_dim]
+    const float* __restrict__ y_fp32_in,  // [n_tokens, n_heads * head_dim]
+    const half* __restrict__ gate, const half* __restrict__ weight, float eps, int n_heads, int head_dim) {
+    const int t = blockIdx.x;
+    const int h = blockIdx.y;
+    const int d = threadIdx.x;
+    if (d >= head_dim)
+        return;
+
+    const int inner = n_heads * head_dim;
+    const int base = t * inner + h * head_dim;
+
+    float val = y_fp32_in[base + d];
+
+    extern __shared__ float s_buf[];
+    s_buf[d] = val * val;
+    __syncthreads();
+    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
+        if (d < stride)
+            s_buf[d] += s_buf[d + stride];
+        __syncthreads();
+    }
+    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
+
+    float normed = val * inv_rms * __half2float(weight[d]);
+
+    float g = __half2float(gate[base + d]);
+    float silu_g = g / (1.0f + expf(-g));
+
+    y_fp16_out[base + d] = __float2half(normed * silu_g);
+}
+
+void gdn_rmsnorm_gated_silu_fp32in(half* y_fp16_out, const float* y_fp32_in, const half* gate,
+                                   const half* weight, float eps, int n_tokens, int n_heads, int head_dim,
+                                   cudaStream_t stream) {
+    size_t smem = head_dim * sizeof(float);
+    dim3 grid(n_tokens, n_heads);
+    gdn_rmsnorm_gated_silu_fp32in_kernel<<<grid, head_dim, smem, stream>>>(y_fp16_out, y_fp32_in, gate,
+                                                                           weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+// FP32-in, FP32-out: keeps full precision through gated norm so ssm_out GEMM
+// sees FP32 input (fixes 6% accumulation drift in FP16-input matmul).
+__global__ void gdn_rmsnorm_gated_silu_fp32inout_kernel(float* __restrict__ y_fp32_out,
+                                                        const float* __restrict__ y_fp32_in,
+                                                        const half* __restrict__ gate,
+                                                        const half* __restrict__ weight, float eps,
+                                                        int n_heads, int head_dim) {
+    const int t = blockIdx.x;
+    const int h = blockIdx.y;
+    const int d = threadIdx.x;
+    if (d >= head_dim)
+        return;
+
+    const int inner = n_heads * head_dim;
+    const int base = t * inner + h * head_dim;
+
+    float val = y_fp32_in[base + d];
+
+    extern __shared__ float s_buf[];
+    s_buf[d] = val * val;
+    __syncthreads();
+    for (int stride = head_dim / 2; stride > 0; stride >>= 1) {
+        if (d < stride)
+            s_buf[d] += s_buf[d + stride];
+        __syncthreads();
+    }
+    float inv_rms = rsqrtf(s_buf[0] / static_cast<float>(head_dim) + eps);
+
+    float normed = val * inv_rms * __half2float(weight[d]);
+
+    float g = __half2float(gate[base + d]);
+    float silu_g = g / (1.0f + expf(-g));
+
+    y_fp32_out[base + d] = normed * silu_g;
+}
+
+void gdn_rmsnorm_gated_silu_fp32inout(float* y_fp32_out, const float* y_fp32_in, const half* gate,
+                                      const half* weight, float eps, int n_tokens, int n_heads, int head_dim,
+                                      cudaStream_t stream) {
+    size_t smem = head_dim * sizeof(float);
+    dim3 grid(n_tokens, n_heads);
+    gdn_rmsnorm_gated_silu_fp32inout_kernel<<<grid, head_dim, smem, stream>>>(y_fp32_out, y_fp32_in, gate,
+                                                                              weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+// Fused RMSNormGated + SiLU
+void gdn_rmsnorm_gated_silu(half* y, const half* gate, const half* weight, float eps, int n_tokens,
+                            int n_heads, int head_dim, cudaStream_t stream) {
+    size_t smem = head_dim * sizeof(float);
+    dim3 grid(n_tokens, n_heads);
+    gdn_rmsnorm_gated_silu_kernel<<<grid, head_dim, smem, stream>>>(y, gate, weight, eps, n_heads, head_dim);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+}  // namespace imp

--- a/src/core/config/gdn.h
+++ b/src/core/config/gdn.h
@@ -50,6 +50,13 @@ struct GDN {
     // exhaustively benched, Phase 1b.1 remains the fastest chunkwise
     // path on sm_120 — the WY-rep + TC-MMA variants all stay behind it.
     bool chunkwise_scan = true;
+    // Store the GDN recurrent state as BF16 instead of FP32 (halves the
+    // state traffic that dominates batched decode; arithmetic stays FP32 in
+    // registers). HD=SS=128 models only; forces the fused scan route (the
+    // chunkwise/ref kernels are FP32-state only) — the executor drops
+    // chunkwise when the pool is BF16, the init resolver refuses the
+    // ref_kernel combo. FP16 state stays refuted (subnormal truncation).
+    bool state_bf16 = false;
     // Override gated-DeltaNet weight layout.
     std::string layout_override;
 };

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -555,7 +555,11 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         //   FP16 subnormal truncation (~6e-5) breaks RMS for near-zero heads on
         //   models with sparse scan activations (Qwen 3.6 L1 head 0).
         const bool use_ref = runtime_config().gdn.ref_kernel;
-        const bool use_chunkwise = runtime_config().gdn.chunkwise_scan && !use_ref;
+        // BF16 recurrent state (gdn.state_bf16): only the fused scan has a
+        // BF16-state kernel — the chunkwise route stays FP32-only, so a BF16
+        // pool drops it here (the init resolver already refused ref_kernel).
+        const bool state_bf16 = (state.ssm_state && state.ssm_state->h_dtype() == QType::BF16);
+        const bool use_chunkwise = runtime_config().gdn.chunkwise_scan && !use_ref && !state_bf16;
         if (use_fp32_scan) {
             // Layout in conv_f32 tail:
             //   [n*conv_channels)                : conv_f32 (done)
@@ -576,6 +580,13 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                            static_cast<float*>(h_st), y_fp32, n, n_heads, head_dim_ssm, ssize,
                                            n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len,
                                            static_cast<float*>(h_snap), h_snap ? state.d_snap_n : nullptr);
+            } else if (state_bf16) {
+                gdn_scan_fused_fp32out_bf16(
+                    conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
+                    static_cast<const half*>(beta_proj_out.data), static_cast<const float*>(ly.ssm_a.data),
+                    static_cast<const float*>(ly.ssm_dt_b.data), static_cast<__nv_bfloat16*>(h_st), y_fp32,
+                    n, n_heads, head_dim_ssm, ssize, n_groups, stream, gl, state.d_chunk_len,
+                    static_cast<__nv_bfloat16*>(h_snap), h_snap ? state.d_snap_n : nullptr);
             } else {
                 gdn_scan_fused_fp32out(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
                                        static_cast<const half*>(beta_proj_out.data),
@@ -617,14 +628,25 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
             // optimisation (it splits ONE sequence's timeline), so it does not
             // apply here — at one token per sequence there is nothing to chunk.
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
-            gdn_scan_fused_f32_batched(
-                conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
-                static_cast<const half*>(beta_proj_out.data), static_cast<const float*>(ly.ssm_a.data),
-                static_cast<const float*>(ly.ssm_dt_b.data),
-                static_cast<float*>(state.ssm_state->h_state(0, ssm_idx)), state.ssm_seq_slots,
-                static_cast<int64_t>(state.ssm_state->per_seq_bytes() / sizeof(float)),
-                static_cast<half*>(y_buf.data), state.ssm_n_seq, /*n_tokens=*/1, n_heads, head_dim_ssm,
-                ssize, n_groups, stream, gl, /*d_real_n=*/nullptr);
+            if (state_bf16) {
+                gdn_scan_fused_bf16_batched(
+                    conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
+                    static_cast<const half*>(beta_proj_out.data), static_cast<const float*>(ly.ssm_a.data),
+                    static_cast<const float*>(ly.ssm_dt_b.data),
+                    static_cast<__nv_bfloat16*>(state.ssm_state->h_state(0, ssm_idx)), state.ssm_seq_slots,
+                    static_cast<int64_t>(state.ssm_state->per_seq_bytes() / sizeof(__nv_bfloat16)),
+                    static_cast<half*>(y_buf.data), state.ssm_n_seq, /*n_tokens=*/1, n_heads, head_dim_ssm,
+                    ssize, n_groups, stream, gl, /*d_real_n=*/nullptr);
+            } else {
+                gdn_scan_fused_f32_batched(
+                    conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
+                    static_cast<const half*>(beta_proj_out.data), static_cast<const float*>(ly.ssm_a.data),
+                    static_cast<const float*>(ly.ssm_dt_b.data),
+                    static_cast<float*>(state.ssm_state->h_state(0, ssm_idx)), state.ssm_seq_slots,
+                    static_cast<int64_t>(state.ssm_state->per_seq_bytes() / sizeof(float)),
+                    static_cast<half*>(y_buf.data), state.ssm_n_seq, /*n_tokens=*/1, n_heads, head_dim_ssm,
+                    ssize, n_groups, stream, gl, /*d_real_n=*/nullptr);
+            }
         } else {
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;
             if (use_chunkwise) {
@@ -635,6 +657,13 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                        static_cast<const float*>(ly.ssm_dt_b.data), static_cast<float*>(h_st),
                                        static_cast<half*>(y_buf.data), n, n_heads, head_dim_ssm, ssize,
                                        n_groups, stream, /*chunk_size=*/64, gl, state.d_chunk_len);
+            } else if (state_bf16) {
+                gdn_scan_fused_bf16(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
+                                    static_cast<const half*>(beta_proj_out.data),
+                                    static_cast<const float*>(ly.ssm_a.data),
+                                    static_cast<const float*>(ly.ssm_dt_b.data),
+                                    static_cast<__nv_bfloat16*>(h_st), static_cast<half*>(y_buf.data), n,
+                                    n_heads, head_dim_ssm, ssize, n_groups, stream, gl, state.d_chunk_len);
             } else {
                 gdn_scan_fused_f32(conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
                                    static_cast<const half*>(beta_proj_out.data),

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -258,6 +258,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gdn.ref_kernel", cfg.gdn.ref_kernel);
     B("gdn.vhead_reorder", cfg.gdn.vhead_reorder);
     B("gdn.chunkwise_scan", cfg.gdn.chunkwise_scan);
+    B("gdn.state_bf16", cfg.gdn.state_bf16);
 
     // [gemm]
     B("gemm.no_dp4a_gemv", cfg.gemm.no_dp4a_gemv);

--- a/src/runtime/engine_init_resolver.cpp
+++ b/src/runtime/engine_init_resolver.cpp
@@ -523,6 +523,23 @@ void Engine::init_resolve_ssm_dtype_() {
         config_.ssm_state_dtype = QType::F16;
         IMP_LOG_INFO("SSM state dtype: auto → FP16 (hybrid SSM model, state_size=%d)", mcfg.ssm_state_size);
     }
+    // gdn.state_bf16: BF16 recurrent state for GDN (halves the state traffic
+    // that dominates batched decode; FP32 arithmetic in registers). Only the
+    // fused scan supports it, and only at HD=SS=128 — the executor drops the
+    // chunkwise route when the pool is BF16; ref_kernel has no BF16 kernel,
+    // so that combo keeps FP32 rather than serving a scan that corrupts.
+    if (has_gdn_for_dtype && runtime_config_.gdn.state_bf16) {
+        const int hd = (mcfg.ssm_dt_rank > 0) ? mcfg.ssm_inner_size / mcfg.ssm_dt_rank : 0;
+        if (runtime_config_.gdn.ref_kernel) {
+            IMP_LOG_WARN("gdn.state_bf16 ignored: gdn.ref_kernel has no BF16-state kernel");
+        } else if (hd != 128 || mcfg.ssm_state_size != 128) {
+            IMP_LOG_WARN("gdn.state_bf16 ignored: no BF16 kernel for HD=%d SS=%d", hd,
+                         mcfg.ssm_state_size);
+        } else {
+            config_.ssm_state_dtype = QType::BF16;
+            IMP_LOG_INFO("SSM state dtype: BF16 (gdn.state_bf16; fused scan route, chunkwise off)");
+        }
+    }
 }
 
 // Auto-detect FP8 prefill. Under runtime.debug_raw or

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -1314,5 +1314,221 @@ TEST(GDNScanTest, PaddedChunkDeviceLength) {
     cudaFree(d_beta);
 }
 
+// ===========================================================================
+// BatchedDecodeScanMicrobench -- per-launch cost and achieved bandwidth of
+// the batched decode scan at Qwen3.8-27B shapes (48 v-heads, HD=SS=128,
+// 16 groups, 32 sequences, n_tokens=1). Cycles through 8 distinct state
+// slabs (~1 GB) so consecutive reps cannot serve the state from L2 — the
+// serving steady state walks 48 different layers' slabs.
+// Set IMP_GDN_MICROBENCH=1 to run.
+// ===========================================================================
+TEST(GDNScanTest, BatchedDecodeScanMicrobench) {
+    if (!std::getenv("IMP_GDN_MICROBENCH")) {
+        GTEST_SKIP() << "Set IMP_GDN_MICROBENCH=1 to run the batched decode scan probe";
+    }
+    constexpr int n_heads = 48, head_dim = 128, state_size = 128, n_groups = 16;
+    constexpr int n_seq = 32, n_tok = 1, n_slabs = 8;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    const size_t state_floats_per_seq = (size_t)n_heads * state_size * head_dim;
+    const size_t slab_floats = state_floats_per_seq * n_seq;
+
+    srand(3);
+    std::vector<float> conv_f32((size_t)n_seq * n_tok * conv_channels);
+    for (auto& v : conv_f32)
+        v = (rand() % 200 - 100) / 100.0f;
+    std::vector<half> h_alpha(n_seq * n_tok * n_heads), h_beta(n_seq * n_tok * n_heads);
+    for (auto& v : h_alpha)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    for (auto& v : h_beta)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    std::vector<float> h_A(n_heads, -0.5f), h_dt(n_heads, 0.5f);
+    std::vector<int> h_slots(n_seq);
+    for (int i = 0; i < n_seq; i++)
+        h_slots[i] = i;
+
+    float *d_conv, *d_A, *d_dt, *d_state;
+    half *d_alpha, *d_beta, *d_y;
+    int* d_slots;
+    ASSERT_EQ(cudaMalloc(&d_conv, conv_f32.size() * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_A, n_heads * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_dt, n_heads * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_state, (size_t)n_slabs * slab_floats * sizeof(float)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_alpha, h_alpha.size() * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_beta, h_beta.size() * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_y, (size_t)n_seq * n_tok * inner * sizeof(half)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&d_slots, n_seq * sizeof(int)), cudaSuccess);
+    cudaMemcpy(d_conv, conv_f32.data(), conv_f32.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha.data(), h_alpha.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta.data(), h_beta.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_slots, h_slots.data(), n_seq * sizeof(int), cudaMemcpyHostToDevice);
+    cudaMemset(d_state, 0, (size_t)n_slabs * slab_floats * sizeof(float));
+
+    cudaEvent_t e0, e1;
+    cudaEventCreate(&e0);
+    cudaEventCreate(&e1);
+    constexpr int reps = 480;  // 60 "steps" of 8 slabs
+    for (int r = 0; r < 48; r++) {  // warmup one slab cycle x6
+        gdn_scan_fused_f32_batched(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt,
+                                   d_state + (r % n_slabs) * slab_floats, d_slots,
+                                   (int64_t)state_floats_per_seq, d_y, n_seq, n_tok, n_heads, head_dim,
+                                   state_size, n_groups, nullptr, /*grouped_layout=*/1);
+    }
+    cudaDeviceSynchronize();
+    cudaEventRecord(e0);
+    for (int r = 0; r < reps; r++) {
+        gdn_scan_fused_f32_batched(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt,
+                                   d_state + (r % n_slabs) * slab_floats, d_slots,
+                                   (int64_t)state_floats_per_seq, d_y, n_seq, n_tok, n_heads, head_dim,
+                                   state_size, n_groups, nullptr, /*grouped_layout=*/1);
+    }
+    cudaEventRecord(e1);
+    cudaEventSynchronize(e1);
+    float ms = 0;
+    cudaEventElapsedTime(&ms, e0, e1);
+    const double us_per_launch = ms * 1000.0 / reps;
+    const double state_bytes = (double)slab_floats * sizeof(float) * 2.0;  // R+W
+    const double conv_bytes = (double)n_seq * conv_channels * sizeof(float);
+    const double gbps = (state_bytes + conv_bytes) / (us_per_launch * 1e-6) / 1e9;
+    std::printf("  batched scan (48h x 32seq, FP32 state): %.2f us/launch, %.0f GB/s effective "
+                "(state R+W %.1f MB + conv %.2f MB), %.1f%% of 1792 GB/s\n",
+                us_per_launch, gbps, state_bytes / 1e6, conv_bytes / 1e6, gbps / 17.92);
+
+    // BF16-state arm: same shapes, half the state bytes.
+    __nv_bfloat16* d_state_bf16;
+    ASSERT_EQ(cudaMalloc(&d_state_bf16, (size_t)n_slabs * slab_floats * sizeof(__nv_bfloat16)),
+              cudaSuccess);
+    cudaMemset(d_state_bf16, 0, (size_t)n_slabs * slab_floats * sizeof(__nv_bfloat16));
+    for (int r = 0; r < 48; r++) {
+        gdn_scan_fused_bf16_batched(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt,
+                                    d_state_bf16 + (r % n_slabs) * slab_floats, d_slots,
+                                    (int64_t)state_floats_per_seq, d_y, n_seq, n_tok, n_heads, head_dim,
+                                    state_size, n_groups, nullptr, /*grouped_layout=*/1);
+    }
+    cudaDeviceSynchronize();
+    cudaEventRecord(e0);
+    for (int r = 0; r < reps; r++) {
+        gdn_scan_fused_bf16_batched(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt,
+                                    d_state_bf16 + (r % n_slabs) * slab_floats, d_slots,
+                                    (int64_t)state_floats_per_seq, d_y, n_seq, n_tok, n_heads, head_dim,
+                                    state_size, n_groups, nullptr, /*grouped_layout=*/1);
+    }
+    cudaEventRecord(e1);
+    cudaEventSynchronize(e1);
+    float ms_bf = 0;
+    cudaEventElapsedTime(&ms_bf, e0, e1);
+    const double us_bf = ms_bf * 1000.0 / reps;
+    const double state_bytes_bf = (double)slab_floats * sizeof(__nv_bfloat16) * 2.0;
+    const double gbps_bf = (state_bytes_bf + conv_bytes) / (us_bf * 1e-6) / 1e9;
+    std::printf("  batched scan (48h x 32seq, BF16 state): %.2f us/launch, %.0f GB/s effective "
+                "(state R+W %.1f MB), %.1f%% of 1792 GB/s, speedup vs FP32 %.2fx\n",
+                us_bf, gbps_bf, state_bytes_bf / 1e6, gbps_bf / 17.92, us_per_launch / us_bf);
+    cudaFree(d_state_bf16);
+
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y);
+    cudaFree(d_slots);
+    cudaEventDestroy(e0);
+    cudaEventDestroy(e1);
+}
+
+// ===========================================================================
+// BF16StateTracksFP32State -- gdn.state_bf16 correctness: 256 DECODE steps
+// (one launch per token, so the state round-trips through storage at every
+// step — the case where BF16 precision actually bites), FP32-state arm vs
+// BF16-state arm on identical inputs. Asserts the y trajectory stays close
+// and the final states are finite and close. Catches layout/stride bugs
+// (garbage) and runaway error growth; the fine-grained quality gate is the
+// e2e battery (degen + long-context drift).
+// ===========================================================================
+TEST(GDNScanTest, BF16StateTracksFP32State) {
+    constexpr int n_heads = 48, head_dim = 128, state_size = 128, n_groups = 16;
+    constexpr int steps = 256;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    const size_t state_elems = (size_t)n_heads * state_size * head_dim;
+
+    srand(19);
+    std::vector<float> conv_all((size_t)steps * conv_channels);
+    for (auto& v : conv_all)
+        v = 0.5f * ((rand() % 200 - 100) / 100.0f);
+    std::vector<half> h_alpha(steps * n_heads), h_beta(steps * n_heads);
+    for (auto& v : h_alpha)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    for (auto& v : h_beta)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    std::vector<float> h_A(n_heads, -0.5f), h_dt(n_heads, 0.5f);
+
+    float *d_conv, *d_A, *d_dt, *d_state_f32;
+    __nv_bfloat16* d_state_bf16;
+    half *d_alpha, *d_beta, *d_y_f32arm, *d_y_bf16arm;
+    cudaMalloc(&d_conv, conv_all.size() * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_state_f32, state_elems * sizeof(float));
+    cudaMalloc(&d_state_bf16, state_elems * sizeof(__nv_bfloat16));
+    cudaMalloc(&d_alpha, h_alpha.size() * sizeof(half));
+    cudaMalloc(&d_beta, h_beta.size() * sizeof(half));
+    cudaMalloc(&d_y_f32arm, (size_t)inner * sizeof(half));
+    cudaMalloc(&d_y_bf16arm, (size_t)inner * sizeof(half));
+    cudaMemcpy(d_conv, conv_all.data(), conv_all.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha.data(), h_alpha.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta.data(), h_beta.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemset(d_state_f32, 0, state_elems * sizeof(float));
+    cudaMemset(d_state_bf16, 0, state_elems * sizeof(__nv_bfloat16));
+
+    double worst_rel = 0.0;
+    std::vector<half> ya(inner), yb(inner);
+    for (int t = 0; t < steps; t++) {
+        const float* conv_t = d_conv + (size_t)t * conv_channels;
+        gdn_scan_fused_f32(conv_t, conv_channels, d_alpha + t * n_heads, d_beta + t * n_heads, d_A, d_dt,
+                           d_state_f32, d_y_f32arm, 1, n_heads, head_dim, state_size, n_groups, nullptr,
+                           /*grouped_layout=*/1);
+        gdn_scan_fused_bf16(conv_t, conv_channels, d_alpha + t * n_heads, d_beta + t * n_heads, d_A, d_dt,
+                            d_state_bf16, d_y_bf16arm, 1, n_heads, head_dim, state_size, n_groups, nullptr,
+                            /*grouped_layout=*/1);
+        if (t % 32 == 31 || t == steps - 1) {
+            ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+            cudaMemcpy(ya.data(), d_y_f32arm, inner * sizeof(half), cudaMemcpyDeviceToHost);
+            cudaMemcpy(yb.data(), d_y_bf16arm, inner * sizeof(half), cudaMemcpyDeviceToHost);
+            double num = 0, den = 0;
+            for (int i = 0; i < inner; i++) {
+                const double a = __half2float(ya[i]);
+                const double b = __half2float(yb[i]);
+                ASSERT_TRUE(std::isfinite(b)) << "BF16-state y not finite at step " << t;
+                num += (a - b) * (a - b);
+                den += a * a;
+            }
+            const double rel = std::sqrt(num / (den + 1e-30));
+            worst_rel = std::max(worst_rel, rel);
+        }
+    }
+    std::printf("  BF16-state vs FP32-state y: worst relative RMS over %d decode steps = %.4f\n", steps,
+                worst_rel);
+    // BF16 has 8 mantissa bits (~0.4%% relative per round-trip); a healthy
+    // trajectory stays low single-digit %%. Garbage (layout/stride bug) is
+    // orders of magnitude above this.
+    EXPECT_LT(worst_rel, 0.05) << "BF16-state trajectory diverged";
+
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state_f32);
+    cudaFree(d_state_bf16);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y_f32arm);
+    cudaFree(d_y_bf16arm);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -144,7 +144,7 @@ def main():
     # 1007 -> 1008 (#1769): LayerNormTest.RMSNormRowBlockDecodeShapes, the
     # row-block batched-decode RMSNorm against the CPU reference on three
     # decode shapes - needs a GPU.
-    PINNED = 1010
+    PINNED = 1012
 
     text = CMAKE.read_text()
     mods = module_sources(text)

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -89,7 +89,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
 "src/runtime/engine_scheduler.cpp" = { code_loc = 2210, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
-"tests/test_gdn.cu" = { code_loc = 1026, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
+"tests/test_gdn.cu" = { code_loc = 1210, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }
 "tests/test_paged_attention.cu" = { code_loc = 1202, reason = "(c) 26 tests of the paged-attention kernel - one test target" }

--- a/tools/kernel_resource_baseline.txt
+++ b/tools/kernel_resource_baseline.txt
@@ -11,8 +11,10 @@
 # the PR which way it moved.
 #
 # kernel<tab>arch<tab>reg<tab>stack<tab>local
-void imp::gdn_scan_fused_kernel<128, 128, __half, 1>	sm_120a	255	96	0
-void imp::gdn_scan_fused_kernel<128, 128, float, 1>	sm_120a	255	96	0
+void imp::gdn_scan_fused_kernel<128, 128, __half, 1, float>	sm_120a	255	96	0
+void imp::gdn_scan_fused_kernel<128, 128, float, 1, float>	sm_120a	255	96	0
+void imp::gdn_scan_fused_kernel<128, 128, __half, 1, __nv_bfloat16>	sm_120a	255	88	0
+void imp::gdn_scan_fused_kernel<128, 128, float, 1, __nv_bfloat16>	sm_120a	255	88	0
 void imp::gdn_scan_chunkwise_kernel<128, 128, 64, __half>	sm_120a	255	80	0
 void imp::gdn_scan_chunkwise_kernel<128, 128, 64, float>	sm_120a	255	80	0
 void imp::fmha_sm120_fa2_kernel<64, 256, true, false, 64, true, false, false>	sm_120a	255	32	0


### PR DESCRIPTION
## What

`gdn.state_bf16` (opt-in): the GDN recurrent state stored as BF16 instead of FP32, arithmetic FP32 in registers. The FP32 scan measures **1527 GB/s isolated** (48h x 32seq, 8 rotating 100-MB slabs against L2) - this box's resident bandwidth ceiling - so halving the bytes is the whole lever. Scan kernel templated on StateT; BF16 twins for the batched/single/fp32out entries (HD=SS=128 only); executor routes on `h_dtype()`, the chunkwise route drops to fused under BF16, the resolver refuses the ref_kernel combo. Gated-norm family split into `gdn_gated_norm.cu` (hard-review ceiling, verbatim).

## Numbers

| | FP32 state | BF16 state |
|---|---:|---:|
| scan us/launch isolated (48h x 32seq) | 132.7 | **64.9 (2.04x)** |
| effective GB/s | 1527 | 1570 |
| 32-stream aggregate, median of 3 (KV pinned 2387 both arms) | 1210.5 | **1362.0 (+12.5%)** |
| pairwise | - | +12.1 / +12.6 / +15.7, 3/3 |
| PPL ppl_corpus_45k | 4.6259 | 4.6356 (+0.21%) |
| state pool | 4848 MiB | 2544 MiB |

degen_suite 50/0 on the BF16 arm; 256-step decode round-trip trajectory 0.18% relative RMS vs FP32 state (GPU test, kills the layout-bug class). Against vLLM's 1477 profiled: gap now ~1.08x.

## Why not default ON yet

Unpinned, the freed 2.3 GB flips #1765 from "plan rejected -> live fallback rescues (2387 blocks)" to "plan succeeds with kv.blocks=128 -> APPLIED" - 32-stream aggregate 510 tok/s from the starved pool alone (evidence on the issue). Flip the default after #1765; until then pin `kv_cache.max_blocks`.

## Also corrected

The resolver's "GDN MUST keep FP32" was a layout constraint (kernels assumed 4 B/element), not numerics; the Qwen3.6 NaN known-issue has the same state-overflow signature. FP16 state stays refuted (subnormal truncation ~6e-5).

Test-lane pin 1010 -> 1012; test_gdn.cu allowlist re-pin (microbench + trajectory test).

[PROV: commit=9862e3b2 date=2026-08-26 hw=RTX5090 model=Qwen3.8-27B-NVFP4 quant=NVFP4-CT cuda=13.3 path=server-api cmd=gdn_bf16_ab.sh n=3/arm flags=max_batch_size=32,max_seq_len=4096,kv_cache.max_blocks=2387]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEZeyiGheY9WfDVvYqHMmv
