### PR TITLE
perf(sched): charge the ragged prefill launch floor once per forward, +2.6% at 32-stream defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ there instead of retelling it.
 
 ### Fixed
 
+- **Ragged prefill members no longer pay the 256-token launch floor each.**
+  The prefill token budget charged every request in a ragged group
+  max(256, chunk) although the group shares one launch set; 30-70-row
+  continuation tails burned a whole engine step per 2-3 tails. The floor is
+  now charged once per forward. 32-stream burst at defaults: aggregate
+  975.9 -> 1001.3 tok/s median (+2.6%, 3/3 alternating trial pairs), TTFT
+  p90 -0.2 s. For burst-shaped workloads `prefill_chunk_decode_cap=4096`
+  buys more (measured 1111-1128 tok/s, TTFT p90 2.5-2.6 s) at the cost of
+  the streamer inter-token bound the 1024 default protects; see the
+  config.h note.
+
 - **A 32-stream burst no longer starves its own tail.** Three defects, one
   per layer, found by tracing per-request arrival and first-prefill times:
   the HTTP worker pool was sized to cores (cpp-httplib default max(8,

--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -1211,3 +1211,33 @@ max_tokens) splits a 32x130 burst into ~8 ragged groups, and once the first
 group's streams decode, the token-charged prefill budget (#1643 policy)
 paces the remaining groups between decode steps. Raising the cap trades
 workspace VRAM; not measured here.
+
+## Ragged budget charging + the decode-cap trade (2026-08-26, follow-up to #1780)
+
+Debug-log trace of a 32-stream burst wave (steady state): after wave start,
+`prefill_chunk_decode_cap=1024` paces ragged groups to "2 seqs, ~690 rows"
+per engine step, with extra steps burned on "2-3 seqs, 30-76 rows"
+continuation tails - each tail request was charged the 256-token launch
+floor although the ragged group shares one launch set.
+
+Shipped: the floor charges once per forward (ragged members charge real
+chunk tokens). Defaults, 4 waves x 3 alternating two-image trials/arm,
+steady-wave medians: 975.9 -> 1001.3 tok/s (+2.6%, pairs +3.7/+3.3/+1.8%),
+TTFT p90 3.65-3.85 -> 3.54-3.69 s.
+
+Config lever, measured and documented (config.h note), NOT default-flipped:
+
+| `prefill_chunk_decode_cap` | aggregate (3 waves) | TTFT p90 |
+|---|---:|---:|
+| 1024 (default) | 1004-1048 | 3.5-3.7 s |
+| 4096 | 1111-1128 | 2.5-2.6 s |
+| 0 (off) | 1108-1113 | 2.5-2.7 s |
+
+The default stays: it bounds a concurrent streamer's inter-token gap during
+another session's ingest (#1643 measurement, 259 -> 112 ms). Burst-shaped
+deployments should set 4096.
+
+Also corrected from the #1780 body: the "512-row workspace cap" claim was a
+stale scheduler comment; dense-GDN max_tokens caps at 2048
+(executor_workspace.cu:252, and has_gdn_ is deliberately set after the cap).
+The wave pacer is the decode cap, not the workspace cap.

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -146,6 +146,14 @@ struct RuntimeConfig {
         // reach this, while the knob that merely CAPS it - the line below - had
         // a key. A CLI value wins over the file.
         int prefill_chunk_size = -1;
+        // Burst-heavy serving note (2026-08-26, Qwen3.8-27B-NVFP4, 32-stream
+        // burst with ragged prefill): this cap paces the post-wave-start
+        // prefill to ~2 prompts per engine step; raising it to 4096 measured
+        // aggregate 1004-1048 -> 1111-1128 tok/s and TTFT p90 3.5-3.7 ->
+        // 2.5-2.6 s (0 = off is equivalent). The default stays 1024 because
+        // it bounds a concurrent STREAMER's inter-token gap during another
+        // session's large ingest (the #1643 measurement) — raise it when the
+        // workload is burst-shaped rather than mixed.
         int prefill_chunk_decode_cap = 1024;
         // Cap the NUMBER of prefill chunk forwards per engine step while other
         // sequences are DECODING (#1643). The size cap above bounds ONE chunk;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -583,8 +583,8 @@ void Engine::step_prefill(cudaStream_t stream) {
     int resolved    = resolve_prefill_chunk_size_();
     int effective_chunk = (resolved > 0) ? resolved : executor_->max_tokens();
     // Hard cap: chunk size must never exceed the executor's max_tokens
-    // (which is itself capped to 256 for SSM/GDN+MoE hybrids and 512 for
-    // dense GDN to bound workspace VRAM). Without this clamp, a server-side
+    // (which is itself capped to 2048 for SSM/GDN hybrids to bound workspace
+    // VRAM — executor_workspace.cu:252). Without this clamp, a server-side
     // prefill_chunk_size default (handlers.cpp) would overflow the
     // workspace and crashes with `n_tokens (X) exceeds max_tokens (Y)` →
     // `terminate: reshape: numel mismatch` on long prompts to e.g. Qwen3.6.
@@ -654,26 +654,43 @@ void Engine::step_prefill(cudaStream_t stream) {
     size_t ran = 0;
     // Cross-sequence ragged prefill (runtime.prefill_batch): eligible requests
     // are collected and run as ONE ragged forward after the loop; ineligible
-    // ones keep the serial path. Selection order, budget charging and the
-    // rotor are identical either way.
+    // ones keep the serial path. Selection order, budget accounting and the
+    // rotor are identical either way, with one pricing difference: the
+    // 256-token launch-cost floor is charged once per FORWARD, so ragged
+    // members charge their real chunk tokens (the group shares one launch
+    // set; a 30-row continuation tail priced at 256 was measured burning a
+    // whole engine step per 2-3 tails on a 32-stream burst). The step's
+    // inserted latency still scales with total rows, which the token budget
+    // continues to bound.
     const bool ragged_mode = prefill_ragged_enabled_();
     std::vector<std::shared_ptr<Request>> ragged_batch;
+    bool ragged_floor_charged = false;
     for (size_t i = 0; i < budget; i++) {
         auto& req = sched_prefill_batch_[(start + i) % n_prefill];
         // Charge from the PRE-call remaining: step_prefill_one advances
         // prefill_offset, so reading it afterwards undercharges any chunk
         // that does not finish the prompt.
         const int remaining = static_cast<int>(req->input_tokens.size()) - req->prefill_offset;
-        const int charge = std::max(kPrefillForwardFloorTokens,
-                                    std::min(std::max(remaining, 0), effective_chunk));
+        const int chunk_tokens = std::min(std::max(remaining, 0), effective_chunk);
+        const bool rides_ragged = ragged_mode && prefill_ragged_req_ok_(*req);
+        int charge;
+        if (rides_ragged) {
+            charge = (ragged_floor_charged || chunk_tokens >= kPrefillForwardFloorTokens)
+                         ? chunk_tokens
+                         : kPrefillForwardFloorTokens;
+        } else {
+            charge = std::max(kPrefillForwardFloorTokens, chunk_tokens);
+        }
         // `budgeted`, not `token_budget > 0`: an exhausted budget must break,
         // not disarm the check (that bug ran the whole batch after charge 4).
         if (budgeted && ran > 0 && charge > token_budget)
             break;
-        if (ragged_mode && prefill_ragged_req_ok_(*req))
+        if (rides_ragged) {
             ragged_batch.push_back(req);
-        else
+            ragged_floor_charged = true;
+        } else {
             step_prefill_one(req, effective_chunk, stream);
+        }
         kv_manager_->touch(req->id);
         ran++;
         sched_prefill_last_id_ = req->id;

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 2219, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 2230, reason = "(c) one scheduler: prefill/decode scheduling + chunked exec + perplexity capture" }
 "tests/test_gdn.cu" = { code_loc = 1285, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
## Ragged budget charging (follow-up to #1780)

The prefill token budget charged every ragged-group member max(256, chunk_tokens) although the group shares one launch set. Debug-trace of a steady burst wave: groups paced to "2 seqs, ~690 rows" per engine step, plus mini-groups of 30-76-row continuation tails each priced at 256, burning an engine step per 2-3 tails. Fix: ragged members charge real chunk tokens, the floor once per forward (`engine_scheduler.cpp` step_prefill loop). Serial requests unchanged.

| defaults, 32-stream burst, steady-wave medians, 3 alternating two-image trials/arm | base | charge-fix |
|---|---:|---:|
| aggregate tok/s | 975.9 | 1001.3 (+2.6%; pairs +3.7/+3.3/+1.8%) |
| TTFT p90 | 3.65-3.85 s | 3.54-3.69 s |

## Documented, not default-flipped

`prefill_chunk_decode_cap` is the burst pacer; measured on the same harness (3 waves/config): 1024 (default) 1004-1048 tok/s / TTFT p90 3.5-3.7 s; **4096: 1111-1128 / 2.5-2.6 s**; 0 equivalent to 4096. Default stays 1024 for the #1643 streamer inter-token bound; note added at the key in `config.h` + plan doc section.

Also fixed: stale scheduler comment claiming a 256/512 hybrid max_tokens cap (actual 2048, `executor_workspace.cu:252`); filesize allowlist re-pin engine_scheduler.cpp 2219 -> 2230.

## Gate

```
make test-gpu: green on this tree (exit 0)
  decode  tg128 =  264.45 tok/s  (baseline  287.19, delta -7.92%)  PASS
  prefill pp512 = 11678.76 tok/s (baseline 12406.87, delta -5.87%) PASS
  own peak VRAM = 20718 MiB (delta 0.01%)                          PASS
=== verify fast: OK ===
```
Gate deltas ran under a 6-8% background GPU load (busy-check samples); the changed path cannot reach the single-stream bench (budget charging engages only with active decoders plus concurrent prefill).

Not in here: any change to the 1024 default or a burst-adaptive cap - policy question, config lever documented instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVv96TCxXPufzS5Vmi7eTt