### PR TITLE
fix(vram): shadow plan charged transient init headroom against KV - pool collapsed to 128 blocks (#1765)

### DIFF
--- a/src/runtime/engine_kv_cache_init.cpp
+++ b/src/runtime/engine_kv_cache_init.cpp
@@ -244,7 +244,14 @@ bool Engine::init_kv_cache() {
     {
         ShadowPlanProbe probe;
         probe.distributable_bytes = effective_free_vram();
-        probe.weight_cache_demand = vram_budget.weight_cache_estimate_bytes;
+        // Steady-state demand only: the transient init headroom folded into
+        // the estimate is free again by the time the pool is sized, and
+        // charging it here handed the "optional caches" everything down to
+        // the one-sequence floor — 128 KV blocks while GiBs sat free (#1765).
+        probe.weight_cache_demand =
+            vram_budget.weight_cache_estimate_bytes > vram_budget.weight_cache_transient_bytes
+                ? vram_budget.weight_cache_estimate_bytes - vram_budget.weight_cache_transient_bytes
+                : 0;
         probe.mandatory_cache_bytes =
             vram_budget.mandatory_sf_bytes + vram_budget.mandatory_moe_bytes;
         probe.ssm_state_bytes = vram_budget.ssm_footprint_bytes;

--- a/src/runtime/vram_budget.cpp
+++ b/src/runtime/vram_budget.cpp
@@ -386,6 +386,9 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                              demand.moe_slab_bytes / (1024.0 * 1024.0),
                              phase3_reserve / (1024.0 * 1024.0));
                 cutlass_sf_estimate = native_need;
+                // The reserve part is init-transient; demand.total() is the
+                // persistent slice. See weight_cache_transient_bytes.
+                budget.weight_cache_transient_bytes = phase3_reserve;
             }
         } else if (per_block_total > 0) {
             // GGUF sources the heuristic can't see: Q4_K/Q3_K weights are not
@@ -437,6 +440,11 @@ VRAMBudget compute_vram_budget(const Model& model, const EngineConfig& config, i
                         plan.projected_vram_bytes / (1024.0 * 1024.0),
                         heuristic / (1024.0 * 1024.0), guarantee_blocks);
                     cutlass_sf_estimate = reserve - nvfp4_estimate;
+                    // Anything the reserve holds beyond the planner's
+                    // projected persistent demand is the init-time margin.
+                    // See weight_cache_transient_bytes.
+                    budget.weight_cache_transient_bytes =
+                        reserve > plan.projected_vram_bytes ? reserve - plan.projected_vram_bytes : 0;
                 }
             }
         }

--- a/src/runtime/vram_budget.h
+++ b/src/runtime/vram_budget.h
@@ -69,6 +69,15 @@ struct VRAMBudget {
     // exposed so plan_memory() can be fed the SAME demand figure and the two
     // allocation policies compared like for like (A7 step 2b).
     size_t weight_cache_estimate_bytes = 0;
+    // The TRANSIENT slice of the estimate above: init-time headroom the
+    // phase-0..3 builders re-derive for themselves (max(total/10, floor) +
+    // margin) that is free again by the time the KV pool is sized. The live
+    // pass needs it inside the estimate (it protects cache builds from the
+    // KV backstop); the steady-state shadow plan must NOT charge it against
+    // KV — doing so granted the "optional caches" everything down to the
+    // one-sequence floor and collapsed the pool to 128 blocks while GiBs sat
+    // free (#1765).
+    size_t weight_cache_transient_bytes = 0;
     // Batch-shaped SSM/GDN state footprint charged as overhead (0 on
     // non-recurrent models). Same reason as above.
     size_t ssm_footprint_bytes = 0;

--- a/tests/test_vram_budget_reserve.cpp
+++ b/tests/test_vram_budget_reserve.cpp
@@ -356,6 +356,69 @@ TEST(VramBudgetReserve, NativeCacheDemandZeroForNonPrequant) {
     EXPECT_EQ(d.moe_slab_bytes, 0u);
 }
 
+// #1765 regression: the TRANSIENT init headroom folded into the weight-cache
+// estimate (phase3 reserve, max(total/10, floor) + margin) must not be
+// charged against KV in the shadow plan. Fed whole, the plan granted the
+// "optional caches" everything above the one-sequence floor and collapsed
+// the KV pool to 128 blocks while GiBs sat free. The engine now feeds
+// estimate - transient; the old feeding is kept in the test as the contrast
+// arm so the assertion cannot pass vacuously.
+TEST(VramBudgetReserve, TransientReserveDoesNotStarveTheKvPlan) {
+    SKIP_IF_NO_CUDA();
+
+    Model m;
+    fill_prequant_model(m);
+
+    EngineConfig config;
+    config.max_seq_len = 4096;
+    config.max_batch_size = 32;
+    config.use_nvfp4_decode = 2;
+    config.use_cuda_graphs = false;
+    config.kv_cache_dtype = QType::F16;
+
+    // Sized so BOTH demands fit, but residual-minus-floor is SMALLER than
+    // the transient reserve: the pre-fix feeding must visibly starve KV
+    // while the fixed feeding still grants the full want.
+    const size_t free_vram = 8704ull * 1024 * 1024;
+    VRAMBudget live = compute_vram_budget(m, config, /*n_kv_layers=*/8, /*head_dim=*/128, free_vram);
+    ASSERT_GT(live.weight_cache_transient_bytes, 0u)
+        << "native-NVFP4 branch did not fold a transient reserve — the fixture no longer "
+           "exercises the #1765 shape";
+    ASSERT_LT(live.weight_cache_transient_bytes, live.weight_cache_estimate_bytes);
+
+    ShadowPlanProbe probe;
+    probe.distributable_bytes = free_vram;
+    probe.mandatory_cache_bytes = live.mandatory_sf_bytes + live.mandatory_moe_bytes;
+    probe.ssm_state_bytes = live.ssm_footprint_bytes;
+    probe.library_reserve_bytes = kMeasuredLibraryReserveBytes;
+    probe.n_kv_layers = 8;
+    probe.max_batch_size = 32;
+    probe.max_seq_len = 4096;
+    probe.kv_block_size = 16;
+    probe.min_kv_tokens = config.min_kv_tokens;
+    probe.kv_block_bytes_per_layer =
+        kv_block_bytes_per_layer(config.kv_cache_dtype, 16, m.config().n_kv_heads, 128);
+
+    const int want_blocks = ((4096 + 15) / 16) * 32;
+
+    // The engine's feeding since the fix: steady-state demand only.
+    probe.weight_cache_demand = live.weight_cache_estimate_bytes - live.weight_cache_transient_bytes;
+    const PlanResult fixed = plan_memory(shadow_plan_input(probe));
+    ASSERT_TRUE(fixed.ok);
+    EXPECT_EQ(fixed.plan.kv.blocks, want_blocks)
+        << "KV plan collapsed toward the one-sequence floor with " << fixed.plan.kv.blocks
+        << " blocks against a want of " << want_blocks;
+
+    // Contrast arm: the pre-fix feeding reproduces the collapse.
+    probe.weight_cache_demand = live.weight_cache_estimate_bytes;
+    const PlanResult old_way = plan_memory(shadow_plan_input(probe));
+    if (old_way.ok) {
+        EXPECT_LT(old_way.plan.kv.blocks, want_blocks)
+            << "the transient charge no longer starves the plan — if this is deliberate, "
+               "the estimate/transient split may be removable";
+    }
+}
+
 TEST(VramBudgetReserve, PreallocCoversDemandAndFreesKv) {
     SKIP_IF_NO_CUDA();
 

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -144,7 +144,7 @@ def main():
     # 1007 -> 1008 (#1769): LayerNormTest.RMSNormRowBlockDecodeShapes, the
     # row-block batched-decode RMSNorm against the CPU reference on three
     # decode shapes - needs a GPU.
-    PINNED = 1010
+    PINNED = 1011
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
Closes #1765.

## Mechanism

The native-NVFP4 weight-cache estimate folds a phase-3 init reserve (max(total/10, floor) + 1 GiB) that is free again by the time the KV pool is sized. plan_memory granted that 'optional cache demand' everything above the ONE-SEQUENCE floor, so the plan returned kv.blocks = blocks_per_seq (128 at seq=4096/bs=32) whenever residual - floor < reserve. When the plan formally succeeded, the 128 was APPLIED over a live pass that sized thousands; when it failed, the live fallback masked the defect. Both sides documented on the issue (510 tok/s at 32 streams from the starved pool with gdn.state_bf16 freeing 2.3 GB; the issue's original mbs=16 repro).

## Fix

VRAMBudget reports the transient slice separately (native-NVFP4 + planner-driven GGUF branches); the shadow probe feeds estimate - transient. The LIVE strategy math keeps the full reserve - it protects cache builds from the KV backstop and that margin is measured load-bearing (see the inline comment history).

## Evidence

| config | before | after |
|---|---|---|
| mbs=16 (issue repro) | plan 128 blocks APPLIED | plan ok, **2048 blocks** (full want) |
| mbs=32 | plan rejected, live fallback 2387 | unchanged (2387) |

Regression test (test-e2e, VramBudgetReserve.TransientReserveDoesNotStarveTheKvPlan): fixed feeding grants the full want; the pre-fix feeding is kept as the contrast arm and must visibly starve - the assertion cannot pass vacuously. Full GPU suite green on this tree; test-lane pin 1010 -> 1011.

Not in scope: the separate 'StoragePlanner: plan failed' WARN (QuantPipeline budget plan; caches build correctly via the heuristic path) - still open on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEZeyiGheY9WfDVvYqHMmv