### PR TITLE
feat(serving): prefill/decode overlap built behind runtime.prefill_overlap - measured NEUTRAL, default off with the verdict

### DIFF
--- a/docs/plans/2026-08-27-prefill-decode-overlap.md
+++ b/docs/plans/2026-08-27-prefill-decode-overlap.md
@@ -1,0 +1,76 @@
+# Prefill/decode overlap - plan and ledger
+
+Goal: run the paced prefill chunk CONCURRENT with the in-flight batched
+decode step instead of serially between two steps. Attribution that prices
+it (step_timing 2026-08-27, 32 streams): outside-step 1.2-1.5 ms/step of
+which prefill-block 0.8-1.0 ms while ingest is pending; bare turnaround
+34 us. Upside is bounded by that block plus decode-idle absorption
+(~2-4% aggregate on burst ingest) plus TTFT.
+
+## What already exists
+
+- `GreenContextManager`: SM partitioning fails on sm_120 (LIMITATIONS.md),
+  but the FALLBACK ships two priority streams (prefill low, decode high)
+  with distinct memSyncDomains and `is_available()==true` - built for
+  exactly this overlap.
+- `Workspace` dual-slot swap (03d50457, 2026-03): slot 0 prefill, slot 1
+  decode; `allocate_decode_workspace(stream, max_batch)` already takes
+  max_batch and the green-gated warmup already passes
+  `config_.max_batch_size` ("Concurrent prefill/decode overlap enabled").
+  The consumer never caught up: `step_decode_forward` uses slot 1 only at
+  `valid_decode.size()==1` (the pre-continuous-batching shape); batched
+  decode resizes and squats slot 0 - which is why the drain-before-prefill
+  serializer exists.
+
+## Shared-state collisions (the actual work)
+
+| shared | users | resolution |
+|---|---|---|
+| slot-0 shared/persistent workspace | prefill + batched decode | decode batch<=decode_max_batch_ runs in slot 1 (flag-gated) |
+| `smallm_xq_` + tags (+ producer fusion) | batched decode; prefill chunks with M<=32 also route there | prefill under overlap declines smallm/producer-xq (one executor member, three gates) - CUTLASS serves small chunks |
+| `qscratch_` fp8_act/d_act_scale(+maxes)/q8_1/d8 | fp8 sidecars in batched decode; prefill fp8/dp4a paths | duplicated at decode size (~<1 MiB), swapped by `use_workspace` |
+| `qscratch_.cutlass_act_*` | prefill CUTLASS act-quant; spec-VERIFY chunks (bs=1) | overlap only enqueues at decode batch >= 2 (no verify there) |
+| `d_sample_result_` parity slots | decode batch sampling; prefill last-chunk sample | dedicated prefill sample buffer (always, 1 KB) |
+| KV pool / GDN state | disjoint requests (PREFILLING vs DECODING) | no cross-stream ordering needed; block alloc host-side |
+| cuBLAS handle | both, single-threaded enqueue | safe: setStream serializes on host |
+
+## DECLINE gates (logged once, #1755 style)
+
+`runtime.prefill_overlap=true` (default false; implies green-context
+streams) AND decode workspace allocated at max_batch AND !has_moe AND
+NVFP4-native (no GGUF decode overlay: `wcache_.nvfp4` empty) AND decode
+batch >= 2 this step. Anything else: serial path, unchanged.
+
+## Phases
+
+1. This PR: flag + slot-1 batched decode + drain relaxation + the three
+   collision fixes + gates. Measure: 32-stream burst A/B (aggregate +
+   TTFT), byte isolation 32-concurrent-vs-serial (the #1780 gate), degen.
+2. If it pays: widen gates (GGUF via per-slot q8 scratch already done;
+   MoE workspace audit), revisit bs==1+verify.
+3. Green-context SM partitioning stays dead on sm_120 (documented).
+
+## Ledger
+
+- 2026-08-27, phase 1 BUILT AND MEASURED NEUTRAL — default stays OFF, with
+  the measurement in the config comment (the #1755 convention).
+  - Gate bug on the way: `!wcache_.nvfp4.empty()` is NOT a GGUF predicate
+    (the map is populated on native-NVFP4 models as the secondary cache);
+    the real one iterates the registry for `dequant_gpu_supported(source)`.
+  - Short prompts (the conc_client shape), 4 waves x 3 alternating
+    trials/arm, mbs=32/seq4096 pinned: OFF 1771.3 vs ON 1777.7 tok/s
+    median, pairs -0.0/-0.3/+1.5% — inside wave noise.
+  - Heavy ingest (~1000-token prompts, streaming TTFT), same discipline:
+    OFF 789.7 vs ON 790.6 median (pairs +0.1/-1.4/+0.6%); TTFT p50
+    3.70 vs 3.74 s. The workload the overlap was built for shows nothing.
+  - Mechanism: green-context SM partitioning is dead on sm_120
+    (LIMITATIONS.md), so both streams contend for the same SMs. The
+    decode step's idle is us-grained inter-node gaps a concurrent
+    low-priority stream cannot fill; the paced serial prefill was never
+    wasted time, it is GPU work that costs the same wall concurrently and
+    stretches the in-flight decode step by roughly its own duration.
+  - Kept (default off, all gates logged): the per-slot quant scratches,
+    slot-1 batched decode, the dedicated prefill sample slot and the
+    ENTERED/DECLINED gate chain — the experiment is one `--set` away on
+    hardware where partitioning is real. degen_suite 50/0 on the ON arm;
+    0 CUDA errors across all ON runs.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -125,10 +125,14 @@ Ranked by what an agent workload notices first.
    prefill-block is 0.8-1.0 ms; with no pending ingest the turnaround is
    34 us. So the between-steps time IS the paced serial prefill
    (`prefill_chunk_decode_cap`, the documented ITL-protection trade),
-   not hidden host work. The lever that remains there is running prefill
-   CONCURRENT with decode (second workspace + stream ordering on the KV
-   write - VRAM-priced, not measured; distinct from the #1755
-   decode-pipeline-on-hybrids refutation). Also recorded: the batch=1
+   not hidden host work. UPDATE 2026-08-27 (later): prefill CONCURRENT
+   with decode was BUILT and measured NEUTRAL on both workload shapes
+   (short prompts 1771.3 vs 1777.7; ~1000-token heavy ingest 789.7 vs
+   790.6, TTFT unchanged) - without green-context SM partitioning (dead
+   on sm_120) the two streams displace each other, so the paced serial
+   prefill was never wasted GPU time. `runtime.prefill_overlap` ships
+   default-off with the verdict in its comment; ledger in
+   docs/plans/2026-08-27-prefill-decode-overlap.md. Also recorded: the batch=1
    async-loop recapture per ~200-token burst (FRESH captures 128 -> 7
    after parking regardless of spec mode) measures +0.2% throughput -
    an ITL-spike fix, not a decode lever; the 27.8 ms/gap read in the

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -350,10 +350,31 @@ public:
     bool allocate_decode_workspace(cudaStream_t stream, int max_batch = 1) {
         return ws_.allocate_decode_workspace(stream, max_batch);
     }
-    void use_workspace(int slot) { ws_.use_workspace(slot); }  // 0=prefill, 1=decode
+    // 0=prefill, 1=decode. Also swaps the collision-prone quant-scratch
+    // family (fp8 activation + q8_1) onto the per-slot copies when the
+    // decode set exists — required for prefill/decode overlap, a no-op
+    // otherwise (see allocate_decode_qscratch).
+    void use_workspace(int slot);
     bool has_decode_workspace() const { return ws_.has_decode_workspace(); }
+    int decode_max_batch() const { return ws_.decode_max_batch(); }
     int active_workspace() const { return ws_.active(); }
     int max_tokens() const { return max_tokens_; }
+
+    // Prefill/decode overlap support (docs/plans/2026-08-27-prefill-decode-overlap.md).
+    // allocate_decode_qscratch: per-slot copies of the quant scratches both
+    // paths would otherwise share (fp8_act family + q8_1/d8), sized for
+    // max_batch rows. set_overlap_prefill_active: the engine marks the
+    // prefill forward it enqueues concurrently with an in-flight decode;
+    // the smallm/producer-xq dispatch paths decline for that forward (their
+    // scratch + tags are decode-owned under overlap).
+    bool allocate_decode_qscratch(int max_batch);
+    void set_overlap_prefill_active(bool v) { overlap_prefill_active_ = v; }
+    // The prefill sample must not land in the decode batch's parity slots
+    // while both run concurrently: the engine points the prefill-side
+    // samplers at a dedicated slot for the duration of an overlap prefill.
+    void set_sample_slot_override(int32_t* slot) { sample_slot_override_ = slot; }
+    bool has_gguf_nvfp4_overlay() const;
+    bool model_has_moe() const { return has_moe_; }
 
     // Capacity of the [n_heads, attn_seq, attn_seq] FP16 attn-scores workspace.
     // Engine's chunked-prefill path must clamp chunk_len so n × ctx_len ≤ cap².
@@ -678,6 +699,17 @@ private:
 
     // Quantization scratch buffers (FP8 act, CUTLASS act, dp4a, dequant, split-K)
     QuantScratch qscratch_;
+    // Per-slot decode copies of the shared quant scratches (overlap only;
+    // null when allocate_decode_qscratch never ran). use_workspace swaps the
+    // seven fields between qscratch_ and the saved prefill values.
+    QuantScratch qscratch_decode_;
+    bool qscratch_decode_ready_ = false;
+    struct {
+        void* fp8_act; size_t fp8_act_size; float* d_act_scale; float* d_fp8_block_maxes;
+        float* d_fp8_absmax; int fp8_max_grid; void* q8_1_buf; float* d8_buf; int q8_1_rows;
+    } qscratch_prefill_save_{};
+    bool overlap_prefill_active_ = false;
+    int32_t* sample_slot_override_ = nullptr;
 
     // CUTLASS NVFP4 LM head for batched-decode (n>1) tensor-core GEMM. Borrows
     // the FP4 data from the NVFP4 decode cache; owns only the SfAtom scales.

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -347,7 +347,8 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
         // dequant+HMMA kernel for A/B. Both read quantized activations
         // (same numerics family as the CUTLASS path). Spec-verify chunks
         // keep their documented paths (argmax parity, #1055).
-        if (runtime_config().gemm.nvfp4_smallm && !ctx.spec_verify_small_m && M <= 32 &&
+        if (runtime_config().gemm.nvfp4_smallm && !ctx.spec_verify_small_m &&
+            !overlap_prefill_active_ && M <= 32 &&
             (ctx.beta == 0.0f || ctx.beta == 1.0f) && input.qtype == QType::F16 &&
             output.qtype == QType::F16 && h.primary_tier == StorageTier::CUTLASS_NVFP4 &&
             h.source_data != nullptr && h.source_scales != nullptr &&
@@ -679,7 +680,7 @@ void GraphExecutor::ensure_smallm_xq_(size_t xq_need, cudaStream_t stream) {
 
 uint8_t* GraphExecutor::smallm_producer_xq_(TensorID consumer_id, int M, int K, cudaStream_t stream,
                                             uint8_t** scales_out) {
-    if (!runtime_config().gemm.nvfp4_smallm || cur_spec_verify_)
+    if (!runtime_config().gemm.nvfp4_smallm || cur_spec_verify_ || overlap_prefill_active_)
         return nullptr;
     if (M < 2 || M > 32 || K <= 0 || (K & 255) != 0)
         return nullptr;
@@ -745,9 +746,9 @@ bool GraphExecutor::try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, cons
     // outputs only. Every decline is a plain `false` — the caller issues the
     // two single dispatches it would have issued anyway.
     if (!runtime_config().gemm.nvfp4_smallm || runtime_config().gemm.nvfp4_smallm_impl != 2 ||
-        !runtime_config().gemm.nvfp4_smallm_pair || ctx.spec_verify_small_m || ctx.beta != 0.0f)
-        return false;
-    if (id_a == kInvalidTensorID || id_b == kInvalidTensorID)
+        !runtime_config().gemm.nvfp4_smallm_pair || ctx.spec_verify_small_m ||
+        overlap_prefill_active_ || ctx.beta != 0.0f || id_a == kInvalidTensorID ||
+        id_b == kInvalidTensorID)
         return false;
     const int M = static_cast<int>(input.shape[0]);
     // M==1 stays on the fused decode GEMVs; M>32 is prefill.

--- a/src/exec/executor_sampling.cu
+++ b/src/exec/executor_sampling.cu
@@ -83,28 +83,29 @@ std::vector<int32_t> GraphExecutor::sample_from_logits(const Tensor& logits, con
         Tensor last_logits = flatten_logits(logits.slice(0, 1));
         apply_pre_sample(last_logits, state);
 
+        // Overlap prefill: the parity slots belong to the concurrent decode
+        // batch — the engine points this path at its dedicated slot.
+        int32_t* slot = sample_slot_override_ ? sample_slot_override_ : d_sample_result_;
         if (state.mirostat == 2) {
             unsigned int seed = state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u;
-            tokens[0] = d_sample_result_
-                            ? sample_mirostat_v2(last_logits, state.temperature, state.mirostat_tau,
-                                                 state.mirostat_eta, &state.mirostat_mu, seed,
-                                                 d_sample_result_, stream)
-                            : sample_mirostat_v2(last_logits, state.temperature, state.mirostat_tau,
-                                                 state.mirostat_eta, &state.mirostat_mu, seed, stream);
+            tokens[0] = slot ? sample_mirostat_v2(last_logits, state.temperature, state.mirostat_tau,
+                                                  state.mirostat_eta, &state.mirostat_mu, seed, slot,
+                                                  stream)
+                             : sample_mirostat_v2(last_logits, state.temperature, state.mirostat_tau,
+                                                  state.mirostat_eta, &state.mirostat_mu, seed, stream);
         } else {
             tokens[0] =
                 (state.temperature <= 0.0f || state.top_k == 1)
-                    ? (d_sample_result_ ? sample_greedy(last_logits, d_sample_result_, stream)
-                                        : sample_greedy(last_logits, stream))
-                    : (d_sample_result_
-                           ? sample_topk_topp(last_logits, state.top_k > 0 ? state.top_k : 50,
-                                              state.top_p > 0.0f ? state.top_p : 1.0f, state.temperature,
-                                              state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u,
-                                              d_sample_result_, stream)
-                           : sample_topk_topp(last_logits, state.top_k > 0 ? state.top_k : 50,
-                                              state.top_p > 0.0f ? state.top_p : 1.0f, state.temperature,
-                                              state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u,
-                                              stream));
+                    ? (slot ? sample_greedy(last_logits, slot, stream)
+                            : sample_greedy(last_logits, stream))
+                    : (slot ? sample_topk_topp(last_logits, state.top_k > 0 ? state.top_k : 50,
+                                               state.top_p > 0.0f ? state.top_p : 1.0f, state.temperature,
+                                               state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u,
+                                               slot, stream)
+                            : sample_topk_topp(last_logits, state.top_k > 0 ? state.top_k : 50,
+                                               state.top_p > 0.0f ? state.top_p : 1.0f, state.temperature,
+                                               state.seed >= 0 ? static_cast<unsigned int>(state.seed) : 42u,
+                                               stream));
         }
     } else {
         // Batched decode: n_tokens == n_sequences, each row is one sequence's

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -1879,4 +1879,110 @@ bool GraphExecutor::ensure_chunk_capture_scratch(int ctx_capacity) {
 // use_workspace(), layer_has_*(), view_tokens(), ensure_logits_pinned()
 // are in executor_workspace_config.cu
 
+// ---------------------------------------------------------------------------
+// Prefill/decode overlap: per-slot quant scratches + the slot switch that
+// swaps them (docs/plans/2026-08-27-prefill-decode-overlap.md).
+// ---------------------------------------------------------------------------
+
+bool GraphExecutor::allocate_decode_qscratch(int max_batch) {
+    if (qscratch_decode_ready_)
+        return true;
+    if (max_batch <= 0)
+        return false;
+    // Mirror the prefill-sized originals at decode-batch rows. A null
+    // original means that family is unused on this model — the copy stays
+    // null and its consumers keep declining exactly as they do today.
+    size_t total = 0;
+    if (qscratch_.fp8_act && qscratch_.fp8_act_size > 0 && max_tokens_ > 0) {
+        const size_t per_row = qscratch_.fp8_act_size / static_cast<size_t>(max_tokens_);
+        qscratch_decode_.fp8_act_size = per_row * max_batch;
+        auto sl = engine_arena().take_bytes(qscratch_decode_.fp8_act_size);
+        auto sc = engine_arena().take_bytes(sizeof(float));
+        int max_n = static_cast<int>(qscratch_decode_.fp8_act_size);
+        qscratch_decode_.fp8_max_grid = (((max_n + 3) / 4) + 255) / 256;
+        auto bm = engine_arena().take_bytes(static_cast<size_t>(qscratch_decode_.fp8_max_grid) *
+                                            sizeof(float));
+        auto am = engine_arena().take_bytes(sizeof(float));
+        if (sl.empty() || sc.empty() || bm.empty() || am.empty()) {
+            IMP_LOG_WARN("decode qscratch: fp8 family unavailable from the T2 arena");
+            return false;
+        }
+        qscratch_decode_.fp8_act = sl.data();
+        qscratch_decode_.d_act_scale = reinterpret_cast<float*>(sc.data());
+        qscratch_decode_.d_fp8_block_maxes = reinterpret_cast<float*>(bm.data());
+        qscratch_decode_.d_fp8_absmax = reinterpret_cast<float*>(am.data());
+        total += qscratch_decode_.fp8_act_size;
+    }
+    if (qscratch_.q8_1_buf && qscratch_.q8_1_max_blocks > 0) {
+        qscratch_decode_.q8_1_max_blocks = qscratch_.q8_1_max_blocks;
+        qscratch_decode_.q8_1_rows = max_batch;
+        size_t q8_sz = static_cast<size_t>(qscratch_decode_.q8_1_max_blocks) * max_batch *
+                       sizeof(block_q8_1);
+        size_t d8_sz = static_cast<size_t>(qscratch_decode_.q8_1_max_blocks) * max_batch *
+                       sizeof(float);
+        auto q8 = engine_arena().take_bytes(q8_sz);
+        auto d8 = engine_arena().take_bytes(d8_sz);
+        if (q8.empty() || d8.empty()) {
+            IMP_LOG_WARN("decode qscratch: q8_1 family unavailable from the T2 arena");
+            return false;
+        }
+        qscratch_decode_.q8_1_buf = q8.data();
+        qscratch_decode_.d8_buf = reinterpret_cast<float*>(d8.data());
+        total += q8_sz + d8_sz;
+    }
+    qscratch_decode_ready_ = true;
+    IMP_LOG_INFO("decode qscratch: per-slot fp8/q8 copies, %.1f KiB for max_batch=%d",
+                 total / 1024.0, max_batch);
+    return true;
+}
+
+void GraphExecutor::use_workspace(int slot) {
+    const int prev = ws_.active();
+    ws_.use_workspace(slot);
+    if (!qscratch_decode_ready_ || ws_.active() == prev)
+        return;
+    if (slot == 1) {
+        qscratch_prefill_save_ = {qscratch_.fp8_act,      qscratch_.fp8_act_size,
+                                  qscratch_.d_act_scale,  qscratch_.d_fp8_block_maxes,
+                                  qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid,
+                                  qscratch_.q8_1_buf,     qscratch_.d8_buf,
+                                  qscratch_.q8_1_rows};
+        if (qscratch_decode_.fp8_act) {
+            qscratch_.fp8_act = qscratch_decode_.fp8_act;
+            qscratch_.fp8_act_size = qscratch_decode_.fp8_act_size;
+            qscratch_.d_act_scale = qscratch_decode_.d_act_scale;
+            qscratch_.d_fp8_block_maxes = qscratch_decode_.d_fp8_block_maxes;
+            qscratch_.d_fp8_absmax = qscratch_decode_.d_fp8_absmax;
+            qscratch_.fp8_max_grid = qscratch_decode_.fp8_max_grid;
+        }
+        if (qscratch_decode_.q8_1_buf) {
+            qscratch_.q8_1_buf = qscratch_decode_.q8_1_buf;
+            qscratch_.d8_buf = qscratch_decode_.d8_buf;
+            qscratch_.q8_1_rows = qscratch_decode_.q8_1_rows;
+        }
+    } else {
+        qscratch_.fp8_act = qscratch_prefill_save_.fp8_act;
+        qscratch_.fp8_act_size = qscratch_prefill_save_.fp8_act_size;
+        qscratch_.d_act_scale = qscratch_prefill_save_.d_act_scale;
+        qscratch_.d_fp8_block_maxes = qscratch_prefill_save_.d_fp8_block_maxes;
+        qscratch_.d_fp8_absmax = qscratch_prefill_save_.d_fp8_absmax;
+        qscratch_.fp8_max_grid = qscratch_prefill_save_.fp8_max_grid;
+        qscratch_.q8_1_buf = qscratch_prefill_save_.q8_1_buf;
+        qscratch_.d8_buf = qscratch_prefill_save_.d8_buf;
+        qscratch_.q8_1_rows = qscratch_prefill_save_.q8_1_rows;
+    }
+}
+
+bool GraphExecutor::has_gguf_nvfp4_overlay() const {
+    // "GGUF class" for the overlap gate = any registered weight whose SOURCE
+    // is a GPU-dequantable GGUF qtype: those decode through the dp4a/dequant
+    // scratches that prefill shares. (`wcache_.nvfp4` is the wrong predicate —
+    // it is also populated on native-NVFP4 models as the secondary cache,
+    // which is how the first cut of this gate declined Qwen3.8-27B-NVFP4.)
+    for (size_t i = 0; i < registry_.size(); ++i)
+        if (dequant_gpu_supported(registry_.handle(static_cast<TensorID>(i)).source_qtype))
+            return true;
+    return false;
+}
+
 }  // namespace imp

--- a/src/exec/workspace.h
+++ b/src/exec/workspace.h
@@ -73,6 +73,7 @@ public:
     int shared_max_tokens() const { return shared_workspace_max_tokens_; }
     int active() const { return active_workspace_; }
     bool has_decode_workspace() const { return decode_workspace_ != nullptr; }
+    int decode_max_batch() const { return decode_max_batch_; }
     // Bumped whenever shared_workspace_ is (re)allocated or freed — consumers
     // holding raw pointers into the arena (captured verify graphs, #847) use
     // this to detect that their baked addresses died.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -167,6 +167,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("runtime.gdn_batched_decode", cfg.runtime.gdn_batched_decode);
     B("runtime.decode_pipeline", cfg.runtime.decode_pipeline);
     B("runtime.prefill_batch", cfg.runtime.prefill_batch);
+    B("runtime.prefill_overlap", cfg.runtime.prefill_overlap);
     I("runtime.vram_budget_mb", cfg.runtime.vram_budget_mb);
 
     // [kv_cache]

--- a/src/runtime/config.h
+++ b/src/runtime/config.h
@@ -227,6 +227,31 @@ struct RuntimeConfig {
         // scoring — and Mamba2 / MLA models, MTP, SWA sizing, residual KV,
         // gdn.fp32_scan/ref_kernel — keep the serial path.
         bool prefill_batch = true;
+
+        // Run the paced prefill chunk CONCURRENT with the in-flight batched
+        // decode step (prefill on the low-priority stream, decode in the
+        // dual-workspace slot 1) instead of serially between two decode
+        // steps. Implies the green-context stream pair (which on sm_120
+        // falls back to priority streams + distinct memSyncDomains —
+        // LIMITATIONS.md). Overlap engages only when every gate holds:
+        // decode workspace allocated at max_batch, no MoE, NVFP4-native
+        // model (no GGUF decode overlay), decode batch >= 2 this step
+        // (spec-verify chunks share the CUTLASS activation scratch and only
+        // exist at batch 1). Otherwise the serial path runs unchanged.
+        //
+        // Default OFF, and since 2026-08-27 that is a MEASURED verdict, not
+        // caution: on Qwen3.8-27B-NVFP4 at 32 streams (3 alternating
+        // trials/arm) the overlap is throughput-neutral on short prompts
+        // (1771.3 vs 1777.7 median, pairs -0.0/-0.3/+1.5%) AND under heavy
+        // ingest (~1000-token prompts: 789.7 vs 790.6, TTFT p50 3.70 vs
+        // 3.74 s). Without green-context SM partitioning — dead on sm_120 —
+        // two compute-bound streams displace each other: the "serial
+        // prefill block" is GPU work that takes the same time concurrently
+        // and stretches the decode step by its own duration. Revisit only
+        // on hardware with real SM partitioning.
+        // Design + collision table + ledger:
+        // docs/plans/2026-08-27-prefill-decode-overlap.md
+        bool prefill_overlap = false;
     } runtime;
 
     cfg::KVCache kv_cache;

--- a/src/runtime/engine.cpp
+++ b/src/runtime/engine.cpp
@@ -586,7 +586,8 @@ bool Engine::init(std::shared_ptr<Model> model, const EngineConfig& config) {
     // with no way to refuse it. Both shipped tools already pass their own
     // value (`handlers.cpp` from imp.conf, `imp-cli/main.cpp` from its flag
     // OR imp.conf), so nothing that ships loses caching. #1299/#1314.
-    config_.use_green_contexts = config_.use_green_contexts || runtime_config_.server.green_contexts;
+    config_.use_green_contexts = config_.use_green_contexts || runtime_config_.server.green_contexts ||
+                                 runtime_config_.runtime.prefill_overlap;
     if (config_.prefix_pin_budget_pct == 25)  // EngineConfig default untouched → take imp.conf
         config_.prefix_pin_budget_pct = runtime_config_.server.prefix_pin_budget_pct;
     if (config_.mmproj_path.empty())

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -423,6 +423,15 @@ private:
     CudaEvent decode_done_;
     int next_request_id_ = 0;
 
+    // Prefill/decode overlap (runtime.prefill_overlap): every static gate
+    // held at warmup — stream pair up, decode workspace + qscratch copies
+    // at max_batch, model class eligible. The per-step gate (decode batch
+    // >= 2) is checked in step_impl_. d_prefill_sample_: dedicated device
+    // slot for the prefill last-chunk greedy sample, so it never aliases
+    // the decode batch's parity slots (arena-owned).
+    bool overlap_ready_ = false;
+    int32_t* d_prefill_sample_ = nullptr;
+
     // ── Decode batching ──────────────────────────────────────────────
     GPUBatchPool decode_batch_pool_;
     BatchBuilder decode_builder_;

--- a/src/runtime/engine_prefill.cpp
+++ b/src/runtime/engine_prefill.cpp
@@ -808,7 +808,13 @@ void Engine::step_prefill_one(std::shared_ptr<Request>& req, int effective_chunk
                 }
             }
 
-            sample_greedy_device(last_logits, executor_->d_sample_result(), h_sample_pinned_.as<int32_t>(),
+            // Under overlap the decode batch owns the parity slots of
+            // d_sample_result_ — the prefill sample gets its own slot
+            // (allocated at warmup whenever overlap is ready; the shared
+            // slot remains the serial-path default).
+            int32_t* sample_slot =
+                d_prefill_sample_ ? d_prefill_sample_ : executor_->d_sample_result();
+            sample_greedy_device(last_logits, sample_slot, h_sample_pinned_.as<int32_t>(),
                                  pf_stream);
 
             if (!prefill_done_)

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -116,17 +116,32 @@ bool Engine::step_impl_() {
         return false;
     }
 
+    // Prefill/decode overlap engages only when the in-flight decode runs in
+    // workspace slot 1 (>= 2 rows; the bs==1 regimes carry spec-verify
+    // chunks, which share the CUTLASS activation scratch with prefill).
+    const bool overlap_step = overlap_ready_ && sched_decode_batch_.size() >= 2;
+
     // A pipelined decode step in flight shares workspace 0 with prefill and
     // pins the batch composition — collect it before any prefill work or
-    // when this step has no decode batch to continue it with.
-    if (bd_pipe_.in_flight && (!sched_prefill_batch_.empty() || sched_decode_batch_.empty()))
+    // when this step has no decode batch to continue it with. Under overlap
+    // the decode step lives in slot 1 with its own quant scratches, so the
+    // prefill no longer forces the drain: it enqueues on the low-priority
+    // stream while the decode step is still running.
+    if (bd_pipe_.in_flight &&
+        ((!overlap_step && !sched_prefill_batch_.empty()) || sched_decode_batch_.empty()))
         drain_decode_pipeline();
 
     // Process prefill requests.
     if (s_ot)
         o3 = std::chrono::steady_clock::now();
     if (!sched_prefill_batch_.empty()) {
+        if (overlap_step) {
+            executor_->set_overlap_prefill_active(true);
+            executor_->set_sample_slot_override(d_prefill_sample_);
+        }
         step_prefill(prefill_stream());
+        executor_->set_overlap_prefill_active(false);
+        executor_->set_sample_slot_override(nullptr);
         ensure_prefill_workspace(executor_.get());
     }
 
@@ -1143,8 +1158,17 @@ void Engine::step_decode_forward(std::vector<std::shared_ptr<Request>>& valid_de
             g_step_timing.outside +=
                 std::chrono::duration<double, std::micro>(tp0 - g_step_timing.last_end).count();
     }
-    // Switch workspace for decode
-    if (executor_->has_decode_workspace() && valid_decode.size() == 1) {
+    // Switch workspace for decode. The historical slot-1 path was bs==1 only
+    // (its 2026-03 shape, pre-continuous-batching); under prefill overlap
+    // the batched step runs there too — the warmup sized slot 1 and the
+    // per-slot quant scratches for max_batch, and the workspace choice must
+    // be a pure function of (flags, batch size) so graph captures stay
+    // consistent with replays.
+    const bool slot1 = executor_->has_decode_workspace() &&
+                       (valid_decode.size() == 1 ||
+                        (overlap_ready_ &&
+                         static_cast<int>(valid_decode.size()) <= executor_->decode_max_batch()));
+    if (slot1) {
         executor_->use_workspace(1);
     } else {
         if (executor_->active_workspace() == 1)

--- a/src/runtime/engine_workspace_warmup.cpp
+++ b/src/runtime/engine_workspace_warmup.cpp
@@ -28,6 +28,7 @@
 #include "runtime/engine_internal.h"
 #include "runtime/think_stop_logic.h"
 #include "compute/sampling.h"
+#include "memory/engine_arena.h"
 #include "memory/mem_account.h"
 #include "memory/plan.h"       // kMeasuredLibraryReserveBytes
 #include "memory/vram_query.h"
@@ -59,6 +60,37 @@ bool Engine::init_features() {
         if (green_ctx_.is_available() && resolve_prefill_chunk_size_() > 0)
             if (executor_->allocate_decode_workspace(stream_, config_.max_batch_size))
                 IMP_LOG_INFO("Concurrent prefill/decode overlap enabled");
+    }
+
+    // Prefill/decode overlap gates (runtime.prefill_overlap; each DECLINE is
+    // logged once, #1755 style — a gate that refuses silently is a gate
+    // nobody can see). The per-step gate (decode batch >= 2, no spec-verify
+    // sharing the CUTLASS activation scratch) lives in step_impl_.
+    if (runtime_config_.runtime.prefill_overlap) {
+        const char* decline = nullptr;
+        if (!green_ctx_.is_available())
+            decline = "no stream pair (green-context init failed entirely)";
+        else if (!executor_->has_decode_workspace() ||
+                 executor_->decode_max_batch() < config_.max_batch_size)
+            decline = "decode workspace not allocated at max_batch";
+        else if (executor_->model_has_moe())
+            decline = "MoE model (expert workspace not per-slot yet — plan phase 2)";
+        else if (executor_->has_gguf_nvfp4_overlay())
+            decline = "GGUF decode overlay (dp4a/dequant scratch shared with prefill)";
+        else if (!executor_->allocate_decode_qscratch(config_.max_batch_size))
+            decline = "per-slot quant scratch allocation failed";
+        if (!decline) {
+            auto slab = engine_arena().take_bytes(SAMPLE_SCRATCH_BYTES);
+            if (slab.empty())
+                decline = "prefill sample slot allocation failed";
+            else
+                d_prefill_sample_ = reinterpret_cast<int32_t*>(slab.data());
+        }
+        overlap_ready_ = (decline == nullptr);
+        if (overlap_ready_)
+            IMP_LOG_INFO("prefill overlap: ENTERED (engages at decode batch >= 2)");
+        else
+            IMP_LOG_INFO("prefill overlap: DECLINED — %s; serial prefill path", decline);
     }
 
     // Chat template

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -78,7 +78,7 @@ roots = ["src", "tools", "tests"]
 "src/compute/schema_constrain.cu" = { code_loc = 1238, reason = "(c) schema-constrained decode token-mask compute (host-side): the shared frame-stack simulator now carries TWO body grammars (JSON schema + Qwen-Coder XML tool calls) around one sim_advance source of truth; split candidate if a third grammar lands. The #1729 free-value phase is not that third grammar: it delegates to JsonGrammar rather than adding phases of its own, which is why it cost 54 lines and not a body's worth" }
 "src/exec/executor_forward.cu" = { code_loc = 828, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1123, reason = "(c) one path: batched-MoE forward dispatch. Host-only until #1548 put the expert-imbalance kernel here, next to the routing hook it reads from: splitting one 30-line diagnostic kernel into its own TU would cost a recompile edge for less than it saves" }
-"src/exec/executor_workspace_buffers.cu" = { code_loc = 1384, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
+"src/exec/executor_workspace_buffers.cu" = { code_loc = 1474, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
 "src/memory/kv_cache_manager.cpp" = { code_loc = 1207, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
 "src/model/gguf_loader.cpp" = { code_loc = 820, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1291, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1303, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
 "tests/test_gdn.cu" = { code_loc = 1285, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }


### PR DESCRIPTION
## What was built (phase 1 of the plan doc)
- The paced prefill chunk can run on the LOW-priority stream concurrent with the in-flight batched decode step. Batched decode moves to dual-workspace slot 1 - the 2026-03 overlap infrastructure (03d50457) that was never extended past bs==1 when continuous batching landed; the drain-before-prefill serializer is skipped under overlap.
- Collision fixes: per-slot fp8/q8 quant scratches (442 KiB, swapped by `use_workspace`); the overlapped prefill forward declines the smallm/producer-xq paths (their scratch+tags are decode-owned); dedicated prefill sample slot (parity slots belong to the decode batch).
- ENTERED/DECLINED gates, each logged (#1755 style): stream pair up, decode workspace at max_batch, no MoE, no GGUF decode overlay, decode batch >= 2 (spec-verify shares the CUTLASS act scratch and only exists at bs 1). Gate bug found on the way: `!wcache_.nvfp4.empty()` is NOT a GGUF predicate (populated on native models as the secondary cache) - the real one scans the registry for `dequant_gpu_supported(source_qtype)`.

## Verdict: NEUTRAL, default stays OFF
| Qwen3.8-27B-NVFP4, 3 alternating trials/arm | OFF | ON |
|---|---:|---:|
| short prompts (conc_client shape), aggregate median | 1771.3 | 1777.7 (pairs -0.0/-0.3/+1.5%) |
| heavy ingest ~1000-tok prompts, aggregate median | 789.7 | 790.6 (pairs +0.1/-1.4/+0.6%) |
| heavy ingest TTFT p50 | 3.70 s | 3.74 s |

Mechanism: green-context SM partitioning is dead on sm_120 (LIMITATIONS.md), so both streams contend for the same SMs - the paced serial prefill was never wasted wall, it is GPU work that costs the same time concurrently and stretches the in-flight decode step by its own duration. The verdict lives in the config comment and the plan ledger; the experiment is one `--set` away on hardware with real partitioning.

## Quality
- degen_suite 50/0 on the ON arm; 0 CUDA errors across all ON runs; ENTERED smoke + graph prewarm exercise the overlap path at init.
- Default-off arm is byte-for-byte today's code path (slot/drain decisions unchanged without the flag).
- pre-push verify-fast PASS (hook aborts on failure; branch landed). Filesize allowlist re-pinned (+90 buffers TU for the scratch copies, +12 scheduler).

Not in here: MoE per-slot workspaces (plan phase 2 - moot unless partitioning arrives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU