### PR TITLE
docs(qwen38): close the port roadmap - all nine items done, answered, or verdict-recorded

### DIFF
--- a/docs/plans/2026-08-24-qwen38-port.md
+++ b/docs/plans/2026-08-24-qwen38-port.md
@@ -230,12 +230,12 @@ model on this card exist in `docs/BENCHMARKS.md`.
 
 | # | work | files | acceptance |
 |---|---|---|---|
-| 1 | HF logits-parity harness for GDN hybrids | `tests/` + a pinned-transformers container | max abs diff < 2e-2, top-5 order, 20 prompts × {short, 4k, 32k} |
+| 1 | ~~HF logits-parity harness~~ CLOSED 08-27 (hardware-blocked, evidence recorded) | phase-2 harness (`dump_final_logits_dir`) | the 2e-2 criterion needs BF16-vs-BF16 and the 51.75 GiB reference does not fit this card; standing evidence: PPL +4.54% vs HF BF16 (the 4-bit price), 46k state bit-stable across processes, top-1 agreement incl. the 46k prompt |
 | 2 | ~~DeltaNet state-drift check at 32k~~ MEASURED 08-25 (internal bound) | `diagnostics.dump_gdn_state_dir` + chunk-size A/B | see below: 46k prefill is bit-stable across processes; chunk-size variance costs +0.33% PPL |
-| 3 | `reasoning_effort` plumbing (G1) | `chat_template.cpp`, `jinja.cpp`, server request parse, `tests/refs/` | `prompt_tokens` differs across the three efforts; golden matches upstream template |
-| 4 | FP8-as-source limitation documented (G2) | `docs/LIMITATIONS.md`, `docs/MODELS.md` | claim carries the 25.87 GiB figure and the sm_120 FP8-GEMM reason |
+| 3 | ~~`reasoning_effort` plumbing (G1)~~ DONE (#1750; e2e-verified 08-27) | `chat_template.cpp`, server parse, `tests/test_qwen38_chat_template.cpp` + golden | measured on the live server: prompt_tokens low=41 / medium=11 / xhigh=53, unset==xhigh. Known edge: an invalid value renders like medium with only a server-side WARN — `raise_exception` is soft (WARN + continue) globally in jinja.cpp |
+| 4 | ~~FP8-as-source limitation documented (G2)~~ DONE (#1750 era) | `docs/LIMITATIONS.md` ("quantization SOURCE, not a servable checkpoint", 25.87 GiB + no sm_120 FP8 GEMM), `docs/MODELS.md` row | both files carry the figures |
 | 5 | ~~Fix the MTP enable-path mismatch~~ DONE 08-25 | `tools/imp-cli/main.cpp` | `--set speculative.mtp_k=2` enables MTP under the CLI |
-| 6 | Recurrent-state paging (G3) | `RecurrentSnapshotStore`, `SSMState`, scheduler admission | 32 admitted sequences at a usable per-sequence context; no cross-sequence divergence |
+| 6 | ~~Recurrent-state paging (G3)~~ CLOSED 08-27: criterion met WITHOUT paging | phase-3 config + BF16 state (#1776) | the acceptance as written holds since phase 3 (32 admitted, 32/32 byte-identical, no divergence; ~2000 tok/seq at defaults today after state_bf16 freed 2.3 GB). Paging remains the future lever for 32 seqs at LONG context - tracked in docs/roadmap.md, not port scope |
 | 7 | ~~Lift the prefill-capture cap (G4)~~ ANSWERED 08-25 | `engine_scheduler.cpp:1110` | the cap is not the binding gate: quantized KV append (D2H absmax sync) blocks capture on every non-F16-KV model, and capture covers only the offset-0 chunk by design. `diagnostics.prefill_graph_ignore_dequant_cap=true` A/B at pp4096: 7800.21 vs 7798.27 tok/s, same path both arms |
 | 8 | ~~MTP prefill regression (Phase 5)~~ DONE 08-25 | `mtp_feed_batch`, `engine_spec_mtp.cpp` | pp512 with MTP -8.8% instead of -83% (residual: one M=1 chain pair per chunk) |
 | 9 | ~~Competitive table~~ DONE 08-25 (vLLM half) | `docs/BENCHMARKS.md` | vLLM 0.27.1 vs imp at concurrency 1/8/32, same CT checkpoint, `[PROV:]`; llama.cpp half stays blocked (b10524 has no Qwen3_5 converter) |
@@ -1289,3 +1289,30 @@ Remaining attention headroom: the scalar kernel at 152 us/launch is
 L2-latency-bound with full grid parallelism; closing it means latency
 engineering against an unknown ceiling, not a traffic fix. Deprioritized
 behind the launch-coupled idle and the smallm in-class residual.
+
+## ROADMAP CLOSED (2026-08-27)
+
+Every numbered item is done, answered, or closed with a recorded verdict;
+nothing in this plan remains actionable on this hardware.
+
+| # | terminal state |
+|---|---|
+| 1 | hardware-blocked, evidence recorded (PPL +4.54% vs HF BF16; 46k state bit-stable; top-1 agreement) |
+| 2 | measured (chunk-size variance +0.33% PPL, benign) |
+| 3 | shipped #1750, e2e-verified 08-27 (prompt_tokens 41/11/53 across efforts) |
+| 4 | documented (LIMITATIONS.md + MODELS.md) |
+| 5 | shipped 08-25 |
+| 6 | criterion met without paging (phase 3 + state_bf16); paging = future long-context lever in docs/roadmap.md |
+| 7 | answered (the dequant cap is not the binding gate) |
+| 8 | shipped 08-25 (pp512 -8.8% instead of -83%) |
+| 9 | done for the vLLM half; llama.cpp blocked upstream (no Qwen3_5 converter in b10524) |
+
+Where the port ended up against the brief: the model is served first-class -
+loads, generates, sees images, speculates with its own head, batches decode
+(#1750) and prefill (#1780) across sequences, and holds 32-way byte-exact
+isolation. Serving stand after this campaign (32-stream burst, defaults):
+~1030-1050 tok/s aggregate, TTFT p50 ~2.5 s; measured gap to vLLM ~1.35x at
+defaults / ~1.08x pinned (BENCHMARKS.md). The engine-side posts that remain
+(launch-coupled idle, smallm in-class residual, recurrent-state paging for
+long-context concurrency, elementwise fusion tail) are engine roadmap items,
+not Qwen3.8-port items - they live in docs/roadmap.md.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,6 +133,13 @@ Ranked by what an agent workload notices first.
    the one-sequence floor) the measured gap to vLLM stands at ~1.08x
    pinned. Largest remaining engine-side posts: (d) above, the
    launch-coupled idle, and the elementwise/gate|up fusion tail.
+   UPDATE 2026-08-27: the Qwen3.8 PORT roadmap is CLOSED - every item in
+   docs/plans/2026-08-24-qwen38-port.md is done, answered, or closed with a
+   recorded verdict (final table there). What remains in THIS file for the
+   serving gap is engine scope, not port scope: launch-coupled idle, the
+   smallm in-class residual, recurrent-state paging (the lever for 32-way
+   concurrency at LONG context - the phase-3 criterion itself is met
+   without it), and the elementwise fusion tail.
    UPDATE 2026-08-26 (attention post priced and closed): the fresh profile
    put NVFP4 decode attention at 8.9% of kernel time, ~13x its per-launch
    DRAM floor - but the GQA-tile variant built against it measured -9% e2e


### PR DESCRIPTION
## The Qwen3.8-27B port roadmap is closed

| # | terminal state |
|---|---|
| 1 HF logits parity | hardware-blocked, evidence recorded: the 2e-2 criterion needs BF16-vs-BF16, the 51.75 GiB reference does not fit this card; standing in: PPL +4.54% vs HF BF16 (the 4-bit price), 46k state bit-stable across processes, top-1 agreement incl. 46k |
| 2 state drift | measured 08-25 (+0.33% PPL chunk-size variance, benign) |
| 3 reasoning_effort | shipped #1750 (table was stale); **e2e-verified today**: prompt_tokens low=41 / medium=11 / xhigh=53, unset==xhigh. Edge noted: invalid values render like medium with a WARN only (`raise_exception` is soft globally in jinja.cpp) |
| 4 FP8-as-source docs | already documented (table stale): LIMITATIONS.md 25.87 GiB + no sm_120 FP8 GEMM, MODELS.md row |
| 5 MTP enable-path | shipped 08-25 |
| 6 recurrent-state paging | CLOSED: the acceptance as written holds since phase 3 WITHOUT paging (32 admitted, 32/32 byte-identical, ~2000 tok/seq at defaults after #1776 freed 2.3 GB). Paging reclassified to the engine roadmap as the long-context-concurrency lever |
| 7 prefill-capture cap | answered 08-25 (cap not the binding gate) |
| 8 MTP prefill | shipped 08-25 (-8.8% instead of -83%) |
| 9 competitive table | vLLM half done; llama.cpp blocked upstream (no Qwen3_5 converter) |

Port outcome: first-class serving - batched decode (#1750) and cross-sequence prefill (#1780), 32-way byte-exact isolation, ~1030-1050 tok/s aggregate / TTFT p50 ~2.5 s at defaults, gap to vLLM ~1.35x defaults / ~1.08x pinned. Remaining engine-scope posts stay in docs/roadmap.md.

Docs-only diff; all docs gates green locally (lint, citations, sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVv96TCxXPufzS5Vmi7eTt