### PR TITLE
test(kv): the other 43 accounting tests leave the GPU lane (62 skips -> 19)

### DIFF
--- a/docs/audit/MUTATION_BASELINE.md
+++ b/docs/audit/MUTATION_BASELINE.md
@@ -168,6 +168,19 @@ one per fault:
 survivor left is M25, the equivalent mutant. `ctest -L unit` went 1624 -> 1629
 macros; the unlaned pin (1054) is unchanged.
 
+The same day the rest of the class followed: `MakeManager()` in
+`test_kv_cache.cpp` builds an accounting cache, so 43 more tests execute in the
+CI lane instead of skipping. **test-core without a GPU: 62 skipped -> 19**, and
+the surviving skips are exactly the tests that read or write KV bytes, drive the
+SWA groups or persist the cache. Four kvcache mutants are now caught by the
+tests written for them rather than by a neighbour: M37 and M39 by
+`PrefixCachingWithPartialLastBlock`, M41 and M42 by
+`EvictMiddleBlocksKeepsSinksAndWindow`.
+
+Note for the next reader: `check_test_lanes.py` counts MACROS per binary, not
+executions, so a test that skips at runtime still reads as "in a CI lane". The
+skip count above is the honest figure for what the merge gate exercises.
+
 ## Method notes that changed a result
 
 * **Cheap-first, full-before-survival.** A mutant is KILLED as soon as any lane

--- a/src/memory/kv_cache.cu
+++ b/src/memory/kv_cache.cu
@@ -129,6 +129,22 @@ KVCache::KVCache(AccountingOnly, int n_layers, int n_kv_heads, int head_dim, QTy
                        ? (static_cast<size_t>(block_size) * n_kv_heads * head_dim / 2)
                        : (static_cast<size_t>(block_size) * n_kv_heads * head_dim * dtype_size(dtype))),
       accounting_only_(true) {
+    // Geometry, including the checks: scale_block_bytes_ is arithmetic on the
+    // shape and the manager reads it, and the NVFP4 head_dim rule is a
+    // constraint on the shape rather than on the allocation. Leaving either out
+    // would make this cache disagree with a real one about what it is.
+    const bool needs_scales = (dtype == QType::INT8 || dtype == QType::INT4 ||
+                               dtype == QType::NVFP4 || dtype == QType::MXFP4_KV);
+    if (needs_scales) {
+        if (dtype == QType::NVFP4 || dtype == QType::MXFP4_KV) {
+            if (head_dim % kNVFP4Group != 0)
+                throw std::runtime_error("KVCache NVFP4: head_dim must be a multiple of 16");
+            scale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * (head_dim / kNVFP4Group);
+        } else {
+            scale_block_bytes_ = static_cast<size_t>(block_size_) * n_kv_heads * sizeof(half);
+        }
+    }
+
     // Same two lines the memory-backed constructor ends with, and nothing else:
     // open_slots() is documented as the mode where the caller owns the memory,
     // so the id space and refcounts are already independent of the pool.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -9,8 +9,7 @@ commit: 01799405
 
 **Most GTest macros in this tree run in no CI lane at all** - they need a GPU,
 and there is no GPU runner. `python3 tools/check_test_lanes.py --report` prints
-the split and pins it; this file does not repeat it, because a copy here is a
-second number nothing checks.
+the split and pins it (macros, not executions).
 
 ## Invariants
 
@@ -19,13 +18,9 @@ second number nothing checks.
   there is not green in CI.
 - **New CPU tests go to test-core**, and must be added to the explicit source
   list in `CMakeLists.txt`.
-- **A test that only needs bookkeeping must not build a pool.** `MakeManager()`
-  in `test_kv_cache.cpp` uses `KVCache::for_accounting()` (block ids, free list,
-  ref counts, geometry, no VRAM) so it runs in the CI lane;
-  `MakeManagerWithMemory()` is for the 12 that read or write KV bytes, drive the
-  SWA groups or persist the cache, and those keep `SKIP_IF_NO_CUDA()`. A data
-  pointer on an accounting cache aborts, so a test that needs bytes says so
-  loudly instead of reading a null offset.
+- **Bookkeeping tests must not build a pool.** `MakeManager()` is
+  accounting-only and runs in CI; `MakeManagerWithMemory()` is for the 12 that
+  touch bytes, SWA or persistence.
 - **A green test proves nothing until it has been mutation-validated.** Break the
   code the test claims to cover and confirm the test fails. This is the standard
   here, not an extra.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -19,6 +19,13 @@ second number nothing checks.
   there is not green in CI.
 - **New CPU tests go to test-core**, and must be added to the explicit source
   list in `CMakeLists.txt`.
+- **A test that only needs bookkeeping must not build a pool.** `MakeManager()`
+  in `test_kv_cache.cpp` uses `KVCache::for_accounting()` (block ids, free list,
+  ref counts, geometry, no VRAM) so it runs in the CI lane;
+  `MakeManagerWithMemory()` is for the 12 that read or write KV bytes, drive the
+  SWA groups or persist the cache, and those keep `SKIP_IF_NO_CUDA()`. A data
+  pointer on an accounting cache aborts, so a test that needs bytes says so
+  loudly instead of reading a null offset.
 - **A green test proves nothing until it has been mutation-validated.** Break the
   code the test claims to cover and confirm the test fails. This is the standard
   here, not an extra.

--- a/tests/test_kv_cache.cpp
+++ b/tests/test_kv_cache.cpp
@@ -23,15 +23,36 @@ namespace {
 // ============================================================================
 
 // 7. KVCacheConstruction
-TEST(KVCacheTest, KVCacheConstruction) {
-    SKIP_IF_NO_CUDA();
+// Manager over an accounting-only cache: block ids, free list, ref counts and
+// geometry, no VRAM (KVCache::for_accounting). Everything the manager tests
+// assert - allocation, eviction, the prefix hash table, pinning, rollback - is
+// that bookkeeping, and it was gated on a device only because the cache
+// allocated a pool. Mutation testing on 2026-09-02 priced that: four real
+// faults in this exact layer were caught by test-kv and invisible to
+// `ctest -L unit`, the only suite CI runs.
+static std::unique_ptr<KVCacheManager> MakeManager(int max_blocks, int n_layers = 2, int n_kv_heads = 4,
+                                                   int head_dim = 64, QType dtype = QType::F16) {
+    auto cache = KVCache::for_accounting(n_layers, n_kv_heads, head_dim, dtype, max_blocks);
+    return std::make_unique<KVCacheManager>(std::move(cache));
+}
 
+// Manager over a real pool, for tests that read or write KV bytes, drive the
+// SWA groups, or persist the cache. Those keep SKIP_IF_NO_CUDA().
+static std::unique_ptr<KVCacheManager> MakeManagerWithMemory(int max_blocks, int n_layers = 2,
+                                                             int n_kv_heads = 4, int head_dim = 64,
+                                                             QType dtype = QType::F16) {
+    auto cache = std::make_unique<KVCache>(n_layers, n_kv_heads, head_dim, dtype, max_blocks);
+    return std::make_unique<KVCacheManager>(std::move(cache));
+}
+
+TEST(KVCacheTest, KVCacheConstruction) {
     const int n_layers = 2;
     const int n_kv_heads = 4;
     const int head_dim = 64;
     const int max_blocks = 8;
 
-    KVCache cache(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
+    auto cache_owner = KVCache::for_accounting(n_layers, n_kv_heads, head_dim, QType::F16, max_blocks);
+    KVCache& cache = *cache_owner;
 
     EXPECT_EQ(cache.n_layers(), n_layers);
     EXPECT_EQ(cache.n_kv_heads(), n_kv_heads);
@@ -50,10 +71,9 @@ TEST(KVCacheTest, KVCacheConstruction) {
 
 // 8. KVCacheBlockAllocation
 TEST(KVCacheTest, KVCacheBlockAllocation) {
-    SKIP_IF_NO_CUDA();
-
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, QType::F16, max_blocks);
+    auto cache_owner = KVCache::for_accounting(2, 4, 64, QType::F16, max_blocks);
+    KVCache& cache = *cache_owner;
 
     // Allocate all 8 blocks and verify IDs are 0..7 in order.
     std::vector<int> ids;
@@ -75,10 +95,9 @@ TEST(KVCacheTest, KVCacheBlockAllocation) {
 
 // 9. KVCacheBlockFree
 TEST(KVCacheTest, KVCacheBlockFree) {
-    SKIP_IF_NO_CUDA();
-
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, QType::F16, max_blocks);
+    auto cache_owner = KVCache::for_accounting(2, 4, 64, QType::F16, max_blocks);
+    KVCache& cache = *cache_owner;
 
     // Allocate 4 blocks.
     std::vector<int> ids;
@@ -100,10 +119,9 @@ TEST(KVCacheTest, KVCacheBlockFree) {
 
 // 10. KVCacheRefCounting
 TEST(KVCacheTest, KVCacheRefCounting) {
-    SKIP_IF_NO_CUDA();
-
     const int max_blocks = 8;
-    KVCache cache(2, 4, 64, QType::F16, max_blocks);
+    auto cache_owner = KVCache::for_accounting(2, 4, 64, QType::F16, max_blocks);
+    KVCache& cache = *cache_owner;
 
     int block = cache.allocate_block();
     ASSERT_GE(block, 0);
@@ -307,8 +325,8 @@ TEST(KVCacheTest, KVCacheNVFP4Layout) {
 
 // 13b. NVFP4 head_dim that is not a multiple of 16 must fail with a clear error.
 TEST(KVCacheTest, KVCacheNVFP4HeadDimReject) {
-    SKIP_IF_NO_CUDA();
-    EXPECT_THROW({ KVCache cache(1, 4, 24, QType::NVFP4, 2); }, std::runtime_error);
+    EXPECT_THROW({ (void)KVCache::for_accounting(1, 4, 24, QType::NVFP4, 2); },
+                 std::runtime_error);
 }
 
 // 13c. NVFP4 per-layer constructor (Gemma 4 dual head_dim 256 SWA / 512 global).
@@ -338,17 +356,9 @@ TEST(KVCacheTest, KVCacheNVFP4PerLayer) {
     }
 }
 
-// Helper to create a KVCacheManager wrapping a fresh KVCache.
-static std::unique_ptr<KVCacheManager> MakeManager(int max_blocks, int n_layers = 2, int n_kv_heads = 4,
-                                                   int head_dim = 64, QType dtype = QType::F16) {
-    auto cache = std::make_unique<KVCache>(n_layers, n_kv_heads, head_dim, dtype, max_blocks);
-    return std::make_unique<KVCacheManager>(std::move(cache));
-}
 
 // 13. ManagerAllocateBlocks
 TEST(KVCacheManagerTest, ManagerAllocateBlocks) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     bool ok = mgr->allocate_blocks(/*seq_id=*/0, /*num_blocks=*/4);
@@ -363,8 +373,6 @@ TEST(KVCacheManagerTest, ManagerAllocateBlocks) {
 
 // 14. ManagerAllocateRollback
 TEST(KVCacheManagerTest, ManagerAllocateRollback) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     // First sequence takes 10 blocks -- should succeed.
@@ -391,8 +399,6 @@ TEST(KVCacheManagerTest, ManagerAllocateRollback) {
 
 // 15. ManagerAppendBlock
 TEST(KVCacheManagerTest, ManagerAppendBlock) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     (void)mgr->allocate_blocks(0, 2);
@@ -408,8 +414,6 @@ TEST(KVCacheManagerTest, ManagerAppendBlock) {
 
 // 16. ManagerFreeSequence
 TEST(KVCacheManagerTest, ManagerFreeSequence) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     (void)mgr->allocate_blocks(0, 4);
@@ -424,8 +428,6 @@ TEST(KVCacheManagerTest, ManagerFreeSequence) {
 
 // 17. ManagerLRUEviction
 TEST(KVCacheManagerTest, ManagerLRUEviction) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     // Fill the entire pool across three sequences.
@@ -458,8 +460,6 @@ TEST(KVCacheManagerTest, ManagerLRUEviction) {
 // only, then fail — the engine reject-newests on that failure rather than
 // preempting a live sequence. This locks the invariant the fix depends on.
 TEST(KVCacheManagerTest, AllocationNeverEvictsLiveSequenceUnderPressure) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
     (void)mgr->allocate_blocks(0, 5);  // seq 0: 5 live blocks
     (void)mgr->allocate_blocks(1, 3);  // seq 1: 3 live blocks -> pool full
@@ -485,8 +485,6 @@ TEST(KVCacheManagerTest, AllocationNeverEvictsLiveSequenceUnderPressure) {
 // KV corrupts it. So this test used to assert that a full pool could still
 // allocate 8 more blocks.
 TEST(KVCacheManagerTest, ManagerCanAllocate) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     (void)mgr->allocate_blocks(0, 4);
@@ -509,8 +507,6 @@ TEST(KVCacheManagerTest, ManagerCanAllocate) {
 
 // 18b. A reservation is subtracted until the blocks are actually written.
 TEST(KVCacheManagerTest, DecodeReservationHoldsUnwrittenBlocks) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     ASSERT_TRUE(mgr->allocate_blocks(0, 2));
@@ -597,8 +593,6 @@ TEST(KVCacheManagerTest, BlockHashDiscriminatesEveryTokenPosition) {
 
 // 22. ContentAddressedPrefixCaching
 TEST(KVCacheManagerTest, ContentAddressedPrefixCaching) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(32);
     mgr->set_prefix_caching_enabled(true);
     EXPECT_TRUE(mgr->prefix_caching_enabled());
@@ -648,7 +642,7 @@ TEST(KVCacheManagerTest, PersistedCacheFingerprintGate) {
 
     // Produce 3 cached blocks and persist them under fingerprint A.
     {
-        auto mgr = MakeManager(32);
+        auto mgr = MakeManagerWithMemory(32);
         mgr->set_prefix_caching_enabled(true);
         std::vector<int32_t> tokens(48);
         std::iota(tokens.begin(), tokens.end(), 100);
@@ -661,14 +655,14 @@ TEST(KVCacheManagerTest, PersistedCacheFingerprintGate) {
 
     // Matching fingerprint → blocks restored.
     {
-        auto mgr = MakeManager(32);
+        auto mgr = MakeManagerWithMemory(32);
         mgr->set_prefix_caching_enabled(true);
         EXPECT_EQ(mgr->load_prefix_cache(path, kFpA), 3);
     }
 
     // Mismatched fingerprint (identical geometry) → rejected, nothing restored.
     {
-        auto mgr = MakeManager(32);
+        auto mgr = MakeManagerWithMemory(32);
         mgr->set_prefix_caching_enabled(true);
         EXPECT_LT(mgr->load_prefix_cache(path, kFpB), 0);
         EXPECT_EQ(mgr->num_cached_blocks(), 0);
@@ -679,8 +673,6 @@ TEST(KVCacheManagerTest, PersistedCacheFingerprintGate) {
 
 // 23. PrefixCachingPartialMatch
 TEST(KVCacheManagerTest, PrefixCachingPartialMatch) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(32);
     mgr->set_prefix_caching_enabled(true);
 
@@ -714,8 +706,6 @@ TEST(KVCacheManagerTest, PrefixCachingPartialMatch) {
 
 // 24. CachedBlockEviction
 TEST(KVCacheManagerTest, CachedBlockEviction) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);  // Small pool to force eviction.
     mgr->set_prefix_caching_enabled(true);
 
@@ -745,8 +735,6 @@ TEST(KVCacheManagerTest, CachedBlockEviction) {
 
 // 25. PrefixCachingDisabled
 TEST(KVCacheManagerTest, PrefixCachingDisabled) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     EXPECT_FALSE(mgr->prefix_caching_enabled());  // Off by default.
 
@@ -767,8 +755,6 @@ TEST(KVCacheManagerTest, PrefixCachingDisabled) {
 
 // 26. PrefixCachingWithPartialLastBlock
 TEST(KVCacheManagerTest, PrefixCachingWithPartialLastBlock) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -801,8 +787,6 @@ TEST(KVCacheManagerTest, PrefixCachingWithPartialLastBlock) {
 
 // 27. PinnedBlocksSurviveEviction
 TEST(KVCacheManagerTest, PinnedBlocksSurviveEviction) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     // Seq 0: 3 blocks, seq 1: 3 blocks, seq 2: 2 blocks.
@@ -839,8 +823,6 @@ TEST(KVCacheManagerTest, PinnedBlocksSurviveEviction) {
 
 // 28. PinnedBlocksSurviveFreeSequence
 TEST(KVCacheManagerTest, PinnedBlocksSurviveFreeSequence) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     (void)mgr->allocate_blocks(0, 4);
@@ -872,8 +854,6 @@ TEST(KVCacheManagerTest, PinnedBlocksSurviveFreeSequence) {
 
 // 29. UnpinAllowsEviction
 TEST(KVCacheManagerTest, UnpinAllowsEviction) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
     mgr->set_prefix_caching_enabled(true);
 
@@ -908,8 +888,6 @@ TEST(KVCacheManagerTest, UnpinAllowsEviction) {
 
 // 30. PinPrefixCanAllocateAccuracy
 TEST(KVCacheManagerTest, PinPrefixCanAllocateAccuracy) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     (void)mgr->allocate_blocks(0, 4);
@@ -967,8 +945,6 @@ TEST(KVCacheManagerTest, HashChainingDistinguishesPosition) {
 
 // 33. Cached block LRU eviction order: earlier-freed blocks evicted first
 TEST(KVCacheManagerTest, CachedBlockLRUEvictionOrder) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(6);  // 6 blocks total
     mgr->set_prefix_caching_enabled(true);
 
@@ -1008,8 +984,6 @@ TEST(KVCacheManagerTest, CachedBlockLRUEvictionOrder) {
 
 // 34. Three sequences with overlapping prefixes of different lengths
 TEST(KVCacheManagerTest, ThreeSequencesOverlappingPrefixes) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1048,8 +1022,6 @@ TEST(KVCacheManagerTest, ThreeSequencesOverlappingPrefixes) {
 
 // 35. Pool exhaustion during allocate_blocks_with_prefix
 TEST(KVCacheManagerTest, PrefixAllocPoolExhaustion) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(3);  // Only 3 blocks total
     mgr->set_prefix_caching_enabled(true);
 
@@ -1067,8 +1039,6 @@ TEST(KVCacheManagerTest, PrefixAllocPoolExhaustion) {
 
 // 36. Rollback then re-prefill reuses cached prefix
 TEST(KVCacheManagerTest, RollbackThenReusePrefix) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1098,8 +1068,6 @@ TEST(KVCacheManagerTest, RollbackThenReusePrefix) {
 
 // 37. Re-registering block hashes for same sequence is idempotent
 TEST(KVCacheManagerTest, DoubleRegisterBlockHashes) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1124,8 +1092,6 @@ TEST(KVCacheManagerTest, DoubleRegisterBlockHashes) {
 
 // 38. Evict all cached blocks then verify pool is fully free
 TEST(KVCacheManagerTest, EvictAllCachedBlocksPoolIntegrity) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1160,8 +1126,6 @@ TEST(KVCacheManagerTest, EvictAllCachedBlocksPoolIntegrity) {
 // baseline — any monotonic drift in free/cached/reclaimable/active counters is
 // a leak or double-free in the block bookkeeping.
 TEST(KVCacheManagerTest, LeakUnderSustainedChurn) {
-    SKIP_IF_NO_CUDA();
-
     constexpr int kPoolBlocks = 32;
     constexpr int kCycles = 200;
     auto mgr = MakeManager(kPoolBlocks);
@@ -1211,8 +1175,6 @@ TEST(KVCacheManagerTest, LeakUnderSustainedChurn) {
 
 // 39. AllocateAtCapacity — exhaust the pool, verify next allocate returns false
 TEST(KVCacheManagerTest, AllocateAtCapacity) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     // Fill the entire pool.
@@ -1233,8 +1195,6 @@ TEST(KVCacheManagerTest, AllocateAtCapacity) {
 
 // 40. AllocateFreeAllocate — fill pool, free, reallocate (block recycling)
 TEST(KVCacheManagerTest, AllocateFreeAllocate) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     // Fill the pool entirely.
@@ -1257,8 +1217,6 @@ TEST(KVCacheManagerTest, AllocateFreeAllocate) {
 
 // 41. EvictionUnderPressure — third sequence triggers eviction of oldest unused
 TEST(KVCacheManagerTest, EvictionUnderPressure) {
-    SKIP_IF_NO_CUDA();
-
     // Pool fits only 2 sequences worth of blocks (4 + 4 = 8).
     auto mgr = MakeManager(8);
 
@@ -1288,8 +1246,6 @@ TEST(KVCacheManagerTest, EvictionUnderPressure) {
 
 // 42. ZeroBlocks — allocating 0 blocks is a no-op, no crash
 TEST(KVCacheManagerTest, ZeroBlocks) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(8);
 
     bool ok = mgr->allocate_blocks(0, 0);
@@ -1300,8 +1256,6 @@ TEST(KVCacheManagerTest, ZeroBlocks) {
 
 // 43. SequenceIdReuse — free seq id=0, then reuse id=0 with fresh state
 TEST(KVCacheManagerTest, SequenceIdReuse) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
 
     // Allocate seq 0 with 4 blocks.
@@ -1326,8 +1280,6 @@ TEST(KVCacheManagerTest, SequenceIdReuse) {
 
 // 44. EvictMiddleBlocksKeepsSinksAndWindow — StreamingLLM smart KV cache.
 TEST(KVCacheManagerTest, EvictMiddleBlocksKeepsSinksAndWindow) {
-    SKIP_IF_NO_CUDA();
-
     // 32 total blocks, default block_size = 16 tokens => 512-token capacity.
     auto mgr = MakeManager(32);
 
@@ -1374,8 +1326,6 @@ TEST(KVCacheManagerTest, EvictMiddleBlocksKeepsSinksAndWindow) {
 
 // 45. EvictMiddleBlocksNoOpWhenSinksExceedSequence — short sequences untouched.
 TEST(KVCacheManagerTest, EvictMiddleBlocksNoOpWhenShort) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     ASSERT_TRUE(mgr->allocate_blocks(0, 3));  // only 48 tokens
     int free_before = mgr->num_free_blocks();
@@ -1392,8 +1342,6 @@ TEST(KVCacheManagerTest, EvictMiddleBlocksNoOpWhenShort) {
 
 // 46. EvictMiddleBlocksRejectsZeroOrNegativeArgs.
 TEST(KVCacheManagerTest, EvictMiddleBlocksZeroArgsAreNoOp) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     ASSERT_TRUE(mgr->allocate_blocks(0, 8));
 
@@ -1429,8 +1377,6 @@ static void MakePinnedFreedSeq(KVCacheManager* mgr, int seq_id, int n_full_block
 // path reconstructed pinned_blocks_ from seq_blocks_, which free_sequence
 // erases — so every freed owner's pins silently vanished.)
 TEST(KVCacheManagerTest, UnpinFreedSeqKeepsOtherFreedSeqPins) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1453,8 +1399,6 @@ TEST(KVCacheManagerTest, UnpinFreedSeqKeepsOtherFreedSeqPins) {
 // oldest owner first; its blocks degrade to normal (reclaimable) cached
 // blocks instead of leaking pinned VRAM.
 TEST(KVCacheManagerTest, PinBudgetEvictsOldestPinFifo) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
     mgr->set_pin_budget_blocks(4);
@@ -1477,8 +1421,6 @@ TEST(KVCacheManagerTest, PinBudgetEvictsOldestPinFifo) {
 // 49. PinLargerThanBudgetIsCappedAndEvictsAll — a single pin larger than the
 // whole budget caps to the budget after evicting every older pin.
 TEST(KVCacheManagerTest, PinLargerThanBudgetIsCapped) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
     mgr->set_pin_budget_blocks(3);
@@ -1494,8 +1436,6 @@ TEST(KVCacheManagerTest, PinLargerThanBudgetIsCapped) {
 // 50. RePinSameSeqReplaces — re-pinning the same owner replaces its pin set
 // (no accumulation); one unpin releases everything.
 TEST(KVCacheManagerTest, RePinSameSeqReplaces) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1518,8 +1458,6 @@ TEST(KVCacheManagerTest, RePinSameSeqReplaces) {
 // physical prefix blocks (cache-hit reuse): unpinning one owner must keep
 // the shared blocks pinned for the other.
 TEST(KVCacheManagerTest, SharedPinnedBlockSurvivesUnpinOfOneOwner) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(16);
     mgr->set_prefix_caching_enabled(true);
 
@@ -1552,7 +1490,7 @@ TEST(KVCacheManagerTest, SharedPinnedBlockSurvivesUnpinOfOneOwner) {
 TEST(KVCacheManagerTest, CacheHitOnCachedBlockKeepsReclaimableCountExact) {
     SKIP_IF_NO_CUDA();
 
-    auto mgr = MakeManager(4);
+    auto mgr = MakeManagerWithMemory(4);
     mgr->set_prefix_caching_enabled(true);
 
     // Seq 0: 2 full blocks, cached on free (2 reclaimable).
@@ -1858,8 +1796,6 @@ TEST(KVCacheManagerTest, SwaSnapshotRestoreExhaustionRollsBack) {
 // illegal memory access on a full-VRAM card, silent garbage attention
 // otherwise). The eviction must keep one extra boundary block.
 TEST(KVCacheManagerTest, EvictMiddleBlocksRetainsKernelWindowStart) {
-    SKIP_IF_NO_CUDA();
-
     auto mgr = MakeManager(64);
     const int bs = mgr->kv_cache()->block_size();
     const int n_sinks = 4;            // < bs → sinks live in block 0

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -91,6 +91,6 @@ roots = ["src", "tools", "tests"]
 "src/runtime/engine_scheduler.cpp" = { code_loc = 1304, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
 "tests/test_gdn.cu" = { code_loc = 1399, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
-"tests/test_kv_cache.cpp" = { code_loc = 1184, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }
+"tests/test_kv_cache.cpp" = { code_loc = 1152, reason = "(c) 60 tests across KV allocator/cache/manager - one test target" }
 "tests/test_paged_attention.cu" = { code_loc = 1202, reason = "(c) 26 tests of the paged-attention kernel - one test target" }
 "tests/test_quant_integration.cu" = { code_loc = 1470, reason = "(c) 25 tests, all exercising the quant_gemm/dequant unit - one test target" }


### PR DESCRIPTION
Follow-up to #1860, which built `KVCache::for_accounting()` and took the four tests the merge gate was proven blind to. This takes the rest of the class.

## What moved

`MakeManager()` in `test_kv_cache.cpp` now builds an accounting cache, so every manager test that asserts bookkeeping runs in `ctest -L unit`: allocation, rollback, LRU order, the prefix hash table, pinning and the pin budget, sequence lifetime, capacity edges. `MakeManagerWithMemory()` serves the 12 that read or write KV bytes, drive the SWA groups or persist the cache; those keep `SKIP_IF_NO_CUDA()`. Five that construct a `KVCache` directly (construction, block allocation, free, refcounting, the NVFP4 head_dim rejection) build an accounting cache instead.

| | before | after |
|---|---|---|
| **test-core without a GPU: skipped** | **62** | **19** |
| test-core without a GPU: passed | 1258 | 1306 |
| test-core with a GPU, `KVCache*`/`KVAccounting*` | 65 pass | 65 pass |

The 19 that still skip are the honest remainder: KV byte reads/writes, the NVFP4 memory layout, the SWA snapshot round-trips, cache persistence.

## The constructor had to learn the geometry

The accounting constructor now also computes `scale_block_bytes_` and enforces the NVFP4 `head_dim % 16` rule, with the same condition as the memory-backed one (checked identical by parsing both out of the file). The manager reads that field in four places; a cache that disagreed with a real one about its own geometry would be a worse test than no test. That also makes `KVCacheNVFP4HeadDimReject` a CPU test, since the rule is a constraint on the shape, not on the allocation.

## Mutation check

Four kvcache mutants are now killed by the test written for that behaviour rather than by a neighbour that happened to notice:

```
M37 (partial trailing blocks registered as full) -> KVCacheManagerTest.PrefixCachingWithPartialLastBlock
M39 (block count rounds down)                    -> KVCacheManagerTest.PrefixCachingWithPartialLastBlock
M41 (StreamingLLM drops the boundary block)      -> KVCacheManagerTest.EvictMiddleBlocksKeepsSinksAndWindow
                                                    KVCacheManagerTest.EvictMiddleBlocksRetainsKernelWindowStart
M42 (sink blocks no longer pinned)               -> KVCacheManagerTest.EvictMiddleBlocksKeepsSinksAndWindow

CI-lane mutation score over the kvcache mutants: 10/11 = 90.9%   (M25 is the equivalent mutant)
```

## A number worth knowing

`check_test_lanes.py` counts GTest MACROS per binary, not executions, so a test that skips at runtime still reads as "in a CI lane". Its 1629 has not moved and is not wrong - it answers a different question. The skip count above is what the merge gate actually exercises, and it is now recorded in `MUTATION_BASELINE.md` and `tests/CLAUDE.md`.

## Also in here

`tools/filesize_thresholds.toml`: `tests/test_kv_cache.cpp` re-pinned 1184 -> 1152 code LOC. That is the 43 removed `SKIP_IF_NO_CUDA()` lines; an allowlist entry is a ceiling, so the pin moves down with the file.

## Gate

```
make verify-fast  OK
  decode  tg128 =  286.92 tok/s  (baseline 287.19, -0.09%)
  prefill pp512 = 12377.72 tok/s (baseline 12406.87, -0.23%)
  own peak VRAM = 20738 MiB      (baseline 20716, +0.11%)
  graphs ON 453.36 tg256 = 2.30x
test-core (no GPU)   1306 passed, 19 skipped, 0 failed
test-core (GPU), KVCache*/KVAccounting*   65 passed, 0 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVcruBPPPA5AKQwzHzn4rr
