### PR TITLE
fix(server): OTLP tracing follow-ups from the Jaeger trial (non-stream queue/cached_tokens, sampled flag, /metrics counters, semconv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ there instead of retelling it.
   prefill / decode children and request ids, model and token counts as
   attributes, joined to the caller's W3C `traceparent`; the request JSONL
   carries the same `trace_id`. Closes roadmap gap 8; `tests/test_server_tracing.py`
-  is the collector-side gate in `make test-server`
+  is the collector-side gate in `make test-server`. Jaeger trial follow-ups:
+  non-streaming spans now carry `imp.queue_ms` / `imp.cached_tokens` (they read
+  fields nothing assigned), an unsampled `traceparent` (flags `00`) is not
+  exported, `gen_ai.operation.name` / `gen_ai.provider.name` / `http.route`
+  added and `gen_ai.response.finish_reasons` is a string array per semconv,
+  `/metrics` gains `imp_otlp_*` counters
 
 - Recurrent-snapshot host tier for hybrid prefix caching
   (`server.recurrent_snapshot_host_mb`, default 2048): snapshots evicted from

--- a/docs/API.md
+++ b/docs/API.md
@@ -303,10 +303,20 @@ exported as an OpenTelemetry span: a SERVER span named after the endpoint
 for streaming requests, where the first token is observed). A W3C
 `traceparent` request header puts the hop inside the caller's trace (its
 trace id, the caller's span as parent); without one a trace id is minted.
-The JSONL record carries the same `trace_id` / `span_id`. Export runs on a
-background thread in one-second batches; an unreachable collector costs one
-warning and dropped batches, never request latency. Service name:
-`server.otlp_service_name` (default `imp-server`).
+A header with the sampled flag clear (`...-00`) is honoured the way a
+parent-based sampler would: ids are minted, nothing is exported. The JSONL
+record carries the same `trace_id` / `span_id` either way. Only requests
+that reach generation are traced; a request refused before it (4xx, 429,
+503) emits no span. Export runs on a background thread in one-second
+batches; an unreachable collector costs one warning and dropped batches,
+never request latency (measured 2026-09-02 on Qwen3.8-27B: median request
+latency 113.6 ms with the collector up, 111.5 ms with it stopped). `/metrics`
+counts `imp_otlp_spans_exported_total`, `imp_otlp_export_failures_total`
+and `imp_otlp_unsampled_requests_total`. Service name:
+`server.otlp_service_name` (default `imp-server`). Verified against Jaeger
+v2.20 (OTLP/HTTP receiver, GenAI view) with an OpenTelemetry-SDK client:
+the hop lands under the client's span with `queue` / `prefill` / `decode`
+children on its timeline.
 
 ## Errors
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -586,8 +586,9 @@ recurrent_snapshot_host_mb = 2048
 # generation request becomes one SERVER span (queue / prefill / decode
 # children; model, token counts, finish reason, request ids as attributes),
 # joined to the caller's trace when the request carries a W3C traceparent
-# header. Export runs on a background thread; a dead collector costs one
-# warning, never latency. http:// only.
+# header (sampled flag clear = not exported). Export runs on a background
+# thread; a dead collector costs one warning, never latency. http:// only.
+# Counters: /metrics imp_otlp_*.
 otlp_endpoint = ""
 otlp_service_name = "imp-server"
 # Green Contexts / prefill-decode overlap streams in the server engine.

--- a/tests/test_server_tracing.py
+++ b/tests/test_server_tracing.py
@@ -60,21 +60,22 @@ def attrs(span):
     return d
 
 
-def chat(stream, trace_id, parent):
+def chat(stream, trace_id, parent, flags="01", rid=None):
     with urllib.request.urlopen(BASE + "/v1/models", timeout=30) as r:
         model = json.loads(r.read())["data"][0]["id"]
     body = json.dumps({"model": model, "messages": [{"role": "user", "content": "Say hello in five words."}],
                        "max_tokens": 16, "temperature": 0, "stream": stream}).encode()
     req = urllib.request.Request(BASE + "/v1/chat/completions", data=body,
                                  headers={"Content-Type": "application/json",
-                                          "X-Request-Id": f"trace-test-{'s' if stream else 'n'}",
-                                          "traceparent": f"00-{trace_id}-{parent}-01"})
+                                          "X-Request-Id": rid or f"trace-test-{'s' if stream else 'n'}",
+                                          "traceparent": f"00-{trace_id}-{parent}-{flags}"})
     with urllib.request.urlopen(req, timeout=120) as r:
         data = r.read()
     if not stream:
