### PR TITLE
fix(graphs): park the async decode graph across bursts regardless of spec mode; record the serving idle attribution

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -118,7 +118,22 @@ Ranked by what an agent workload notices first.
    per-row eager argmax/penalty launches between graph replays (~124
    launches/step, 6.6% of serving wall incl. their host gaps) now batch
    like the top-k stash; +2.2% aggregate (1740.9 -> 1779.4 median, 3/3
-   pairs). Still open in class: elementwise. (d) cross-sequence
+   pairs). UPDATE 2026-08-27 (host turnaround attributed and CLOSED as a
+   defect class): diagnostics.step_timing at 32 streams reads, per step,
+   build 63-82 us / fwd-enqueue 34-47 / distribute 7 (the #1758 deferral
+   holds) / schedule 1-2 - and outside-step 1.2-1.5 ms of which
+   prefill-block is 0.8-1.0 ms; with no pending ingest the turnaround is
+   34 us. So the between-steps time IS the paced serial prefill
+   (`prefill_chunk_decode_cap`, the documented ITL-protection trade),
+   not hidden host work. The lever that remains there is running prefill
+   CONCURRENT with decode (second workspace + stream ordering on the KV
+   write - VRAM-priced, not measured; distinct from the #1755
+   decode-pipeline-on-hybrids refutation). Also recorded: the batch=1
+   async-loop recapture per ~200-token burst (FRESH captures 128 -> 7
+   after parking regardless of spec mode) measures +0.2% throughput -
+   an ITL-spike fix, not a decode lever; the 27.8 ms/gap read in the
+   nsys profile was CUPTI inflating graph instantiation. Still open in
+   class: elementwise. (d) cross-sequence
    prefill batching: a 32-prompt burst prefills one sequence per forward
    at ~1700 tok/s effective (launch-bound, 64 layers), so every first
    token waits 2-3.5 s; batching prefill rows the way decode batches

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -290,11 +290,16 @@ int Engine::step_async_graph_resume() {
 
         auto saved_req = async_graph_req_;
 
-        // Burst-hybrid speculation: keep the captured graph + block-table
-        // buffer parked so the next burst of this request rearms instead of
-        // recapturing (~10-20 ms per capture). Fully torn down on request
-        // finish or when a different request launches.
-        const bool park = saved_req && spec_ngram_enabled_(*saved_req) && !generation_done;
+        // Keep the captured graph + block-table buffer parked so the next
+        // burst of this request rearms instead of recapturing (~10-20 ms per
+        // capture). Fully torn down on request finish or when a different
+        // request launches (the FRESH path cleans a foreign park). This used
+        // to be gated on spec_ngram_enabled_ — the burst-hybrid path was the
+        // frequent relauncher — but the KV reservation clamps every burst to
+        // ~128 steps (#1636), so a spec-OFF generation relaunched just as
+        // often and paid a full recapture each time: 78 rebuilds x 27.8 ms in
+        // a 116 s batch=1 bench window (nsys 2026-08-27), ~1.9% of wall.
+        const bool park = saved_req && !generation_done;
         if (park) {
             async_parked_req_id_ = saved_req->id;
         } else {


### PR DESCRIPTION
## Async-graph park across bursts
- The captured-graph park (cheap rearm vs ~10-20 ms recapture) was gated on `spec_ngram_enabled_`; the KV reservation clamps every burst to ~128-200 steps (#1636), so a spec-OFF generation recaptured at every burst boundary. Parking unconditionally: FRESH captures **128 -> 7** per bench run; a foreign request still cleans the park in the FRESH path.
- **Throughput-neutral by measurement** (tg8192, two-image alternating A/B, 3 trials: 86.47 -> 86.63 median; pairs +0.25/+0.29/+0.03% - inside noise). What it removes is the 10-20 ms inter-token spike at every burst boundary. The 27.8 ms/gap the nsys profile showed was CUPTI inflating graph instantiation - recorded in the roadmap so nobody chases it again.
- 600-token deterministic output byte-identical across arms; degen_suite 50/0.

## Serving idle attribution (roadmap 0(c), closes the host-turnaround question)
`diagnostics.step_timing` at 32 streams, per step: build 63-82 us, fwd-enqueue 34-47, **distribute 7** (#1758 deferral holds), schedule 1-2; outside-step 1.2-1.5 ms of which prefill-block 0.8-1.0 ms; **bare turnaround with no pending ingest: 34 us**. The between-steps time is the paced serial prefill (`prefill_chunk_decode_cap`, the documented ITL trade), not hidden host work. Remaining lever named and priced in the roadmap: prefill concurrent with decode (second workspace, KV-write stream ordering) - not built here.

## Gate
- pre-push verify-fast PASS (hook aborts on failure; branch landed). Static gates green.

Not in here: prefill/decode overlap; elementwise fusion tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU