### PR TITLE
docs(quickstart): name the MTP-head option on the walkthrough model

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -127,10 +127,10 @@ This checkpoint ships a trained MTP head the default load leaves off. Adding
   --set speculative.mtp_k=1 --set speculative.ngram=false
 ```
 
-buys +17-21 % single-stream decode (measured 102.1-105.9 vs 87.2-87.6 tok/s on
-1024-token thinking chats, 2026-08-27) for 0.79 GiB of VRAM. `GET /health`
-repeats this hint as `mtp_head_hint` whenever the head is present but unloaded;
-the trade is documented in [`LIMITATIONS.md`](LIMITATIONS.md).
+buys +17-21 % single-stream decode for 0.79 GiB of VRAM. `GET /health` repeats
+this hint as `mtp_head_hint` whenever the head is present but unloaded; the
+measured numbers, their provenance and the trade are in
+[`LIMITATIONS.md`](LIMITATIONS.md).
 
 ## 3. Ask it something
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -121,6 +121,17 @@ than the graph-capture workspace cap, so **prefill** graph capture is disabled
 while decode capture stays on. Weights land at 17.9 GiB, leaving room for the KV
 cache on a 32 GB card.
 
+This checkpoint ships a trained MTP head the default load leaves off. Adding
+
+```bash
+  --set speculative.mtp_k=1 --set speculative.ngram=false
+```
+
+buys +17-21 % single-stream decode (measured 102.1-105.9 vs 87.2-87.6 tok/s on
+1024-token thinking chats, 2026-08-27) for 0.79 GiB of VRAM. `GET /health`
+repeats this hint as `mtp_head_hint` whenever the head is present but unloaded;
+the trade is documented in [`LIMITATIONS.md`](LIMITATIONS.md).
+
 ## 3. Ask it something
 
 The `model` field is required, and its value is the file or directory basename.


### PR DESCRIPTION
The quickstart walks a first-time reader through Qwen3.8-27B-NVFP4 and never mentioned the checkpoint's MTP head: `--set speculative.mtp_k=1 --set speculative.ngram=false` measured +17-21% single-stream decode (102.1-105.9 vs 87.2-87.6 tok/s, #1796) for 0.79 GiB. Mirrors the /health hint and LIMITATIONS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HG3FNArGLAXocS7kCbmyhU