### PR TITLE
build: test-core could not link without the server sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Sanitizers` CI lane and `make asan` could not link `test-core`:
+  `tests/test_mtp_auto.cpp` and `tools/imp-cli/args.cpp` are compiled
+  unconditionally while the sources defining the symbols they call
+  (`tools/common/mtp_auto.cpp`, `tools/common/args_common.cpp`) sat inside the
+  `IMP_BUILD_SERVER` block, which those configurations turn off. Broken since
+  #1809; `Build` is a different configuration and stayed green throughout.
+
 ## [0.33.0] - 2026-08-30
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,14 @@ if(IMP_BUILD_TESTS)
         tests/test_sentencepiece_loader.cpp
         tests/test_config.cpp
         tests/test_mtp_auto.cpp
+        # Both of these define symbols the two tests above and args.cpp call,
+        # and neither pulls nlohmann or httplib. They lived in the
+        # IMP_BUILD_SERVER block until this change, which made test-core unlinkable
+        # in every -DIMP_BUILD_SERVER=OFF configuration - that is what the
+        # Sanitizers lane and `make asan` configure, so both had been failing
+        # to link since #1809 while `Build` stayed green.
+        tools/common/mtp_auto.cpp
+        tools/common/args_common.cpp
         # apply_config_pins: the bench pins guard tests/perf_baseline.json's
         # raw-decode semantics, so they get a test rather than a smoke run.
         tools/imp-cli/args.cpp
@@ -780,9 +788,7 @@ if(IMP_BUILD_TESTS)
             tools/imp-server/tool_call.cpp
             tools/imp-server/tool_call_gemma.cpp
         tools/imp-server/tool_call_gemma.cpp
-        tools/common/args_common.cpp
-    tools/common/mtp_auto.cpp
-    tools/imp-server/args.cpp
+            tools/imp-server/args.cpp
             tests/test_anthropic_transform.cpp
             tests/test_responses_transform.cpp
             tests/test_sse_stream_utils.cpp


### PR DESCRIPTION
## The break

`main` CI has been red since #1817's run. The failing job is `Sanitizers`, and
it never gets as far as running a sanitizer:

```
tests/test_mtp_auto.cpp:93: undefined reference to
    `imp::tools::mtp_auto_request_k(imp::RuntimeConfig const&, int)'
tools/imp-cli/args.cpp:114: undefined reference to
    `parse_common_flag(CommonArgs&, int, char**, int&)'
collect2: error: ld returned 1 exit status
```

`tests/test_mtp_auto.cpp` and `tools/imp-cli/args.cpp` are compiled into
`test-core` unconditionally. The sources defining the symbols they call,
`tools/common/mtp_auto.cpp` and `tools/common/args_common.cpp`, sat inside the
`IMP_BUILD_SERVER` block. Every `-DIMP_BUILD_SERVER=OFF` configuration therefore
cannot link `test-core`, and that is exactly what the `Sanitizers` lane and
`make asan` configure.

## Not #1817, and not a day old by accident

`git log -S` puts both lines in #1809 (`a1148fbd`, 2026-08-29), which added the
test unconditionally and the source conditionally in one commit. `Build` uses a
different configuration and stayed green, so nothing surfaced it until the next
`main` run that executed the lane, which happened to be #1817's the following
morning. The lane was blind for a day, and the fix is not urgent for `Build`,
only for anyone running `make asan`.

Neither source needs the server dependencies (`mtp_auto.cpp` includes
`core/logging.h`; `args_common.cpp` includes `<cstdlib>` and `<cstring>`), so
they belong in the unconditional list next to the tests that call them.

## Verified in the configuration that fails

```
cmake -B /b -S . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
      -DIMP_BUILD_TOOLS=OFF -DIMP_BUILD_BENCH=OFF -DIMP_BUILD_SERVER=OFF
cmake --build /b --target test-core
```

With this change: `[341/341] Linking CXX executable test-core`. Without it, the
same three undefined references CI reports. Full GPU suite green in the
pre-commit hook.

Not in here: the `Sanitizers` lane itself is unchanged, and no sanitizer finding
is addressed, because the job never ran one.