### PR TITLE
feat(server): serving KPI harness, /metrics latency histograms on every generation path, preemption counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ there instead of retelling it.
   utilization, prefix-cache hit rate, speculative acceptance and preemption
   counters from `/metrics`, and J per 1k output tokens from `nvidia-smi`.
   Definitions in `docs/internals/BENCHMARKING.md`, first table in
-  `docs/PERF.md`
+  `docs/PERF.md` (Qwen3-8B-NVFP4-cortecs, 32 streams: 4633.7 output tok/s,
+  TPOT p50 5.8 ms, goodput 100 %); GGUF batched decode is dequant-bound
+  (Qwen3-8B-Q8_0, 8 streams: 136.2 tok/s, TPOT p50 51.8 ms), recorded in
+  `docs/LIMITATIONS.md` (#1896)
 - `/metrics`: `imp_streaming_kv_auto_enables_total` and
   `imp_prefix_cache_evictions_total` (the two preemption events that were log
   lines only) and `imp_decode_batch_last_rows` (sequences in the most recent
-  decode step, 0 when idle)
+  decode step, 0 when idle) (#1896)
 
 ### Fixed
 
@@ -33,7 +36,7 @@ there instead of retelling it.
   queue / duration, the non-stream chat loop no ITL, and a request cancelled
   or timed out before admission left no queue observation. The non-stream
   chat timeout now also counts in `imp_requests_timed_out_total`. Gate:
-  `tests/test_server_metrics.py` in `make test-server`
+  `tests/test_server_metrics.py` in `make test-server` (#1896)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Added
+
+- Serving KPI harness `tools/analysis/serving_kpi.py`: per concurrency level
+  TTFT / TPOT / ITL / E2E / normalized latency at p50 / p95 / p99, req/s,
+  input / output / total tok/s, goodput against an SLO pair (TTFT <= 500 ms,
+  TPOT <= 50 ms by default), the server's queue wait, rows per step, KV
+  utilization, prefix-cache hit rate, speculative acceptance and preemption
+  counters from `/metrics`, and J per 1k output tokens from `nvidia-smi`.
+  Definitions in `docs/internals/BENCHMARKING.md`, first table in
+  `docs/PERF.md`
+- `/metrics`: `imp_streaming_kv_auto_enables_total` and
+  `imp_prefix_cache_evictions_total` (the two preemption events that were log
+  lines only) and `imp_decode_batch_last_rows` (sequences in the most recent
+  decode step, 0 when idle)
+
+### Fixed
+
+- `/metrics` latency histograms are fed by every generation path:
+  `/v1/completions` (stream and non-stream) observed none of TTFT / ITL /
+  queue / duration, the non-stream chat loop no ITL, and a request cancelled
+  or timed out before admission left no queue observation. The non-stream
+  chat timeout now also counts in `imp_requests_timed_out_total`. Gate:
+  `tests/test_server_metrics.py` in `make test-server`
+
 ### Changed
 
 - Streaming TTFT: the reasoning scan no longer holds the first 8 tokens of a

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,8 +91,25 @@ the server log (#1640, #1641):
 | `imp_requests_timed_out_total` | the server ended a request at `--request-timeout`. The client sees `finish_reason: "length"`, which is also what a spent token budget produces - this counter is the only way to tell them apart |
 | `imp_kv_pressure_rejections_total` | a request was cancelled because the KV pool could not give it blocks (admission or mid-decode). Not incremented for a failed metadata allocation or a snapshot mismatch, which are different faults |
 | `imp_kv_pool_growths_total` | the growable pool committed more memory. A pool that keeps growing under load is the signal that arrives before it stops being able to |
+| `imp_streaming_kv_auto_enables_total` | the KV pool ran nearly full on an F16-KV model and StreamingLLM eviction switched itself on. The same event demotes CUDA graphs one-way for the rest of the process. `usage.prompt_tokens_details.evicted_tokens` is the per-request size, this is the rate |
+| `imp_prefix_cache_evictions_total` | a cached prefix block was reclaimed for a new allocation. Rising while `imp_tokens_cached_total` stalls means the pool is smaller than the working set |
 
 `imp_requests_cancelled_total` remains client-disconnect only.
+
+`imp_decode_batch_last_rows` (gauge) is the number of sequences in the most
+recent decode step, 0 while the worker idles: the live batch, where
+`imp_decode_batch_rows_total / imp_decode_batch_steps_total` is a windowed
+mean and `imp_decode_batch_max` never resets.
+
+The four latency histograms (`imp_request_duration_seconds`,
+`imp_ttft_seconds`, `imp_queue_time_seconds`, `imp_inter_token_seconds`) are
+fed by every generation path: chat stream and non-stream, `/v1/completions`
+stream and non-stream. A request cancelled or timed out before the worker
+admitted it contributes its wait to `imp_queue_time_seconds` as well. Gate:
+`tests/test_server_metrics.py` in `make test-server`. The serving KPI harness
+reads the histograms and counters back per concurrency level
+(`tools/analysis/serving_kpi.py`, definitions in
+[`internals/BENCHMARKING.md`](internals/BENCHMARKING.md)).
 
 `imp_kv_blocks_reserved` (gauge) is what admission has promised to running
 requests for the rest of their generation and not yet written (#1635). Free

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,8 +1,8 @@
 <!--
 layer: L1
 audience: operators
-verified: 2026-08-28
-commit: be825e4a
+verified: 2026-09-04
+commit: c7d7356e
 -->
 
 # Limitations
@@ -67,6 +67,14 @@ Absent instruments: nothing in the tree produces the number, so no threshold can
 Both need a GPU runner or a long-running machine with a card; CI has neither.
 
 ## Known-bad and known-limited behaviour
+
+- **GGUF batched decode is dequant-bound.** A GGUF source keeps its NVFP4 decode cache as a
+  single-sequence overlay; a decode step with two or more sequences takes the prefill route and
+  dequantizes the whole source to FP16 first (`src/exec/executor_gemm_dispatch.cu:536`, the
+  class of #667). Qwen3-8B-Q8_0 serves 8 streams slower than 1 and every request misses the
+  TPOT SLO; the native NVFP4 checkpoint of the same model does not. Numbers and the control
+  arm in [`PERF.md`](PERF.md) ("Serving KPIs"). Serve GGUF single-stream; concurrency wants a
+  native NVFP4 checkpoint.
 
 - **`server.green_contexts=true` does not give green contexts on this chip.**
   `cudaDevResourceGenerateDesc` fails for the decode partition (`one or more resources passed in

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,8 +1,8 @@
 <!--
 layer: L1
 audience: operators
-verified: 2026-08-28
-commit: be825e4a
+verified: 2026-09-04
+commit: c7d7356e
 -->
 
 # Performance
@@ -97,6 +97,49 @@ the 2026-07-12 sweep:
 
 Where imp loses is in [`LIMITATIONS.md`](LIMITATIONS.md), and it is in the README
 too, on purpose.
+
+## Serving KPIs
+
+The serving set defined in
+[`internals/BENCHMARKING.md`](internals/BENCHMARKING.md) ("Serving KPIs"):
+closed loop per concurrency level, 300-token greedy completions on unique
+prompts of about 35 tokens, server defaults (auto batch 32, n-gram
+speculation on, FP8 KV), one warmup wave. Goodput counts requests with
+TTFT <= 500 ms and TPOT <= 50 ms.
+
+[PROV: commit=c7d7356e date=2026-09-04 hw=RTX5090 model=Qwen3-8B-NVFP4-cortecs quant=NVFP4 cuda=13.3.1 path=paged_fp8+fa2_fp16qk cmd="tools/analysis/serving_kpi.py --levels 1,8,32 --max-tokens 300" n=1]
+
+| KPI | c=1 | c=8 | c=32 |
+|---|---|---|---|
+| req/s | 1.11 | 5.46 | 17.76 |
+| output tok/s | 291.4 | 1413.6 | 4633.7 |
+| TTFT p50 / p95 / p99 ms | 11 / 31 / 34 | 25 / 37 / 41 | 50 / 232 / 238 |
+| TPOT p50 / p95 / p99 ms | 3.4 / 3.5 / 3.5 | 5.1 / 5.4 / 5.4 | 5.8 / 6.4 / 6.4 |
+| ITL p50 / p95 / p99 ms | 3.3 / 4.7 / 7.2 | 4.6 / 9.2 / 16.6 | 4.7 / 10.6 / 21.7 |
+| E2E p50 / p95 / p99 s | 0.94 / 1.04 / 1.06 | 1.36 / 1.64 / 1.64 | 1.62 / 1.96 / 1.97 |
+| goodput req/s (SLO attainment) | 1.11 (100 %) | 5.46 (100 %) | 17.76 (100 %) |
+| queue wait p50 / p95 / p99 ms | 2.5 / 4.8 / 5.0 | 3.1 / 8.7 / 9.7 | 8.0 / 45.3 / 49.1 |
+| decode rows per step | 1.00 | 7.30 | 27.82 |
+| power W / J per 1k output tokens | 512 / 1751 | 367 / 254 | 381 / 73 |
+
+**GGUF batched decode is dequant-bound.** A GGUF source carries its NVFP4
+decode cache as a single-sequence overlay; every step with more than one
+sequence takes the prefill route and dequantizes the whole Q8_0 source
+(`src/exec/executor_gemm_dispatch.cu:536`, the class of #667). Same harness
+and defaults on Qwen3-8B-Q8_0: the step costs about 52 ms from two sequences
+up, flat in batch size, at a third of the power. `gemm.q8_imma_enabled=true`
+reads the same (115 tok/s at c=8). The published v0.36.0 image reads the
+same at c=8 (120 tok/s, ITL p50 63.5 ms): the standing state, not a
+regression. Concurrency needs a native NVFP4 checkpoint (table above).
+
+[PROV: commit=c7d7356e date=2026-09-04 hw=RTX5090 model=Qwen3-8B-Q8_0 quant=Q8_0 cuda=13.3.1 path=paged_fp8+fa2_fp16qk cmd="tools/analysis/serving_kpi.py --levels 1,8,32 --max-tokens 300" n=1]
+
+| KPI | c=1 | c=8 | c=32 |
+|---|---|---|---|
+| output tok/s | 225.6 | 136.2 | 481.9 |
+| TPOT p50 / p99 ms | 4.2 / 4.6 | 51.8 / 57.3 | 57.0 / 60.3 |
+| goodput req/s (SLO attainment) | 0.86 (100 %) | 0.02 (3 %) | 0.00 (0 %) |
+| power W | 420 | 185 | 193 |
 
 ## Reproducing any of this
 

--- a/docs/internals/BENCHMARKING.md
+++ b/docs/internals/BENCHMARKING.md
@@ -131,7 +131,7 @@ published table is in [`../PERF.md`](../PERF.md) ("Serving KPIs").
 
 ```
 python3 tools/analysis/serving_kpi.py --url http://127.0.0.1:8080 --levels 1,8,32 \
-    --max-tokens 300 --md out.md --json out.json
+    --max-tokens 300 --md-out kpi.md --json kpi.json
 ```
 
 ## Profiling builds

--- a/docs/internals/BENCHMARKING.md
+++ b/docs/internals/BENCHMARKING.md
@@ -1,8 +1,8 @@
 <!--
 layer: L2
 audience: kernel-devs
-verified: 2026-08-30
-commit: e3e91b9f
+verified: 2026-09-04
+commit: c7d7356e
 -->
 
 # Benchmarking methodology
@@ -94,6 +94,45 @@ confident numbers before it produced a true one (2026-08-29, full ledger in
 - **Why 8 % and not 3 %.** The threshold has to sit above this host's own movement, or it reports the box instead of the diff. Within one session the gate is tight (three independent processes agree to 0.16 %), but *between* sessions the same tree reads 287.63 one day and 276.92 the next (−3.58 %) at healthy clocks, and six quiet runs spanned 278.59…289.77. Ordinary desktop use (a stream, a browser) costs a few percent more; a depressed-host day costs 8-15 %. The old 3 % sat below all of that and failed on docs-only changes. What the gate still catches: the split-K mutation M29 measured **−36 %**, a 4.5x margin. A red gate has never been a regression on its own; the proof is a paired A/B against `main`, alternating the arms.
 - **Peak VRAM is gated too** (`scripts/verify.sh`, both `verify` and `verify-fast`): a `--mem-report` run vs the pinned `metrics.memory_mb.own_peak_mb` against `thresholds.vram_increase_pct`. It gates `own_peak` (this process's allocations since engine init), **not** device `peak_used`, which also carries the CUDA primary context and any neighbour process. `own_peak` measures byte-identical across repeat runs, a stricter signal than any throughput number. (Skip with `IMP_VERIFY_SKIP_VRAM=1`.)
 - **Intentional perf moves:** refresh the baseline with `scripts/gen_perf_baseline.sh` (cold-median: 5 trials, median per metric; re-pins `own_peak_mb` in the same run) and **say so in the PR**. A change that intentionally moves VRAM needs the same refresh.
+
+## Serving KPIs
+
+The single-stream numbers above do not describe a server under load.
+`tools/analysis/serving_kpi.py` measures the serving set per concurrency
+level: closed loop (C workers, each sends its next request when its previous
+one finished), unique prompts per request (the prefix cache stays cold unless
+that is the point, `--prompt-tokens` adds filler), one warmup wave at the
+largest level first (graph captures and the clock ramp), `--max-tokens 300`
+and `temperature 0` by default, `--ignore-eos` for equal token counts across
+arms.
+
+| KPI | definition | source |
+|---|---|---|
+| TTFT | first content delta minus request send, per request | client |
+| TPOT | (last token - first token) / (output tokens - 1), per request | client |
+| ITL | gap between consecutive token deltas, pooled over every token of every request | client |
+| E2E, normalized latency | request wall; E2E / output tokens | client |
+| req/s, output / input / total tok/s | over the level's wall | client |
+| goodput | requests with TTFT <= `--slo-ttft-ms` AND TPOT <= `--slo-tpot-ms` (defaults 500 and 50), as req/s and tok/s; attainment = their share of finished requests | client |
+| queue wait | `imp_queue_time_seconds` delta across the level, quantiles interpolated like `histogram_quantile` | `/metrics` |
+| rows per step, active sequences | `imp_decode_batch_rows_total / imp_decode_batch_steps_total` delta; `imp_decode_batch_last_rows` sampled four times a second | `/metrics` |
+| KV utilization | `imp_kv_blocks_live / imp_kv_blocks_total`, sampled | `/metrics` |
+| prefix-cache hit rate | `imp_tokens_cached_total / imp_tokens_prompt_total` delta | `/metrics` |
+| speculative acceptance | `imp_spec_accepted_total / imp_spec_drafted_total` delta | `/metrics` |
+| preemption | deltas of `imp_kv_pressure_rejections_total`, `imp_streaming_kv_auto_enables_total`, `imp_prefix_cache_evictions_total` | `/metrics` |
+| energy | `nvidia-smi power.draw` integrated over the level: mean W and J per 1k output tokens; the mean SM clock beside it is the host-health check of rule 6 | host |
+
+Percentiles are p50 / p95 / p99 with linear interpolation; no latency is
+reported as a mean. The rules above (free GPU, one server per arm, clocks
+sampled) apply unchanged. The level's wall includes the closed loop's tail,
+so keep `--requests-per-level` at least twice the concurrency (the default).
+Not reported: tok/s per GPU and cost per token, imp targets one card. The
+published table is in [`../PERF.md`](../PERF.md) ("Serving KPIs").
+
+```
+python3 tools/analysis/serving_kpi.py --url http://127.0.0.1:8080 --levels 1,8,32 \
+    --max-tokens 300 --md out.md --json out.json
+```
 
 ## Profiling builds
 

--- a/scripts/test_server.sh
+++ b/scripts/test_server.sh
@@ -19,6 +19,8 @@
 #   - test_server_messages_stream.py   Anthropic /v1/messages event sequence
 #   - test_server_vision_and_utf8.py   images refused when unusable (#1198),
 #                                     non-ASCII survives json_schema (#1197)
+#   - test_server_metrics.py           /v1/completions and non-stream chat feed the
+#                                     latency histograms; preemption counters exist
 #
 # Usage:   make test-server   (or: scripts/test_server.sh)
 # Env:     IMP_SRV_MODEL    (default Qwen3-8B-NVFP4-cortecs) — needs chat+tools+embeddings
@@ -101,6 +103,7 @@ run "ignore_eos"          python3 tests/test_server_ignore_eos.py
 run "messages stream"     python3 tests/test_server_messages_stream.py
 run "thinking toggle"     python3 tests/test_server_thinking_toggle.py
 run "tracing (OTLP spans)" python3 tests/test_server_tracing.py
+run "metrics (every path feeds the histograms)" python3 tests/test_server_metrics.py
 run "vision refusal + utf8 (#1197/#1198)" python3 tests/test_server_vision_and_utf8.py
 run "embed/chat interleave" bash tests/test_server_embed_chat_interleave.sh 15
 run "0-token battery (#710)" env N=8 LOAD=80 FAIL_THRESHOLD=0.10 python3 tests/test_server_0token_battery.py

--- a/src/memory/kv_cache_manager.cpp
+++ b/src/memory/kv_cache_manager.cpp
@@ -683,6 +683,7 @@ int KVCacheManager::reclaim_cached_block() {
     int block_id = cached_blocks_lru_.front();
     cached_blocks_lru_.pop_front();
     reclaimable_cached_count_--;
+    cached_block_evictions_.fetch_add(1, std::memory_order_relaxed);
 
     // Remove from hash tables.
     auto hash_it = block_id_to_hash_.find(block_id);

--- a/src/memory/kv_cache_manager.h
+++ b/src/memory/kv_cache_manager.h
@@ -2,6 +2,7 @@
 
 #include "memory/kv_cache.h"
 #include <cuda_runtime_api.h>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <list>
@@ -164,6 +165,11 @@ public:
     // Cached (unreferenced) blocks that are actually reclaimable, i.e.
     // excluding pinned blocks. O(1).
     int num_reclaimable_cached_blocks() const { return reclaimable_cached_count_; }
+    // Cached prefix blocks reclaimed for new allocations since start: the
+    // prefix cache's churn. Read by /metrics at scrape time.
+    uint64_t cached_block_evictions() const {
+        return cached_block_evictions_.load(std::memory_order_relaxed);
+    }
 
     // ── SWA-aware sizing (kv_cache.swa_sizing) ───────────────────────
     //
@@ -508,6 +514,7 @@ private:
     // (cached_blocks_lru_.size() minus pinned cached blocks).
     // Avoids O(C) linear scan in can_allocate().
     int reclaimable_cached_count_ = 0;
+    std::atomic<uint64_t> cached_block_evictions_{0};
 
     // Try to reclaim a cached block. Returns the block_id, or -1.
     int reclaim_cached_block();

--- a/src/runtime/engine.h
+++ b/src/runtime/engine.h
@@ -352,6 +352,17 @@ public:
     // Counted by the pool itself, not mirrored here: growth is decided in
     // KVCache::try_grow_to and a second copy is a second thing to keep in sync.
     uint64_t kv_pool_growths() const noexcept { return kv_cache_raw_ ? kv_cache_raw_->growths() : 0; }
+    // StreamingLLM auto-enable events (pool >90% full). Each one also demotes
+    // CUDA graphs one-way for the rest of the process, so it is the
+    // preemption signal an operator wants as a counter, not as a WARN line.
+    uint64_t streaming_kv_auto_enables() const noexcept {
+        return streaming_kv_auto_enables_.load(std::memory_order_relaxed);
+    }
+    // Counted by the manager (the reclaim is decided there), read here so
+    // /metrics needs no manager handle.
+    uint64_t prefix_cache_evictions() const noexcept {
+        return kv_manager_ ? kv_manager_->cached_block_evictions() : 0;
+    }
     Model* model() const noexcept { return model_.get(); }
     // Effective context window actually allocated by the engine (after VRAM-aware
     // auto-sizing in init_compute_max_seq_len_). May be < the model's declared
@@ -416,6 +427,7 @@ private:
     KVCache* kv_cache_raw_ = nullptr;  // Non-owning pointer (owned by kv_manager_)
     bool kv_pool_floored_ = false;     // the pool is the rescue floor, not a size
     std::atomic<uint64_t> kv_pressure_rejections_{0};
+    std::atomic<uint64_t> streaming_kv_auto_enables_{0};
     std::unique_ptr<GraphExecutor> executor_;
     GreenContextManager green_ctx_;
     CudaStream stream_;

--- a/src/runtime/engine_scheduler.cpp
+++ b/src/runtime/engine_scheduler.cpp
@@ -899,6 +899,7 @@ void Engine::step_decode(cudaStream_t dec_stream) {
             if (pool_total > 0 && st.free_blocks + reclaimable < pool_total / 10) {
                 if (kv_cache_raw_ && kv_cache_raw_->qtype() == QType::F16) {
                     config_.streaming_kv_enabled = true;
+                    streaming_kv_auto_enables_.fetch_add(1, std::memory_order_relaxed);
                     int n_sinks = (config_.streaming_kv_n_sinks > 0) ? config_.streaming_kv_n_sinks : 4;
                     int win = (config_.streaming_kv_window > 0) ? config_.streaming_kv_window
                                                                 : model_->config().sliding_window;

--- a/tests/api/mock_server.py
+++ b/tests/api/mock_server.py
@@ -195,6 +195,15 @@ class MockHandler(BaseHTTPRequestHandler):
                 f"# HELP imp_queue_depth Queue depth\n"
                 f"# TYPE imp_queue_depth gauge\n"
                 f"imp_queue_depth 0\n"
+                f"# HELP imp_decode_batch_last_rows Sequences in the most recent decode step\n"
+                f"# TYPE imp_decode_batch_last_rows gauge\n"
+                f"imp_decode_batch_last_rows 0\n"
+                f"# HELP imp_streaming_kv_auto_enables_total StreamingLLM auto-enable events\n"
+                f"# TYPE imp_streaming_kv_auto_enables_total counter\n"
+                f"imp_streaming_kv_auto_enables_total 0\n"
+                f"# HELP imp_prefix_cache_evictions_total Cached prefix blocks reclaimed\n"
+                f"# TYPE imp_prefix_cache_evictions_total counter\n"
+                f"imp_prefix_cache_evictions_total 0\n"
             )
             self.send_response(200)
             self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")

--- a/tests/api/test_contract.py
+++ b/tests/api/test_contract.py
@@ -284,3 +284,12 @@ class TestMetricsEndpoint:
     def test_metrics_has_model_loaded(self, client):
         r = client.get("/metrics")
         assert "imp_model_loaded" in r.text
+
+    def test_metrics_has_preemption_and_batch_series(self, client):
+        # Emitted with or without a model (zeros), so the model-less lane and
+        # the mock both carry them: the preemption rates that used to be log
+        # lines, and the sequences decoding together right now.
+        text = client.get("/metrics").text
+        for name in ("imp_streaming_kv_auto_enables_total", "imp_prefix_cache_evictions_total",
+                     "imp_decode_batch_last_rows"):
+            assert name in text, name

--- a/tests/api/test_serving_kpi.py
+++ b/tests/api/test_serving_kpi.py
@@ -1,0 +1,128 @@
+"""tools/analysis/serving_kpi.py: the KPI arithmetic, without a server.
+
+Percentiles, the Prometheus-style histogram quantile the harness applies to
+imp_queue_time_seconds deltas, the /metrics text parser, and the per-level
+summary (TTFT / TPOT / ITL / E2E / normalized latency, goodput against the
+SLO pair). Lane-agnostic: no request is made.
+"""
+import importlib.util
+import math
+import pathlib
+
+import pytest
+
+_PATH = pathlib.Path(__file__).resolve().parents[2] / "tools" / "analysis" / "serving_kpi.py"
+_SPEC = importlib.util.spec_from_file_location("serving_kpi", _PATH)
+kpi = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(kpi)
+
+
+def test_pct_interpolates_like_numpy():
+    xs = [10, 20, 30, 40]
+    assert kpi.pct(xs, 50) == 25.0
+    assert kpi.pct(xs, 0) == 10
+    assert kpi.pct(xs, 100) == 40
+    assert kpi.pct(xs, 95) == pytest.approx(38.5)
+    assert kpi.pct([7], 99) == 7
+    assert math.isnan(kpi.pct([], 50))
+
+
+def test_hist_quantile_interpolates_inside_the_crossing_bucket():
+    # 10 observations: 4 at <=0.1, 4 more at <=0.5, 2 more at <=1.0.
+    buckets = {"0.1": 4, "0.5": 8, "1.0": 10, "+Inf": 10}
+    assert kpi.hist_quantile(buckets, 0.5) == pytest.approx(0.2)   # rank 5 of 4..8 over 0.1..0.5
+    assert kpi.hist_quantile(buckets, 0.9) == pytest.approx(0.75)  # rank 9 of 8..10 over 0.5..1.0
+    assert kpi.hist_quantile(buckets, 0.2) == pytest.approx(0.05)  # rank 2 of 0..4 over 0..0.1
+    assert math.isnan(kpi.hist_quantile({}, 0.5))
+    assert math.isnan(kpi.hist_quantile({"0.1": 0, "+Inf": 0}, 0.5))
+    # Everything beyond the last finite bound resolves to that bound.
+    assert kpi.hist_quantile({"0.1": 0, "+Inf": 3}, 0.5) == 0.1
+
+
+def test_parse_metrics_separates_plain_series_and_buckets():
+    text = "\n".join([
+        "# HELP imp_requests_total Total",
+        "# TYPE imp_requests_total counter",
+        "imp_requests_total 12",
+        'imp_queue_time_seconds_bucket{le="0.005"} 3',
+        'imp_queue_time_seconds_bucket{le="+Inf"} 7',
+        "imp_queue_time_seconds_sum 0.42",
+        'imp_memory_live_bytes{tier="weights"} 100',
+    ])
+    plain, hists = kpi.parse_metrics(text)
+    assert plain["imp_requests_total"] == 12
+    assert plain["imp_queue_time_seconds_sum"] == pytest.approx(0.42)
+    assert "imp_memory_live_bytes" not in plain  # labeled, not a scalar
+    assert hists["imp_queue_time_seconds"] == {"0.005": 3, "+Inf": 7}
+
+
+def _rec(t0, ttft_s, n_out, tpot_s, prompt=100, ok=True, cached=0):
+    stamps = [t0 + ttft_s + k * tpot_s for k in range(n_out)]
+    return {"ok": ok, "t0": t0, "t_first": stamps[0] if stamps else None,
+            "t_end": stamps[-1] if stamps else t0 + ttft_s, "stamps": stamps,
+            "prompt_tokens": prompt, "completion_tokens": n_out, "cached_tokens": cached}
+
+
+def test_summarize_level_goodput_counts_only_requests_meeting_both_slos():
+    recs = [
+        _rec(0.0, 0.100, 11, 0.020),   # meets both
+        _rec(0.0, 0.900, 11, 0.020),   # TTFT over
+        _rec(0.0, 0.100, 11, 0.080),   # TPOT over
+        _rec(0.0, 0.200, 11, 0.030, cached=50),  # meets both
+        {"ok": False, "t0": 0.0, "t_first": None, "t_end": 1.0, "stamps": [],
+         "prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0},
+    ]
+    s = kpi.summarize_level(recs, wall_s=10.0, slo_ttft_ms=500, slo_tpot_ms=50)
+    assert s["ok"] == 4 and s["err"] == 1
+    assert s["req_s"] == pytest.approx(0.4)
+    assert s["output_tokens"] == 44 and s["input_tokens"] == 400
+    assert s["output_tok_s"] == pytest.approx(4.4)
+    assert s["total_tok_s"] == pytest.approx(44.4)
+    assert s["goodput_req_s"] == pytest.approx(0.2)
+    assert s["goodput_tok_s"] == pytest.approx(2.2)
+    assert s["slo_attainment_pct"] == pytest.approx(50.0)
+    assert s["ttft_ms"]["n"] == 4 and s["tpot_ms"]["n"] == 4
+    assert s["itl_ms"]["n"] == 40  # 10 gaps per stream
+    # TPOT = (t_last - t_first) / (n_out - 1) = the synthetic gap.
+    assert s["tpot_ms"]["p50"] == pytest.approx(25.0)
+    assert s["tpot_ms"]["p99"] == pytest.approx(78.5)
+    # Normalized latency = E2E / output tokens: E2E 0.3 / 1.1 / 0.9 / 0.5 s
+    # over 11 tokens, p50 interpolates between the two middle values.
+    assert s["norm_ms_per_tok"]["p50"] == pytest.approx((0.5 + 0.9) / 2 / 11 * 1e3)
+    assert s["e2e_s"]["p99"] == pytest.approx(1.1 - 0.2 * 0.03)
+    assert s["cached_tokens"] == 50
+
+
+def test_summarize_level_single_token_request_has_no_tpot():
+    s = kpi.summarize_level([_rec(0.0, 0.05, 1, 0.0)], wall_s=1.0, slo_ttft_ms=500, slo_tpot_ms=50)
+    assert s["tpot_ms"]["n"] == 0 and math.isnan(s["tpot_ms"]["p50"])
+    assert s["itl_ms"]["n"] == 0
+    assert s["slo_attainment_pct"] == 100.0  # TTFT alone decides
+
+
+def test_server_summary_rates_from_deltas():
+    m0 = {"imp_decode_batch_steps_total": 100, "imp_decode_batch_rows_total": 1000,
+          "imp_tokens_prompt_total": 1000, "imp_tokens_cached_total": 100,
+          "imp_spec_drafted_total": 0, "imp_spec_accepted_total": 0,
+          "imp_kv_pressure_rejections_total": 1, "imp_streaming_kv_auto_enables_total": 0,
+          "imp_prefix_cache_evictions_total": 5}
+    m1 = {"imp_decode_batch_steps_total": 200, "imp_decode_batch_rows_total": 4200,
+          "imp_tokens_prompt_total": 3000, "imp_tokens_cached_total": 600,
+          "imp_spec_drafted_total": 40, "imp_spec_accepted_total": 30,
+          "imp_kv_pressure_rejections_total": 3, "imp_streaming_kv_auto_enables_total": 1,
+          "imp_prefix_cache_evictions_total": 5}
+    h0 = {"imp_queue_time_seconds": {"0.01": 5, "0.1": 5, "+Inf": 5}}
+    h1 = {"imp_queue_time_seconds": {"0.01": 5, "0.1": 15, "+Inf": 15}}
+    samples = [{"kv_util_pct": 40.0, "active": 8}, {"kv_util_pct": 60.0, "active": 32}]
+    s = kpi.server_summary(m0, h0, m1, h1, samples)
+    assert s["rows_per_step"] == pytest.approx(32.0)
+    assert s["prefix_hit_pct"] == pytest.approx(25.0)
+    assert s["spec_accept_pct"] == pytest.approx(75.0)
+    assert s["kv_pressure_rejections"] == 2
+    assert s["streaming_kv_auto_enables"] == 1
+    assert s["prefix_cache_evictions"] == 0
+    assert s["kv_util_mean_pct"] == 50.0 and s["kv_util_max_pct"] == 60.0
+    assert s["active_seqs_mean"] == 20.0 and s["active_seqs_max"] == 32
+    # All 10 new queue observations sit in (0.01, 0.1]: p50 interpolates to 55 ms.
+    assert s["queue_ms"]["p50"] == pytest.approx(55.0)
+    assert s["queue_ms"]["n"] == 10

--- a/tests/test_server_metrics.py
+++ b/tests/test_server_metrics.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""/metrics latency histograms are fed by EVERY generation path.
+
+Before this battery the four histograms (request duration, TTFT, queue wait,
+inter-token) were observed by the chat streaming driver and, minus ITL, the
+chat non-stream loop; /v1/completions (both modes) fed none of them, which is
+the endpoint every serving harness in tools/analysis/ uses. Also checks the
+preemption counters and the last-batch gauge exist and that the gauge reads 0
+once the server idles. Needs a running imp-server (IMP_HOST/IMP_PORT/IMP_MODEL,
+defaults localhost:8080 and Qwen3-8B-NVFP4-cortecs). Exit 1 on any failure."""
+import json
+import os
+import re
+import sys
+import time
+import urllib.request
+
+HOST = os.environ.get("IMP_HOST", "localhost")
+PORT = int(os.environ.get("IMP_PORT", "8080"))
+M = os.environ.get("IMP_MODEL", "Qwen3-8B-NVFP4-cortecs")
+BASE = f"http://{HOST}:{PORT}"
+N = 24
+fails = []
+
+
+def check(label, cond, detail):
+    print(f"{'ok  ' if cond else 'FAIL'} {label}: {detail}")
+    if not cond:
+        fails.append(label)
+
+
+def metrics():
+    with urllib.request.urlopen(BASE + "/metrics", timeout=10) as r:
+        text = r.read().decode()
+    out = {}
+    for line in text.splitlines():
+        m = re.match(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)\s+(-?[0-9.eE+]+)$", line.strip())
+        if m:
+            out[m.group(1)] = float(m.group(2))
+    return out, text
+
+
+def post(path, body, stream):
+    req = urllib.request.Request(BASE + path, data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=300) as r:
+        if not stream:
+            return json.loads(r.read())
+        n = 0
+        for raw in r:
+            if raw.startswith(b"data:") and b"[DONE]" not in raw:
+                n += 1
+        return n
+
+
+HIST = ("imp_request_duration_seconds_count", "imp_ttft_seconds_count",
+        "imp_queue_time_seconds_count", "imp_inter_token_seconds_count")
+
+CASES = [
+    ("chat non-stream", "/v1/chat/completions",
+     {"model": M, "messages": [{"role": "user", "content": "Count from one to thirty in words."}],
+      "max_tokens": N, "temperature": 0, "ignore_eos": True}, False),
+    ("chat stream", "/v1/chat/completions",
+     {"model": M, "messages": [{"role": "user", "content": "Count from one to thirty in words."}],
+      "max_tokens": N, "temperature": 0, "stream": True, "ignore_eos": True}, True),
+    ("completions non-stream", "/v1/completions",
+     {"model": M, "prompt": "One two three four five six seven", "max_tokens": N,
+      "temperature": 0, "ignore_eos": True}, False),
+    ("completions stream", "/v1/completions",
+     {"model": M, "prompt": "One two three four five six seven", "max_tokens": N,
+      "temperature": 0, "stream": True, "ignore_eos": True}, True),
+]
+
+for label, path, body, stream in CASES:
+    m0, _ = metrics()
+    post(path, body, stream)
+    m1, _ = metrics()
+    d = {k: m1.get(k, 0) - m0.get(k, 0) for k in HIST}
+    check(f"{label}: duration/ttft/queue observed once",
+          d[HIST[0]] == 1 and d[HIST[1]] == 1 and d[HIST[2]] == 1, d)
+    # N tokens delivered => N-1 gaps; a stop token swallowed by the loop may
+    # cost one, so demand most of them rather than the exact count.
+    check(f"{label}: ITL observed per token", d[HIST[3]] >= N - 4, f"{d[HIST[3]]:.0f} gaps for {N} tokens")
+
+_, text = metrics()
+for name in ("imp_streaming_kv_auto_enables_total", "imp_prefix_cache_evictions_total",
+             "imp_decode_batch_last_rows", "imp_kv_pressure_rejections_total"):
+    check(f"series {name} present", re.search(rf"^{name} ", text, re.M) is not None, name)
+
+time.sleep(1.0)
+m, _ = metrics()
+check("imp_decode_batch_last_rows is 0 when idle", m.get("imp_decode_batch_last_rows", -1) == 0,
+      m.get("imp_decode_batch_last_rows"))
+
+print(f"{len(fails)} failure(s)")
+sys.exit(1 if fails else 0)

--- a/tools/analysis/serving_kpi.py
+++ b/tools/analysis/serving_kpi.py
@@ -27,7 +27,7 @@
 #   serving_kpi.py --url http://127.0.0.1:8080 --levels 1,8,32 --max-tokens 300
 #       [--requests-per-level N (default max(32, 2*C))] [--prompt-tokens 0]
 #       [--slo-ttft-ms 500] [--slo-tpot-ms 50] [--ignore-eos] [--endpoint chat|completions]
-#       [--no-power] [--json out.json] [--md out.md] [--tag x]
+#       [--no-power] [--json FILE] [--md-out FILE] [--tag x]
 import argparse
 import json
 import math
@@ -443,7 +443,7 @@ def main():
     ap.add_argument("--no-power", action="store_true")
     ap.add_argument("--tag", default=f"kpi{int(time.time()) % 100000}")
     ap.add_argument("--json", default="")
-    ap.add_argument("--md", default="")
+    ap.add_argument("--md-out", default="", help="write the markdown table to this file")
     args = ap.parse_args()
 
     levels = [int(x) for x in args.levels.split(",") if x]
@@ -479,8 +479,8 @@ def main():
 
     md = markdown(results, args)
     print(md)
-    if args.md:
-        with open(args.md, "w") as f:
+    if args.md_out:
+        with open(args.md_out, "w") as f:
             f.write(md + "\n")
     if args.json:
         with open(args.json, "w") as f:

--- a/tools/analysis/serving_kpi.py
+++ b/tools/analysis/serving_kpi.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+# serving_kpi.py - serving KPI sweep against an OpenAI-compatible server
+# (imp-server; vLLM accepts the same requests, its /metrics differ).
+#
+# Per concurrency level (closed loop: C workers, each sends its next request
+# when the previous one finished):
+#   latency    TTFT, TPOT (per request), ITL (per token), E2E, normalized
+#              latency (E2E / output tokens), each p50 / p95 / p99
+#   throughput req/s, output / input / total tok/s over the level's wall
+#   goodput    requests meeting BOTH SLOs (TTFT <= --slo-ttft-ms and
+#              TPOT <= --slo-tpot-ms), as req/s, tok/s and attainment %
+#   server     /metrics deltas across the level: queue wait p50/p95/p99 from
+#              imp_queue_time_seconds, decode rows per step, prefix-cache hit
+#              rate, speculative acceptance, KV-pressure rejections,
+#              StreamingLLM auto-enables, prefix-cache evictions; sampled
+#              imp_kv_blocks_live / imp_kv_blocks_total and
+#              imp_decode_batch_last_rows (mean, max)
+#   power      nvidia-smi power.draw integrated over the level: mean W,
+#              J per 1k output tokens, mean SM clock (the host-health check of
+#              docs/internals/BENCHMARKING.md)
+#
+# Stdlib only, runs on the host like the other tools/analysis clients. Prompts
+# are unique per request (a header token plus --prompt-tokens of filler), so
+# the prefix cache does not turn the sweep into a cache benchmark.
+#
+# Usage:
+#   serving_kpi.py --url http://127.0.0.1:8080 --levels 1,8,32 --max-tokens 300
+#       [--requests-per-level N (default max(32, 2*C))] [--prompt-tokens 0]
+#       [--slo-ttft-ms 500] [--slo-tpot-ms 50] [--ignore-eos] [--endpoint chat|completions]
+#       [--no-power] [--json out.json] [--md out.md] [--tag x]
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+FILLER = [
+    "A translation lookaside buffer caches recent virtual-to-physical page mappings so most loads skip the page walk.",
+    "Set-associative caches index a set by address bits and compare the tag against every way in that set.",
+    "Write-back caches mark a line dirty and defer the memory write until the line is evicted.",
+    "A hardware prefetcher watches the stream of misses and issues loads for the lines it expects next.",
+    "Out-of-order cores track dependencies with a reorder buffer and commit results in program order.",
+    "Branch predictors keep global and local histories and combine them to guess the next instruction address.",
+    "Cache coherence protocols such as MESI keep one writer or many readers per line across cores.",
+    "Huge pages cut TLB pressure by mapping two megabytes or a gigabyte with one entry.",
+]
+QUESTIONS = [
+    "Explain how a CPU cache works in three sentences.",
+    "Describe the water cycle briefly.",
+    "Summarize how photosynthesis works.",
+    "Give a short definition of entropy in physics.",
+    "Explain recursion with a tiny example.",
+    "What is the capital of Japan and one fact about it?",
+    "List five prime numbers and explain what makes them prime.",
+    "Write a short paragraph about the ocean.",
+]
+
+
+# ---------------------------------------------------------------- statistics
+
+def pct(xs, p):
+    """Percentile with linear interpolation (numpy default). p in [0, 100]."""
+    if not xs:
+        return float("nan")
+    s = sorted(xs)
+    if len(s) == 1:
+        return s[0]
+    k = (len(s) - 1) * (p / 100.0)
+    lo = math.floor(k)
+    hi = math.ceil(k)
+    if lo == hi:
+        return s[lo]
+    return s[lo] + (s[hi] - s[lo]) * (k - lo)
+
+
+def hist_quantile(buckets, q):
+    """Prometheus-style quantile from cumulative {le: count} buckets (deltas).
+
+    Linear interpolation inside the bucket that crosses the rank, like
+    histogram_quantile(); the +Inf bucket resolves to its lower bound.
+    Returns nan when the histogram is empty.
+    """
+    items = sorted(((float(le), float(c)) for le, c in buckets.items()), key=lambda t: t[0])
+    if not items or items[-1][1] <= 0:
+        return float("nan")
+    total = items[-1][1]
+    rank = q * total
+    prev_le, prev_c = 0.0, 0.0
+    for le, c in items:
+        if c >= rank:
+            if math.isinf(le):
+                return prev_le
+            if c == prev_c:
+                return le
+            return prev_le + (le - prev_le) * (rank - prev_c) / (c - prev_c)
+        prev_le, prev_c = le, c
+    return items[-1][0]
+
+
+def summarize_level(records, wall_s, slo_ttft_ms, slo_tpot_ms):
+    """records: list of dicts {ok, t0, t_first, t_end, stamps, prompt_tokens,
+    completion_tokens, cached_tokens}. Times in seconds (perf_counter)."""
+    ok = [r for r in records if r["ok"]]
+    err = len(records) - len(ok)
+    ttft, tpot, itl, e2e, norm = [], [], [], [], []
+    met, met_tokens, out_tokens, in_tokens, cached = 0, 0, 0, 0, 0
+    for r in ok:
+        n_out = r["completion_tokens"]
+        out_tokens += n_out
+        in_tokens += r["prompt_tokens"]
+        cached += r.get("cached_tokens", 0)
+        if r["t_first"] is None or n_out <= 0:
+            continue
+        t_ttft = (r["t_first"] - r["t0"]) * 1e3
+        t_e2e = r["t_end"] - r["t0"]
+        ttft.append(t_ttft)
+        e2e.append(t_e2e)
+        norm.append(t_e2e * 1e3 / n_out)
+        st = r["stamps"]
+        itl.extend((b - a) * 1e3 for a, b in zip(st, st[1:]))
+        if n_out >= 2:
+            t_tpot = (r["t_end"] - r["t_first"]) * 1e3 / (n_out - 1)
+            tpot.append(t_tpot)
+        else:
+            t_tpot = 0.0
+        if t_ttft <= slo_ttft_ms and t_tpot <= slo_tpot_ms:
+            met += 1
+            met_tokens += n_out
+
+    def trio(xs):
+        return {"p50": pct(xs, 50), "p95": pct(xs, 95), "p99": pct(xs, 99), "n": len(xs)}
+
+    w = wall_s if wall_s > 0 else float("nan")
+    return {
+        "requests": len(records), "ok": len(ok), "err": err, "wall_s": wall_s,
+        "req_s": len(ok) / w,
+        "output_tok_s": out_tokens / w, "input_tok_s": in_tokens / w,
+        "total_tok_s": (out_tokens + in_tokens) / w,
+        "output_tokens": out_tokens, "input_tokens": in_tokens, "cached_tokens": cached,
+        "ttft_ms": trio(ttft), "tpot_ms": trio(tpot), "itl_ms": trio(itl),
+        "e2e_s": trio(e2e), "norm_ms_per_tok": trio(norm),
+        "goodput_req_s": met / w, "goodput_tok_s": met_tokens / w,
+        "slo_attainment_pct": (100.0 * met / len(ttft)) if ttft else float("nan"),
+        "slo": {"ttft_ms": slo_ttft_ms, "tpot_ms": slo_tpot_ms},
+    }
+
+
+# ---------------------------------------------------------------- /metrics
+
+_LINE = re.compile(r'^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+(-?[0-9.eE+\-]+|NaN|\+Inf)$')
+
+
+def parse_metrics(text):
+    """{name: value} for unlabeled series, {name: {le: count}} for _bucket series."""
+    plain, hists = {}, {}
+    for line in text.splitlines():
+        m = _LINE.match(line.strip())
+        if not m:
+            continue
+        name, labels, val = m.group(1), m.group(2), m.group(3)
+        v = float("inf") if val == "+Inf" else float(val)
+        if labels and name.endswith("_bucket"):
+            le = re.search(r'le="([^"]+)"', labels)
+            if le:
+                hists.setdefault(name[:-len("_bucket")], {})[le.group(1)] = v
+        elif not labels:
+            plain[name] = v
+    return plain, hists
+
+
+def scrape(url):
+    try:
+        with urllib.request.urlopen(url + "/metrics", timeout=5) as r:
+            return parse_metrics(r.read().decode("utf-8", "ignore"))
+    except Exception as e:  # noqa: BLE001
+        print(f"WARN /metrics: {e}", file=sys.stderr)
+        return {}, {}
+
+
+def hist_delta(before, after, name):
+    a, b = after.get(name, {}), before.get(name, {})
+    return {le: a[le] - b.get(le, 0.0) for le in a}
+
+
+def delta(before, after, name):
+    if name not in after:
+        return float("nan")
+    return after[name] - before.get(name, 0.0)
+
+
+def server_summary(m0, h0, m1, h1, samples):
+    q = hist_delta(h0, h1, "imp_queue_time_seconds")
+    steps = delta(m0, m1, "imp_decode_batch_steps_total")
+    rows = delta(m0, m1, "imp_decode_batch_rows_total")
+    prompt = delta(m0, m1, "imp_tokens_prompt_total")
+    cached = delta(m0, m1, "imp_tokens_cached_total")
+    drafted = delta(m0, m1, "imp_spec_drafted_total")
+    accepted = delta(m0, m1, "imp_spec_accepted_total")
+    kv_util = [s["kv_util_pct"] for s in samples if s.get("kv_util_pct") is not None]
+    active = [s["active"] for s in samples if s.get("active") is not None]
+    return {
+        "queue_ms": {"p50": hist_quantile(q, 0.5) * 1e3, "p95": hist_quantile(q, 0.95) * 1e3,
+                     "p99": hist_quantile(q, 0.99) * 1e3, "n": q.get("+Inf", float("nan"))},
+        "rows_per_step": rows / steps if steps and steps > 0 else float("nan"),
+        "decode_steps": steps,
+        "active_seqs_mean": (sum(active) / len(active)) if active else float("nan"),
+        "active_seqs_max": max(active) if active else float("nan"),
+        "kv_util_mean_pct": (sum(kv_util) / len(kv_util)) if kv_util else float("nan"),
+        "kv_util_max_pct": max(kv_util) if kv_util else float("nan"),
+        "prefix_hit_pct": (100.0 * cached / prompt) if prompt and prompt > 0 else float("nan"),
+        "spec_accept_pct": (100.0 * accepted / drafted) if drafted and drafted > 0 else float("nan"),
+        "spec_drafted": drafted,
+        "kv_pressure_rejections": delta(m0, m1, "imp_kv_pressure_rejections_total"),
+        "streaming_kv_auto_enables": delta(m0, m1, "imp_streaming_kv_auto_enables_total"),
+        "prefix_cache_evictions": delta(m0, m1, "imp_prefix_cache_evictions_total"),
+        "requests_rejected": delta(m0, m1, "imp_requests_rejected_total"),
+        "requests_timed_out": delta(m0, m1, "imp_requests_timed_out_total"),
+    }
+
+
+class Sampler(threading.Thread):
+    """Polls /metrics gauges and nvidia-smi power while a level runs."""
+
+    def __init__(self, url, power, period=0.25):
+        super().__init__(daemon=True)
+        self.url, self.power, self.period = url, power, period
+        self.samples, self.power_samples = [], []  # power: (t, watts, sm_mhz)
+        self._stop = threading.Event()
+
+    def run(self):
+        while not self._stop.is_set():
+            t = time.perf_counter()
+            m, _ = scrape(self.url)
+            tot, live = m.get("imp_kv_blocks_total"), m.get("imp_kv_blocks_live")
+            self.samples.append({
+                "t": t,
+                "kv_util_pct": (100.0 * live / tot) if tot and live is not None else None,
+                "active": m.get("imp_decode_batch_last_rows"),
+            })
+            if self.power:
+                try:
+                    out = subprocess.run(
+                        ["nvidia-smi", "--query-gpu=power.draw,clocks.sm",
+                         "--format=csv,noheader,nounits"],
+                        capture_output=True, text=True, timeout=2).stdout.strip().split(",")
+                    self.power_samples.append((t, float(out[0]), float(out[1])))
+                except Exception:  # noqa: BLE001
+                    pass
+            self._stop.wait(self.period)
+
+    def stop(self):
+        self._stop.set()
+        self.join()
+
+    def energy(self, t_lo, t_hi):
+        pts = [p for p in self.power_samples if t_lo <= p[0] <= t_hi]
+        if len(pts) < 2:
+            return {"joules": float("nan"), "power_mean_w": float("nan"), "sm_mhz_mean": float("nan")}
+        joules = sum((b[0] - a[0]) * (a[1] + b[1]) / 2 for a, b in zip(pts, pts[1:]))
+        return {"joules": joules,
+                "power_mean_w": sum(p[1] for p in pts) / len(pts),
+                "sm_mhz_mean": sum(p[2] for p in pts) / len(pts)}
+
+
+# ---------------------------------------------------------------- client
+
+def make_prompt(tag, level, i, prompt_tokens):
+    head = f"[{tag}-c{level}-r{i}] "
+    fill = ""
+    if prompt_tokens > 0:
+        n = max(1, prompt_tokens // 20)
+        fill = " ".join(FILLER[(i + k) % len(FILLER)] for k in range(n)) + " "
+    return head + fill + QUESTIONS[i % len(QUESTIONS)]
+
+
+def one_request(args, level, i):
+    prompt = make_prompt(args.tag, level, i, args.prompt_tokens)
+    extra = {"ignore_eos": True} if args.ignore_eos else {}
+    if args.endpoint == "chat":
+        path = "/v1/chat/completions"
+        body = {"model": args.model, "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": args.max_tokens, "temperature": 0, "stream": True,
+                "stream_options": {"include_usage": True}, **extra}
+    else:
+        path = "/v1/completions"
+        body = {"model": args.model, "prompt": prompt, "max_tokens": args.max_tokens,
+                "temperature": 0, "stream": True, "stream_options": {"include_usage": True},
+                **extra}
+    headers = {"Content-Type": "application/json"}
+    if args.api_key:
+        headers["Authorization"] = "Bearer " + args.api_key
+    req = urllib.request.Request(args.url + path, data=json.dumps(body).encode(), headers=headers)
+    rec = {"ok": False, "t0": time.perf_counter(), "t_first": None, "t_end": None, "stamps": [],
+           "prompt_tokens": 0, "completion_tokens": 0, "cached_tokens": 0, "err": None}
+    usage = {}
+    try:
+        with urllib.request.urlopen(req, timeout=args.timeout) as r:
+            for raw in r:
+                line = raw.decode("utf-8", "ignore").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    break
+                try:
+                    j = json.loads(payload)
+                except ValueError:
+                    continue
+                if j.get("usage"):
+                    usage = j["usage"]
+                ch = j.get("choices") or []
+                if not ch:
+                    continue
+                c0 = ch[0]
+                d = c0.get("delta") or {}
+                if d.get("content") or d.get("reasoning_content") or c0.get("text"):
+                    now = time.perf_counter()
+                    if rec["t_first"] is None:
+                        rec["t_first"] = now
+                    rec["stamps"].append(now)
+        rec["ok"] = True
+    except Exception as e:  # noqa: BLE001
+        rec["err"] = str(e)
+    rec["t_end"] = time.perf_counter()
+    rec["prompt_tokens"] = int(usage.get("prompt_tokens", 0))
+    rec["completion_tokens"] = int(usage.get("completion_tokens", len(rec["stamps"])))
+    rec["cached_tokens"] = int((usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0))
+    return rec
+
+
+def run_level(args, level, n_requests, sampler):
+    records = [None] * n_requests
+    next_i = [0]
+    lock = threading.Lock()
+
+    def worker():
+        while True:
+            with lock:
+                i = next_i[0]
+                next_i[0] += 1
+            if i >= n_requests:
+                return
+            records[i] = one_request(args, level, i)
+
+    m0, h0 = scrape(args.url)
+    n_before = len(sampler.samples)
+    t_lo = time.perf_counter()
+    threads = [threading.Thread(target=worker) for _ in range(level)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    t_hi = time.perf_counter()
+    m1, h1 = scrape(args.url)
+    client = summarize_level(records, t_hi - t_lo, args.slo_ttft_ms, args.slo_tpot_ms)
+    server = server_summary(m0, h0, m1, h1, sampler.samples[n_before:])
+    power = sampler.energy(t_lo, t_hi)
+    out_tok = client["output_tokens"]
+    power["j_per_1k_output_tok"] = (power["joules"] / (out_tok / 1000.0)) if out_tok else float("nan")
+    errs = [r["err"] for r in records if r and r["err"]]
+    return {"concurrency": level, "client": client, "server": server, "power": power,
+            "sample_err": errs[0] if errs else None}
+
+
+# ---------------------------------------------------------------- report
+
+def fmt(v, nd=1):
+    if v is None or (isinstance(v, float) and math.isnan(v)):
+        return "-"
+    if isinstance(v, float):
+        return f"{v:.{nd}f}"
+    return str(v)
+
+
+def markdown(results, args):
+    rows = []
+
+    def add(label, fn, nd=1):
+        rows.append((label, [fmt(fn(r), nd) for r in results]))
+
+    def trio(sec, key, nd=1):
+        return lambda r: " / ".join(fmt(r[sec][key][p], nd) for p in ("p50", "p95", "p99"))
+
+    add("requests ok / err", lambda r: f"{r['client']['ok']} / {r['client']['err']}")
+    add("wall s", lambda r: r["client"]["wall_s"], 2)
+    add("req/s", lambda r: r["client"]["req_s"], 2)
+    add("output tok/s", lambda r: r["client"]["output_tok_s"])
+    add("input tok/s", lambda r: r["client"]["input_tok_s"])
+    add("total tok/s", lambda r: r["client"]["total_tok_s"])
+    add("TTFT p50 / p95 / p99 ms", trio("client", "ttft_ms", 0))
+    add("TPOT p50 / p95 / p99 ms", trio("client", "tpot_ms", 1))
+    add("ITL p50 / p95 / p99 ms", trio("client", "itl_ms", 1))
+    add("E2E p50 / p95 / p99 s", trio("client", "e2e_s", 2))
+    add("normalized p50 / p95 / p99 ms/tok", trio("client", "norm_ms_per_tok", 1))
+    add(f"goodput req/s (TTFT<={args.slo_ttft_ms:.0f} ms, TPOT<={args.slo_tpot_ms:.0f} ms)",
+        lambda r: r["client"]["goodput_req_s"], 2)
+    add("goodput tok/s", lambda r: r["client"]["goodput_tok_s"])
+    add("SLO attainment %", lambda r: r["client"]["slo_attainment_pct"])
+    add("queue p50 / p95 / p99 ms (server)", trio("server", "queue_ms", 1))
+    add("decode rows / step", lambda r: r["server"]["rows_per_step"], 2)
+    add("active seqs mean / max (sampled)",
+        lambda r: f"{fmt(r['server']['active_seqs_mean'])} / {fmt(r['server']['active_seqs_max'], 0)}")
+    add("KV live mean / max %",
+        lambda r: f"{fmt(r['server']['kv_util_mean_pct'])} / {fmt(r['server']['kv_util_max_pct'])}")
+    add("prefix-cache hit %", lambda r: r["server"]["prefix_hit_pct"])
+    add("spec accept % (drafted)",
+        lambda r: f"{fmt(r['server']['spec_accept_pct'])} ({fmt(r['server']['spec_drafted'], 0)})")
+    add("KV rejections / StreamingLLM auto / prefix evictions",
+        lambda r: " / ".join(fmt(r["server"][k], 0) for k in
+                             ("kv_pressure_rejections", "streaming_kv_auto_enables",
+                              "prefix_cache_evictions")))
+    add("power mean W", lambda r: r["power"]["power_mean_w"], 0)
+    add("J per 1k output tok", lambda r: r["power"]["j_per_1k_output_tok"])
+    add("SM clock mean MHz", lambda r: r["power"]["sm_mhz_mean"], 0)
+    head = "| KPI | " + " | ".join(f"c={r['concurrency']}" for r in results) + " |"
+    sep = "|---|" + "|".join("---" for _ in results) + "|"
+    lines = [head, sep] + [f"| {label} | " + " | ".join(cells) + " |" for label, cells in rows]
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--url", default="http://127.0.0.1:8080")
+    ap.add_argument("--api-key", default="")
+    ap.add_argument("--model", default=os.environ.get("MODEL_NAME", "x"))
+    ap.add_argument("--endpoint", choices=("chat", "completions"), default="chat")
+    ap.add_argument("--levels", default="1,8,32")
+    ap.add_argument("--requests-per-level", type=int, default=0, help="default max(32, 2*C)")
+    ap.add_argument("--max-tokens", type=int, default=300)
+    ap.add_argument("--prompt-tokens", type=int, default=0, help="filler tokens per prompt")
+    ap.add_argument("--ignore-eos", action="store_true", help="every request runs to --max-tokens")
+    ap.add_argument("--slo-ttft-ms", type=float, default=500.0)
+    ap.add_argument("--slo-tpot-ms", type=float, default=50.0)
+    ap.add_argument("--warmup", type=int, default=1, help="warmup waves at the largest level (64 tokens)")
+    ap.add_argument("--timeout", type=float, default=900.0)
+    ap.add_argument("--no-power", action="store_true")
+    ap.add_argument("--tag", default=f"kpi{int(time.time()) % 100000}")
+    ap.add_argument("--json", default="")
+    ap.add_argument("--md", default="")
+    args = ap.parse_args()
+
+    levels = [int(x) for x in args.levels.split(",") if x]
+    power = not args.no_power and shutil.which("nvidia-smi") is not None
+    sampler = Sampler(args.url, power)
+    sampler.start()
+
+    if args.warmup > 0:
+        c = max(levels)
+        saved = args.max_tokens
+        args.max_tokens = 64
+        for _ in range(args.warmup):
+            run_level(args, c, c, sampler)
+        args.max_tokens = saved
+        print(f"warmup: {args.warmup} wave(s) at c={c}", file=sys.stderr)
+
+    results = []
+    for c in levels:
+        n = args.requests_per_level or max(32, 2 * c)
+        r = run_level(args, c, n, sampler)
+        results.append(r)
+        cl = r["client"]
+        print(f"c={c}: {cl['ok']}/{cl['requests']} ok, {cl['output_tok_s']:.1f} out tok/s, "
+              f"{cl['req_s']:.2f} req/s, TTFT p50/p95/p99 {fmt(cl['ttft_ms']['p50'], 0)}/"
+              f"{fmt(cl['ttft_ms']['p95'], 0)}/{fmt(cl['ttft_ms']['p99'], 0)} ms, "
+              f"TPOT p50/p99 {fmt(cl['tpot_ms']['p50'])}/{fmt(cl['tpot_ms']['p99'])} ms, "
+              f"goodput {cl['goodput_req_s']:.2f} req/s ({fmt(cl['slo_attainment_pct'], 0)} %)",
+              file=sys.stderr, flush=True)
+        if r["sample_err"]:
+            print(f"  sample error: {r['sample_err']}", file=sys.stderr)
+        time.sleep(2)
+    sampler.stop()
+
+    md = markdown(results, args)
+    print(md)
+    if args.md:
+        with open(args.md, "w") as f:
+            f.write(md + "\n")
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump({"args": vars(args), "results": results}, f, indent=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/filesize_thresholds.toml
+++ b/tools/filesize_thresholds.toml
@@ -81,7 +81,7 @@ roots = ["src", "tools", "tests"]
 "src/exec/executor_forward.cu" = { code_loc = 850, reason = "(c) executor forward orchestration (one dense forward path + 2 scale helpers)" }
 "src/exec/executor_forward_moe_batch.cu" = { code_loc = 1123, reason = "(c) one path: batched-MoE forward dispatch. Host-only until #1548 put the expert-imbalance kernel here, next to the routing hook it reads from: splitting one 30-line diagnostic kernel into its own TU would cost a recompile edge for less than it saves" }
 "src/exec/executor_workspace_buffers.cu" = { code_loc = 1535, reason = "(c) one concern: executor scratch/workspace sizing+allocation (host-only)" }
-"src/memory/kv_cache_manager.cpp" = { code_loc = 1207, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
+"src/memory/kv_cache_manager.cpp" = { code_loc = 1208, reason = "(c) one manager: block alloc + residual pool + prefix cache + eviction" }
 "src/model/gguf_loader.cpp" = { code_loc = 820, reason = "(a->c) the (a) split already happened: gguf_parse.cpp + gguf_tensor_assign.cpp came out of it and left 788 (AUDIT_FILESIZE.md). The residue is one linear load flow (mmap, header, metadata -> ModelConfig, shard stitch, tensor wiring) like the allowlisted safetensors_loader.cpp, and the file is in maintenance mode per its own header. Crossed 800 with the #1324 declared-layers consistency check." }
 "src/model/hf_config_loader.cpp" = { code_loc = 943, reason = "(tu) central HF config→ModelConfig parser; one accreting block per arch (MLA/YaRN/MoE/SWA/rope); splitting scatters the single parse flow" }
 "src/model/jinja.cpp" = { code_loc = 2407, reason = "(c) one cohesive Jinja2 engine: Value + Lexer + Parser + Evaluator" }
@@ -90,7 +90,7 @@ roots = ["src", "tools", "tests"]
 "src/model/weight_map.cpp" = { code_loc = 1071, reason = "(c) one mapping module: weight-name parse + layer-index + arch inference" }
 "src/model/weight_upload.cu" = { code_loc = 2004, reason = "(c) one upload pipeline: pinned staging + checked malloc + tensor load orchestration" }
 "src/runtime/cuda_graph.cu" = { code_loc = 1069, reason = "(c) one module: graph capture/mode-resolve + PDL edges + barrier insert + replay" }
-"src/runtime/engine_scheduler.cpp" = { code_loc = 1307, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
+"src/runtime/engine_scheduler.cpp" = { code_loc = 1308, reason = "(c) one scheduler: step loop + scheduling + batched decode step + perplexity capture. Prefill execution (engine_prefill.cpp) and the decode pipeline (engine_decode_pipeline.cpp) were split out 2026-08-26 when the file hit 2230" }
 "tests/test_gdn.cu" = { code_loc = 1399, reason = "(c) 12 tests of the GDN state-recurrent module - one test target" }
 "tests/test_gemm_kernel_registry.cu" = { code_loc = 1259, reason = "(c) 41 tests of the gemm_kernel_registry dispatch contract - one test target" }
 "tests/test_kv_cache.cpp" = { code_loc = 844, reason = "(c) 51 bookkeeping tests across KV allocator/cache/manager - one test target" }

--- a/tools/imp-server/batching_engine.cpp
+++ b/tools/imp-server/batching_engine.cpp
@@ -255,8 +255,10 @@ void BatchingEngine::worker_loop() {
             }
         }
 
-        if (active_requests_.empty())
+        if (active_requests_.empty()) {
+            decode_batch_last.store(0, std::memory_order_relaxed);
             continue;
+        }
 
         // 2. Check for cancelled requests before stepping. A pipelined
         // batched-decode step may still be in flight and WRITING these
@@ -294,6 +296,7 @@ void BatchingEngine::worker_loop() {
                     sr->request->status != imp::RequestStatus::CANCELLED)
                     rows++;
             }
+            decode_batch_last.store(rows, std::memory_order_relaxed);
             if (rows > 0) {
                 decode_steps.fetch_add(1, std::memory_order_relaxed);
                 decode_rows.fetch_add(rows, std::memory_order_relaxed);

--- a/tools/imp-server/batching_engine.h
+++ b/tools/imp-server/batching_engine.h
@@ -89,6 +89,10 @@ public:
     std::atomic<int64_t> decode_steps{0};
     std::atomic<int64_t> decode_rows{0};
     std::atomic<int64_t> decode_batch_max{0};
+    // Rows of the most recent step, 0 while the worker idles: the sequences
+    // decoding together right now. The counter pair above gives only the
+    // windowed mean and decode_batch_max never resets.
+    std::atomic<int64_t> decode_batch_last{0};
 
     BatchingEngine() = default;
     ~BatchingEngine();

--- a/tools/imp-server/handlers.h
+++ b/tools/imp-server/handlers.h
@@ -140,6 +140,16 @@ struct ServerMetrics {
     // Time from admission to the first decode step, i.e. how long a request
     // waited behind others. Nothing measured queueing before (#1580).
     LatencyHistogram queue_time;
+    // Queue wait of a request the handler gives up on (client gone, or the
+    // server's --request-timeout) before the worker admitted it. The wait is
+    // otherwise closed at the first token, so a queue that times requests out
+    // read as empty in imp_queue_time_seconds.
+    void observe_unadmitted_queue_wait(std::chrono::steady_clock::time_point t_submit, double queue_ms) {
+        if (queue_ms >= 0.0 || t_submit == std::chrono::steady_clock::time_point{})
+            return;
+        queue_time.observe(
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - t_submit).count());
+    }
     // (Decode batch size lives on the BatchingEngine, where the batch is
     // formed; /metrics reads it from there.)
     // 4xx refusals. requests_failed counts 5xx only, and every rejection this

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -433,6 +433,8 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
 
                 auto request_start_c = std::chrono::steady_clock::now();
                 auto last_keepalive_c = request_start_c;
+                double ttft_ms = -1.0;
+                auto t_prev_token = t_start;  // last delivered token (ITL)
                 for (;;) {
                     // #757: the is_last token sets `finish` then falls through
                     // to think-stripping, which `continue`s on every swallowed
@@ -448,6 +450,9 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                     if (!sink.is_writable()) {
                         server_req->cancel();
                         state.metrics.requests_cancelled++;
+                        state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                                    server_req->queue_ms.load(
+                                                                        std::memory_order_relaxed));
                         finish = "cancelled";
                         break;
                     }
@@ -458,6 +463,9 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                         if (elapsed > std::chrono::seconds(state.request_timeout)) {
                             server_req->cancel();
                             state.metrics.requests_timed_out++;
+                            state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                                        server_req->queue_ms.load(
+                                                                            std::memory_order_relaxed));
                             finish = "length";
                             break;
                         }
@@ -483,6 +491,25 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                     }
 
                     int32_t token = evt.token_id;
+
+                    // First token closes TTFT and the queue wait, every later
+                    // one is an ITL sample. This loop fed none of the four
+                    // latency histograms before, so /v1/completions traffic
+                    // (every serving harness in tools/analysis/) left them
+                    // empty.
+                    {
+                        const auto t_tok = std::chrono::high_resolution_clock::now();
+                        if (ttft_ms < 0.0) {
+                            ttft_ms = std::chrono::duration<double, std::milli>(t_tok - t_start).count();
+                            const double q = server_req->queue_ms.load(std::memory_order_relaxed);
+                            if (q >= 0.0)
+                                state.metrics.queue_time.observe(q / 1000.0);
+                        } else {
+                            state.metrics.inter_token.observe(
+                                std::chrono::duration<double>(t_tok - t_prev_token).count());
+                        }
+                        t_prev_token = t_tok;
+                    }
 
                     if (evt.is_last) {
                         if (token == snap_tok->eos_id() && !ignore_eos) {
@@ -650,6 +677,11 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
                 state.metrics.tokens_prompt_total += n_prompt_tokens;
                 state.metrics.tokens_completion_total += n_output_tokens;
                 state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+                state.metrics.request_duration.observe(ms / 1000.0);
+                if (ttft_ms >= 0.0) {
+                    state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+                    state.metrics.ttft.observe(ttft_ms / 1000.0);
+                }
 
                 return true;
             });
@@ -661,12 +693,17 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
         std::string output_text;
 
         auto ns_comp_start = std::chrono::steady_clock::now();
+        double ttft_ms = -1.0;
+        auto t_prev_token = t_start;  // last delivered token (ITL)
         for (;;) {
             if (state.request_timeout > 0) {
                 auto elapsed = std::chrono::steady_clock::now() - ns_comp_start;
                 if (elapsed > std::chrono::seconds(state.request_timeout)) {
                     server_req->cancel();
                     state.metrics.requests_timed_out++;
+                    state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                                server_req->queue_ms.load(
+                                                                    std::memory_order_relaxed));
                     finish = "length";
                     break;
                 }
@@ -683,6 +720,20 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
             }
 
             int32_t token = evt.token_id;
+
+            {
+                const auto t_tok = std::chrono::high_resolution_clock::now();
+                if (ttft_ms < 0.0) {
+                    ttft_ms = std::chrono::duration<double, std::milli>(t_tok - t_start).count();
+                    const double q = server_req->queue_ms.load(std::memory_order_relaxed);
+                    if (q >= 0.0)
+                        state.metrics.queue_time.observe(q / 1000.0);
+                } else {
+                    state.metrics.inter_token.observe(
+                        std::chrono::duration<double>(t_tok - t_prev_token).count());
+                }
+                t_prev_token = t_tok;
+            }
 
             if (evt.is_last) {
                 if (token == snap_tok->eos_id() && !ignore_eos) {
@@ -747,6 +798,11 @@ void handle_completions(const httplib::Request& req, httplib::Response& res, Ser
         state.metrics.tokens_prompt_total += n_prompt_tokens;
         state.metrics.tokens_completion_total += n_output_tokens;
         state.metrics.last_request_duration_ms = static_cast<int64_t>(ms);
+        state.metrics.request_duration.observe(ms / 1000.0);
+        if (ttft_ms >= 0.0) {
+            state.metrics.last_ttft_ms = static_cast<int64_t>(ttft_ms);
+            state.metrics.ttft.observe(ttft_ms / 1000.0);
+        }
 
         // Build logprobs if requested
         // #1589: this is /v1/completions, so it gets the Completions shape.

--- a/tools/imp-server/handlers_chat_core.cpp
+++ b/tools/imp-server/handlers_chat_core.cpp
@@ -827,12 +827,17 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
         std::string matched_stop;  // which stop sequence ended it, for the Anthropic shim (#1550)
 
         auto ns_request_start = std::chrono::steady_clock::now();
+        auto t_prev_token = std::chrono::high_resolution_clock::now();  // last delivered token (ITL)
         for (;;) {
             // Check request timeout
             if (state.request_timeout > 0) {
                 auto elapsed = std::chrono::steady_clock::now() - ns_request_start;
                 if (elapsed > std::chrono::seconds(state.request_timeout)) {
                     server_req->cancel();
+                    state.metrics.requests_timed_out++;
+                    state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                                server_req->queue_ms.load(
+                                                                    std::memory_order_relaxed));
                     finish = "length";
                     break;
                 }
@@ -903,17 +908,24 @@ void nonstream_chat_response_(httplib::Response& res, ServerState& state, ChatRe
             // TTFT was recorded on the streaming path only, while this one
             // still incremented requests_total - so the histogram described
             // half the traffic and said nothing about which half (#1578).
+            const auto t_tok = std::chrono::high_resolution_clock::now();
             if (output_ids.empty() && ttft_ms < 0.0) {
-                ttft_ms = std::chrono::duration<double, std::milli>(
-                              std::chrono::high_resolution_clock::now() - ctx.t_start)
-                              .count();
+                ttft_ms = std::chrono::duration<double, std::milli>(t_tok - ctx.t_start).count();
                 // Same point as the streaming path: by the first token the
                 // worker has admitted the request, so queue_ms is final
                 // (#1580).
                 const double q = server_req->queue_ms.load(std::memory_order_relaxed);
                 if (q >= 0.0)
                     state.metrics.queue_time.observe(q / 1000.0);
+            } else if (!output_ids.empty()) {
+                // ITL was observed on the streaming path only (#1577), so the
+                // histogram described streaming traffic and said nothing
+                // about this loop's tokens. Per completion: the first token of
+                // a second n>1 completion is not a gap.
+                state.metrics.inter_token.observe(
+                    std::chrono::duration<double>(t_tok - t_prev_token).count());
             }
+            t_prev_token = t_tok;
             output_ids.push_back(token);
 
             // Check text-level stop sequences

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -201,10 +201,12 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
     // ServerMetrics: the decision is the engine's, and a second copy is a
     // second thing to keep in sync (#1641).
     {
-        uint64_t kv_rejects = 0, kv_growths = 0;
+        uint64_t kv_rejects = 0, kv_growths = 0, kv_auto_stream = 0, prefix_evictions = 0;
         if (state.ctx && state.ctx->engine) {
             kv_rejects = state.ctx->engine->kv_pressure_rejections();
             kv_growths = state.ctx->engine->kv_pool_growths();
+            kv_auto_stream = state.ctx->engine->streaming_kv_auto_enables();
+            prefix_evictions = state.ctx->engine->prefix_cache_evictions();
         }
         out +=
             "# HELP imp_kv_pressure_rejections_total Requests cancelled because the KV pool "
@@ -214,6 +216,20 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
         out += "# HELP imp_kv_pool_growths_total Times the growable KV pool committed more memory\n";
         out += "# TYPE imp_kv_pool_growths_total counter\n";
         out += "imp_kv_pool_growths_total " + std::to_string(kv_growths) + "\n";
+        // The two preemption events that were log lines only: StreamingLLM
+        // auto-enable (which also demotes CUDA graphs one-way) and prefix-cache
+        // block reclaims. usage.evicted_tokens is the per-request size; these
+        // are the rates.
+        out +=
+            "# HELP imp_streaming_kv_auto_enables_total Times the KV pool ran >90% full and "
+            "StreamingLLM eviction was auto-enabled (CUDA graphs demoted one-way)\n";
+        out += "# TYPE imp_streaming_kv_auto_enables_total counter\n";
+        out += "imp_streaming_kv_auto_enables_total " + std::to_string(kv_auto_stream) + "\n";
+        out +=
+            "# HELP imp_prefix_cache_evictions_total Cached prefix blocks reclaimed for new "
+            "allocations\n";
+        out += "# TYPE imp_prefix_cache_evictions_total counter\n";
+        out += "imp_prefix_cache_evictions_total " + std::to_string(prefix_evictions) + "\n";
     }
     out += "# HELP imp_last_ttft_ms Time to first token of last request in milliseconds\n";
     out += "# TYPE imp_last_ttft_ms gauge\n";
@@ -270,12 +286,13 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
     // The counters live on the BatchingEngine, which is where the batch is
     // formed; read under the same bounded lock the rest of this endpoint uses.
     {
-        int64_t steps = 0, rows = 0, bmax = 0;
+        int64_t steps = 0, rows = 0, bmax = 0, blast = 0;
         std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
         if (lock.owns_lock() && state.batching) {
             steps = state.batching->decode_steps.load();
             rows = state.batching->decode_rows.load();
             bmax = state.batching->decode_batch_max.load();
+            blast = state.batching->decode_batch_last.load();
         }
         out += "# HELP imp_decode_batch_steps_total Decode steps executed\n";
         out += "# TYPE imp_decode_batch_steps_total counter\n";
@@ -286,6 +303,11 @@ void handle_metrics(const httplib::Request& /*req*/, httplib::Response& res, Ser
         out += "# HELP imp_decode_batch_max Largest decode batch seen since start\n";
         out += "# TYPE imp_decode_batch_max gauge\n";
         out += "imp_decode_batch_max " + std::to_string(bmax) + "\n";
+        out +=
+            "# HELP imp_decode_batch_last_rows Sequences in the most recent decode step, 0 while "
+            "idle\n";
+        out += "# TYPE imp_decode_batch_last_rows gauge\n";
+        out += "imp_decode_batch_last_rows " + std::to_string(blast) + "\n";
     }
     out += "# HELP imp_model_loaded Whether a model is currently loaded\n";
     out += "# TYPE imp_model_loaded gauge\n";

--- a/tools/imp-server/stream_driver.cpp
+++ b/tools/imp-server/stream_driver.cpp
@@ -202,6 +202,8 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
         if (!sink.is_writable()) {
             server_req->cancel();
             state.metrics.requests_cancelled++;
+            state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                        server_req->queue_ms.load(std::memory_order_relaxed));
             finish = "cancelled";
             break;
         }
@@ -218,6 +220,9 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
             if (elapsed > std::chrono::seconds(state.request_timeout)) {
                 server_req->cancel();
                 state.metrics.requests_timed_out++;
+                state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                            server_req->queue_ms.load(
+                                                                std::memory_order_relaxed));
                 IMP_LOG_WARN(
                     "request ended at --request-timeout (%d s); the client sees "
                     "finish_reason=length, which is indistinguishable from a spent "
@@ -244,6 +249,9 @@ bool run_stream_loop_(httplib::DataSink& sink, ChatRequestContext& ctx, ServerSt
                 if (!d.keepalive()) {
                     server_req->cancel();
                     state.metrics.requests_cancelled++;
+                    state.metrics.observe_unadmitted_queue_wait(server_req->t_submit,
+                                                                server_req->queue_ms.load(
+                                                                    std::memory_order_relaxed));
                     finish = "cancelled";
                     break;
                 }


### PR DESCRIPTION
Serving KPI harness, `/metrics` coverage fixes, three new series, first published serving table.

## Harness

`tools/analysis/serving_kpi.py` (stdlib, host): closed loop per concurrency level, per level TTFT / TPOT / ITL / E2E / normalized latency at p50 / p95 / p99, req/s, input / output / total tok/s, goodput against an SLO pair (defaults TTFT <= 500 ms, TPOT <= 50 ms), `/metrics` deltas (queue wait via histogram interpolation, rows per step, KV live %, prefix hit %, spec accept %, KV rejections / StreamingLLM auto-enables / prefix evictions) and `nvidia-smi` energy (mean W, J per 1k output tokens, mean SM clock). Definitions: `docs/internals/BENCHMARKING.md` "Serving KPIs". Math test: `tests/api/test_serving_kpi.py` (mock lane, 6 tests).

## `/metrics` fixes

| path | before | after |
|---|---|---|
| `/v1/completions` stream + non-stream | none of duration / TTFT / queue / ITL observed | all four |
| chat non-stream | no ITL; timeout not counted | ITL per token; `imp_requests_timed_out_total` |
| cancel / timeout before admission | no queue observation | wait observed (`observe_unadmitted_queue_wait`) |

Every serving harness in `tools/analysis/` drives `/v1/completions`, so the four histograms were empty for every bench run so far. Gate: `tests/test_server_metrics.py` in `make test-server` (4 paths x duration/TTFT/queue = 1 and ITL >= N-4; new series present; last-rows gauge 0 when idle).

New series: `imp_streaming_kv_auto_enables_total`, `imp_prefix_cache_evictions_total` (counted in the engine / KV manager, read at scrape), `imp_decode_batch_last_rows` (gauge, 0 when idle). Mock and contract test mirror them (model-less lane safe: all three emit zeros without a model).

## Measured (imp:test from this branch, Qwen3-8B, defaults, levels 1/8/32, 300 tokens)

Qwen3-8B-NVFP4-cortecs:

| KPI | c=1 | c=8 | c=32 |
|---|---|---|---|
| output tok/s | 291.4 | 1413.6 | 4633.7 |
| TTFT p50 / p95 / p99 ms | 11 / 31 / 34 | 25 / 37 / 41 | 50 / 232 / 238 |
| TPOT p50 / p99 ms | 3.4 / 3.5 | 5.1 / 5.4 | 5.8 / 6.4 |
| goodput req/s (attainment) | 1.11 (100 %) | 5.46 (100 %) | 17.76 (100 %) |
| J per 1k output tokens | 1751 | 254 | 73 |

Qwen3-8B-Q8_0 (GGUF):

| KPI | c=1 | c=8 | c=32 |
|---|---|---|---|
| output tok/s | 225.6 | 136.2 | 481.9 |
| TPOT p50 / p99 ms | 4.2 / 4.6 | 51.8 / 57.3 | 57.0 / 60.3 |
| goodput req/s (attainment) | 0.86 (100 %) | 0.02 (3 %) | 0.00 (0 %) |
| power W | 420 | 185 | 193 |

GGUF batched decode is dequant-bound: M>1 takes the prefill route and dequantizes the whole Q8_0 source per step (`src/exec/executor_gemm_dispatch.cu:536`, class of #667). Isolation: `burst_stream_client.py` on the same server reads 136-138 tok/s at 8 streams (ITL p50 56.5 ms), `speculative.ngram=false` 133 tok/s, `gemm.q8_imma_enabled=true` 115 tok/s, published `ghcr.io/kekzl/imp:latest` (v0.36.0) 120 tok/s: standing state, not this branch. Documented in `docs/LIMITATIONS.md` and `docs/PERF.md`; lever filed as a follow-up issue.

Observation, not investigated: `imp_kv_pressure_rejections_total` +1 during the NVFP4 c=32 level with KV live max 2.6 % and 64/64 requests ok.

## Gates

- `make test-server`: 12/12 PASS (incl. the new metrics battery)
- `make test-gpu`: 1 red, `SmallMDenseTest.BenchDecodeShape` (timing threshold, 174.8 vs < 140 us in the full run); isolated reruns 70.6 and 64.4 us, pass (the contention class of `NvFP4SmallMTest.BandwidthAboveStarvationFloor`)
- mock lane: 11 passed (`test_serving_kpi.py`, `TestMetricsEndpoint`); `make dev-test` 9/9
- clang-format on added lines clean; `tools/filesize_thresholds.toml` re-pinned +1 LOC each for `kv_cache_manager.cpp` and `engine_scheduler.cpp` (one counter increment each)
## Gate (pre-push `make verify-fast`, captured from the push log)

```
  decode  tg128 =  291.70 tok/s  (baseline  287.19, delta 1.57%)
  prefill pp512 = 12541.28 tok/s  (baseline 12406.87, delta 1.08%)
PASS decode within 8% threshold
PASS prefill within 8% threshold
  prefill pp4096 = 15561.10 tok/s  (baseline 15324.70, delta 1.54%, FA2)
PASS long-ctx prefill (pp4096/FA2) within 8% threshold
  own peak VRAM = 20742 MiB  (baseline 20716, delta 0.13%)
PASS peak VRAM within 10% of baseline
PASS graphs ON delivers >=1.3x decode speedup
```

Not in here: a fix for the GGUF batched-decode route (follow-up issue), MBU/MFU at concurrency, and a harness test against a streaming mock (the API mock sends the SSE body in one write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gyGp3FNmQMxu2LWhZWz3v
