### PR TITLE
perf(gemm): batched residual accumulation measured NEGATIVE - the elementwise class was already wall-free; class closed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ set(IMP_RUNTIME_SOURCES
 set(IMP_EXEC_SOURCES
     src/exec/executor.cu
     src/exec/executor_sampling.cu
+    src/exec/executor_gemm_smallm.cu
     src/exec/executor_kernels.cu
     src/exec/executor_kv_write_kernels.cu
     src/exec/executor_elementwise.cu

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,12 +132,22 @@ Ranked by what an agent workload notices first.
    on sm_120) the two streams displace each other, so the paced serial
    prefill was never wasted GPU time. `runtime.prefill_overlap` ships
    default-off with the verdict in its comment; ledger in
-   docs/plans/2026-08-27-prefill-decode-overlap.md. Also recorded: the batch=1
+   docs/plans/2026-08-27-prefill-decode-overlap.md.
+   UPDATE 2026-08-27 (final 0(c) item): the ELEMENTWISE class is CLOSED by
+   measurement - batched residual accumulation (o/down/GDN-out with beta=1
+   into hidden via the smallm accumulate path, `gemm.nvfp4_residual_beta1`)
+   was built and measured -0.9% median, all three alternating pairs
+   negative (1779.0 -> 1763.6, degen 50/0 both arms): the residual adds
+   already overlap the next layer's GEMMs in the captured graph
+   (wall-free), and the accumulate moves their bytes onto the critical
+   GEMM's epilogue. The batch=1 "launch classes overlap away" rule holds
+   for this class at batch 32 too. With that, every 0(c) sub-post is
+   shipped or verdict-closed. Also recorded: the batch=1
    async-loop recapture per ~200-token burst (FRESH captures 128 -> 7
    after parking regardless of spec mode) measures +0.2% throughput -
    an ITL-spike fix, not a decode lever; the 27.8 ms/gap read in the
    nsys profile was CUPTI inflating graph instantiation. Still open in
-   class: elementwise. (d) cross-sequence
+   class: elementwise (CLOSED 2026-08-27 below by measurement). (d) cross-sequence
    prefill batching: a 32-prompt burst prefills one sequence per forward
    at ~1700 tok/s effective (launch-bound, 64 layers), so every first
    token waits 2-3.5 s; batching prefill rows the way decode batches
@@ -159,7 +169,8 @@ Ranked by what an agent workload notices first.
    +0.21%. Together with the #1765 plan fix (KV no longer collapsible to
    the one-sequence floor) the measured gap to vLLM stands at ~1.08x
    pinned. Largest remaining engine-side posts: (d) above, the
-   launch-coupled idle, and the elementwise fusion tail (the gate|up half
+   launch-coupled idle (since attributed and closed), and the elementwise
+   fusion tail (closed by measurement 2026-08-27; the gate|up half
    shipped 2026-08-27 as the sibling-pair launch, see (c)).
    UPDATE 2026-08-27: the Qwen3.8 PORT roadmap is CLOSED - every item in
    docs/plans/2026-08-24-qwen38-port.md is done, answered, or closed with a
@@ -167,7 +178,7 @@ Ranked by what an agent workload notices first.
    serving gap is engine scope, not port scope: launch-coupled idle, the
    smallm in-class residual, recurrent-state paging (the lever for 32-way
    concurrency at LONG context - the phase-3 criterion itself is met
-   without it), and the elementwise fusion tail.
+   without it); the elementwise fusion tail closed by measurement 2026-08-27.
    UPDATE 2026-08-26 (attention post priced and closed): the fresh profile
    put NVFP4 decode attention at 8.9% of kernel time, ~13x its per-launch
    DRAM floor - but the GQA-tile variant built against it measured -9% e2e