-        return json.loads(data)["id"]
+        d = json.loads(data)
+        return d["id"], d.get("usage", {}).get("prompt_tokens_details", {}).get("cached_tokens", 0)
     ids = [json.loads(l[5:]).get("id") for l in data.decode().splitlines() if l.startswith("data:") and "[DONE]" not in l]
-    return next(i for i in ids if i)
+    return next(i for i in ids if i), None
 
 
 def main():
@@ -82,8 +83,13 @@ def main():
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     tid_s, par_s = "4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7"
     tid_n, par_n = "1234567890abcdef1234567890abcdef", "fedcba9876543210"
-    id_s = chat(True, tid_s, par_s)
-    id_n = chat(False, tid_n, par_n)
+    tid_u, par_u = "0af7651916cd43dd8448eb211c80319c", "b7ad6b7169203331"
+    id_s, _ = chat(True, tid_s, par_s)
+    # The same prompt again: the prefix cache now hits, so the span's
+    # imp.cached_tokens has a non-zero value to agree with the API's usage.
+    id_n, cached_n = chat(False, tid_n, par_n)
+    # Sampled flag clear: the caller is not recording this trace, so no span.
+    chat(False, tid_u, par_u, flags="00", rid="trace-test-unsampled")
     deadline = time.time() + 15
     while time.time() < deadline:
         names = {s["traceId"] for s in spans()}
@@ -131,6 +137,10 @@ def main():
                       "prefill end != decode start")
         else:
             check("prefill" not in children, "non-stream request must not claim a prefill/decode split")
+            check("imp.queue_ms" in a, "non-stream root lacks imp.queue_ms (the engine queue wait)")
+            check(int(a.get("imp.cached_tokens", -1)) == cached_n,
+                  f"non-stream imp.cached_tokens {a.get('imp.cached_tokens')} != API cached_tokens {cached_n}")
+    check(tid_u not in by_trace, f"unsampled traceparent (flags 00) was exported: {len(by_trace.get(tid_u, []))} spans")
     srv.shutdown()
     if fails:
         print("FAIL:\n  " + "\n  ".join(fails))

--- a/tests/test_tracing.cpp
+++ b/tests/test_tracing.cpp
@@ -56,6 +56,28 @@ TEST(TracingTest, ParseTraceparentAcceptsOnlyWellFormedVersion00) {
     EXPECT_TRUE(untouched.trace_id.empty());
 }
 
+TEST(TracingTest, SampledFlagIsHonouredOnlyForWellFormedHeaders) {
+    EXPECT_TRUE(traceparent_sampled(""));
+    EXPECT_TRUE(traceparent_sampled("garbage"));
+    EXPECT_TRUE(traceparent_sampled("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"));
+    EXPECT_TRUE(traceparent_sampled("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03"));
+    EXPECT_FALSE(traceparent_sampled("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"));
+    EXPECT_FALSE(traceparent_sampled("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02"));
+    // Unsampled: ids are still minted for the JSONL join, nothing is queued.
+    Tracer t;
+    t.init("http://127.0.0.1:9/v1/traces", "imp-server", "0");
+    ASSERT_TRUE(t.enabled());
+    RequestSpan r = sample_request();
+    r.traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00";
+    const auto ids = t.record(r);
+    EXPECT_EQ(ids.first, "4bf92f3577b34da6a3ce929d0e0e4736");
+    EXPECT_EQ(ids.second.size(), 16u);
+    t.stop();
+    EXPECT_EQ(t.unsampled_requests(), 1u);
+    EXPECT_EQ(t.failed_batches(), 0u) << "nothing was queued, so nothing was posted to the dead port";
+    EXPECT_EQ(t.exported_spans(), 0u);
+}
+
 TEST(TracingTest, RandomIdsHaveTheRightWidthAndAreNeverZero) {
     for (int i = 0; i < 64; i++) {
         const std::string t = random_hex_id(16), s = random_hex_id(8);
@@ -158,6 +180,24 @@ TEST(TracingTest, OtlpJsonIsTheProto3MappingACollectorAccepts) {
     EXPECT_TRUE(saw_tokens);
     EXPECT_EQ(js[1]["parentSpanId"], "aaaaaaaaaaaaaaaa");
     EXPECT_FALSE(js[0].contains("parentSpanIdX"));
+    // GenAI / HTTP semantic conventions a backend's GenAI view keys on;
+    // finish_reasons is a string[] there, not a string.
+    json attrs;
+    for (const auto& a : root["attributes"])
+        attrs[a["key"].get<std::string>()] = a["value"];
+    EXPECT_EQ(attrs["gen_ai.operation.name"]["stringValue"], "chat");
+    EXPECT_EQ(attrs["gen_ai.provider.name"]["stringValue"], "imp");
+    EXPECT_EQ(attrs["http.request.method"]["stringValue"], "POST");
+    EXPECT_EQ(attrs["http.route"]["stringValue"], "chat.completions");
+    ASSERT_TRUE(attrs["gen_ai.response.finish_reasons"].contains("arrayValue"));
+    EXPECT_EQ(attrs["gen_ai.response.finish_reasons"]["arrayValue"]["values"][0]["stringValue"], "stop");
+    RequestSpan legacy = sample_request();
+    legacy.endpoint = "/v1/completions";
+    bool saw_text_completion = false;
+    for (const auto& [k, v] : spans_for_request(legacy)[0].str_attrs)
+        if (k == "gen_ai.operation.name" && v == "text_completion")
+            saw_text_completion = true;
+    EXPECT_TRUE(saw_text_completion);
 }
 
 TEST(TracingTest, TracerDisabledWithoutEndpointAndRefusesHttps) {

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -1175,12 +1175,14 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
     if (!choices.empty() && choices[0].contains("finish_reason") && choices[0]["finish_reason"].is_string()) {
         nonstream_finish = choices[0]["finish_reason"].get_ref<const std::string&>().c_str();
     }
-        ctx.trace.model = ctx.snap.model_name;
+    ctx.trace.model = ctx.snap.model_name;
     ctx.trace.stream = false;
-    if (ctx.server_req)
-        ctx.trace.queue_ms = ctx.server_req->queue_ms.load(std::memory_order_relaxed);
-    if (ctx.imp_req && ctx.imp_req->cached_tokens > 0)
-        ctx.trace.cached_tokens = ctx.imp_req->cached_tokens;
+    // The request objects are the parameters (the last completion's for
+    // n > 1), not context fields: nothing ever assigned those.
+    if (server_req)
+        ctx.trace.queue_ms = server_req->queue_ms.load(std::memory_order_relaxed);
+    if (imp_req && imp_req->cached_tokens > 0)
+        ctx.trace.cached_tokens = imp_req->cached_tokens;
     log_request_jsonl(state, ctx.log_skip, ctx.t_log_start, comp_id, ctx.log_endpoint, ctx.log_client_ip,
                       ctx.log_raw_body, ms, ctx.snap.n_prompt_tokens, total_output_tokens, nonstream_finish,
                       response, ctx.log_client_request_id, &ctx.trace);

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -176,8 +176,6 @@ struct ChatRequestContext {
     // (queue, first token); filled where the numbers become known.
     RequestSpan trace;
     bool log_skip = false;
-    std::shared_ptr<imp::Request> imp_req;
-    std::shared_ptr<ServerRequest> server_req;
 };
 
 // cache_creation_input_tokens (Anthropic): full prompt blocks newly written

--- a/tools/imp-server/handlers_messages.cpp
+++ b/tools/imp-server/handlers_messages.cpp
@@ -597,9 +597,11 @@ static void handle_messages_impl(const httplib::Request& req, httplib::Response&
         // shim_res): client id when sent, this dialect's message id otherwise.
         res.set_header("X-Request-Id",
                        log_client_request_id.empty() ? req_id : log_client_request_id);
-                RequestSpan trace;
+        RequestSpan trace;
         trace.traceparent = req.get_header_value("traceparent");
         trace.model = anth_response.value("model", std::string());
+        trace.cached_tokens =
+            anth_response.value("usage", json::object()).value("cache_read_input_tokens", 0);
         log_request_jsonl(state, /*skip=*/false, t_log_start, req_id, log_endpoint, log_client_ip,
                           log_raw_body, ms, prompt_t, completion_t,
                           stop_reason.empty() ? nullptr : stop_reason.c_str(), anth_response,

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -160,6 +160,16 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
     out += "# HELP imp_requests_failed_total Failed inference requests\n";
     out += "# TYPE imp_requests_failed_total counter\n";
     out += "imp_requests_failed_total " + std::to_string(m.requests_failed.load()) + "\n";
+    // OTLP span export (server.otlp_endpoint); all zero while it is off.
+    out += "# HELP imp_otlp_spans_exported_total Spans accepted by the OTLP collector\n";
+    out += "# TYPE imp_otlp_spans_exported_total counter\n";
+    out += "imp_otlp_spans_exported_total " + std::to_string(state.tracer.exported_spans()) + "\n";
+    out += "# HELP imp_otlp_export_failures_total OTLP batches the collector did not accept (spans dropped)\n";
+    out += "# TYPE imp_otlp_export_failures_total counter\n";
+    out += "imp_otlp_export_failures_total " + std::to_string(state.tracer.failed_batches()) + "\n";
+    out += "# HELP imp_otlp_unsampled_requests_total Requests whose traceparent cleared the sampled flag (not exported)\n";
+    out += "# TYPE imp_otlp_unsampled_requests_total counter\n";
+    out += "imp_otlp_unsampled_requests_total " + std::to_string(state.tracer.unsampled_requests()) + "\n";
 
     out += "# HELP imp_constrained_eager_fallback_total Constrained requests that requested "
            "logprobs and fell back from the ConstrainedPipeline to eager decode\n";

--- a/tools/imp-server/handlers_responses.cpp
+++ b/tools/imp-server/handlers_responses.cpp
@@ -470,9 +470,12 @@ void handle_responses(const httplib::Request& req, httplib::Response& res, Serve
         std::string status = response.value("status", "");
         res.set_header("X-Request-Id",
                        log_client_request_id.empty() ? response_id : log_client_request_id);
-                RequestSpan trace;
+        RequestSpan trace;
         trace.traceparent = req.get_header_value("traceparent");
         trace.model = req_model;
+        trace.cached_tokens = response.value("usage", json::object())
+                                  .value("input_tokens_details", json::object())
+                                  .value("cached_tokens", 0);
         log_request_jsonl(state, /*skip=*/false, t_log_start, response_id, log_endpoint,
                           log_client_ip, log_raw_body, ms, prompt_t, completion_t,
                           status.empty() ? nullptr : status.c_str(), response,

--- a/tools/imp-server/tracing.cpp
+++ b/tools/imp-server/tracing.cpp
@@ -39,6 +39,12 @@ json attr_int(const std::string& k, int64_t v) {
     return json{{"key", k}, {"value", json{{"intValue", std::to_string(v)}}}};
 }
 json attr_bool(const std::string& k, bool v) { return json{{"key", k}, {"value", json{{"boolValue", v}}}}; }
+json attr_str_array(const std::string& k, const std::vector<std::string>& vs) {
+    json values = json::array();
+    for (const auto& v : vs)
+        values.push_back(json{{"stringValue", v}});
+    return json{{"key", k}, {"value", json{{"arrayValue", json{{"values", values}}}}}};
+}
 
 }  // namespace
 
@@ -56,6 +62,11 @@ bool parse_traceparent(const std::string& header, TraceContext& ctx) {
     ctx.parent_id = pid;
     ctx.sampled = (std::stoi(flags, nullptr, 16) & 1) != 0;
     return true;
+}
+
+bool traceparent_sampled(const std::string& header) {
+    TraceContext ctx;
+    return header.empty() || !parse_traceparent(header, ctx) || ctx.sampled;
 }
 
 std::string random_hex_id(int n_bytes) {
@@ -95,13 +106,21 @@ std::vector<OtlpSpan> spans_for_request(const RequestSpan& r, const std::string&
         root.str_attrs.push_back({"imp.client_request_id", r.client_request_id});
     if (!r.model.empty())
         root.str_attrs.push_back({"gen_ai.request.model", r.model});
+    // GenAI semantic conventions: provider.name is the current key,
+    // gen_ai.system its predecessor (dashboards still key on it).
+    root.str_attrs.push_back({"gen_ai.provider.name", "imp"});
     root.str_attrs.push_back({"gen_ai.system", "imp"});
+    root.str_attrs.push_back(
+        {"gen_ai.operation.name", r.endpoint == "/v1/completions" ? "text_completion" : "chat"});
+    root.str_attrs.push_back({"http.request.method", "POST"});
+    if (!r.endpoint.empty())
+        root.str_attrs.push_back({"http.route", r.endpoint});
     root.int_attrs.push_back({"gen_ai.usage.input_tokens", r.prompt_tokens});
     root.int_attrs.push_back({"gen_ai.usage.output_tokens", r.completion_tokens});
     root.int_attrs.push_back({"imp.cached_tokens", r.cached_tokens});
     root.int_attrs.push_back({"http.response.status_code", r.http_status});
-    if (!r.finish_reason.empty())
-        root.str_attrs.push_back({"gen_ai.response.finish_reasons", r.finish_reason});
+    if (!r.finish_reason.empty())  // semconv: string[] (one per choice)
+        root.str_array_attrs.push_back({"gen_ai.response.finish_reasons", {r.finish_reason}});
     root.bool_attrs.push_back({"imp.stream", r.stream});
     if (r.queue_ms >= 0)
         root.int_attrs.push_back({"imp.queue_ms", static_cast<int64_t>(r.queue_ms)});
@@ -158,6 +177,8 @@ std::string otlp_json(const std::vector<OtlpSpan>& spans, const std::string& ser
             attrs.push_back(attr_int(k, v));
         for (const auto& [k, v] : s.bool_attrs)
             attrs.push_back(attr_bool(k, v));
+        for (const auto& [k, v] : s.str_array_attrs)
+            attrs.push_back(attr_str_array(k, v));
         js["attributes"] = attrs;
         jspans.push_back(js);
     }
@@ -201,6 +222,12 @@ std::pair<std::string, std::string> Tracer::record(const RequestSpan& r) {
         return {};
     auto spans = spans_for_request(r);
     const std::pair<std::string, std::string> ids{spans[0].trace_id, spans[0].span_id};
+    if (!traceparent_sampled(r.traceparent)) {
+        // The caller's trace is not being recorded; our hop would be an
+        // orphan in the backend. Ids still go to the JSONL for the join.
+        unsampled_requests_++;
+        return ids;
+    }
     {
         std::lock_guard<std::mutex> lk(mu_);
         for (auto& s : spans)

--- a/tools/imp-server/tracing.h
+++ b/tools/imp-server/tracing.h
@@ -30,6 +30,11 @@ struct TraceContext {
 // version-00 header with non-zero ids.
 bool parse_traceparent(const std::string& header, TraceContext& ctx);
 
+// False only for a well-formed traceparent whose sampled flag is clear: the
+// caller decided not to record this trace, so an exported hop would dangle
+// (parent-based sampling). Empty or malformed headers count as sampled.
+bool traceparent_sampled(const std::string& header);
+
 // What a request hands to the tracer at accounting time. Times are
 // system_clock (unix epoch) so the spans line up with other services.
 struct RequestSpan {
@@ -59,6 +64,7 @@ struct OtlpSpan {
     std::vector<std::pair<std::string, std::string>> str_attrs;
     std::vector<std::pair<std::string, int64_t>> int_attrs;
     std::vector<std::pair<std::string, bool>> bool_attrs;
+    std::vector<std::pair<std::string, std::vector<std::string>>> str_array_attrs;
 };
 
 std::string random_hex_id(int n_bytes);  // 8 -> span id, 16 -> trace id
@@ -83,12 +89,14 @@ public:
               const std::string& service_version);
     bool enabled() const { return enabled_; }
     // Returns the root span's ids (trace_id, span_id) so the caller can
-    // write them next to the request log record.
+    // write them next to the request log record. A request whose traceparent
+    // clears the sampled flag gets ids but is not exported.
     std::pair<std::string, std::string> record(const RequestSpan& r);
     void stop();
-    // Counters for /metrics and tests.
+    // Counters for /metrics (imp_otlp_*) and tests.
     uint64_t exported_spans() const { return exported_spans_; }
     uint64_t failed_batches() const { return failed_batches_; }
+    uint64_t unsampled_requests() const { return unsampled_requests_; }
 
 private:
     void worker_();
@@ -103,5 +111,6 @@ private:
     std::thread thread_;
     std::atomic<uint64_t> exported_spans_{0};
     std::atomic<uint64_t> failed_batches_{0};
+    std::atomic<uint64_t> unsampled_requests_{0};
     bool warned_ = false;
 };


### PR DESCRIPTION
## Trial of #1855 against a real collector

Jaeger v2.20 (`jaegertracing/jaeger:latest`, OTLP/HTTP receiver) + an OpenTelemetry-SDK Python client (`requests` auto-instrumentation) against imp-server on Qwen3.8-27B-NVFP4-vllm, 2026-09-02.

| scenario | result |
|---|---|
| stream chat under a client span | joined: client `POST` -> `imp-server /v1/chat/completions` (1186.1 ms) -> `queue` 0 / `prefill` 210.7 / `decode` 975.4 ms, 88 output tokens; Jaeger GenAI view renders it |
| 8 concurrent streams (one parent) | 8 server spans under 8 client spans, queue 7-12 ms, the 8 `prefill` children end at the same +200.4 ms (one ragged forward), decode 1.34-1.40 s |
| `/v1/messages` stream, `/v1/responses` | exactly one span each (no shim double-count), children on the messages stream |
| client aborts mid-stream | span exported, `finish_reasons=cancelled`, 5 output tokens, 75 ms |
| collector stopped | median request latency 113.6 ms (up) / 111.5, 110.2 (down) / 111.2 (back); one warning; spans after restart arrive |
| SIGTERM right after a request | pending span flushed and received |
| uppercase-hex traceparent | rejected per W3C, trace id minted |
| rejected requests (404 model, 400 body) | no span (now documented) |

## Defects found and fixed

| | before | after |
|---|---|---|
| non-stream `imp.cached_tokens` (API usage said 32) | 0 | 32 |
| non-stream `imp.queue_ms` / `queue` child | absent (`ctx.server_req` / `ctx.imp_req` were fields nothing assigned) | present |
| `traceparent ...-00` (sampled flag clear) | exported (orphan in the backend) | not exported, `imp_otlp_unsampled_requests_total` +1, ids still in the JSONL |
| `/metrics` | no tracing counters (the header claimed them) | `imp_otlp_spans_exported_total`, `imp_otlp_export_failures_total`, `imp_otlp_unsampled_requests_total` |
| semconv | `gen_ai.system` only, `finish_reasons` a string | + `gen_ai.operation.name`, `gen_ai.provider.name`, `http.request.method`, `http.route`; `finish_reasons` a string array |
| `/v1/messages`, `/v1/responses` non-stream `imp.cached_tokens` | 0 | from the response usage |

Dead fields `ChatRequestContext::imp_req` / `server_req` removed (nothing assigned them since #784).

## Tests

- `TracingTest.SampledFlagIsHonouredOnlyForWellFormedHeaders` (new), semconv/array assertions in `OtlpJsonIsTheProto3MappingACollectorAccepts`: 7/7 pass (`make dev-test`).
- `tests/test_server_tracing.py` extended: non-stream `imp.queue_ms` present, `imp.cached_tokens` == API `cached_tokens`, unsampled request not exported. Against the `imp:test` main binary: FAIL 3/3 (those three). Against this build: `PASS: 6 spans across 2 traces`.
- Static gates docs / citations / filesize: pass. clang-format: no violations on added lines.

## Gate

```
verify: started 09:06:46Z (fast)
SKIP build (IMP_VERIFY_SKIP_BUILD=1)   (image built by make build 6 min earlier, binary carries imp_otlp_*)
PASS fast gtest filter
SKIP perf gate (no src/ change; hook drops it)
  own peak VRAM = 20738 MiB  (baseline 20716, delta 0.11%)
PASS peak VRAM within 10% of baseline
  graphs OFF tg256 =  178.36 tok/s
  graphs ON  tg256 =  467.76 tok/s   (2.62x, threshold 1.3x)
PASS graphs ON delivers >=1.3x decode speedup
PASS Qwen3-4B Q8_0 (dense) (distinct=11, tokens=11, max-run=1, max-3gram=1, contains 'Paris')
=== verify fast: OK === (started 09:06:46Z, ended 09:07:07Z)
```

Not in here: spans for requests rejected before generation (4xx/429/503), a `traceresponse` header for callers without a traceparent, OTLP/gRPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW5AcHYTFe4TbgzctmGMhx
