### PR TITLE
build: exclude imp.conf and build-dev/ from the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,5 @@ AGENTS.md
 LICENSE
 logo.svg
 compile_commands.json
+imp.conf
+build-dev/


### PR DESCRIPTION
A gitignored local `imp.conf` (agentic profile: fp8 KV, 40% prefix pin, dated Jul 9) sat in the repo root and was copied into `/src` by the builder stage's `COPY . .` - any binary run from the builder image's WORKDIR silently loaded it (`imp.conf loaded from ./imp.conf`). Found via an nsys profile showing fp8 paged-attention kernels where the serving default is NVFP4 KV. `.gitignore` does not cover the Docker context; `.dockerignore` now does. `build-dev/` joins for context size.

Not in here: deleting the local imp.conf (it is the user's serving profile) or a runtime guard against CWD configs - the explicit `./imp.conf` load is a documented feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVv96TCxXPufzS5Vmi7eTt