--- a/src/core/config/gemm.h
+++ b/src/core/config/gemm.h
@@ -145,6 +145,25 @@ struct GEMM {
     // fixed cost + one tail wave per pair, 112 launches per 64-layer decode
     // step on Qwen3.8-27B. Kill switch for A/B; requires impl 2.
     bool nvfp4_smallm_pair = true;
+    // Batched-decode residual accumulation on the CUTLASS_NVFP4 tier: the
+    // o / down / GDN-out projections at 2..32 rows run with beta=1 straight
+    // into the hidden buffer (the smallm kernel's accumulate path, the same
+    // numerics family the #1055 verify GEMMs use) instead of GEMM-to-scratch
+    // + elementwise add (+ a copy-back on GDN). n==1 keeps its fused
+    // residual GEMVs; prefill(>32), spec-verify, LoRA, post-norm and
+    // fp32-accum layers keep the scratch+add path.
+    //
+    // Default OFF by measurement (2026-08-27, Qwen3.8-27B-NVFP4, 32-stream
+    // burst, 3 alternating trials/arm): 1779.0 -> 1763.6 tok/s median,
+    // ALL THREE pairs negative (-2.7/-0.9/-0.2%), degen 50/0 on both arms.
+    // Mechanism: the elementwise residual adds sit AFTER their GEMM and
+    // overlap the next layer's independent GEMMs in the captured graph —
+    // they are already wall-free — while the accumulate path moves their
+    // bytes into the critical GEMM's epilogue. The batch=1 refutation of
+    // launch-class levers ("they overlap away") holds for THIS class at
+    // batch 32 too, unlike norms/act-quantize which sat on the critical
+    // path. Kept as a kill-switch-style A/B knob only.
+    bool nvfp4_residual_beta1 = false;
     // (gemm.nvfp4_ssm_proj — the 2026-05-30 opt-in that forced GGUF-hybrid
     // GDN projections into the NVFP4 decode cache — was REMOVED 2026-07-11:
     // it had bit-rotted in the tier refactors (measured 71 tok/s vs its

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -376,6 +376,20 @@ public:
     bool has_gguf_nvfp4_overlay() const;
     bool model_has_moe() const { return has_moe_; }
 
+    // Batched-decode residual accumulation eligibility (gemm.nvfp4_residual_beta1):
+    // the o / down / GDN-out projection may run beta=1 straight into the
+    // hidden buffer when it will take the smallm accumulate path. Shared by
+    // the three call sites so the gates cannot drift apart.
+    bool residual_beta1_nvfp4_ok_(TensorID id, int n, const Tensor& h) const {
+        if (!runtime_config().gemm.nvfp4_residual_beta1 || id == kInvalidTensorID)
+            return false;
+        if (n <= 1 || n > 32 || h.qtype != QType::F16)
+            return false;
+        if (cur_spec_verify_ || overlap_prefill_active_ || lora_ != nullptr)
+            return false;
+        return registry_.handle(id).primary_tier == StorageTier::CUTLASS_NVFP4;
+    }
+
     // Capacity of the [n_heads, attn_seq, attn_seq] FP16 attn-scores workspace.
     // Engine's chunked-prefill path must clamp chunk_len so n × ctx_len ≤ cap².
     // Returns 0 if the buffer wasn't allocated (VRAM-constrained / WMMA fallback).

--- a/src/exec/executor_attention.cu
+++ b/src/exec/executor_attention.cu
@@ -193,8 +193,18 @@ void GraphExecutor::run_attention(int layer, const InferenceState& state, cudaSt
     bool will_fuse_o_dequant_beta1 = (!has_post_attn_norm && !will_fuse_o_residual && !will_fuse_o_nvfp4 &&
                                       !will_fuse_o_beta1 && n > 1 && qscratch_.dequant != nullptr &&
                                       dequant_gpu_supported(ly.wo.qtype));
+    // Batched-decode residual accumulation on the CUTLASS_NVFP4 tier
+    // (gemm.nvfp4_residual_beta1): h += o_proj(ao) via the smallm accumulate
+    // path — replaces GEMM-to-scratch + elementwise_add_store and skips the
+    // residual save below. Small ragged prefill chunks (n <= 32) take it
+    // too, which is correct (same accumulate) and still one launch fewer.
+    bool will_fuse_o_beta1_nvfp4 =
+        (!has_post_attn_norm && !will_fuse_o_residual && !will_fuse_o_nvfp4 && !will_fuse_o_beta1 &&
+         !will_fuse_o_dequant_beta1 && n > 1 && n <= 32 && h.qtype == QType::F16 &&
+         wo_tier == StorageTier::CUTLASS_NVFP4 && runtime_config().gemm.nvfp4_residual_beta1 &&
+         !cur_spec_verify_ && !overlap_prefill_active_ && lora_ == nullptr && !using_fp32_accum);
     if (!will_fuse_o_residual && !will_fuse_o_beta1 && !will_fuse_o_dequant_beta1 && !will_fuse_o_nvfp4 &&
-        !using_fp32_accum) {
+        !will_fuse_o_beta1_nvfp4 && !using_fp32_accum) {
         IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(r.data, h.data, h.nbytes(), cudaMemcpyDeviceToDevice, stream));
     }
 
@@ -660,6 +670,11 @@ after_attention:
         quantize_fp16_to_fp8_e4m3(ao, fp8_ao, qscratch_.d_act_scale, stream, qscratch_.d_fp8_block_maxes,
                                   qscratch_.d_fp8_absmax, qscratch_.fp8_max_grid);
         gemm_cublaslt(fp8_ao, fp8_wo, h, 1.0f, 1.0f, qscratch_.d_act_scale, wo_h.payload.fp8.d_scale, stream);
+    } else if (will_fuse_o_beta1_nvfp4) {
+        // Batched-decode NVFP4: hidden += attn_out @ wo^T via the smallm
+        // accumulate path (falls through to a beta-honouring handler if the
+        // smallm route declines — the cutlass handler refuses beta != 0).
+        gemm_via_handle_(ly.wo_id, ao, h, ctx.with_beta(1.0f));
     } else if (will_fuse_o_beta1 && wo_tier == StorageTier::FP16) {
         // Fused: hidden = attn_out @ wo^T + hidden (cuBLAS beta=1).
         // Safe: hidden is only READ (never written) between attn_norm and here.

--- a/src/exec/executor_ffn.cu
+++ b/src/exec/executor_ffn.cu
@@ -107,8 +107,19 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                                          !will_fuse_down_nvfp4 && !will_fuse_down_beta1 && n > 1 &&
                                          qscratch_.dequant != nullptr &&
                                          dequant_gpu_supported(ly.w_down.qtype));
