### PR TITLE
perf(gdn): ragged batched scan + cross-sequence prefill batching phase 0 (GO)

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -1096,3 +1096,70 @@ cross-sequence prefill batching.
 [PROV: commit=7f9005a3 date=2026-08-26 hw=RTX5090 model=Qwen3.8-27B-NVFP4
        quant=NVFP4-CT cuda=13.3 path=server-api cmd=producer_quant_ab.sh
        n=6/arm flags=max_batch_size=32,max_seq_len=4096]
+## Cross-sequence prefill batching - Phase 0 scoping (2026-08-26)
+
+### The measured problem (existing numbers)
+
+A 32-prompt burst prefills ONE sequence per forward at ~1700 tok/s
+effective - launch-bound (64 layers x ~100 launches at M~120), not
+compute-bound. 32 x ~120 tokens = 3840 tokens = ~2.3 s serial prefill per
+wave; single-sequence pp at this size runs >10k tok/s, so the same tokens
+in ONE ragged forward cost ~0.4 s. On the 4-wave closed-loop bench a wave
+is ~8.1 s at 906.9 tok/s defaults - the serial prefill is ~25% of the
+wave. The win is both TTFT (-1.5-2 s for every stream in a burst) and,
+on burst-shaped load, aggregate.
+
+### The architecture that avoids new attention kernels
+
+Same trick as the GDN batched-decode breakthrough: batch the row-
+independent 82% (all GEMMs, norms, producer-quantize, elementwise) over
+the CONCATENATED rows of K prompts, and drop to per-sequence work only
+where sequences genuinely differ:
+
+- attention (16 of 64 layers): loop K per-seq FMHA calls over row
+  sub-ranges - launch count for attention is unchanged, and FA2 needs NO
+  varlen/cu_seqlens support (verified: only q_offset exists today).
+- conv1d + GDN scan (48 layers): the batched scan already takes
+  (seq_slots, n_seq) but assumes UNIFORM n_tokens per seq (rebases by
+  seq * n_tokens); ragged needs a per-seq row-offset table - a small
+  kernel-parameter change, not a new kernel. Same for the batched conv1d.
+- RoPE: takes a per-token positions array already (M-RoPE uses it) -
+  pass per-row positions of each prompt.
+- KV append + block allocation: per-seq loop at chunk boundaries
+  (host-side, cheap).
+
+### What the scheduler must add
+
+- Assemble a ragged prefill batch: rows = concat of the chunk of each
+  admitted ingest (respecting the existing token budget / rotor), plus a
+  row->seq map and per-seq offsets.
+- Chunk-size interaction: requests sit at different prefill_offsets;
+  each contributes min(remaining, effective_chunk) rows. No padding
+  needed for the GEMM class; the scan path pads or takes the offset
+  table.
+- Decode interleaving unchanged (token-charged budget stays the policy).
+
+### Phased plan
+
+1. Executor: ragged-forward plumbing behind `runtime.prefill_batch`
+   (default off) - concat rows, per-seq attention loop, offset-table scan.
+   Uniform-length special case first (equal chunks), measured vs serial.
+2. Ragged offsets in the batched scan + conv1d.
+3. Scheduler assembly + budget integration; A/B on the 4-wave bench +
+   TTFT distribution; degen + spec-verify interaction check.
+4. Default-on decision by measurement.
+
+### Risks
+
+- Prefix-cache hits shorten individual chunks mid-assembly (offsets must
+  be post-prefix-resolution).
+- Spec-verify chunks must stay OUT of the ragged path (documented verify
+  semantics).
+- Peak activation memory scales with total rows - cap total ragged rows
+  at effective_chunk (the budget already denominates in tokens).
+
+### GO/NO-GO
+
+GO: ~25% of burst-wave wall is serial prefill; the plumbing reuses the
+batched-decode pattern end to end; the only kernel-adjacent change is an
+offset table on kernels that already batch sequences.

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -64,11 +64,22 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     // blockIdx.x. Tokens within one sequence stay sequential, which is the part
     // that genuinely cannot batch.
     const int* __restrict__ seq_slots = nullptr,
-    int64_t h_state_seq_stride = 0) {
+    int64_t h_state_seq_stride = 0,
+    // Ragged batch (cross-sequence prefill batching, roadmap 0(d)): prefix
+    // sums [n_seq+1] into the CONCATENATED row arrays. Sequence `seq` owns
+    // rows [off[seq], off[seq+1]); n_tokens is ignored per-seq. Uniform
+    // batches pass nullptr and keep the seq * n_tokens rebase, byte-for-byte.
+    // d_real_n is a single-sequence contract and must be nullptr when ragged.
+    const int* __restrict__ seq_row_offsets = nullptr) {
     const int h = blockIdx.x;
     if (h >= n_heads)
         return;
     const int seq = blockIdx.y;
+    size_t seq_row0 = static_cast<size_t>(seq) * n_tokens;
+    if (seq_row_offsets) {
+        seq_row0 = static_cast<size_t>(seq_row_offsets[seq]);
+        n_tokens = seq_row_offsets[seq + 1] - seq_row_offsets[seq];
+    }
     // SPLIT partners are ADJACENT lanes (d = tid / SPLIT), so the cross-partner
     // reductions below are a warp shuffle rather than a shared-memory round.
     const int d = (SPLIT == 1) ? static_cast<int>(threadIdx.x) : static_cast<int>(threadIdx.x) / SPLIT;
@@ -96,10 +107,10 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     if (seq_slots) {
         h_state += static_cast<size_t>(seq_slots[seq]) * static_cast<size_t>(h_state_seq_stride);
     }
-    conv_f32 += static_cast<size_t>(seq) * n_tokens * conv_channels;
-    alpha_all += static_cast<size_t>(seq) * n_tokens * n_heads;
-    beta_all += static_cast<size_t>(seq) * n_tokens * n_heads;
-    y_out += static_cast<size_t>(seq) * n_tokens * inner;
+    conv_f32 += seq_row0 * conv_channels;
+    alpha_all += seq_row0 * n_heads;
+    beta_all += seq_row0 * n_heads;
+    y_out += seq_row0 * inner;
     const int BC_size = n_groups * SS;
     const float scale = rsqrtf(static_cast<float>(HD));
 
@@ -342,9 +353,12 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
                                 float* h_state_pool, const int* seq_slots, int64_t h_state_seq_stride,
                                 half* y, int n_seq, int n_tokens, int n_heads, int head_dim_ssm,
                                 int state_size, int n_groups, cudaStream_t stream, int grouped_layout,
-                                const int* d_real_n) {
+                                const int* d_real_n, const int* seq_row_offsets) {
     if (n_seq <= 0)
         return;
+    if (seq_row_offsets && d_real_n)
+        throw std::runtime_error(
+            "gdn_scan_fused_f32_batched: d_real_n is a single-sequence contract - nullptr when ragged");
     dim3 grid(n_heads, n_seq);
     if (head_dim_ssm == 128 && state_size == 128) {
         // SPLIT=2: two threads per state column. At SS=128 one-thread-per-column
@@ -371,14 +385,14 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
         gdn_scan_fused_kernel<128, 128, half, SPLIT><<<grid, 128 * SPLIT, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
             conv_channels, grouped_layout, d_real_n, static_cast<float*>(nullptr), nullptr, seq_slots,
-            h_state_seq_stride);
+            h_state_seq_stride, seq_row_offsets);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         const size_t smem = (2 * 64 + 64) * sizeof(float);
         gdn_scan_fused_kernel<64, 64, half><<<grid, 64, smem, stream>>>(
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
             conv_channels, grouped_layout, d_real_n, static_cast<float*>(nullptr), nullptr, seq_slots,
-            h_state_seq_stride);
+            h_state_seq_stride, seq_row_offsets);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         IMP_LOG_ERROR("gdn_scan_fused_f32_batched: unsupported head_dim=%d state_size=%d", head_dim_ssm,
@@ -394,9 +408,12 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
                                  __nv_bfloat16* h_state_pool, const int* seq_slots,
                                  int64_t h_state_seq_stride, half* y, int n_seq, int n_tokens, int n_heads,
                                  int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                                 int grouped_layout, const int* d_real_n) {
+                                 int grouped_layout, const int* d_real_n, const int* seq_row_offsets) {
     if (n_seq <= 0)
         return;
+    if (seq_row_offsets && d_real_n)
+        throw std::runtime_error(
+            "gdn_scan_fused_bf16_batched: d_real_n is a single-sequence contract - nullptr when ragged");
     if (head_dim_ssm != 128 || state_size != 128)
         throw std::runtime_error("gdn_scan_fused_bf16_batched: no kernel for HD=" +
                                  std::to_string(head_dim_ssm) + " SS=" + std::to_string(state_size));
@@ -406,7 +423,7 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
     gdn_scan_fused_kernel<128, 128, half, SPLIT, __nv_bfloat16><<<grid, 128 * SPLIT, smem, stream>>>(
         conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups, conv_channels,
         grouped_layout, d_real_n, static_cast<__nv_bfloat16*>(nullptr), nullptr, seq_slots,
-        h_state_seq_stride);
+        h_state_seq_stride, seq_row_offsets);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -21,12 +21,17 @@ namespace imp {
 // Batched scan over N independent sequences (concurrent decode). Tokens within
 // a sequence stay sequential; sequences parallelise across blockIdx.y. See the
 // launcher comment in gdn.cu for the layout contract.
+// seq_row_offsets (optional): prefix sums [n_seq+1] into CONCATENATED row
+// arrays for a RAGGED batch (cross-sequence prefill batching, roadmap 0(d))
+// - sequence i owns rows [off[i], off[i+1]) and n_tokens is ignored per-seq.
+// d_real_n must be nullptr when ragged (single-sequence contract).
 void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const half* alpha,
                                 const half* beta, const float* A_log, const float* dt_bias,
                                 float* h_state_pool, const int* seq_slots, int64_t h_state_seq_stride,
                                 half* y, int n_seq, int n_tokens, int n_heads, int head_dim_ssm,
                                 int state_size, int n_groups, cudaStream_t stream,
-                                int grouped_layout = 0, const int* d_real_n = nullptr);
+                                int grouped_layout = 0, const int* d_real_n = nullptr,
+                                const int* seq_row_offsets = nullptr);
 
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                         const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
@@ -44,7 +49,8 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
                                  __nv_bfloat16* h_state_pool, const int* seq_slots,
                                  int64_t h_state_seq_stride, half* y, int n_seq, int n_tokens, int n_heads,
                                  int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
