### PR TITLE
perf(spec): MTP survives thinking traffic; verify argmax masks banned tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ there instead of retelling it.
 
 ### Fixed
 
+- **The verify-chunk argmax never applied the banned-token mask.** Every other
+  sampling path masks chat-template delimiters before its argmax; the spec
+  verify (which emits accepted + bonus tokens) did not, so it was the one path
+  that could pick e.g. `<|im_start|>` mid-generation and end a request with
+  empty content. Affects n-gram speculation (default-on) too.
+
+- **MTP drafting survived thinking traffic for the first time.** The
+  think-interior loop burst desynced the MTP cache (no host hiddens, sync gate
+  then skips feeding forever) and the in-think emit trim capped every verify
+  at 1 token, tripping the economics guard on a head accepting 87%. MTP-bound
+  requests now stay eager through think, verify inside the block (budget
+  forcing keeps the eager step), and the trim only fires on crossing a think
+  boundary. Qwen3.8-27B-NVFP4, 1024-token thinking chat:
+  `--set speculative.mtp_k=1 --set speculative.ngram=false` 102.1-105.9 tok/s
+  vs 87.2-87.6 default (+17-21%), degen suite 50/0 twice. Default stays
+  `mtp_k=0`; details and the ngram=false caveat in docs/LIMITATIONS.md.
+
 - **The StoragePlanner no longer fails its budget check on every native-NVFP4
   load** (#1765, last open item). It priced prequant weights at full tier
   bytes although the decode cache borrows the resident source storage

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -202,6 +202,28 @@ neither.
   since `ea547a53` — `speculative.mtp_k=1` measured +21.3 % — but **only at k=1**:
   an extra chunk row still costs half a decode step, so k=3 buys 2 %. Numbers and
   the profile that localises that cost: [`roadmap.md`](roadmap.md).
+
+  *Updated 2026-08-27:* until that date MTP was effectively dead on thinking
+  traffic - the think-interior loop burst desynced the MTP cache and the head
+  drafted ~once per generation (drafted_total 1 over a 768-token essay). Three
+  fixes (burst-site exclusions for MTP-bound requests, verify inside the think
+  block, the in-think emit trim) plus the verify-argmax banned-token mask make
+  it pay: **`mtp_k=1` with `speculative.ngram=false` measures 102.1-105.9 tok/s
+  against 87.2-87.6 default on a 1024-token thinking chat (+17-21 %, all six
+  MTP runs above all six default runs), degen suite 50/0 twice.** Keep `ngram=false` in the pair: with the matcher ON the
+  mixed chunk shapes reproducibly derail one trivial prompt into an
+  empty-content completion (the model stops inside think; greedy trajectories
+  under chunk-shaped forwards are not the eager trajectories), and k=2 shows
+  the same class. The default stays `mtp_k=0`: the head costs 0.79 GiB and
+  chunk-greedy != eager-greedy remains a real trade.
+
+  [PROV: commit=3ce0c326+mtp-fixes date=2026-08-27 hw=RTX5090
+         model=Qwen3.8-27B-NVFP4 quant=NVFP4 cuda=13.3 path=imp-server
+         n=3 runs/arm, /v1/chat/completions, 1024-token thinking answer,
+         temperature=0
+         cmd=`imp-server --set speculative.mtp_k=1 --set
+         speculative.ngram=false` vs defaults; degen:
+         `tools/analysis/degen_suite.py` 2x 50 checks]
 - **MTP is released for one model class, and the class that is left out has a
   measured defect, not a missing feature.** `speculative.mtp_k` stays **0
   everywhere** — nothing below is on by default; the table says what a user opts

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -162,7 +162,8 @@ public:
                            const int32_t* d_hist = nullptr, int n_hist = 0,
                            const int32_t* d_draft = nullptr, float rep_pen = 1.0f,
                            float freq_pen = 0.0f, float pres_pen = 0.0f,
-                           int32_t* d_topm = nullptr, int topm = 0);
+                           int32_t* d_topm = nullptr, int topm = 0,
+                           const int32_t* d_banned = nullptr, int n_banned = 0);
 
     // Materialize the LM-head projection of hidden_[0..n_rows) into d_out
     // ([n_rows, vocab_size] fp32) — same batched re-projection as

--- a/src/exec/executor_perplexity.cu
+++ b/src/exec/executor_perplexity.cu
@@ -20,6 +20,7 @@
 
 #include "exec/executor.h"
 #include "exec/executor_gemv_helpers.h"
+#include "exec/executor_sampling_internal.h"
 #include "compute/gemm.h"
 #include "exec/executor_kernels.h"
 #include "exec/gemm_context.h"
@@ -429,7 +430,8 @@ void GraphExecutor::prewarm_verify_scratch() {
 void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t stream,
                                       const int32_t* d_hist, int n_hist, const int32_t* d_draft,
                                       float rep_pen, float freq_pen, float pres_pen,
-                                      int32_t* d_topm, int topm) {
+                                      int32_t* d_topm, int topm, const int32_t* d_banned,
+                                      int n_banned) {
     if (!initialized_ || n_rows <= 0 || d_out == nullptr) {
         return;
     }
@@ -461,6 +463,17 @@ void GraphExecutor::greedy_argmax_all(int n_rows, int32_t* d_out, cudaStream_t s
                 static_cast<float*>(lg.data), row0, V, verify_pen_counts_, d_draft, rep_pen,
                 freq_pen, pres_pen);
             IMP_CUDA_CHECK_LAUNCH();
+        }
+        // Banned special tokens (chat-template delimiters): every OTHER path
+        // masks them before its argmax (forward(), sample_from_logits - see
+        // the comment there), and this argmax EMITS tokens (accepted rows +
+        // the bonus). Without the mask the verify chunk was the one path that
+        // could pick e.g. <|im_start|> mid-think, ending the request with
+        // empty content (deterministic on some prompts, degen_suite [stream]).
+        if (d_banned != nullptr && n_banned > 0) {
+            for (int r = 0; r < csz; ++r)
+                launch_ban_logits(static_cast<float*>(lg.data) + static_cast<size_t>(r) * V,
+                                  d_banned, n_banned, V, stream);
         }
         dim3 grid(csz, kArgmaxSplits);
         rowwise_argmax_partial_kernel<<<grid, 256, 0, stream>>>(

--- a/src/model/safetensors_loader.cpp
+++ b/src/model/safetensors_loader.cpp
@@ -1098,10 +1098,10 @@ std::unique_ptr<Model> load_safetensors(const std::string& path, bool load_mtp_h
         // make. Costs a name scan, no weight bytes.
         IMP_LOG_INFO(
             "MTP head present in this checkpoint but not loaded (speculative.mtp_k=0). "
-            "Enable with --set speculative.mtp_k=2: measured +15 %% decode on "
-            "Qwen3.8-27B-NVFP4, range +8 to +22 %%, in exchange for the head's VRAM "
-            "(0.79 GiB there) and reproducible output across processes. "
-            "See docs/LIMITATIONS.md");
+            "Enable with --set speculative.mtp_k=1 --set speculative.ngram=false: "
+            "measured +17-21 %% single-stream decode on Qwen3.8-27B-NVFP4 (2026-08-27), "
+            "in exchange for the head's VRAM (0.79 GiB there) and eager-equal greedy "
+            "trajectories. See docs/LIMITATIONS.md");
         mtp_available_unloaded = true;
     }
 

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -632,6 +632,15 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             if (try_launch_async_graph_loop(sreq, sreq->output_tokens.back(), dec_stream, lim))
                 return;
         } else if (decode_batch[0]->think_budget > 0.0f && decode_batch[0]->in_think_block &&
+                   // An MTP-bound request must stay on the eager path: the
+                   // per-step chain feed below needs host hiddens for every
+                   // token, and one device-side burst desyncs the MTP cache
+                   // for the rest of the generation (the sync gate then skips
+                   // feeding forever, #847). This think-burst was the one loop
+                   // site without the MTP exclusion the process_outputs launch
+                   // has - measured on Qwen3.8-27B-NVFP4: drafted_total 1 vs
+                   // 436 over a 768-token essay, 84.7 vs 104.3 tok/s.
+                   !(mtp_spec_decode_enabled() && mtp_bound_req_ == decode_batch[0]->id) &&
                    spec_verify_gates_ok_(*decode_batch[0], /*ignore_think=*/true) &&
                    spec_burst_launch_ok_(*decode_batch[0]) &&
                    // Budget exhausted → the EAGER step must run: it forces

--- a/src/runtime/engine_spec_ngram.cpp
+++ b/src/runtime/engine_spec_ngram.cpp
@@ -42,6 +42,7 @@
 #include "runtime/ngram_draft.h"
 #include "runtime/request.h"
 #include "runtime/suffix_draft.h"
+#include "runtime/think_stop_logic.h"
 #include "compute/rowwise_topm.h"
 
 #include <cuda_runtime.h>
@@ -167,9 +168,23 @@ const char* Engine::spec_verify_gate_refusal_(const Request& req, bool ignore_th
         return "constrained_decode";  // verify replicates no FSM masks (#1002)
     // Think budget forces tokens INSIDE the think block (loop/host-side) —
     // verify only outside it; the think interior runs loop bursts, which
-    // handle the budget device-side.
-    if (!ignore_think && req.think_budget > 0.0f && req.in_think_block)
-        return "think_budget_in_block";
+    // handle the budget device-side. Exception: an MTP-bound request already
+    // runs the interior eager (a loop burst would desync the MTP cache for
+    // the rest of the generation, #847), and the eager step owns the budget
+    // forcing - verifies between forcing points are legal and overshoot the
+    // budget by at most k tokens per chunk. Without this the interior pays
+    // the eager tax with no speculation, which on think-heavy chat eats the
+    // MTP win.
+    if (!ignore_think && req.think_budget > 0.0f && req.in_think_block) {
+        if (!(mtp_spec_decode_enabled() && mtp_bound_req_ == req.id))
+            return "think_budget_in_block";
+        // Forcing due: the eager step must run NOW to force </think>; a
+        // verify would emit past the exhausted budget instead.
+        if (think_logic::should_force_think_end(req.think_budget, think_end_id_, req.max_tokens,
+                                                req.output_tokens, think_start_id_,
+                                                req.started_in_think))
+            return "think_budget_in_block";
+    }
     if (req.status != RequestStatus::DECODING || req.output_tokens.empty()) return "not_decoding";
     if (spec_history_too_short_(req)) return "cold_start";  // see speculative.min_history
     // Long-context economics on the DENSE path (#964): the captured chunk
@@ -413,8 +428,13 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         // Skip the eager probe step entirely when a bounded loop burst can
         // take over right away — the eager path costs ~2x per token and the
-        // burst forwards output.back() itself.
-        if (scfg.miss_burst > 0 && !req->spec_ngram_given_up && spec_burst_launch_ok_(*req) &&
+        // burst forwards output.back() itself. Not while MTP is bound to this
+        // request: a stale chain resyncs on the very next eager step (the
+        // per-step chain feed), while a burst desyncs the MTP cache for the
+        // rest of the generation (#847 sync gate).
+        if (scfg.miss_burst > 0 && !req->spec_ngram_given_up &&
+            !(mtp_spec_decode_enabled() && mtp_bound_req_ == req->id) &&
+            spec_burst_launch_ok_(*req) &&
             try_launch_async_graph_loop(req, req->output_tokens.back(), stream,
                                         spec_effective_miss_burst_(*req))) {
             return true;  // step handled by the burst launch
@@ -797,7 +817,9 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     executor_->greedy_argmax_all(chunk_len, d_spec_argmax_, stream, d_hist, n_hist,
                                  d_spec_tokens_ + 1, req->repetition_penalty,
                                  req->frequency_penalty, req->presence_penalty,
-                                 recycle_m > 0 ? d_spec_topm_ : nullptr, recycle_m);
+                                 recycle_m > 0 ? d_spec_topm_ : nullptr, recycle_m,
+                                 banned_tokens_device_(stream),
+                                 static_cast<int>(banned_token_ids_.size()));
     // One D2H covers [argmax | topm] (contiguous block, #1055); without the
     // harvest only the argmax prefix is copied.
     const size_t d2h_ints =
@@ -853,6 +875,12 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
     const int acc_len = mc_on ? static_cast<int>(acc->size()) : K;
     int matched = 0;  // accepted draft tokens (their KV entries are valid)
     int emitted = 0;
+    // Whether this chunk STARTED inside a budgeted think block. Verifies run
+    // inside think for MTP-bound requests (gate exception above); the break
+    // below must fire only on ENTERING the block mid-chunk, or every in-think
+    // verify emits 1 token, reads as avg 1.0 emitted/verify and trips the
+    // economics guard on a head that is accepting fine.
+    const bool think_at_chunk_start = req->in_think_block;
     for (int j = 0; j + mc_row0 < chunk_len; ++j) {
         if (mc_on && j > acc_len) break;  // stay inside the winning group
         const int32_t tokj = h_spec_argmax_.as<int32_t>()[mc_row0 + j];
@@ -872,9 +900,13 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
         }
         if (j >= acc_len || tokj != (*acc)[j]) break;  // bonus reached or draft diverged
         matched++;
-        // Entering a budgeted think block mid-chunk: the budget forcing lives
-        // in the loop/eager path — stop extending; the accepted prefix stays.
-        if (req->think_budget > 0.0f && req->in_think_block) break;
+        // Crossing a think boundary mid-chunk (either direction): stop
+        // extending; the accepted prefix stays. Entering: the budget forcing
+        // lives in the loop/eager path. Leaving: the post-</think> stop/grace
+        // window is the boundary where chunk-argmax noise diverges from the
+        // eager path (empty-content completions in degen_suite) - hand it to
+        // the eager step, which is byte-identical to the pre-MTP behavior.
+        if (req->think_budget > 0.0f && req->in_think_block != think_at_chunk_start) break;
     }
     kv_manager_->touch(req->id);
 
@@ -1040,8 +1072,11 @@ bool Engine::step_spec_verify_(std::shared_ptr<Request>& req, cudaStream_t strea
             cfg_min < 0.0f ? 1.0f + kMtpEconAccept * static_cast<float>(mtp_spec_decode_k()) : cfg_min;
         if (min_emit > 0.0f && mtp_econ_verifies_ >= kMtpEconSample &&
             static_cast<float>(mtp_econ_emitted_) <
-                static_cast<float>(mtp_econ_verifies_) * min_emit)
+                static_cast<float>(mtp_econ_verifies_) * min_emit) {
+            IMP_LOG_INFO("[mtp-econ] verifies=%d emitted=%d min_emit=%.2f this_emitted=%d matched=%d",
+                         mtp_econ_verifies_, mtp_econ_emitted_, min_emit, emitted, matched);
             mtp_unbind_("uneconomic: avg emitted/verify below break-even");
+        }
     }
     const bool acceptance_poor =
         req->spec_verifies >= 8 &&

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -88,7 +88,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1046, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1303, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1304, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
 "tests/test_gdn.cu" = { code_loc = 1285, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -118,7 +118,7 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
         body["kv_pool_growable"] = kv_growable;
     }
     // #1537: the checkpoint carries an MTP head this load did not take, because
-    // speculative.mtp_k defaults to 0. That is a documented +8 to +22% decode
+    // speculative.mtp_k defaults to 0. That is a documented +17-21% decode
     // sitting switched off, and the only notice was one INFO line at startup -
     // which an operator running a container never sees. Reported here so it is
     // discoverable without grepping a log.
@@ -126,8 +126,9 @@ void handle_health(const httplib::Request& /*req*/, httplib::Response& res, Serv
         body["mtp_head_available"] = true;
         body["mtp_head_hint"] =
             "this checkpoint ships an MTP head that is not loaded "
-            "(speculative.mtp_k=0). --set speculative.mtp_k=2 measured +15% decode "
-            "on Qwen3.8-27B-NVFP4 (range +8 to +22%), for the head's VRAM.";
+            "(speculative.mtp_k=0). --set speculative.mtp_k=1 --set "
+            "speculative.ngram=false measured +17-21% single-stream decode on "
+            "Qwen3.8-27B-NVFP4 (2026-08-27), for the head's VRAM (0.79 GiB).";
     }
 
     if (!unservable.empty()) {


### PR DESCRIPTION
## The finding

`speculative.mtp_k` was effectively dead on thinking traffic: over a 768-token essay the head drafted **once** (drafted_total=1) and then never again, so the documented +21.3% never materialized in real chat. Three chained defects, found by instrumenting the chain lifecycle:

1. **Think-interior loop burst desyncs the MTP cache** (`engine_scheduler.cpp` think-burst site): the per-step MTP chain feed needs host hiddens for every token; one device-side burst leaves a gap the #847 sync gate then (correctly) refuses to feed past - for the rest of the generation. The process_outputs launch site already excluded MTP for exactly this reason; the think site did not.
2. **Miss-burst site, same mechanism** (`engine_spec_ngram.cpp`): a matcher miss launched an 8-token burst; for an MTP-bound request the next eager step would have resynced the chain instead.
3. **In-think emit trim** halved verify value: the mid-chunk break fired on *being in* a think block instead of *entering* one, so every in-think verify emitted exactly 1 token - avg 1.0 emitted/verify trips the economics guard (break-even 1.4) on a head accepting 87% (`[mtp-econ] verifies=8 emitted=8`).

Fixes: MTP-bound requests stay eager through think, verify inside the block (budget forcing keeps the eager step; the trim fires only on crossing a think boundary), both burst sites exclude them.

## Separate correctness fix (affects default n-gram spec too)

The verify-chunk argmax (`greedy_argmax_all` - it EMITS accepted + bonus tokens) never applied the banned-token mask that every other sampling path applies (the comment in `executor_sampling.cu` documents the exact failure). It reproducibly picked `<|im_start|>` mid-think on one prompt, ending the request with empty content. Now masked via `launch_ban_logits` per chunk row (19 ids x <=17 rows, negligible).

## Measured (Qwen3.8-27B-NVFP4, imp:test image, 1024-token thinking chat, 2 rounds alternating, 3 trials/arm)

| arm | tok/s |
|---|---|
| default | 87.2 / 87.5 / 87.3 / 87.4 / 87.2 / 87.6 |
| `mtp_k=1` + `ngram=false` | 102.8 / 104.8 / 102.1 / 105.7 / 105.9 / 102.1 |

**+17-21%, all six MTP runs above all six default runs.** degen_suite 50/0 twice on that config, 50/0 default.

## Why `ngram=false` in the recommendation

With the matcher ON, mixed chunk shapes reproducibly derail one trivial prompt ("List 1 to 10") into an empty-content completion - the model stops inside think; chunk-shaped greedy trajectories are not the eager trajectories. Pure k=1 MTP chunks are stable on the same prompt. k=2 shows the same derail class. Documented with PROV in docs/LIMITATIONS.md; both operator hints (init log + /health) updated from the stale "+15% k=2" to the measured pair.

`mtp_k` stays 0 by default (0.79 GiB head, chunk-greedy != eager-greedy trade). verify-fast green (gate measures spec-off, untouched); filesize allowlist re-pin: gemm_cutlass_sm120.cu 600 -> 601 (pre-existing +1 drift, not from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU