### PR TITLE
docs(internals): KV-pressure valve honours I7; NVFP4 dispatch row names the grouped kernels

### DIFF
--- a/docs/internals/ATTENTION_DISPATCH.md
+++ b/docs/internals/ATTENTION_DISPATCH.md
@@ -2,7 +2,7 @@
 layer: L2
 audience: kernel-devs
 verified: 2026-09-03
-commit: f70e072a
+commit: b3cc2079
 -->
 
 # Attention dispatch
@@ -57,7 +57,7 @@ The decode dispatch (further down in `executor_attention.cu`) is a single `switc
 | FP8 (E4M3) | `paged_attention_decode_fp8` | `_decode_fp8_kernel`, `_splitk_fp8_kernel`, `_splitk_fp8_pipeline_kernel`; HD=128 without split-K: `_decode_fp8_multitok_kernel<128,4>` in `attention_paged_fp8_multitok.cu` (`attention.paged_fp8_multitok`); tile variants in `attention_paged_fp8_tile.cu` |
 | INT8 | `paged_attention_decode_int8` | `_decode_int8_kernel`, `_splitk_int8_kernel` |
 | INT4 | `paged_attention_decode_int4` | `_decode_int4_kernel`, `_splitk_int4_kernel`, `_splitk_int4_pipeline_kernel` |
-| NVFP4 | `paged_attention_decode_nvfp4` / `_nvfp4_tc` | default: `_decode_nvfp4_multitok_kernel<HD>` and `_splitk_nvfp4_multitok_kernel<HD>` in `attention_paged_nvfp4_multitok.cu` (`attention.paged_nvfp4_multitok`); scalar: `_decode_nvfp4_kernel`, `_splitk_nvfp4_kernel`; TC: `_decode_nvfp4_tc_kernel`, `_splitk_nvfp4_tc_kernel`, `_residual_reduce_kernel` |
+| NVFP4 | `paged_attention_decode_nvfp4` / `_nvfp4_tc` | default: the Q-head-grouped `_decode_nvfp4_multitok_gqa_kernel<HD,HPC>` and `_splitk_nvfp4_multitok_gqa_kernel<HD,HPC>` in `attention_paged_nvfp4_multitok_gqa.cu` when 2, 3 or 4 divides the GQA ratio, else `_decode_nvfp4_multitok_kernel<HD>` and `_splitk_nvfp4_multitok_kernel<HD>` in `attention_paged_nvfp4_multitok.cu` (`attention.paged_nvfp4_multitok`); scalar: `_decode_nvfp4_kernel`, `_splitk_nvfp4_kernel`; TC: `_decode_nvfp4_tc_kernel`, `_splitk_nvfp4_tc_kernel`, `_residual_reduce_kernel` |
 | MXFP4 KV | `paged_attention_decode_mxfp4_kv` (`attention_paged_nvfp4.cu:465`) | shares the NVFP4 kernels with UE8M0 scales |
 
 **Not every head_dim is served.** Each launcher templates a fixed set; a miss now throws instead of leaving `O` unwritten (#1674). `paged_attention_serves_head_dim()` in `attention_paged.h` is the table, and the resolver falls back to FP16 KV before init when a model's head_dim is not in it. FP16 and FP8 serve 64/96/128/256/512, INT8 and INT4 serve 64/96/128/256, NVFP4 serves 64/128/256/512 - **no 96**.

--- a/docs/internals/MEMORY.md
+++ b/docs/internals/MEMORY.md
@@ -1,8 +1,8 @@
 <!--
 layer: L2
 audience: kernel-devs
-verified: 2026-08-28
-commit: be825e4a
+verified: 2026-09-03
+commit: b3cc2079
 -->
 
 # imp Memory Architecture
@@ -539,6 +539,8 @@ Concretely:
 **Cancellation, disconnect, error paths** leak refcounts today because each path frees by hand. Under `BlockRef` they are one path: the `SequenceSlot` is destroyed and its refs unwind, including on exception. The slot destructor asserts its net contribution is zero (A3.4); criterion 4's cancellation-heavy soak is the system-level proof.
 
 **Nuance the design must not lose:** `evict_middle_blocks()` (StreamingLLM) replaces freed slots with sentinel `-1` while keeping the table *length*; the attention kernels depend on positional alignment. So `seq_blocks_` is `std::vector<std::optional<BlockRef>>` and the sentinel is `nullopt`. Same for the SWA positional table (documented `-1` holes by design).
+
+**The KV-pressure valve counts reclaimable blocks (#1879).** `Engine` auto-enables StreamingLLM and demotes CUDA graphs one-way when the pool is "over 90% full"; until 2026-09-03 the check compared the free list with the blocks live sequences hold, so a pool one third full of reclaimable prefix-cache blocks read as full ("0/2016 free" with 984 reclaimable), and every wave after the first ran eager (Llama-3.2-3B-Q8_0, 32 x 1000-token streams: 2387 -> 1443-1485 tok/s). The check now adds `num_reclaimable_cached_blocks()` and compares against `total_blocks()`; the I7 distinction (occupied vs reclaimable) that `/metrics` already exported is what the scheduler had ignored.
 
 ### A5.2 CUDA graph pool
 


### PR DESCRIPTION
## What

- `docs/internals/MEMORY.md` A5.1: the KV-pressure valve (StreamingLLM auto-enable, one-way graph demotion) now counts reclaimable prefix-cache blocks against the pool (#1879); the paragraph records the failure shape ("0/2016 free" with 984 reclaimable, 2387 -> 1443-1485 tok/s on Llama-3.2-3B at 32 streams) next to the I7 invariant it violated.
- `docs/internals/ATTENTION_DISPATCH.md`: the NVFP4 row names the Q-head-grouped kernels and their TU (#1886) and the rule that selects them (2, 3 or 4 divides the GQA ratio).

Headers bumped; `scripts/ci_static_gates.sh docs citations` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVcruBPPPA5AKQwzHzn4rr