+    // Batched-decode residual accumulation on the CUTLASS_NVFP4 tier
+    // (gemm.nvfp4_residual_beta1): h += down(so) via the smallm accumulate
+    // path — replaces GEMM-to-scratch + elementwise_add_store and skips the
+    // residual save below (see the o-projection twin in executor_attention.cu).
+    bool will_fuse_down_beta1_nvfp4 =
+        (!has_post_ffn_norm && !will_fuse_down_residual && !will_fuse_down_nvfp4 &&
+         !will_fuse_down_beta1 && !will_fuse_down_dequant_beta1 && !will_fuse_down_mxfp4 && n > 1 &&
+         n <= 32 && h.qtype == QType::F16 && wd_tier == StorageTier::CUTLASS_NVFP4 &&
+         runtime_config().gemm.nvfp4_residual_beta1 && !cur_spec_verify_ && !overlap_prefill_active_ &&
+         lora_ == nullptr && !using_fp32_accum);
     if (!will_fuse_down_residual && !will_fuse_down_beta1 && !will_fuse_down_dequant_beta1 &&
-        !will_fuse_down_nvfp4 && !will_fuse_down_mxfp4 && !using_fp32_accum) {
+        !will_fuse_down_nvfp4 && !will_fuse_down_mxfp4 && !will_fuse_down_beta1_nvfp4 &&
+        !using_fp32_accum) {
         device_copy_async(r.data, h.data, h.nbytes(), stream);  // kernel copy — see device_copy_async
     }
 
@@ -464,6 +475,10 @@ void GraphExecutor::run_ffn(int layer, cudaStream_t stream) {
                 Tensor fp8_wd(hwd->payload.fp8.data, QType::FP8_E4M3, 2, wshape, true);
                 gemm_cublaslt(fp8_so, fp8_wd, h, 1.0f, 1.0f, qscratch_.d_act_scale, hwd->payload.fp8.d_scale,
                               stream);
+            } else if (will_fuse_down_beta1_nvfp4) {
+                // Batched-decode NVFP4: hidden += swiglu_out @ w_down^T via
+                // the smallm accumulate path.
+                gemm_via_handle_(ly.w_down_id, so, h, ctx.with_beta(1.0f));
             } else if (will_fuse_down_beta1 && wd_tier == StorageTier::FP16) {
                 // Fused: hidden = swiglu_out @ w_down^T + hidden (cuBLAS beta=1).
                 gemm_via_handle_(ly.w_down_id, so, h, ctx.with_beta(1.0f));

--- a/src/exec/executor_gemm_dispatch.cu
+++ b/src/exec/executor_gemm_dispatch.cu
@@ -599,6 +599,12 @@ void GraphExecutor::gemm_via_handle_(TensorID id, const Tensor& input,
                                      ctx.act_quant_hint_data == input.data &&
                                      ctx.act_quant_hint_m == M &&
                                      ctx.act_quant_hint_k == static_cast<int>(input.shape[1]));
+            // Thread beta through: the cutlass_nvfp4 handler cannot honour a
+            // nonzero beta and DECLINES on it (its epilogue bakes beta=0) —
+            // without this line a beta=1 dispatch that reached here would
+            // silently overwrite the residual instead of falling through to
+            // a beta-honouring handler.
+            args.beta = ctx.beta;
             GemmStrategy strat{StorageTier::CUTLASS_NVFP4, QType::F16, false};
             if (GemmKernelRegistry::instance().dispatch(strat, args) == GemmDispatchResult::Ok)
                 return;
@@ -678,146 +684,9 @@ void GraphExecutor::ensure_smallm_xq_(size_t xq_need, cudaStream_t stream) {
     smallm_xq_from_producer_ = false;
 }
 
-uint8_t* GraphExecutor::smallm_producer_xq_(TensorID consumer_id, int M, int K, cudaStream_t stream,
-                                            uint8_t** scales_out) {
-    if (!runtime_config().gemm.nvfp4_smallm || cur_spec_verify_ || overlap_prefill_active_)
-        return nullptr;
-    if (M < 2 || M > 32 || K <= 0 || (K & 255) != 0)
-        return nullptr;
-    if (consumer_id == kInvalidTensorID)
-        return nullptr;
-    const auto& h = registry_.handle(consumer_id);
-    if (h.primary_tier != StorageTier::CUTLASS_NVFP4 || h.source_data == nullptr ||
-        h.source_scales == nullptr || dequant_gpu_supported(h.source_qtype) ||
-        static_cast<int>(h.shape[1] * 2) != K)
-        return nullptr;
-    const size_t xq_need = (size_t)32 * (K / 2) + (size_t)32 * (K / 16);
-    ensure_smallm_xq_(xq_need, stream);
-    if (smallm_xq_bytes_ < xq_need)
-        return nullptr;
-    *scales_out = static_cast<uint8_t*>(smallm_xq_) + (size_t)32 * (K / 2);
-    return static_cast<uint8_t*>(smallm_xq_);
-}
+// smallm_producer_xq_/tag_, rmsnorm/swiglu_for_smallm_ and
+// try_smallm_pair_dispatch_ live in executor_gemm_smallm.cu (2026-08-27
+// split — see its header comment).
 
-void GraphExecutor::smallm_producer_tag_(const void* out_data, int M, int K) {
-    smallm_xq_src_ = out_data;
-    smallm_xq_src_m_ = M;
-    smallm_xq_src_k_ = K;
-    smallm_xq_from_producer_ = true;
-}
-
-void GraphExecutor::rmsnorm_for_smallm_(const Tensor& h, const Tensor& w, Tensor& no,
-                                        TensorID consumer_id, int n, float eps, cudaStream_t stream,
-                                        float weight_offset) {
-    const int K = static_cast<int>(h.shape[1]);
-    uint8_t* xq_scales = nullptr;
-    uint8_t* xq_packed = smallm_producer_xq_(consumer_id, n, K, stream, &xq_scales);
-    if (xq_packed != nullptr &&
-        rmsnorm_nvfp4(h, w, no, xq_packed, xq_scales, eps, stream, weight_offset)) {
-        smallm_producer_tag_(no.data, n, K);
-        return;
-    }
-    rmsnorm(h, w, no, eps, stream, weight_offset);
-    // The unfused write may have replaced the content behind a still-matching
-    // tag (same buffer, same shape, new values) — invalidate it.
-    if (smallm_xq_src_ == no.data && smallm_xq_src_m_ == n && smallm_xq_src_k_ == K)
-        smallm_xq_from_producer_ = false;
-}
-
-void GraphExecutor::swiglu_for_smallm_(const Tensor& go, const Tensor& uo, Tensor& so,
-                                       TensorID consumer_id, int n, cudaStream_t stream) {
-    const int K = static_cast<int>(so.shape[1]);
-    uint8_t* xq_scales = nullptr;
-    uint8_t* xq_packed = smallm_producer_xq_(consumer_id, n, K, stream, &xq_scales);
-    if (xq_packed != nullptr && swiglu_quantize_nvfp4(go, uo, so, xq_packed, xq_scales, stream)) {
-        smallm_producer_tag_(so.data, n, K);
-        return;
-    }
-    swiglu(go, uo, so, stream);
-    if (smallm_xq_src_ == so.data && smallm_xq_src_m_ == n && smallm_xq_src_k_ == K)
-        smallm_xq_from_producer_ = false;
-}
-
-bool GraphExecutor::try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, const Tensor& input,
-                                              Tensor& out_a, Tensor& out_b, const GemmContext& ctx) {
-    // Mirror of the single-tensor smallm v2 eligibility in gemm_via_handle_
-    // (see the block there for the rationale of each condition) applied to
-    // BOTH weights, plus: same K, v2 only, stripes==1 shapes only, fresh
-    // outputs only. Every decline is a plain `false` — the caller issues the
-    // two single dispatches it would have issued anyway.
-    if (!runtime_config().gemm.nvfp4_smallm || runtime_config().gemm.nvfp4_smallm_impl != 2 ||
-        !runtime_config().gemm.nvfp4_smallm_pair || ctx.spec_verify_small_m ||
-        overlap_prefill_active_ || ctx.beta != 0.0f || id_a == kInvalidTensorID ||
-        id_b == kInvalidTensorID)
-        return false;
-    const int M = static_cast<int>(input.shape[0]);
-    // M==1 stays on the fused decode GEMVs; M>32 is prefill.
-    if (M < 2 || M > 32)
-        return false;
-    if (input.qtype != QType::F16 || out_a.qtype != QType::F16 || out_b.qtype != QType::F16)
-        return false;
-    const auto& ha = registry_.handle(id_a);
-    const auto& hb = registry_.handle(id_b);
-    auto eligible = [](const WeightHandle& h) {
-        return h.primary_tier == StorageTier::CUTLASS_NVFP4 && h.source_data != nullptr &&
-               h.source_scales != nullptr && !dequant_gpu_supported(h.source_qtype);
-    };
-    if (!eligible(ha) || !eligible(hb))
-        return false;
-    const int K = static_cast<int>(ha.shape[1] * 2);
-    if (static_cast<int>(hb.shape[1] * 2) != K || (K % 256) != 0)
-        return false;
-    const int N1 = static_cast<int>(ha.shape[0]);
-    const int N2 = static_cast<int>(hb.shape[0]);
-    if ((N1 % 64) != 0 || (N2 % 64) != 0)
-        return false;
-    if (gemm_nvfp4_smallm_v2_stripes(N1, K) != 1 || gemm_nvfp4_smallm_v2_stripes(N2, K) != 1)
-        return false;
-    const size_t xq_need = (size_t)32 * (K / 2) + (size_t)32 * (K / 16);
-    ensure_smallm_xq_(xq_need, ctx.stream);
-    if (smallm_xq_bytes_ < xq_need)
-        return false;
-    // Same statistic the single path records: both weights consume `input`.
-    if (calib_) {
-        calib_->accumulate(cur_layer_, ha.kind, input, ctx.stream);
-        calib_->accumulate(cur_layer_, hb.kind, input, ctx.stream);
-    }
-    uint8_t* xq_packed = static_cast<uint8_t*>(smallm_xq_);
-    uint8_t* xq_scales = xq_packed + (size_t)32 * (K / 2);
-    // Quantize dedupe — identical contract to the single-tensor block: a
-    // matching scratch tag plus either the caller's act-quant hint or a
-    // producer-side tag skips the re-quantize.
-    const bool tag_match = smallm_xq_src_ == input.data && smallm_xq_src_m_ == M && smallm_xq_src_k_ == K;
-    const bool hint_match = ctx.act_quant_hint_data != nullptr && ctx.act_quant_hint_data == input.data &&
-                            ctx.act_quant_hint_m == M && ctx.act_quant_hint_k == K;
-    if (!(tag_match && (hint_match || smallm_xq_from_producer_))) {
-        quantize_fp16_to_nvfp4_into(input.data, M, K, xq_packed, xq_scales,
-                                    /*tensor_scale=*/1.0f, ctx.stream);
-        smallm_xq_src_ = input.data;
-        smallm_xq_src_m_ = M;
-        smallm_xq_src_k_ = K;
-        smallm_xq_from_producer_ = false;
-    }
-    NvFP4QuantResult nva;
-    nva.packed_data = const_cast<void*>(ha.source_data);
-    nva.micro_scales = ha.source_scales;
-    nva.tensor_scale = ha.source_tensor_scale;
-    nva.N = N1;
-    nva.K = K;
-    NvFP4QuantResult nvb;
-    nvb.packed_data = const_cast<void*>(hb.source_data);
-    nvb.micro_scales = hb.source_scales;
-    nvb.tensor_scale = hb.source_tensor_scale;
-    nvb.N = N2;
-    nvb.K = K;
-    NvFP4QuantResult xq;
-    xq.packed_data = xq_packed;
-    xq.micro_scales = xq_scales;
-    xq.tensor_scale = 1.0f;
-    xq.N = M;
-    xq.K = K;
-    return gemm_nvfp4_smallm_v2_pair_a4(nva, nvb, xq, reinterpret_cast<half*>(out_a.data),
-                                        reinterpret_cast<half*>(out_b.data), M, N1, N2, K, ctx.stream);
-}
 
 }  // namespace imp

--- a/src/exec/executor_gemm_smallm.cu
+++ b/src/exec/executor_gemm_smallm.cu
@@ -1,0 +1,166 @@
+// executor_gemm_smallm.cu — the small-M NVFP4 dispatch family of
+// GraphExecutor, moved VERBATIM out of executor_gemm_dispatch.cu on
+// 2026-08-27 (that TU sat at the 600-LOC kernel hard threshold; this family
+// — producer-side activation quantize, its rmsnorm/swiglu wrappers and the
+// sibling-pair dispatch — is one coherent unit, and splitting it isolates
+// smallm edits from re-ptxas-ing the whole dispatch chain).
+
+#include "exec/executor.h"
+#include "exec/gemm_context.h"
+#include "quant/nvfp4_gemm.h"
+#include "quant/nvfp4_quant.h"
+#include "compute/layernorm.h"
+#include "compute/activation.h"
+#include "quant/dequant_gpu.h"
+#include "core/logging.h"
+#include "memory/engine_arena.h"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <algorithm>
+
+namespace imp {
+
+uint8_t* GraphExecutor::smallm_producer_xq_(TensorID consumer_id, int M, int K, cudaStream_t stream,
+                                            uint8_t** scales_out) {
+    if (!runtime_config().gemm.nvfp4_smallm || cur_spec_verify_ || overlap_prefill_active_)
+        return nullptr;
+    if (M < 2 || M > 32 || K <= 0 || (K & 255) != 0)
+        return nullptr;
+    if (consumer_id == kInvalidTensorID)
+        return nullptr;
+    const auto& h = registry_.handle(consumer_id);
+    if (h.primary_tier != StorageTier::CUTLASS_NVFP4 || h.source_data == nullptr ||
+        h.source_scales == nullptr || dequant_gpu_supported(h.source_qtype) ||
+        static_cast<int>(h.shape[1] * 2) != K)
+        return nullptr;
+    const size_t xq_need = (size_t)32 * (K / 2) + (size_t)32 * (K / 16);
+    ensure_smallm_xq_(xq_need, stream);
+    if (smallm_xq_bytes_ < xq_need)
+        return nullptr;
+    *scales_out = static_cast<uint8_t*>(smallm_xq_) + (size_t)32 * (K / 2);
+    return static_cast<uint8_t*>(smallm_xq_);
+}
+
+void GraphExecutor::smallm_producer_tag_(const void* out_data, int M, int K) {
+    smallm_xq_src_ = out_data;
+    smallm_xq_src_m_ = M;
+    smallm_xq_src_k_ = K;
+    smallm_xq_from_producer_ = true;
+}
+
+void GraphExecutor::rmsnorm_for_smallm_(const Tensor& h, const Tensor& w, Tensor& no,
+                                        TensorID consumer_id, int n, float eps, cudaStream_t stream,
+                                        float weight_offset) {
+    const int K = static_cast<int>(h.shape[1]);
+    uint8_t* xq_scales = nullptr;
+    uint8_t* xq_packed = smallm_producer_xq_(consumer_id, n, K, stream, &xq_scales);
+    if (xq_packed != nullptr &&
+        rmsnorm_nvfp4(h, w, no, xq_packed, xq_scales, eps, stream, weight_offset)) {
+        smallm_producer_tag_(no.data, n, K);
+        return;
+    }
+    rmsnorm(h, w, no, eps, stream, weight_offset);
+    // The unfused write may have replaced the content behind a still-matching
+    // tag (same buffer, same shape, new values) — invalidate it.
+    if (smallm_xq_src_ == no.data && smallm_xq_src_m_ == n && smallm_xq_src_k_ == K)
+        smallm_xq_from_producer_ = false;
+}
+
+void GraphExecutor::swiglu_for_smallm_(const Tensor& go, const Tensor& uo, Tensor& so,
+                                       TensorID consumer_id, int n, cudaStream_t stream) {
+    const int K = static_cast<int>(so.shape[1]);
+    uint8_t* xq_scales = nullptr;
+    uint8_t* xq_packed = smallm_producer_xq_(consumer_id, n, K, stream, &xq_scales);
+    if (xq_packed != nullptr && swiglu_quantize_nvfp4(go, uo, so, xq_packed, xq_scales, stream)) {
+        smallm_producer_tag_(so.data, n, K);
+        return;
+    }
+    swiglu(go, uo, so, stream);
+    if (smallm_xq_src_ == so.data && smallm_xq_src_m_ == n && smallm_xq_src_k_ == K)
+        smallm_xq_from_producer_ = false;
+}
+
+bool GraphExecutor::try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, const Tensor& input,
+                                              Tensor& out_a, Tensor& out_b, const GemmContext& ctx) {
+    // Mirror of the single-tensor smallm v2 eligibility in gemm_via_handle_
+    // (see the block there for the rationale of each condition) applied to
+    // BOTH weights, plus: same K, v2 only, stripes==1 shapes only, fresh
+    // outputs only. Every decline is a plain `false` — the caller issues the
+    // two single dispatches it would have issued anyway.
+    if (!runtime_config().gemm.nvfp4_smallm || runtime_config().gemm.nvfp4_smallm_impl != 2 ||
+        !runtime_config().gemm.nvfp4_smallm_pair || ctx.spec_verify_small_m ||
+        overlap_prefill_active_ || ctx.beta != 0.0f || id_a == kInvalidTensorID ||
+        id_b == kInvalidTensorID)
+        return false;
+    const int M = static_cast<int>(input.shape[0]);
+    // M==1 stays on the fused decode GEMVs; M>32 is prefill.
+    if (M < 2 || M > 32)
+        return false;
+    if (input.qtype != QType::F16 || out_a.qtype != QType::F16 || out_b.qtype != QType::F16)
+        return false;
+    const auto& ha = registry_.handle(id_a);
+    const auto& hb = registry_.handle(id_b);
+    auto eligible = [](const WeightHandle& h) {
+        return h.primary_tier == StorageTier::CUTLASS_NVFP4 && h.source_data != nullptr &&
+               h.source_scales != nullptr && !dequant_gpu_supported(h.source_qtype);
+    };
+    if (!eligible(ha) || !eligible(hb))
+        return false;
+    const int K = static_cast<int>(ha.shape[1] * 2);
+    if (static_cast<int>(hb.shape[1] * 2) != K || (K % 256) != 0)
+        return false;
+    const int N1 = static_cast<int>(ha.shape[0]);
+    const int N2 = static_cast<int>(hb.shape[0]);
+    if ((N1 % 64) != 0 || (N2 % 64) != 0)
+        return false;
+    if (gemm_nvfp4_smallm_v2_stripes(N1, K) != 1 || gemm_nvfp4_smallm_v2_stripes(N2, K) != 1)
+        return false;
+    const size_t xq_need = (size_t)32 * (K / 2) + (size_t)32 * (K / 16);
+    ensure_smallm_xq_(xq_need, ctx.stream);
+    if (smallm_xq_bytes_ < xq_need)
+        return false;
+    // Same statistic the single path records: both weights consume `input`.
+    if (calib_) {
+        calib_->accumulate(cur_layer_, ha.kind, input, ctx.stream);
+        calib_->accumulate(cur_layer_, hb.kind, input, ctx.stream);
+    }
+    uint8_t* xq_packed = static_cast<uint8_t*>(smallm_xq_);
+    uint8_t* xq_scales = xq_packed + (size_t)32 * (K / 2);
+    // Quantize dedupe — identical contract to the single-tensor block: a
+    // matching scratch tag plus either the caller's act-quant hint or a
+    // producer-side tag skips the re-quantize.
+    const bool tag_match = smallm_xq_src_ == input.data && smallm_xq_src_m_ == M && smallm_xq_src_k_ == K;
+    const bool hint_match = ctx.act_quant_hint_data != nullptr && ctx.act_quant_hint_data == input.data &&
+                            ctx.act_quant_hint_m == M && ctx.act_quant_hint_k == K;
+    if (!(tag_match && (hint_match || smallm_xq_from_producer_))) {
+        quantize_fp16_to_nvfp4_into(input.data, M, K, xq_packed, xq_scales,
+                                    /*tensor_scale=*/1.0f, ctx.stream);
+        smallm_xq_src_ = input.data;
+        smallm_xq_src_m_ = M;
+        smallm_xq_src_k_ = K;
+        smallm_xq_from_producer_ = false;
+    }
+    NvFP4QuantResult nva;
+    nva.packed_data = const_cast<void*>(ha.source_data);
+    nva.micro_scales = ha.source_scales;
+    nva.tensor_scale = ha.source_tensor_scale;
+    nva.N = N1;
+    nva.K = K;
+    NvFP4QuantResult nvb;
+    nvb.packed_data = const_cast<void*>(hb.source_data);
+    nvb.micro_scales = hb.source_scales;
+    nvb.tensor_scale = hb.source_tensor_scale;
+    nvb.N = N2;
+    nvb.K = K;
+    NvFP4QuantResult xq;
+    xq.packed_data = xq_packed;
+    xq.micro_scales = xq_scales;
+    xq.tensor_scale = 1.0f;
+    xq.N = M;
+    xq.K = K;
+    return gemm_nvfp4_smallm_v2_pair_a4(nva, nvb, xq, reinterpret_cast<half*>(out_a.data),
+                                        reinterpret_cast<half*>(out_b.data), M, N1, N2, K, ctx.stream);
+}
+
+}  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -274,13 +274,19 @@ void GraphExecutor::run_ssm(int layer, const InferenceState& state, cudaStream_t
     // 9. Group RMSNorm on y  [AFTER gating, per llama.cpp reference]
     group_rmsnorm(y_buf, ly.ssm_norm_w, y_buf, n_groups, eps, stream);
 
-    // 10. ssm_out projection: [n, inner] @ ssm_out^T -> [n, d_model]
-    Tensor out_buf = view_tokens(ssm_out_buf_, n);
-    gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);
-
-    // 11. Residual add: hidden = output + residual
-    elementwise_add(out_buf, r, stream);
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(h.data, out_buf.data, h.nbytes(), cudaMemcpyDeviceToDevice, stream));
+    // 10.+11. ssm_out projection + residual. h still holds the residual (r is
+    // its save and nothing wrote h since), so on the batched-decode NVFP4
+    // path the projection accumulates straight into h (smallm beta=1) —
+    // replacing GEMM-to-scratch + elementwise_add + the copy-back.
+    if (residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h)) {
+        gemm_via_handle_(ly.ssm_out_id, y_buf, h, ctx.with_beta(1.0f));
+    } else {
+        Tensor out_buf = view_tokens(ssm_out_buf_, n);
+        gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);
+        elementwise_add(out_buf, r, stream);
+        IMP_CUDA_CHECK_LOG(
+            cudaMemcpyAsync(h.data, out_buf.data, h.nbytes(), cudaMemcpyDeviceToDevice, stream));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -799,6 +805,12 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                                                static_cast<__half*>(h.data), total);
         IMP_CUDA_CHECK_LAUNCH();
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
+    } else if (residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h) && !dump_hidden_dir()) {
+        // Batched-decode NVFP4: h += out_proj(y) via the smallm accumulate
+        // path (h still holds the residual — see run_ssm's twin). The
+        // pre-residual dump hook needs the scratch, so an active dump dir
+        // keeps the old path.
+        gemm_via_handle_(ly.ssm_out_id, y_buf, h, ctx.with_beta(1.0f));
     } else {
         gemm_via_handle_(ly.ssm_out_id, y_buf, out_buf, ctx);
         // Per-element dump: linear_attn_out post-ssm_out GEMM, pre-residual.

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -290,6 +290,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gemm.nvfp4_smallm", cfg.gemm.nvfp4_smallm);
     I("gemm.nvfp4_smallm_impl", cfg.gemm.nvfp4_smallm_impl);
     B("gemm.nvfp4_smallm_pair", cfg.gemm.nvfp4_smallm_pair);
+    B("gemm.nvfp4_residual_beta1", cfg.gemm.nvfp4_residual_beta1);
     B("gemm.nvfp4_attn_proj", cfg.gemm.nvfp4_attn_proj);
     B("gemm.fp8_ssm_proj", cfg.gemm.fp8_ssm_proj);
     S("gemm.fp8_attn_proj", cfg.gemm.fp8_attn_proj);


### PR DESCRIPTION
## The lever, built and refuted
- `gemm.nvfp4_residual_beta1`: o/down/GDN-out at 2..32 rows run beta=1 straight into hidden via the smallm accumulate path, replacing GEMM-to-scratch + elementwise add (+ the GDN copy-back) - ~190 launches and ~175 MB of DRAM round-trips per 32-row step.

| Qwen3.8-27B-NVFP4, 32-stream burst, 3 alternating trials/arm | OFF | ON |
|---|---:|---:|
| aggregate tok/s (median) | **1779.0** | 1763.6 |
| pairwise | | **-2.7 / -0.9 / -0.2%** (3/3 negative) |

- degen_suite 50/0 on BOTH arms. **Mechanism:** the residual adds sit after their GEMM and overlap the next layer's independent GEMMs in the captured graph - they were already wall-free - while the accumulate moves their bytes onto the critical GEMM's epilogue. The batch=1 rule ("launch classes overlap away") holds for this class at batch 32 too, unlike norms/act-quantize which sat on the critical path.
- Default OFF with the verdict in the config comment; roadmap 0(c)'s elementwise sub-post - the last open one - is closed by measurement.

## Shipped alongside (each stands on its own)
- **Correctness:** the CUTLASS prefill block now threads `ctx.beta` into its registry args. The cutlass handler declines beta!=0 (its epilogue bakes beta=0) - a beta=1 dispatch reaching it would previously have silently overwritten the residual instead of falling through to a beta-honouring handler.
- **Structure:** the smallm dispatch family (producer-xq, rmsnorm/swiglu wrappers, sibling-pair dispatch) moved VERBATIM to `src/exec/executor_gemm_smallm.cu` - `executor_gemm_dispatch.cu` sat at the 600-LOC kernel hard threshold, and smallm edits no longer re-ptxas the whole dispatch chain.

## Gate
- GPU batteries after the move: SmallMV2Pair 4/4, GdnBatchedScan 8/8, RaggedPrefill 3/3. pre-push verify-fast PASS (hook aborts on failure; branch landed); static gates green.

Not in here: nothing further in roadmap 0(c) - every sub-post is now shipped or verdict-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU