### PR TITLE
perf(gemm): sibling-pair small-M launch - gate|up and GDN in|z in one kernel, +1.7% at 32 streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ there instead of retelling it.
 
 ### Added
 
+- **Sibling-pair small-M GEMM launch (`gemm.nvfp4_smallm_pair`, default ON):
+  +1.7% aggregate at 32 streams.** FFN gate|up and GDN in|z each consume the
+  same quantized activation; they now run as ONE smallm v2 launch (two weight
+  sets, per-CTA selection, same CTA body) instead of two - 112 fewer GEMM
+  launches per 64-layer decode step. Qwen3.8-27B-NVFP4, 4 waves x 3
+  alternating trials/arm, mbs=32/seq4096 pinned: 1713.3 -> 1742.0 tok/s
+  aggregate median (pairs +2.0/+1.4/+1.2%). Bit-identical per tensor to the
+  two single launches (`SmallMV2Pair` gate, two mutants killed); M=1 and
+  prefill paths unchanged.
+
 - **Cross-sequence prefill batching (`runtime.prefill_batch`, default ON):
   +6.2% aggregate and TTFT p50 4.11 -> 2.55 s on a 32-stream burst.** The
   prefill chunks of several admitted requests run as ONE ragged forward:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -109,8 +109,12 @@ Ranked by what an agent workload notices first.
    +2.6% aggregate at 32 streams (1160.4 -> 1191.0 median, 3/3 pairs);
    the GDN-out half of the remainder was built and measured NEUTRAL
    (+0.4% over 6 trials, PR #1774 closed unmerged - the class left after
-   #1773 is under the noise floor); still open in class: elementwise,
-   gate|up single-launch. (d) cross-sequence
+   #1773 is under the noise floor). UPDATE 2026-08-27: the gate|up
+   single-launch idea is SHIPPED and generalized - `gemm.nvfp4_smallm_pair`
+   (default ON) runs FFN gate|up and GDN in|z as one sibling-pair smallm
+   launch each (112 fewer launches per step), measured +1.7% aggregate at 32
+   streams (1713.3 -> 1742.0 median, 3/3 alternating pairs positive).
+   Still open in class: elementwise. (d) cross-sequence
    prefill batching: a 32-prompt burst prefills one sequence per forward
    at ~1700 tok/s effective (launch-bound, 64 layers), so every first
    token waits 2-3.5 s; batching prefill rows the way decode batches
@@ -132,7 +136,8 @@ Ranked by what an agent workload notices first.
    +0.21%. Together with the #1765 plan fix (KV no longer collapsible to
    the one-sequence floor) the measured gap to vLLM stands at ~1.08x
    pinned. Largest remaining engine-side posts: (d) above, the
-   launch-coupled idle, and the elementwise/gate|up fusion tail.
+   launch-coupled idle, and the elementwise fusion tail (the gate|up half
+   shipped 2026-08-27 as the sibling-pair launch, see (c)).
    UPDATE 2026-08-27: the Qwen3.8 PORT roadmap is CLOSED - every item in
    docs/plans/2026-08-24-qwen38-port.md is done, answered, or closed with a
    recorded verdict (final table there). What remains in THIS file for the

--- a/src/core/config/gemm.h
+++ b/src/core/config/gemm.h
@@ -139,6 +139,12 @@ struct GEMM {
     // producer/consumer pipeline (nvfp4_gemm_smallm_v2.cu; isolated 10.4 us
     // on M=32 N=5120 K=5120 vs v1's 23.9 and CUTLASS's 41.4 in-situ).
     int nvfp4_smallm_impl = 2;
+    // Sibling-pair launch for the v2 kernel: two weights that consume the
+    // SAME activation (FFN gate|up, GDN in|z) run as ONE launch — same CTA
+    // body, bit-identical per tensor (SmallMV2Pair gate), saves one launch's
+    // fixed cost + one tail wave per pair, 112 launches per 64-layer decode
+    // step on Qwen3.8-27B. Kill switch for A/B; requires impl 2.
+    bool nvfp4_smallm_pair = true;
     // (gemm.nvfp4_ssm_proj — the 2026-05-30 opt-in that forced GGUF-hybrid
     // GDN projections into the NVFP4 decode cache — was REMOVED 2026-07-11:
     // it had bit-rotted in the tier refactors (measured 71 tok/s vs its

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -794,6 +794,13 @@ private:
     // (dp4a on original quant is fastest). Caller passes both the TensorID
     void gemm_via_handle_(TensorID id, const Tensor& input,
                           Tensor& output, const GemmContext& ctx);
+    // Sibling-pair small-M dispatch: both weights consume the SAME input and
+    // both route to the smallm v2 kernel — run them as one launch
+    // (gemm_nvfp4_smallm_v2_pair_a4). Returns false (and does nothing) when
+    // either weight would not take that route; the caller then issues the
+    // two gemm_via_handle_ calls it would have issued anyway.
+    bool try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, const Tensor& input,
+                                   Tensor& out_a, Tensor& out_b, const GemmContext& ctx);
     // True when an M>1 dispatch of `id` is guaranteed to take the CUTLASS
     // NVFP4 prefill block in gemm_via_handle_ (which quantizes the input
     // into the shared activation scratch). Gate for the act-quant-hint

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -237,6 +237,9 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 if (n > 1 && fused_gu) {
                     // Batched gate+up: single cuBLAS call for both projections
                     gemm_pair_batched(no, *fused_gu, go, uo, stream);
+                } else if (try_smallm_pair_dispatch_(ly.w_gate_id, ly.w_up_id, no, go, uo, ctx)) {
+                    // Batched-decode sibling pair: gate and up in ONE smallm
+                    // v2 launch (same quantized activation, two weight sets).
                 } else {
                     // NVFP4-CUTLASS prefill gate/up share the normed input —
                     // gate's dispatch quantizes it into the activation

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -737,4 +737,86 @@ void GraphExecutor::swiglu_for_smallm_(const Tensor& go, const Tensor& uo, Tenso
         smallm_xq_from_producer_ = false;
 }
 
+bool GraphExecutor::try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, const Tensor& input,
+                                              Tensor& out_a, Tensor& out_b, const GemmContext& ctx) {
+    // Mirror of the single-tensor smallm v2 eligibility in gemm_via_handle_
+    // (see the block there for the rationale of each condition) applied to
+    // BOTH weights, plus: same K, v2 only, stripes==1 shapes only, fresh
+    // outputs only. Every decline is a plain `false` — the caller issues the
+    // two single dispatches it would have issued anyway.
+    if (!runtime_config().gemm.nvfp4_smallm || runtime_config().gemm.nvfp4_smallm_impl != 2 ||
+        !runtime_config().gemm.nvfp4_smallm_pair || ctx.spec_verify_small_m || ctx.beta != 0.0f)
+        return false;
+    if (id_a == kInvalidTensorID || id_b == kInvalidTensorID)
+        return false;
+    const int M = static_cast<int>(input.shape[0]);
+    // M==1 stays on the fused decode GEMVs; M>32 is prefill.
+    if (M < 2 || M > 32)
+        return false;
+    if (input.qtype != QType::F16 || out_a.qtype != QType::F16 || out_b.qtype != QType::F16)
+        return false;
+    const auto& ha = registry_.handle(id_a);
+    const auto& hb = registry_.handle(id_b);
+    auto eligible = [](const WeightHandle& h) {
+        return h.primary_tier == StorageTier::CUTLASS_NVFP4 && h.source_data != nullptr &&
+               h.source_scales != nullptr && !dequant_gpu_supported(h.source_qtype);
+    };
+    if (!eligible(ha) || !eligible(hb))
+        return false;
+    const int K = static_cast<int>(ha.shape[1] * 2);
+    if (static_cast<int>(hb.shape[1] * 2) != K || (K % 256) != 0)
+        return false;
+    const int N1 = static_cast<int>(ha.shape[0]);
+    const int N2 = static_cast<int>(hb.shape[0]);
+    if ((N1 % 64) != 0 || (N2 % 64) != 0)
+        return false;
+    if (gemm_nvfp4_smallm_v2_stripes(N1, K) != 1 || gemm_nvfp4_smallm_v2_stripes(N2, K) != 1)
+        return false;
+    const size_t xq_need = (size_t)32 * (K / 2) + (size_t)32 * (K / 16);
+    ensure_smallm_xq_(xq_need, ctx.stream);
+    if (smallm_xq_bytes_ < xq_need)
+        return false;
+    // Same statistic the single path records: both weights consume `input`.
+    if (calib_) {
+        calib_->accumulate(cur_layer_, ha.kind, input, ctx.stream);
+        calib_->accumulate(cur_layer_, hb.kind, input, ctx.stream);
+    }
+    uint8_t* xq_packed = static_cast<uint8_t*>(smallm_xq_);
+    uint8_t* xq_scales = xq_packed + (size_t)32 * (K / 2);
+    // Quantize dedupe — identical contract to the single-tensor block: a
+    // matching scratch tag plus either the caller's act-quant hint or a
+    // producer-side tag skips the re-quantize.
+    const bool tag_match = smallm_xq_src_ == input.data && smallm_xq_src_m_ == M && smallm_xq_src_k_ == K;
+    const bool hint_match = ctx.act_quant_hint_data != nullptr && ctx.act_quant_hint_data == input.data &&
+                            ctx.act_quant_hint_m == M && ctx.act_quant_hint_k == K;
+    if (!(tag_match && (hint_match || smallm_xq_from_producer_))) {
+        quantize_fp16_to_nvfp4_into(input.data, M, K, xq_packed, xq_scales,
+                                    /*tensor_scale=*/1.0f, ctx.stream);
+        smallm_xq_src_ = input.data;
+        smallm_xq_src_m_ = M;
+        smallm_xq_src_k_ = K;
+        smallm_xq_from_producer_ = false;
+    }
+    NvFP4QuantResult nva;
+    nva.packed_data = const_cast<void*>(ha.source_data);
+    nva.micro_scales = ha.source_scales;
+    nva.tensor_scale = ha.source_tensor_scale;
+    nva.N = N1;
+    nva.K = K;
+    NvFP4QuantResult nvb;
+    nvb.packed_data = const_cast<void*>(hb.source_data);
+    nvb.micro_scales = hb.source_scales;
+    nvb.tensor_scale = hb.source_tensor_scale;
+    nvb.N = N2;
+    nvb.K = K;
+    NvFP4QuantResult xq;
+    xq.packed_data = xq_packed;
+    xq.micro_scales = xq_scales;
+    xq.tensor_scale = 1.0f;
+    xq.N = M;
+    xq.K = K;
+    return gemm_nvfp4_smallm_v2_pair_a4(nva, nvb, xq, reinterpret_cast<half*>(out_a.data),
+                                        reinterpret_cast<half*>(out_b.data), M, N1, N2, K, ctx.stream);
+}
+
 }  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -340,6 +340,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     //    GDN: no z-split, no dt — the full projection goes to conv1d.
     int64_t proj_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
     Tensor proj;
+    bool gate_paired = false;
     if (fused_input) {
         // One GEMV produces [proj | gate | alpha | beta] contiguously in
         // gdn_fused_proj_buf_; the views below take offset slices.
@@ -352,7 +353,15 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         // Original path: ssm_proj_buf_ is [max_tokens, ssm_in_dim] but we only
         // need [n, conv_channels].
         proj = Tensor(ssm_proj_buf_.data, compute_dtype_, 2, proj_shape, true);
-        gemm_via_handle_(ly.ssm_in_id, no, proj, ctx);
+        // Batched-decode sibling pair: in-projection and gate both consume
+        // `no`, and the gate output buffer (ssm_z_buf_) is untouched until
+        // RMSNormGated after the scan — computing the gate here is a pure
+        // reorder. One smallm v2 launch for both when both route there.
+        int64_t gate_shape_early[2] = {static_cast<int64_t>(n), static_cast<int64_t>(inner)};
+        Tensor gate_early(ssm_z_buf_.data, compute_dtype_, 2, gate_shape_early, true);
+        gate_paired = try_smallm_pair_dispatch_(ly.ssm_in_id, ly.gdn_gate_id, no, proj, gate_early, ctx);
+        if (!gate_paired)
+            gemm_via_handle_(ly.ssm_in_id, no, proj, ctx);
     }
     dump_tensor_npy("gdn_ssm_in_out", proj, stream, layer, cur_decode_step_);
 
@@ -522,14 +531,18 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         gate_out = Tensor(gate_ptr, compute_dtype_, 2, gate_shape, true);
     } else {
         gate_out = Tensor(ssm_z_buf_.data, compute_dtype_, 2, gate_shape, true);
-        // ssm_in (above) quantized the same normed input into the activation
-        // scratch and no GEMM dispatches in between — mark it shared (the
-        // dispatch verifies against its scratch tag before skipping).
-        GemmContext gate_ctx = ctx;
-        if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.ssm_in_id, n) &&
-            prefill_routes_cutlass_nvfp4_(ly.gdn_gate_id, n))
-            gate_ctx = ctx.with_act_quant_hint(no.data, n, static_cast<int>(no.shape[1]));
-        gemm_via_handle_(ly.gdn_gate_id, no, gate_out, gate_ctx);
+        // Pair path already produced it in step 2 (one launch with ssm_in).
+        if (!gate_paired) {
+            // ssm_in (above) quantized the same normed input into the
+            // activation scratch and no GEMM dispatches in between — mark it
+            // shared (the dispatch verifies against its scratch tag before
+            // skipping).
+            GemmContext gate_ctx = ctx;
+            if (n > 1 && prefill_routes_cutlass_nvfp4_(ly.ssm_in_id, n) &&
+                prefill_routes_cutlass_nvfp4_(ly.gdn_gate_id, n))
+                gate_ctx = ctx.with_act_quant_hint(no.data, n, static_cast<int>(no.shape[1]));
+            gemm_via_handle_(ly.gdn_gate_id, no, gate_out, gate_ctx);
+        }
     }
 
     const bool use_fp32_scan = runtime_config().gdn.fp32_scan;

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -67,6 +67,14 @@ bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& 
 bool gemm_nvfp4_smallm_v2_a4_tuned(const NvFP4QuantResult& W, const NvFP4QuantResult& Xq, half* y, int M,
                                    int N_out, int K, void* d_workspace, cudaStream_t stream,
                                    bool accumulate, int stages, int stripes);
+// Sibling-pair variant: two weights with the same K sharing one quantized
+// activation (FFN gate|up, GDN in|z) in ONE launch. stripes==1 shapes only
+// (both Ns >= 5120), fresh outputs (no accumulate); returns false otherwise
+// and the caller falls back to two single calls. Bit-identical per tensor to
+// the single-tensor kernel (same CTA body, same tile order).
+bool gemm_nvfp4_smallm_v2_pair_a4(const NvFP4QuantResult& W1, const NvFP4QuantResult& W2,
+                                  const NvFP4QuantResult& Xq, half* y1, half* y2, int M, int N1, int N2,
+                                  int K, cudaStream_t stream);
 
 void gemm_nvfp4_batched(const NvFP4QuantResult& A, const half* x, half* y, int N_out, int K,
                         int n_act, cudaStream_t stream);

--- a/src/quant/nvfp4_gemm_smallm_v2.cu
+++ b/src/quant/nvfp4_gemm_smallm_v2.cu
@@ -125,25 +125,19 @@ __device__ __forceinline__ void mma_mxf4nvf4(float acc[4], const uint32_t a[4], 
 
 // ---- kernel -----------------------------------------------------------------
 
-// grid = (N/kNR, stripes). Each CTA walks a contiguous stripe of K-tiles for
-// its n-tile and writes one FP32 partial plane per stripe (stripe-exclusive
-// -> deterministic reduce). Dynamic smem: kStages * kStageBytes.
+// Shared CTA body. All tensor-dependent values arrive resolved (w/y/ts/N/
+// n_base); the single-tensor and pair kernels differ only in how they resolve
+// them from blockIdx. Everything from barrier init through the epilogue is
+// identical to the shipped single-tensor kernel.
 template <int kStages>
-__global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed,
-                                            const uint8_t* __restrict__ w_scales,
-                                            const uint8_t* __restrict__ xq_packed,
-                                            const uint8_t* __restrict__ xq_scales,
-                                            float* __restrict__ ws_partials, half* __restrict__ y, float ts,
-                                            int acc_flag, int M, int N_out, int K, int stripes) {
-    extern __shared__ uint8_t smem[];
-    __shared__ uint64_t bar_full[kStages];
-    __shared__ uint64_t bar_empty[kStages];
-
+__device__ __forceinline__ void smallm_v2_cta_body(
+    const uint8_t* __restrict__ w_packed, const uint8_t* __restrict__ w_scales,
+    const uint8_t* __restrict__ xq_packed, const uint8_t* __restrict__ xq_scales,
+    float* __restrict__ ws_partials, half* __restrict__ y, float ts, int acc_flag, int M, int N_out, int K,
+    int stripes, int n_base, int stripe, uint8_t* smem, uint64_t* bar_full, uint64_t* bar_empty) {
     const int tid = threadIdx.x;
     const int warp = tid / 32;
     const int lane = tid & 31;
-    const int n_base = blockIdx.x * kNR;
-    const int stripe = blockIdx.y;
 
     if (tid == 0) {
 #pragma unroll
@@ -298,6 +292,47 @@ __global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed
     }
 }
 
+// grid = (N/kNR, stripes). Each CTA walks a contiguous stripe of K-tiles for
+// its n-tile and writes one FP32 partial plane per stripe (stripe-exclusive
+// -> deterministic reduce). Dynamic smem: kStages * kStageBytes.
+template <int kStages>
+__global__ void gemm_nvfp4_smallm_v2_kernel(const uint8_t* __restrict__ w_packed,
+                                            const uint8_t* __restrict__ w_scales,
+                                            const uint8_t* __restrict__ xq_packed,
+                                            const uint8_t* __restrict__ xq_scales,
+                                            float* __restrict__ ws_partials, half* __restrict__ y, float ts,
+                                            int acc_flag, int M, int N_out, int K, int stripes) {
+    extern __shared__ uint8_t smem[];
+    __shared__ uint64_t bar_full[kStages];
+    __shared__ uint64_t bar_empty[kStages];
+    smallm_v2_cta_body<kStages>(w_packed, w_scales, xq_packed, xq_scales, ws_partials, y, ts, acc_flag, M,
+                                N_out, K, stripes, blockIdx.x * kNR, blockIdx.y, smem, bar_full, bar_empty);
+}
+
+// Pair variant: two weight tensors sharing ONE quantized activation, one
+// launch. grid.x covers the n-tiles of W1 then W2; each CTA resolves which
+// tensor it owns and runs the shared body unchanged. stripes == 1 only (every
+// call-site N is >= 5120, where the stripe policy is 1), so there is no
+// workspace and no reduce. Saves one launch's fixed cost + one tail wave per
+// sibling pair (FFN gate|up, GDN in|z) per layer per batched-decode step.
+template <int kStages>
+__global__ void gemm_nvfp4_smallm_v2_pair_kernel(
+    const uint8_t* __restrict__ w1, const uint8_t* __restrict__ s1, half* __restrict__ y1, float ts1,
+    int n_tiles1, int N1, const uint8_t* __restrict__ w2, const uint8_t* __restrict__ s2,
+    half* __restrict__ y2, float ts2, int N2, const uint8_t* __restrict__ xq_packed,
+    const uint8_t* __restrict__ xq_scales, int M, int K) {
+    extern __shared__ uint8_t smem[];
+    __shared__ uint64_t bar_full[kStages];
+    __shared__ uint64_t bar_empty[kStages];
+    const int nt = blockIdx.x;
+    const bool second = nt >= n_tiles1;
+    smallm_v2_cta_body<kStages>(second ? w2 : w1, second ? s2 : s1, xq_packed, xq_scales,
+                                /*ws_partials=*/nullptr, second ? y2 : y1, second ? ts2 : ts1,
+                                /*acc_flag=*/0, M, second ? N2 : N1, K, /*stripes=*/1,
+                                (second ? nt - n_tiles1 : nt) * kNR, /*stripe=*/0, smem, bar_full,
+                                bar_empty);
+}
+
 // Reduce the stripe partial planes into FP16 y, applying the combined tensor
 // scale. kAcc adds onto the existing y (o/down residual call sites, beta=1).
 template <bool kAcc>
@@ -398,6 +433,38 @@ bool gemm_nvfp4_smallm_v2_a4(const NvFP4QuantResult& W, const NvFP4QuantResult& 
     if (!smallm_v2_args_ok(W, Xq, M, N_out, K, d_workspace, stripes))
         return false;
     return launch_smallm_v2<kDefaultStages>(W, Xq, y, M, N_out, K, d_workspace, stream, accumulate, stripes);
+}
+
+// Two sibling tensors (same K, same quantized activation), one launch. Only
+// the stripes==1 regime (both Ns >= 5120) — a caller with a striped shape gets
+// `false` and falls back to two single launches. No workspace, no accumulate:
+// every pair call site writes fresh outputs (beta = 0).
+bool gemm_nvfp4_smallm_v2_pair_a4(const NvFP4QuantResult& W1, const NvFP4QuantResult& W2,
+                                  const NvFP4QuantResult& Xq, half* y1, half* y2, int M, int N1, int N2,
+                                  int K, cudaStream_t stream) {
+    if (gemm_nvfp4_smallm_v2_stripes(N1, K) != 1 || gemm_nvfp4_smallm_v2_stripes(N2, K) != 1)
+        return false;
+    if (!smallm_v2_args_ok(W1, Xq, M, N1, K, /*d_workspace=*/nullptr, /*stripes=*/1) ||
+        !smallm_v2_args_ok(W2, Xq, M, N2, K, /*d_workspace=*/nullptr, /*stripes=*/1))
+        return false;
+    static const bool smem_ok = [] {
+        return cudaFuncSetAttribute(gemm_nvfp4_smallm_v2_pair_kernel<kDefaultStages>,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                    kDefaultStages * kStageBytes) == cudaSuccess;
+    }();
+    if (!smem_ok)
+        return false;
+    const int n_tiles1 = N1 / kNR;
+    const dim3 grid(n_tiles1 + N2 / kNR);
+    gemm_nvfp4_smallm_v2_pair_kernel<kDefaultStages><<<grid, kThreads, kDefaultStages * kStageBytes, stream>>>(
+        reinterpret_cast<const uint8_t*>(W1.packed_data), reinterpret_cast<const uint8_t*>(W1.micro_scales),
+        y1, W1.tensor_scale * Xq.tensor_scale, n_tiles1, N1,
+        reinterpret_cast<const uint8_t*>(W2.packed_data), reinterpret_cast<const uint8_t*>(W2.micro_scales),
+        y2, W2.tensor_scale * Xq.tensor_scale, N2,
+        reinterpret_cast<const uint8_t*>(Xq.packed_data), reinterpret_cast<const uint8_t*>(Xq.micro_scales),
+        M, K);
+    IMP_CUDA_CHECK_LAUNCH();
+    return true;
 }
 
 // Tuning hook for the isolated sweep (tests only): explicit stage depth and

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -288,6 +288,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gemm.nvfp4_lm_head_cutlass", cfg.gemm.nvfp4_lm_head_cutlass);
     B("gemm.nvfp4_smallm", cfg.gemm.nvfp4_smallm);
     I("gemm.nvfp4_smallm_impl", cfg.gemm.nvfp4_smallm_impl);
+    B("gemm.nvfp4_smallm_pair", cfg.gemm.nvfp4_smallm_pair);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
     B("gemm.fp8_ssm_proj", cfg.gemm.fp8_ssm_proj);
     S("gemm.fp8_attn_proj", cfg.gemm.fp8_attn_proj);

--- a/tests/test_nvfp4_batched_smallm_equiv.cu
+++ b/tests/test_nvfp4_batched_smallm_equiv.cu
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <random>
 #include <vector>
 
@@ -176,6 +177,106 @@ TEST_F(BatchedSmallM, MatchesDequantisedReference) {
     }
 }
 
+
+// The sibling-pair v2 launch (FFN gate|up, GDN in|z: two weights, one
+// quantized activation, one kernel) must be BIT-identical per tensor to the
+// two single v2 launches it replaces — same CTA body, same tile order, so any
+// difference is a selection-prologue bug (wrong weight, wrong n_base, wrong
+// ts, wrong y stride). Shapes are stripes==1 (both Ns >= 5120), which is the
+// only regime the pair entry accepts.
+TEST(SmallMV2Pair, PairMatchesTwoSingleCallsBitExact) {
+    if (!has_sm120())
+        GTEST_SKIP() << "sm_120 required";
+    constexpr int kPK = 5120;
+    constexpr int kN1 = 5120;
+    constexpr int kN2 = 6144;  // deliberately unequal: exercises the n_tiles1 split
+    std::mt19937 rng(4242);
+    std::normal_distribution<float> dist(0.0f, 0.05f);
+
+    auto make_w = [&](int n_rows) {
+        std::vector<half> host(static_cast<size_t>(n_rows) * kPK);
+        for (auto& h : host)
+            h = __float2half(dist(rng));
+        void* d_w = nullptr;
+        EXPECT_EQ(cudaMalloc(&d_w, host.size() * sizeof(half)), cudaSuccess);
+        EXPECT_EQ(cudaMemcpy(d_w, host.data(), host.size() * sizeof(half), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        int64_t shape[2] = {n_rows, kPK};
+        imp::Tensor wt(d_w, imp::QType::F16, 2, shape, true);
+        imp::NvFP4QuantResult w{};
+        imp::quantize_fp16_to_nvfp4(wt, w, nullptr);
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        cudaFree(d_w);
+        return w;
+    };
+    imp::NvFP4QuantResult w1 = make_w(kN1);
+    imp::NvFP4QuantResult w2 = make_w(kN2);
+
+    for (int m : {2, 7, 32}) {
+        // One quantized activation, shared by every call — exactly the
+        // production contract (the pair reads the same xq the singles read).
+        std::vector<half> x(static_cast<size_t>(m) * kPK);
+        for (auto& h : x)
+            h = __float2half(dist(rng));
+        void* d_x = nullptr;
+        ASSERT_EQ(cudaMalloc(&d_x, x.size() * sizeof(half)), cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(d_x, x.data(), x.size() * sizeof(half), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        int64_t xshape[2] = {m, kPK};
+        imp::Tensor xt(d_x, imp::QType::F16, 2, xshape, true);
+        imp::NvFP4QuantResult xq{};
+        imp::quantize_fp16_to_nvfp4(xt, xq, nullptr);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        cudaFree(d_x);
+
+        auto alloc_y = [&](int n_rows) {
+            half* d = nullptr;
+            EXPECT_EQ(cudaMalloc(&d, static_cast<size_t>(m) * n_rows * sizeof(half)), cudaSuccess);
+            EXPECT_EQ(cudaMemset(d, 0xEE, static_cast<size_t>(m) * n_rows * sizeof(half)), cudaSuccess);
+            return d;
+        };
+        half* y1s = alloc_y(kN1);
+        half* y2s = alloc_y(kN2);
+        half* y1p = alloc_y(kN1);
+        half* y2p = alloc_y(kN2);
+
+        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(w1, xq, y1s, m, kN1, kPK, nullptr, nullptr, false));
+        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_a4(w2, xq, y2s, m, kN2, kPK, nullptr, nullptr, false));
+        ASSERT_TRUE(imp::gemm_nvfp4_smallm_v2_pair_a4(w1, w2, xq, y1p, y2p, m, kN1, kN2, kPK, nullptr));
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+        auto fetch = [&](half* d, int n_rows) {
+            std::vector<half> h(static_cast<size_t>(m) * n_rows);
+            EXPECT_EQ(cudaMemcpy(h.data(), d, h.size() * sizeof(half), cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            cudaFree(d);
+            return h;
+        };
+        const std::vector<half> a1 = fetch(y1s, kN1), b1 = fetch(y1p, kN1);
+        const std::vector<half> a2 = fetch(y2s, kN2), b2 = fetch(y2p, kN2);
+        ASSERT_EQ(std::memcmp(a1.data(), b1.data(), a1.size() * sizeof(half)), 0) << "m=" << m << " W1";
+        ASSERT_EQ(std::memcmp(a2.data(), b2.data(), a2.size() * sizeof(half)), 0) << "m=" << m << " W2";
+        imp::free_nvfp4_result(xq);
+    }
+    imp::free_nvfp4_result(w1);
+    imp::free_nvfp4_result(w2);
+}
+
+// The pair entry must refuse the striped regime rather than compute it with
+// stripes silently forced to 1 (a small-N weight would then be produced by a
+// single K-stripe with no reduce — numerically wrong under split-K rounding
+// AND slower). N=512 has stripes > 1 by the shipped policy.
+TEST(SmallMV2Pair, RefusesStripedShapes) {
+    if (!has_sm120())
+        GTEST_SKIP() << "sm_120 required";
+    ASSERT_GT(imp::gemm_nvfp4_smallm_v2_stripes(512, 5120), 1);
+    imp::NvFP4QuantResult dummy{};
+    // args_ok fails on null pointers anyway, but the stripe check must come
+    // first and be decisive on its own: a fully valid striped weight is the
+    // dangerous input, so assert the policy gate directly.
+    ASSERT_FALSE(imp::gemm_nvfp4_smallm_v2_pair_a4(dummy, dummy, dummy, nullptr, nullptr, 2, 512, 5120,
+                                                   5120, nullptr));
+}
 
 // DISABLED by default: a measurement, not an assertion. Run it with
 //   ./build-dev/test-quant --gtest_also_run_disabled_tests \\

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -144,7 +144,7 @@ def main():
     # 1007 -> 1008 (#1769): LayerNormTest.RMSNormRowBlockDecodeShapes, the
     # row-block batched-decode RMSNorm against the CPU reference on three
     # decode shapes - needs a GPU.
-    PINNED = 1017
+    PINNED = 1019
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
## Sibling-pair smallm launch
- FFN gate|up and GDN in|z consume the same quantized activation; each pair now runs as ONE `gemm_nvfp4_smallm_v2_pair` launch (two weight sets, per-CTA selection, shared CTA body). 112 fewer GEMM launches per 64-layer decode step.
- `gemm.nvfp4_smallm_pair` default ON (kill switch, requires impl 2); M=1, prefill, spec-verify and striped shapes keep their existing paths (`try_smallm_pair_dispatch_` declines, callers fall back to the two single dispatches).
- Fresh serving profile before the change: smallm class 59.8% of kernel time, GPU idle 10.7%; per-shape table in the A/B log.

| 32-stream burst, 4 waves x 3 alternating trials/arm, mbs=32/seq4096 pinned | OFF | ON |
|---|---:|---:|
| aggregate tok/s (median) | 1713.3 | **1742.0 (+1.7%)** |
| pairwise | | +2.0 / +1.4 / +1.2% |

## Correctness
- Kernel bit-identical per tensor to the two single launches: `SmallMV2Pair.PairMatchesTwoSingleCallsBitExact` (M=2/7/32, unequal N1/N2), `RefusesStripedShapes`; two mutants killed (swapped ts selection, n_base off-by-one).
- degen_suite 50/0 on the ON arm; GdnBatchedScanTest 8/8, RaggedPrefillTest 3/3.
- Byte A/B ON vs OFF (4 concurrent, deterministic): 2/4 identical, divergences are the known batch-shape class (same as the #1780 gate).

## Gate
- verify-fast: decode 284.86 vs 287.19 baseline (-0.81%), pp512 +1.02%, pp4096 +0.53%, peak VRAM ok, graphs >=1.3x ok. Gated model (Qwen3-8B Q8_0, GGUF) never routes to the pair path; baseline not refreshed on purpose.
- Test-lane pin 1017 -> 1019 (two new GPU tests).

Not in here: elementwise-family fusion (still open in roadmap 0(c)); attention qkv is already a fused tensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU