### PR TITLE
docs: drop the numbers nothing checks, and record which ones earn their place

### DIFF
--- a/.claude/skills/docs-layers/SKILL.md
+++ b/.claude/skills/docs-layers/SKILL.md
@@ -17,6 +17,18 @@ paragraph into the wrong layer is the most common defect here, and it is what
 3. **A claim needs a code path; a number needs provenance.** What cannot be
    backed is *deleted*, not softened. "experimental", "partial" and "planned"
    are not rescue words.
+3b. **A number also needs something that FAILS when it goes wrong** - otherwise
+   it is a maintenance bill with no reader, and it will be wrong. Three kinds
+   qualify: gate thresholds (8%/8%/10%, `verify.sh` enforces exactly those),
+   hardware constants (32 GB, 1792 GB/s - they cannot drift), and dated
+   measurements, which are findings rather than inventory and are true of the
+   afternoon they name. Counts of files, LOC or test cases and exact
+   build/test runtimes qualify for none of it: **write the command that prints
+   the number**, or the magnitude that changes a decision ("seconds" vs
+   "minutes"), and stop. Restating a gated number in prose does not inherit its
+   gate - the pin in `check_test_lanes.py` guards the tool's constant, not a
+   copy of it in a doc. Applied in bulk 2026-08-31; `tests/CLAUDE.md` had lost
+   this argument twice by then (#1673, then all four of its literals again).
 4. **Records are not documentation.** Excluded from the linter: `CHANGELOG.md`,
    `docs/MISSION_JOURNAL.md`, `docs/vram_audit.md`, root `AUDIT.md`,
    `docs/roadmap.md`, plus the prefixes `docs/archive/`, `docs/audit/`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ global rules below; each role then narrows scope and lists explicit **MAY NOT** 
   active compute process. A busy GPU corrupts numbers and can OOM.
 - **Iterate with `make dev`, gate with `make build`.** `make dev` is an incremental
   compile against a persistent `build-dev/` (seconds); `make build` recompiles the whole
-  tree in a fresh image (~3.5 min) regardless of how little changed. Use `make dev` /
+  tree in a fresh image regardless of how little changed. Use `make dev` /
   `make dev-test` (= CI's `ctest -L unit`) for the edit-compile loop. **Benchmarks, the
   perf gate and anything pushed must be built by `make build`** — an incremental tree is
   where a stale object hides, and this repo re-pins baselines off measured numbers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ commit: 81ffa573
 
 # imp — Project Instructions
 
-From-scratch C++23/CUDA LLM inference engine targeting **exactly one chip: NVIDIA Blackwell `sm_120a`** (RTX 5090 / GB202, 32 GB GDDR7, 1792 GB/s, native FP4 tensor cores). No portability layer, no FP16 dequant fallback in the hot path. ~135k LOC (src/ + include/; ~220k with tests/). See [`docs/internals/ARCHITECTURE.md`](docs/internals/ARCHITECTURE.md) (canonical narrative) and [`docs/internals/SM120.md`](docs/internals/SM120.md).
+From-scratch C++23/CUDA LLM inference engine targeting **exactly one chip: NVIDIA Blackwell `sm_120a`** (RTX 5090 / GB202, 32 GB GDDR7, 1792 GB/s, native FP4 tensor cores). No portability layer, no FP16 dequant fallback in the hot path. See [`docs/internals/ARCHITECTURE.md`](docs/internals/ARCHITECTURE.md) (canonical narrative) and [`docs/internals/SM120.md`](docs/internals/SM120.md).
 
 **This file is the router, not the manual.** It holds what applies to every task; the playbooks live in the skills below and are loaded on demand. If something here is also in a skill, the skill is the copy that gets maintained.
 
@@ -60,9 +60,9 @@ Canonical references: `docs/internals/ARCHITECTURE.md` (narrative), `docs/intern
 The host has **no CUDA toolkit** by design — build inside Docker. `build/` and `build-dev/` are root-owned by the container; remove them via `make dev-clean` or a throwaway container, never `sudo`.
 
 ```
-make dev / make dev-test   # incremental (2-14 s) + the real CI lane — iterate here
-make build                 # full image (~3.5 min) — the gate, benchmarks, pre-push
-make verify-fast           # pre-push gate: build + 37 s script (#1587)   make verify   # full
+make dev / make dev-test   # incremental (seconds) + the real CI lane - iterate here
+make build                 # full image (minutes) - the gate, benchmarks, pre-push
+make verify-fast           # pre-push gate (#1587)             make verify   # full
 ```
 
 `make build` for anything you *measure* or push; `make dev` for everything else. `make test-unit` is a different binary from the CI lane — green there is not green in CI. Details, target list and CI job names: skill **building-and-testing**.

--- a/src/compute/CLAUDE.md
+++ b/src/compute/CLAUDE.md
@@ -7,7 +7,7 @@ commit: 01799405
 
 # src/compute — CUDA kernels
 
-Attention, GEMM/GEMV, norms, sampling, SSM/GDN scans. 147 files, `sm_120a` only.
+Attention, GEMM/GEMV, norms, sampling, SSM/GDN scans. `sm_120a` only.
 This is the hot path.
 
 ## Invariants
@@ -38,10 +38,10 @@ calls); this directory holds the kernels it selects between. The prefill gate is
 ## Build & test
 
 ```
-make dev          # incremental, 2-14 s — iterate here
+make dev          # incremental, seconds - iterate here
 make dev-test     # the CI lane (ctest -L unit)
 make build        # builds image imp:test + build/ binaries; required to MEASURE
-make verify-fast  # ~45 s gate (37 s script), the only kernel-vs-check run
+make verify-fast  # the only thing running a kernel against a check
 ```
 
 **Scoped to this directory:** after `make build`, the per-module binaries in

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -7,11 +7,10 @@ commit: 01799405
 
 # tests — lanes, and which one actually gates
 
-**1021 of 2636 GTest macros run in no CI lane** - they need a GPU, and there is
-no GPU runner. Trust that split and no other count here: `check_test_lanes.py`
-pins it and fails when it moves, while the four hand-written literals this file
-carried until 2026-08-31 had every one drifted. Re-derive with
-`python3 tools/check_test_lanes.py --report`.
+**Most GTest macros in this tree run in no CI lane at all** - they need a GPU,
+and there is no GPU runner. `python3 tools/check_test_lanes.py --report` prints
+the split and pins it; this file does not repeat it, because a copy here is a
+second number nothing checks.
 
 ## Invariants
 
@@ -37,8 +36,8 @@ carried until 2026-08-31 had every one drifted. Re-derive with
 ## Build & test
 
 ```
-make dev-test        # the CI lane, 7.6 s, no CUDA kernel runs
-make test-gpu        # the GPU suite; start it correctly or it silently skips 63
+make dev-test        # the CI lane, no CUDA kernel runs
+make test-gpu        # the GPU suite; start it wrong and it silently skips most
 make verify-fast     # the only gate that runs a kernel against a check
 ```
 


### PR DESCRIPTION
Follow-up to #1825, which paid a maintenance bill instead of questioning it: it
"fixed" `144 -> 147 files` and `0.39 s -> 7.6 s`. Both will be wrong again
shortly, and nothing would notice. Removed instead.

(Replaces #1826, which I branched off the #1825 branch rather than `main` and
which therefore went DIRTY once #1825 squash-merged. Same change, rebuilt from
`main`.)

## The test

**Does something fail when this number goes wrong?**

| kept | why |
|---|---|
| gate thresholds 8%/8%/10% | `verify.sh` enforces exactly those |
| hardware constants (32 GB, 1792 GB/s) | cannot drift |
| dated measurements | findings, true of the afternoon they name - not inventory. "all 82 assertions described the mock" is past tense and stays |

| removed | was in |
|---|---|
| `~135k LOC` / `~220k with tests` | root `CLAUDE.md` |
| `147 files` | `src/compute/CLAUDE.md` |
| `1021 of 2636 GTest macros`, `silently skips 63` | `tests/CLAUDE.md` |
| `2-14 s`, `~3.5 min`, `37 s`, `~45 s`, `7.6 s` | root, `src/compute`, `tests`, `AGENTS.md` |

Runtimes collapse to the magnitude that picks a target ("seconds" vs "minutes")
and disappear where even that changes nothing.

The lane split is the interesting case: it **is** pinned, but by
`check_test_lanes.py`, not by the sentence quoting it. Restating a gated number
in prose does not inherit its gate, so the doc now states the fact and names the
command.

## Where the rule lives

In the `docs-layers` skill, not the root `CLAUDE.md` - that file's own policy is
"if something here is also in a skill, the skill is the copy that gets
maintained". The first draft put it in `CLAUDE.md` and pushed it over its
2000-token budget, which is a fair verdict on adding prose about avoiding prose.

## Verification

Docs only. `bash scripts/ci_static_gates.sh` all groups pass; `make dev-test`
8/8; `docs_lint` clean of FAILs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvfZX6NNFLBksYyPFRSxPR