### PR TITLE
perf(moe): settle two of the four moe.mr_nr tiles, leave the default at 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ there instead of retelling it.
 
 ### Changed
 
+- `moe.mr_nr` swept and left at 8: 16 and 32 are measured losses (-0.96 %, -5.15 % tg128 on
+  Qwen3-Coder-30B-A3B-FP4) and are now settled; 4 led 8 of 9 paired runs but by less than this
+  host's noise floor. Comment carries the numbers so the sweep is not repeated (#1925)
 - NVFP4 K-par decode GEMVs drop their 12-CTA `__launch_bounds__` term (ptxas 40 -> 42 registers): tg128 Qwen3-8B-Q8_0
   +1.9 %, Qwen3-14B-NVFP4 +0.7 %, @32 Qwen3.8-27B +1.1 % (3/3 each); the single-sequence GDN scan runs the SPLIT=2 instance
   (+0.15 %, no spill); the batched LM-head GEMV is PDL-registered (@32 +0.8 %, 2/3) (dispatch #11, A2-2 / A2-3, #1923)

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -487,7 +487,9 @@ nvfp4_device_args    = true
 # Opt-in smallM kernel branch for NVFP4 MoE prefill + its M threshold.
 nvfp4_smallM         = false
 nvfp4_smallM_threshold = 64
-# Rows-per-block for multi-row NVFP4 MoE decode GEMV (4|8|16|32).
+# Rows-per-block for multi-row NVFP4 MoE decode GEMV (4|8|16|32). Swept
+# 2026-09-06: 16 and 32 lose (-0.96 %, -5.15 % tg128), 4 is within noise of 8.
+# Single-sequence decode only, and bit-identical output across values.
 mr_nr                = 8
 # Pin host-resident experts in page-locked memory. Decode is unaffected (cache
 # hits 96-98 %); prefill is what the transfers cost. Six paired rounds, not

--- a/src/core/config/moe.h
+++ b/src/core/config/moe.h
@@ -123,6 +123,23 @@ struct MoE {
     // row, so threads-per-block = NR * 32. Higher NR amortizes block
     // launch overhead at the cost of fewer concurrent CTAs. Valid
     // values: 4, 8 (default), 16, 32. Other values fall back to 8.
+    //
+    // Swept 2026-09-06, interleaved arms, `imp-cli --bench` tg128, 3 rounds
+    // each. The knob only ever reaches single-sequence decode
+    // (`can_decode_fast` refuses n != 1) and greedy output is bit-identical
+    // across values (each row is one warp's own reduction), so it is a pure
+    // occupancy choice:
+    //   NR=16  -0.96 %   NR=32  -5.15 %  (Qwen3-Coder-30B-A3B-FP4, quiet host,
+    //                                     per-arm spread under 0.1 %)
+    // Those two are settled: do not re-litigate them. NR=4 is NOT settled. It
+    // led 8 of 9 paired runs (+0.67 % Coder-30B, +0.15 % Qwen3.6-35B), but a
+    // repeat an hour later spread +-1.5 % and handed one round to NR=8, which
+    // is larger than the whole claimed effect. A foreign GPU tenant (7-8 GiB,
+    // Windows-side, invisible to `docker ps`) was holding the card right after
+    // that repeat, so it cannot separate the knob from the host either way.
+    // The default stays at 8 until someone resolves 0.5 % against this host's
+    // noise floor; the 2026-07-13 sweep that read the class as refuted is not
+    // contradicted by what we have.
     int mr_nr = 8;
 };
 }  // namespace imp::cfg

--- a/src/quant/nvfp4_gemv_moe.cu
+++ b/src/quant/nvfp4_gemv_moe.cu
@@ -179,8 +179,10 @@ __global__ void gemv_nvfp4_moe_decode_mr_kernel(
 static bool use_moe_multirow(int K) { return (K / kMicroBlockSize) <= 512; }
 
 // Tile-tuning knob: read NR from RuntimeConfig, clamp to {4, 8, 16, 32}.
-// Default 8 = legacy behavior; 4/16/32 are A/B candidates for the perf
-// regression recovery work (see PR opening MoE NVFP4 decode tile sweep).
+// Default stays 8: the 2026-09-06 sweep settled 16 and 32 as losses (-0.96 %,
+// -5.15 % tg128) and left 4 unresolved — it led 8 of 9 paired runs but by less
+// than this host's noise floor once the card is busy. Numbers and method in
+// `src/core/config/moe.h`.
 static int resolve_mr_nr() {
     int v = imp::process_diag_moe_mr_nr();
     if (v == 4 || v == 8 || v == 16 || v == 32) return v;


### PR DESCRIPTION
`moe.mr_nr` shipped with a comment reading "4/16/32 are A/B candidates for the perf
regression recovery work" and no numbers behind it. This closes two of the three
candidates and says plainly that the third is unresolved.

Method: interleaved arms (one round visits every value, so host drift hits all arms
alike), `imp-cli --bench` tg128, 3 rounds per arm, `imp:test` from this tree.

## Settled

Qwen3-Coder-30B-A3B-FP4, quiet host, per-arm spread under 0.1 %:

| NR | tg128 | vs default 8 |
|---|---|---|
| 4 | 341.23 | +0.67 % |
| 8 | 338.95 | — |
| 16 | 335.70 | **-0.96 %** |
| 32 | 321.48 | **-5.15 %** |

16 and 32 are losses and need no further work.

## Not settled, and why the default does not move

NR=4 led 8 of 9 paired runs: +0.67 % on Coder-30B and +0.15 % on Qwen3.6-35B-A3B-NVFP4
(325.59 vs 325.09, 3/3, arms not overlapping). But a repeat an hour later read
328.63 vs 328.38 with a +-1.5 % spread and one round going to NR=8 — larger than the
whole claimed effect. A foreign GPU tenant (7-8 GiB, Windows-side, invisible to
`docker ps`) was holding the card right after that repeat, so the repeat cannot
separate the knob from the host in either direction.

0.5 % is below what this host resolves unless the card is quiet, so the default stays
at 8 and the comment now carries the numbers. The 2026-07-13 sweep that read this
class as refuted is not contradicted by anything measured here.

## Scope of the knob, established while measuring

- It reaches **single-sequence decode only**: `can_decode_fast` returns false for
  `n != 1`, so batched decode never sees it.
- Greedy output is **bit-identical** across values (SHA-256 over a 128-token greedy
  completion at NR=4 and NR=8), so it is a pure occupancy choice, not a numerics one.

Also checked and worth recording: the `(kKparThreads, 12)` `__launch_bounds__` still on
`gemv_nvfp4_moe_{decode,gate_up_fused}_kernel` — the last of the class #1923 removed — is
unreachable on every local MoE checkpoint. `use_moe_multirow(K)` sends K <= 8192 to the
MR kernels, which carry no launch bound at all, and every MoE-NVFP4 model here has K far
below that. Dropping it costs 40 -> 52 and 40 -> 48 registers (12 CTAs down to 9 and 10),
so it is not a free removal either; left alone.

No behaviour change in this PR: comments and `imp.conf.example` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cish2ozd1Ujm9U4DYBa9YD