-                                 int grouped_layout = 0, const int* d_real_n = nullptr);
+                                 int grouped_layout = 0, const int* d_real_n = nullptr,
+                                 const int* seq_row_offsets = nullptr);
 void gdn_scan_fused_bf16(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                          const float* A_log, const float* dt_bias, __nv_bfloat16* h_state, half* y,
                          int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,

--- a/tests/test_gdn.cu
+++ b/tests/test_gdn.cu
@@ -1530,5 +1530,97 @@ TEST(GDNScanTest, BF16StateTracksFP32State) {
     cudaFree(d_y_bf16arm);
 }
 
+// ===========================================================================
+// RaggedBatchedScanMatchesSequential -- the seq_row_offsets path (prefill
+// batching groundwork): a ragged batch of 3 sequences (lengths 5/1/9) must
+// produce bit-identical y and final states to three sequential single-
+// sequence calls. Same kernel, same order per sequence, so exact equality.
+// ===========================================================================
+TEST(GDNScanTest, RaggedBatchedScanMatchesSequential) {
+    constexpr int n_heads = 8, head_dim = 128, state_size = 128, n_groups = 4;
+    constexpr int n_seq = 3;
+    const int lens[n_seq] = {5, 1, 9};
+    constexpr int total_rows = 15;
+    constexpr int inner = n_heads * head_dim, BC_size = n_groups * state_size;
+    constexpr int conv_channels = 2 * BC_size + inner;
+    const size_t state_elems = (size_t)n_heads * state_size * head_dim;
+
+    srand(23);
+    std::vector<float> conv((size_t)total_rows * conv_channels);
+    for (auto& v : conv)
+        v = (rand() % 200 - 100) / 100.0f;
+    std::vector<half> h_alpha(total_rows * n_heads), h_beta(total_rows * n_heads);
+    for (auto& v : h_alpha)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    for (auto& v : h_beta)
+        v = __float2half((rand() % 200 - 100) / 100.0f);
+    std::vector<float> h_A(n_heads, -0.5f), h_dt(n_heads, 0.5f);
+    int h_off[n_seq + 1] = {0, 5, 6, 15};
+    int h_slots[n_seq] = {0, 1, 2};
+
+    float *d_conv, *d_A, *d_dt, *d_state_seq, *d_state_rag;
+    half *d_alpha, *d_beta, *d_y_seq, *d_y_rag;
+    int *d_off, *d_slots;
+    cudaMalloc(&d_conv, conv.size() * sizeof(float));
+    cudaMalloc(&d_A, n_heads * sizeof(float));
+    cudaMalloc(&d_dt, n_heads * sizeof(float));
+    cudaMalloc(&d_state_seq, n_seq * state_elems * sizeof(float));
+    cudaMalloc(&d_state_rag, n_seq * state_elems * sizeof(float));
+    cudaMalloc(&d_alpha, h_alpha.size() * sizeof(half));
+    cudaMalloc(&d_beta, h_beta.size() * sizeof(half));
+    cudaMalloc(&d_y_seq, (size_t)total_rows * inner * sizeof(half));
+    cudaMalloc(&d_y_rag, (size_t)total_rows * inner * sizeof(half));
+    cudaMalloc(&d_off, (n_seq + 1) * sizeof(int));
+    cudaMalloc(&d_slots, n_seq * sizeof(int));
+    cudaMemcpy(d_conv, conv.data(), conv.size() * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_A, h_A.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_dt, h_dt.data(), n_heads * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_alpha, h_alpha.data(), h_alpha.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_beta, h_beta.data(), h_beta.size() * sizeof(half), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_off, h_off, sizeof(h_off), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_slots, h_slots, sizeof(h_slots), cudaMemcpyHostToDevice);
+    cudaMemset(d_state_seq, 0, n_seq * state_elems * sizeof(float));
+    cudaMemset(d_state_rag, 0, n_seq * state_elems * sizeof(float));
+
+    // Reference: three sequential BATCHED calls with n_seq=1 on row
+    // sub-ranges - same SPLIT=2 instantiation as the ragged call (the
+    // single-sequence entry runs SPLIT=1, whose reduce order differs).
+    for (int i = 0; i < n_seq; i++) {
+        gdn_scan_fused_f32_batched(d_conv + (size_t)h_off[i] * conv_channels, conv_channels,
+                                   d_alpha + h_off[i] * n_heads, d_beta + h_off[i] * n_heads, d_A, d_dt,
+                                   d_state_seq + (size_t)i * state_elems, d_slots, /*stride=*/0,
+                                   d_y_seq + (size_t)h_off[i] * inner, /*n_seq=*/1, lens[i], n_heads,
+                                   head_dim, state_size, n_groups, nullptr, /*grouped_layout=*/1);
+    }
+    // Ragged batched call.
+    gdn_scan_fused_f32_batched(d_conv, conv_channels, d_alpha, d_beta, d_A, d_dt, d_state_rag, d_slots,
+                               (int64_t)state_elems, d_y_rag, n_seq, /*n_tokens=*/0, n_heads, head_dim,
+                               state_size, n_groups, nullptr, /*grouped_layout=*/1,
+                               /*d_real_n=*/nullptr, d_off);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    std::vector<uint8_t> a((size_t)total_rows * inner * sizeof(half)), b(a.size());
+    cudaMemcpy(a.data(), d_y_seq, a.size(), cudaMemcpyDeviceToHost);
+    cudaMemcpy(b.data(), d_y_rag, b.size(), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(0, memcmp(a.data(), b.data(), a.size())) << "ragged y differs from sequential";
+
+    std::vector<uint8_t> sa(n_seq * state_elems * sizeof(float)), sb(sa.size());
+    cudaMemcpy(sa.data(), d_state_seq, sa.size(), cudaMemcpyDeviceToHost);
+    cudaMemcpy(sb.data(), d_state_rag, sb.size(), cudaMemcpyDeviceToHost);
+    EXPECT_EQ(0, memcmp(sa.data(), sb.data(), sa.size())) << "ragged final states differ";
+
+    cudaFree(d_conv);
+    cudaFree(d_A);
+    cudaFree(d_dt);
+    cudaFree(d_state_seq);
+    cudaFree(d_state_rag);
+    cudaFree(d_alpha);
+    cudaFree(d_beta);
+    cudaFree(d_y_seq);
+    cudaFree(d_y_rag);
+    cudaFree(d_off);
+    cudaFree(d_slots);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -144,7 +144,7 @@ def main():
     # 1007 -> 1008 (#1769): LayerNormTest.RMSNormRowBlockDecodeShapes, the
     # row-block batched-decode RMSNorm against the CPU reference on three
     # decode shapes - needs a GPU.
-    PINNED = 1013
+    PINNED = 1014
 
     text = CMAKE.read_text()
     mods = module_sources(text)

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -89,7 +89,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
 "src/runtime/engine_scheduler.cpp" = { code_loc = 2210, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
-"tests/test_gdn.cu" = { code_loc = 1210, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
+"tests/test_gdn.cu" = { code_loc = 1285, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }
 "tests/test_paged_attention.cu" = { code_loc = 1202, reason = "(c) 26 tests of the paged-attention kernel - one test target" }


### PR DESCRIPTION
Groundwork + scoping for roadmap 0(d).

**Ragged scan**: the batched entries take optional prefix-sum `seq_row_offsets` [n_seq+1] so a ragged batch of K prompts runs in ONE launch; uniform callers are byte-for-byte unchanged (offsets nullptr keeps the seq*n_tokens rebase), d_real_n refused when ragged. Bit-identity GPU test vs sequential n_seq=1 calls (lengths 5/1/9; reference matches the SPLIT=2 instantiation), offset-drop mutant killed. Full GDN suite 166/166.

**Phase 0 scoping** (plan doc, GO): serial prefill is ~25% of a burst wave (32 x ~120 tokens at ~1700 tok/s launch-bound vs >10k batched). Architecture: batch the row-independent 82% (GEMMs/norms/producer-quantize) over concatenated rows, loop attention (16/64 layers) and conv per-seq - verified no varlen FA2 needed (only q_offset exists), RoPE already takes per-token positions, the scan now takes ragged offsets. Phased plan + risks in the doc.

Test-lane pin 1013 -> 1014; test_gdn.cu allowlist re-pin. Gate note in the commit (first hook run flaked, immediate full rerun green - #1769 class).

[PROV: commit=HEAD date=2026-08-26 hw=RTX5090 cuda=13.3 tests=test-moe-gdn 166/166]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEZeyiGheY9WfDVvYqHMmv