### PR TITLE
perf(gdn): state_bf16 default ON - +7.7% at pure defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ there instead of retelling it.
 
 ### Added
 
-- **BF16 recurrent state for the GDN scan (`gdn.state_bf16`, opt-in): +12.5%
+- **BF16 recurrent state for the GDN scan (`gdn.state_bf16`, default ON since the follow-up flip): +12.5%
   aggregate at 32 streams.** The FP32 scan sits at this box's resident
   bandwidth ceiling (1527 GB/s measured isolated), so halving the state
   bytes is the whole win: 132.7 -> 64.9 us/launch isolated (2.04x), e2e
@@ -152,9 +152,12 @@ there instead of retelling it.
   4.6356 (+0.21%) over ppl_corpus_45k, degen_suite 50/0, 256-step decode
   trajectory 0.18% relative RMS vs FP32 state. Arithmetic stays FP32 in
   registers; FP16 state remains refuted (subnormal truncation). Not yet the
-  default: an unpinned start trips #1765 (the VRAM plan collapses KV to 128
-  blocks when it formally succeeds) - pin `kv_cache.max_blocks` until that
-  is fixed.
+  default at first: an unpinned start tripped #1765 (the VRAM plan
+  collapsed KV to 128 blocks when it formally succeeded). With that fixed,
+  the default flip measures +7.7% at pure defaults (842.2 -> 906.9 tok/s
+  median at 32 streams, 3/3 pairs, plan applied at the full want of 2628
+  blocks); degen_suite 50/0 on the default config. Opt out via
+  `gdn.state_bf16=false`.
 
 - **Producer-side NVFP4 activation quantize for batched decode (+2.6%
   aggregate at 32 streams).** The fused rmsnorm+quantize and swiglu+quantize

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -502,6 +502,20 @@ project) and cross-sequence prefill batching (`docs/roadmap.md` item
        quant=NVFP4-CT cuda=13.3 path=server-api cmd=bench_conc.py+waves3.py n=3
        flags=max_batch_size=32,max_seq_len=4096]
 
+**Update after the 2026-08-26 pair (producer-quantize fusion #1773, BF16
+GDN state #1776 + plan fix #1777):** the same pinned 32-stream wave reads
+**1362.0 tok/s** median (alternating flag A/B, 3/3 pairs: FP32 state
+1210.5), and pure defaults read 906.9 (from 842.2). Against vLLM's 1477
+profiled the pinned gap stands at **~1.08x**. The scan itself is at the
+bandwidth ceiling in both dtypes (1527/1570 GB/s isolated); what remains
+is the launch-coupled idle, cross-sequence prefill batching and the
+elementwise fusion tail (`docs/roadmap.md` item 0).
+
+[PROV: commit=b516d9a7 date=2026-08-26 hw=RTX5090 model=Qwen3.8-27B-NVFP4
+       quant=NVFP4-CT cuda=13.3 path=server-api cmd=gdn_bf16_ab.sh+gdn_default_ab.sh
+       n=3/arm flags=max_batch_size=32,max_seq_len=4096,kv_cache.max_blocks=2387
+       (pinned arm) / defaults (default arm)]
+
 
 ### The GEMM-class lever, shipped (2026-08-25, night)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,6 +124,15 @@ Ranked by what an agent workload notices first.
    batch; auto=28 sustains full rate under continuous arrival); raising
    slots per GiB is still what the plan's item 6 (recurrent-state paging)
    would buy.
+   UPDATE 2026-08-26: the GDN-scan post itself is PAID - the FP32 scan
+   measured at this box's resident bandwidth ceiling (1527 GB/s isolated),
+   so `gdn.state_bf16` (BF16 state storage, FP32 arithmetic; default ON)
+   halves its bytes: scan 2.04x isolated, aggregate 1210.5 -> 1362.0
+   (+12.5%, KV pinned) and 842.2 -> 906.9 (+7.7%) at pure defaults, PPL
+   +0.21%. Together with the #1765 plan fix (KV no longer collapsible to
+   the one-sequence floor) the measured gap to vLLM stands at ~1.08x
+   pinned. Largest remaining engine-side posts: (d) above, the
+   launch-coupled idle, and the elementwise/gate|up fusion tail.
 
 1. **Scheduling has no per-request priority.** Nothing in the scheduler reads
    one, so a caller cannot say which request matters. `max_concurrent` bounds

--- a/src/core/config/gdn.h
+++ b/src/core/config/gdn.h
@@ -52,11 +52,15 @@ struct GDN {
     bool chunkwise_scan = true;
     // Store the GDN recurrent state as BF16 instead of FP32 (halves the
     // state traffic that dominates batched decode; arithmetic stays FP32 in
-    // registers). HD=SS=128 models only; forces the fused scan route (the
-    // chunkwise/ref kernels are FP32-state only) — the executor drops
-    // chunkwise when the pool is BF16, the init resolver refuses the
-    // ref_kernel combo. FP16 state stays refuted (subnormal truncation).
-    bool state_bf16 = false;
+    // registers). Default ON since the #1776/#1777 pair: +12.5% aggregate at
+    // 32 streams on Qwen3.8-27B-NVFP4 for +0.21% PPL, and the freed state
+    // bytes go to the KV pool now that the plan no longer starves it.
+    // HD=SS=128 models only; forces the fused scan route (the chunkwise/ref
+    // kernels are FP32-state only) — the executor drops chunkwise when the
+    // pool is BF16, the init resolver refuses the ref_kernel combo and keeps
+    // FP32 on unsupported shapes. FP16 state stays refuted (subnormal
+    // truncation). Opt out via gdn.state_bf16=false.
+    bool state_bf16 = true;
     // Override gated-DeltaNet weight layout.
     std::string layout_override;
 };


### PR DESCRIPTION
Follow-up to #1776/#1777: flips `gdn.state_bf16` to default ON now that the plan collapse is fixed.

| arm (defaults, no pins) | aggregate @32 median of 3 | KV pool |
|---|---:|---|
| gdn.state_bf16=false | 842.2 | 3469 blocks (plan rejects, live fallback) |
| default (ON) | **906.9 (+7.7%, 3/3 pairs)** | 2628 blocks = full want, plan APPLIED |

Pinned reference (from #1776): 1210.5 -> 1362.0 (+12.5%). degen_suite 50/0 on the pure-default config. Resolver guards unchanged (FP32 on unsupported shapes / ref_kernel; opt out via gdn.state_bf16=false). Roadmap item 0 and the BENCHMARKS concurrency section updated: pinned gap to vLLM ~1.08x.

[PROV: commit=b516d9a7 date=2026-08-26 hw=RTX5090 model=Qwen3.8-27B-NVFP4 quant=NVFP4-CT cuda=13.3 path=server-api cmd=gdn_default_ab.sh n=3/arm flags=defaults]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEZeyiGheY9WfDVvYqHMmv