### PR TITLE
fix(verify): the degeneration gate judged eleven tokens and called them the last 32

### DIFF
--- a/.claude/skills/check-degeneration/SKILL.md
+++ b/.claude/skills/check-degeneration/SKILL.md
@@ -25,7 +25,10 @@ Run the battery after touching the forward pass, graph capture, MoE routing, KV 
 
 ## Pass criteria
 
-1. No token repeats >4x in a row, no 3-gram repeats >3x.
+1. No token repeats >4x in a row; at most 70 % of the output made of repeated 3-grams.
+   (The old "no 3-gram more than 3x" failed a correct list answer and passed a 10-token
+   phrase on a loop; `scripts/degen_verdict.sh` carries the calibrated set, exercised by
+   `guard_degen_thresholds` in the CPU lane.)
 2. >=10 generated tokens before any stop (unless single-word factual).
 3. stderr clean (grep below).
 4. Decode within 30% of the model's row in `tests/perf_baseline.json` (>30% drop = graphs fell back silently).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ there instead of retelling it.
 
 ### Fixed
 
+- The degeneration gate in `scripts/verify.sh` judged eleven tokens of every run and called them
+  "the last 32": imp-cli caps its `[tok=]` markers at ten decode steps. New `--token-trace` lifts
+  the cap and the gate uses it, so a repetition loop starting at step 11 is now visible (#1933)
+- Degeneration thresholds recalibrated against real streams and put under a CPU-lane guard
+  (`guard_degen_thresholds`). The flat "3-gram more than 3 times" failed a correct list answer;
+  a 10-token phrase on a loop passed. `make verify` is green again, red since 2026-08-27 (#1933)
 - The GGUF loader names what it skipped, grouped by tensor-name family, instead of one DEBUG line
   per tensor that is invisible at the default log level. Same report the SafeTensors side got in
   #1929 (#1932)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1139,6 +1139,17 @@ if(IMP_BUILD_TESTS)
         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_lane_filter_copy.sh
                 ${CMAKE_CURRENT_SOURCE_DIR})
 
+    # The degeneration thresholds in scripts/degen_verdict.sh, exercised against
+    # known token streams. They had never been exercised at all: verify.sh read
+    # imp-cli's [tok=...] markers, imp-cli capped them at the first ten decode
+    # steps, and the gate judged those eleven and called them "the last 32
+    # tokens". The first run that could see a whole generation failed CORRECT
+    # output on two of the three thresholds. No GPU: the verdict is a function
+    # of the stream.
+    add_test(NAME guard_degen_thresholds
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/check_degen_thresholds.sh
+                ${CMAKE_CURRENT_SOURCE_DIR})
+
     # No skipped test in the three lanes above. DEPENDS only orders: a lane
     # that crashed leaves its previous report behind, and is red on its own.
     add_test(NAME guard_unit_skips
@@ -1149,6 +1160,7 @@ if(IMP_BUILD_TESTS)
                          guard_det_suite_filter guard_cancel_teardown
                          guard_verify_filter guard_precommit_filter guard_unit_skips
                          guard_makefile_filters guard_lane_filter_copy
+                         guard_degen_thresholds
         PROPERTIES LABELS "unit")
 
     add_test(NAME gpu_compute   COMMAND test-compute)

--- a/scripts/check_degen_thresholds.sh
+++ b/scripts/check_degen_thresholds.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Pin the degeneration verdicts against known token streams.
+#
+# The thresholds in degen_verdict.sh had never been exercised on a real
+# generation: verify.sh read imp-cli's `[tok=...]` markers and imp-cli capped
+# them at the first ten decode steps, so the gate judged eleven tokens of every
+# run and called them "the last 32". The first run that could see a whole
+# generation failed CORRECT output on two of the three thresholds. They are
+# calibrated here, against streams whose verdict is not in question, so a future
+# edit cannot quietly re-break them.
+#
+# The healthy streams are real: the 64 tokens Qwen3-4B-Instruct-2507-Q8_0 and
+# Qwen3.5-4B-mxfp4 produced for "The capital of France is" on 2026-09-07.
+#
+# Usage: check_degen_thresholds.sh <repo-root>
+# Exit 0 = every case matches; 1 = a verdict moved.
+
+set -uo pipefail
+ROOT="${1:?usage: check_degen_thresholds.sh <repo-root>}"
+VERDICT="$ROOT/scripts/degen_verdict.sh"
+
+if [ ! -x "$VERDICT" ] && [ ! -r "$VERDICT" ]; then
+    echo "check_degen_thresholds: $VERDICT not found" >&2
+    exit 1
+fi
+
+FAILURES=0
+
+# want: OK | FAIL
+check() {
+    local name="$1" want="$2" min_toks="$3" toks="$4"
+    local out got
+    out=$(printf '%s\n' $toks | bash "$VERDICT" "$min_toks" 2>&1)
+    case "$out" in
+        OK*)   got=OK ;;
+        FAIL*) got=FAIL ;;
+        *)     got="?($out)" ;;
+    esac
+    if [ "$got" = "$want" ]; then
+        printf '  ok    %-22s %s\n' "$name" "$out"
+    else
+        printf '  FAIL  %-22s want %s, got: %s\n' "$name" "$want" "$out"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Some cases must fail for a specific reason, not merely fail.
+check_reason() {
+    local name="$1" want="$2" min_toks="$3" toks="$4" out
+    out=$(printf '%s\n' $toks | bash "$VERDICT" "$min_toks" 2>&1)
+    case "$out" in
+        *"$want"*) printf '  ok    %-22s reason: %s\n' "$name" "$want" ;;
+        *) printf '  FAIL  %-22s want reason %s, got: %s\n' "$name" "$want" "$out"
+           FAILURES=$((FAILURES + 1)) ;;
+    esac
+}
+
+rep() { python3 -c "import sys; print(' '.join(sys.argv[1].split()*int(sys.argv[2])))" "$1" "$2"; }
+
+echo "degeneration verdicts:"
+
+# --- healthy, must pass -----------------------------------------------------
+# Qwen3-4B dense: " Paris, and the capital of Germany is Berlin. The capital of
+# Spain is Madrid, ..." - "the capital of" recurs 4 times because the CONTENT is
+# a list of capitals. The old flat "3-gram more than 3 times" limit failed this.
+check "dense-capitals" OK 5 \
+  "12095 11 323 279 6722 315 9856 374 19846 13 576 6722 315 17689 374 24081 11 323 279 6722 315 15344 374 21718 13 576 6722 315 279 3639 15072 374 7148 11 323 279 6722 315 279 3639 4180 374 6515 11 422 727 13 576 6722 315 6323 374 26194 11 323 279 6722 315 5616 374 26549 13 576 6722"
+
+# Qwen3.5-4B MXFP4 (GDN), same prompt, an A/B/C/D list. This is the stream that
+# had `make verify` red: eleven of these tokens carry 7 distinct values, under
+# the old flat threshold of 8.
+check "gdn-list" OK 5 \
+  "11751 13 32 13 2503 33 13 3557 271 785 6722 315 9856 374 25 4230 13 19846 425 13 21718 356 13 24081 422 13 7148 271 785 6722 315 17689 374 25 4230 13 21718 425 13 24081 356 13 19846 422 13 7148 271 785 6722"
+
+# A short but correct answer: the window is 11, so the distinct threshold has to
+# scale or this reads as degenerate.
+check "short-correct" OK 5 "11751 13 198 32 13 2912 198 33 13 3439 198"
+
+# --- degenerate, must fail --------------------------------------------------
+# The classic loop. runmax is 1, so the run-length check cannot see it.
+check "abc-loop" FAIL 5 "$(rep '101 102 103' 21)"
+# A stuck single token.
+check "stuck-token" FAIL 5 "$(rep '999' 64)"
+# Two-token alternation: runmax 1 again.
+check "alternation" FAIL 5 "$(rep '77 88' 32)"
+# A long phrase on a loop. This is the case ONLY the coverage rule catches: 10
+# distinct tokens is well above the distinct threshold and runmax is 1, so both
+# other checks pass while the output is a loop.
+check "phrase-loop" FAIL 5 "$(rep '11 12 13 14 15 16 17 18 19 20' 6)"
+check_reason "phrase-loop" "repeated 3-grams" 5 "$(rep '11 12 13 14 15 16 17 18 19 20' 6)"
+# Low variety WITHOUT literal repetition: a de Bruijn sequence over 4 token ids
+# contains every 3-gram exactly once, so the repeated-3-gram share is 0 and the
+# run length is 1. Only the distinct-token check sees it. A model emitting four
+# token types in a shuffled order is broken even though nothing repeats.
+check "low-variety" FAIL 5 "101 101 101 102 101 101 103 101 101 104 101 102 102 101 102 103 101 102 104 101 103 102 101 103 103 101 103 104 101 104 102 101 104 103 101 104 104 102 102 102 103 102 102 104 102 103 103 102 103 104 102 104 103 102 104 104 103 103 103 104 103 104 104 104"
+check_reason "low-variety" "distinct tokens" 5 "101 101 101 102 101 101 103 101 101 104 101 102 102 101 102 103 101 102 104 101 103 102 101 103 103 101 103 104 101 104 102 101 104 103 101 104 104 102 102 102 103 102 102 104 102 103 103 102 103 104 102 104 103 102 104 104 103 103 103 104 103 104 104 104"
+# ` own own own own own` - the shape the gate is named for.
+check "own-run" FAIL 5 "1 2 3 4 5 6 7 7 7 7 7 7 7 7 8 9 10 11 12 13 14 15 16"
+# Early abort: three tokens against a min of 5. Must fail on LENGTH, not on a
+# coverage figure computed from three tokens, so the reason is checked too.
+check "early-abort" FAIL 5 "100 200 300"
+check_reason "early-abort" "stopped after 3 tokens" 5 "100 200 300"
+# A short but varied output above the minimum must not trip the coverage rule
+# just because the sample is small.
+check "short-varied" OK 5 "11 22 33 44 55 66 77 88 99 10 20 21"
+# Nothing at all.
+check "empty" FAIL 5 ""
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo "check_degen_thresholds: $FAILURES verdict(s) moved" >&2
+    exit 1
+fi
+echo "check_degen_thresholds: all verdicts hold"

--- a/scripts/check_degen_thresholds.sh
+++ b/scripts/check_degen_thresholds.sh
@@ -72,6 +72,10 @@ check "dense-capitals" OK 5 \
 check "gdn-list" OK 5 \
   "11751 13 32 13 2503 33 13 3557 271 785 6722 315 9856 374 25 4230 13 19846 425 13 21718 356 13 24081 422 13 7148 271 785 6722 315 17689 374 25 4230 13 21718 425 13 24081 356 13 19846 422 13 7148 271 785 6722"
 
+# The same GDN model over a full 64-token run: the worst healthy observation in
+# the set at 45 % repeated 3-grams, which is what sets the distance to the
+# 70 % threshold. Captured from the shipped gate on 2026-09-07.
+check "gdn-64tok" OK 5 "11751 13 198 32 13 2912 198 33 13 3439 198 15666 25 198 32 271 22365 314 279 2614 369 4045 264 3478 14367 303 279 3516 4042 30 198 32 13 27509 198 33 13 23607 198 34 13 14935 198 35 13 26097 35317 198 15666 25 198 35 271 22365 314 279 2614 369 4045 264 3478 14367 303 279"
 # A short but correct answer: the window is 11, so the distinct threshold has to
 # scale or this reads as degenerate.
 check "short-correct" OK 5 "11751 13 198 32 13 2912 198 33 13 3439 198"

--- a/scripts/degen_verdict.sh
+++ b/scripts/degen_verdict.sh
@@ -51,9 +51,12 @@ DISTINCT_MIN=$(( WINDOW / 4 ))
 #    in check_degen_thresholds.sh:
 #
 #      healthy dense prose  37 %      "a b c" loop            100 %
-#      healthy GDN list     31 %      stuck single token      100 %
-#      short correct answer  0 %      two-token alternation   100 %
-#                                     10-token phrase on loop 100 %
+#      healthy GDN, 64 tok  45 %      stuck single token      100 %
+#      healthy GDN, 49 tok  31 %      two-token alternation   100 %
+#      short correct answer  0 %      10-token phrase on loop 100 %
+#
+#    45 % is the worst healthy observation and is what sets the distance to the
+#    threshold; the loops leave no room for argument at 100 %.
 #
 #    The top-3-gram share, which is the obvious metric, does NOT work: a
 #    10-token phrase repeated six times spreads over ten different 3-grams, so

--- a/scripts/degen_verdict.sh
+++ b/scripts/degen_verdict.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# The degeneration verdict, as a function of a token stream.
+#
+# Extracted from scripts/verify.sh so the thresholds can be exercised without a
+# GPU. They had never been exercised at all: verify.sh read imp-cli's `[tok=...]`
+# markers, imp-cli capped those at the first ten decode steps, and the gate
+# treated the eleven it got as "the last 32 tokens". Every threshold below was
+# therefore being applied to the opening of a generation, and a repetition loop
+# starting at step 11 was invisible to the detector built to catch it.
+#
+# Usage:  degen_verdict.sh <min_toks> < token-ids-one-per-line
+# Prints  OK <stats>            and exits 0
+#     or  FAIL <reason>         and exits 1
+#
+# scripts/check_degen_thresholds.sh pins the verdicts against known streams.
+
+set -uo pipefail
+
+MIN_TOKS="${1:?usage: degen_verdict.sh <min_toks> < token-ids}"
+
+ALL_TOKS=$(cat)
+N_TOKS=$(printf '%s\n' "$ALL_TOKS" | grep -c .)
+
+if [ "$N_TOKS" -eq 0 ]; then
+    echo "FAIL no tokens were generated"
+    exit 1
+fi
+
+# The trailing window the distinct-token check looks at.
+TOKS=$(printf '%s\n' "$ALL_TOKS" | tail -32)
+WINDOW=$(printf '%s\n' "$TOKS" | grep -c .)
+DISTINCT=$(printf '%s\n' "$TOKS" | sort -u | grep -c .)
+
+# Longest run of one token, and the most frequent 3-gram.
+RUNMAX=$(printf '%s\n' "$ALL_TOKS" | uniq -c | awk '{if($1>m)m=$1}END{print m+0}')
+GRAMMAX=$(printf '%s\n' "$ALL_TOKS" | awk '{a[NR]=$0} END{
+    for(i=1;i+2<=NR;i++){k=a[i]" "a[i+1]" "a[i+2]; c[k]++; if(c[k]>m)m=c[k]}
+    print m+0}')
+
+# 1. Distinct tokens, scaled to the window that actually exists. The flat "8 in
+#    the last 32" was written for a full window; applied to a short run it fails
+#    correct output, because a legitimate short answer repeats its separators.
+#    A run that stops early is the min_toks check's job, not this one's.
+DISTINCT_MIN=$(( WINDOW / 4 ))
+[ "$DISTINCT_MIN" -gt 8 ] && DISTINCT_MIN=8
+[ "$DISTINCT_MIN" -lt 2 ] && DISTINCT_MIN=2
+
+# 2. Repetition is degeneration when the output is MADE OF repeats, not when a
+#    phrase merely recurs. The share of 3-gram positions whose 3-gram occurs at
+#    least twice separates the two with a wide margin, measured over the streams
+#    in check_degen_thresholds.sh:
+#
+#      healthy dense prose  37 %      "a b c" loop            100 %
+#      healthy GDN list     31 %      stuck single token      100 %
+#      short correct answer  0 %      two-token alternation   100 %
+#                                     10-token phrase on loop 100 %
+#
+#    The top-3-gram share, which is the obvious metric, does NOT work: a
+#    10-token phrase repeated six times spreads over ten different 3-grams, so
+#    its top one covers only 30 % while the output is entirely a loop. The
+#    run-length check misses every one of these four (runmax is 1 for three of
+#    them), so this is the check carrying them.
+REPEAT_PCT=$(printf '%s\n' "$ALL_TOKS" | awk '{a[NR]=$0} END{
+    n=0; for(i=1;i+2<=NR;i++){k=a[i]" "a[i+1]" "a[i+2]; c[k]++; n++}
+    if(n==0){print 0; exit}
+    r=0; for(k in c) if(c[k]>=2) r+=c[k]
+    printf "%d", r*100/n}')
+
+STATS="distinct=$DISTINCT/$WINDOW need $DISTINCT_MIN, tokens=$N_TOKS, max-run=$RUNMAX, 3gram=$GRAMMAX repeat=$REPEAT_PCT%"
+
+# Length first, so a run that stopped early is reported as that and not as a
+# statistic derived from three tokens.
+if [ "$N_TOKS" -lt "$MIN_TOKS" ]; then
+    echo "FAIL stopped after $N_TOKS tokens (limit: $MIN_TOKS)"
+    exit 1
+fi
+if [ "$DISTINCT" -lt "$DISTINCT_MIN" ]; then
+    echo "FAIL degenerate (only $DISTINCT distinct tokens in a $WINDOW-token window, need $DISTINCT_MIN)"
+    exit 1
+fi
+if [ "$RUNMAX" -gt 4 ]; then
+    echo "FAIL a token repeats $RUNMAX times in a row (limit: 4)"
+    exit 1
+fi
+# Needs a sample to be a statistic; below 12 tokens the length and distinct
+# checks above carry the range. Threshold sits in the gap between the 37 % of
+# the worst healthy stream and the 100 % of every looped one.
+if [ "$N_TOKS" -ge 12 ] && [ "$REPEAT_PCT" -gt 70 ]; then
+    echo "FAIL $REPEAT_PCT% of the output is repeated 3-grams (limit: 70%), top 3-gram x$GRAMMAX"
+    exit 1
+fi
+
+echo "OK $STATS"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -757,75 +757,53 @@ smoke_prompt() {
     fi
     model_gate_ran
     local ERR; ERR=$(mktemp)
-    OUT=$("$BIN" --model "$MODELS/$model" --prompt "$prompt" \
+    # --token-trace is load-bearing, not cosmetic. Without it imp-cli caps the
+    # markers at the first ten decode steps (mode_oneshot.cpp), so this gate read
+    # eleven tokens out of a 64-token run and called them "the last 32": every
+    # check below ran on the OPENING of the generation, and a repetition loop
+    # starting at step 11 was invisible to the detector built to catch it. It
+    # also made the distinct-token count fail a correct short answer, which is
+    # what had `make verify` red on Qwen3.5-4B MXFP4 since 2026-08-27.
+    OUT=$("$BIN" --model "$MODELS/$model" --prompt "$prompt" --token-trace \
           --max-tokens 64 --temperature 0 --chat-template none 2>"$ERR")
     # Token markers '[tok=NNNN ' word']' land on stderr.
-    TOKS=$(grep -oP '\[tok=\K[0-9]+' "$ERR" | tail -32)
-    DISTINCT=$(echo "$TOKS" | sort -u | wc -l)
-    # Generated word stream (stripped of token id prefix) for NaN/Inf scan
-    WORDS=$(grep -oP "\[tok=[0-9]+ '\K[^']*" "$ERR" | tr '\n' ' ')
-    # The repetition and early-abort checks below read the WHOLE run, not the
-    # trailing window. Derived here so the temp file is gone before any of the
-    # early returns below - they used to be the only `rm` and adding checks in
-    # front of it would have leaked one file per failed smoke run.
     ALL_TOKS=$(grep -oP '\[tok=\K[0-9]+' "$ERR")
+    WORDS=$(grep -oP "\[tok=[0-9]+ '\K[^']*" "$ERR" | tr '\n' ' ')
     rm -f "$ERR"
-    N_TOKS=$(printf '%s\n' "$ALL_TOKS" | grep -c .)
-    RUNMAX=$(printf '%s\n' "$ALL_TOKS" | uniq -c | awk '{if($1>m)m=$1}END{print m+0}')
-    GRAMMAX=$(printf '%s\n' "$ALL_TOKS" | awk '{a[NR]=$0} END{
-        for(i=1;i+2<=NR;i++){k=a[i]" "a[i+1]" "a[i+2]; c[k]++; if(c[k]>m)m=c[k]}
-        print m+0}')
 
+    # NaN/Inf first: it is a different failure from degeneration and the verdict
+    # script only sees ids, not pieces.
+    #
     # Herestrings, not `echo ... | grep -q`: grep -q leaves at the first match and
     # closes the pipe, echo dies of EPIPE, and `set -o pipefail` (:40) turns that
     # into a non-zero pipeline even though grep MATCHED. Here that would swallow a
     # NaN report; three lines down, where the test is negated, it fails a smoke
-    # run whose output was correct. $OUT carries the whole cli log, so it is well
-    # past the point where the producer writes in one block.
+    # run whose output was correct.
     if grep -qiE ' (nan|inf|-inf|-nan) ' <<< " $WORDS "; then
         fail "$label — NaN/Inf token in output"
         echo "  words: $WORDS"
         return
     fi
-    if [ "$DISTINCT" -lt 8 ]; then
-        fail "$label — degenerate (only $DISTINCT distinct tokens in last 32)"
-        echo "  tokens: $(echo "$TOKS" | tr '\n' ' ')"
-        return
-    fi
-    # The distinct-token count is one shape of degeneration, and the skill this
-    # gate stands in for names three more (#1573). Two of them are checkable
-    # here, from output this gate already collects, with the skill's own
-    # thresholds:
-    #
-    #   1. verbatim repetition — no token more than 4 times in a row, no 3-gram
-    #      more than 3 times. "a b c a b c a b c a b c" has 3 distinct tokens
-    #      per window and passes the count above; it is the shape #1248 had.
-    #   2. early abort — at least 10 generated tokens. A 3-token answer to a
-    #      sentence-completion prompt is a stop-condition defect, and it also
-    #      makes every check above vacuous: 3 tokens cannot fail a 32-token
-    #      window.
-    if [ "$RUNMAX" -gt 4 ]; then
-        fail "$label — a token repeats $RUNMAX times in a row (skill limit: 4)"
+
+    # The thresholds live in scripts/degen_verdict.sh so the CPU lane can
+    # exercise them without a GPU (guard_degen_thresholds). They never had been:
+    # this gate used to judge the eleven markers imp-cli printed and call them
+    # "the last 32 tokens".
+    local VERDICT
+    VERDICT=$(printf '%s\n' "$ALL_TOKS" | bash "$ROOT/scripts/degen_verdict.sh" "$min_toks" 2>&1)
+    if [ "${VERDICT#OK}" = "$VERDICT" ]; then
+        fail "$label — ${VERDICT#FAIL }"
         echo "  tokens: $(printf '%s ' $ALL_TOKS)"
         return
     fi
-    if [ "$GRAMMAX" -gt 3 ]; then
-        fail "$label — a 3-gram repeats $GRAMMAX times (skill limit: 3)"
-        echo "  tokens: $(printf '%s ' $ALL_TOKS)"
-        return
-    fi
-    if [ "$N_TOKS" -lt "$min_toks" ]; then
-        fail "$label — stopped after $N_TOKS tokens (limit: $min_toks)"
-        echo "  words: $WORDS"
-        return
-    fi
+
     # Generated text appears interleaved with logs on stdout — substring match works
     if ! grep -q "$expect" <<< "$OUT$WORDS"; then
         fail "$label — expected '$expect' in output"
         echo "  words: $WORDS"
         return
     fi
-    pass "$label (distinct=$DISTINCT, tokens=$N_TOKS, max-run=$RUNMAX, max-3gram=$GRAMMAX, contains '$expect')"
+    pass "$label (${VERDICT#OK }, contains '$expect')"
 }
 
 smoke_prompt "Qwen3-4B Q8_0 (dense)" \

--- a/tools/imp-cli/args.cpp
+++ b/tools/imp-cli/args.cpp
@@ -72,6 +72,8 @@ void print_usage(const char* prog) {
             "deepseek_r1, phi\n"
             "  --prefill-chunk-size <n> Max tokens per prefill chunk (0 = single-chunk, default: per-arch)\n"
             "  --prefill-fp8         Use FP8 E4M3 weight cache for ~2x prefill throughput\n"
+            "  --token-trace         Emit a [tok=ID 'piece'] marker on stderr for every generated\n"
+            "                        token, not just the first ten decode steps\n"
             "  --mtp-spec-decode <k> MTP drafting for the verify loop, chain length k (sidecar or embedded mtp.* head)\n"
             "  --decode-nvfp4        Force mode 1 (additive: FP8 prefill + NVFP4 decode caches).\n"
             "                        Auto-default for dense Q*_K (6-8 bit GGUF) on sm_120 since\n"
@@ -177,6 +179,8 @@ CliArgs parse_args(int argc, char** argv) {
             args.mtp_spec_decode_k = std::atoi(argv[++i]);
         } else if (std::strcmp(arg, "--prefill-fp8") == 0) {
             args.prefill_fp8 = true;
+        } else if (std::strcmp(arg, "--token-trace") == 0) {
+            args.token_trace = true;
         } else if (std::strcmp(arg, "--prefix-caching") == 0) {
             args.prefix_caching = true;
         } else if (std::strcmp(arg, "--streaming-kv") == 0) {

--- a/tools/imp-cli/args.h
+++ b/tools/imp-cli/args.h
@@ -49,6 +49,13 @@ struct CliArgs : CommonArgs {
     bool interactive = false;
     int mtp_spec_decode_k = 0;           // --mtp-spec-decode K: 0 = off, >0 = MTP draft length
     bool prefill_fp8 = false;            // --prefill-fp8: use FP8 E4M3 weight cache for prefill
+    // --token-trace: emit a `[tok=ID 'piece']` marker on stderr for EVERY
+    // generated token. Off by default because a 4k generation would bury the
+    // rest of stderr; the decode loop otherwise caps the markers at the first
+    // ten steps. `scripts/verify.sh` turns it on: its degeneration gate reads
+    // that stream, and with the cap it was reading the opening of every run
+    // while its own comment said "the last 32 tokens".
+    bool token_trace = false;
     bool prefix_caching = false;         // --prefix-caching: reuse KV blocks for shared prefixes
     bool streaming_kv = false;           // --streaming-kv: StreamingLLM smart KV cache (sinks + window)
     bool no_streaming_kv_auto = false;   // --no-streaming-kv-auto: disable auto-StreamingLLM on KV pressure

--- a/tools/imp-cli/mode_oneshot.cpp
+++ b/tools/imp-cli/mode_oneshot.cpp
@@ -211,7 +211,13 @@ int run_oneshot(ImpContext ctx, ImpModel model, const CliArgs& args, ImpGenerate
                 hide_token = true;
             }
             std::string piece = tok->decode_token(token);
-            if (step < 10)
+            // The cap keeps stderr readable on a long run. It also made the
+            // marker stream a sample of the OPENING of a generation, not of the
+            // generation: `scripts/verify.sh`'s degeneration gate reads exactly
+            // this stream and treated the eleven markers it got as "the last 32
+            // tokens", so a repetition loop starting at step 11 was invisible
+            // to it. `--token-trace` lifts the cap for callers that measure.
+            if (args.token_trace || step < 10)
                 fprintf(stderr, "[tok=%d '%s'] ", token, piece.c_str());
             if (!hide_token) {
                 printf("%s", piece.c_str());


### PR DESCRIPTION
`make verify` has been red since 2026-08-27. The known cause, a stale copy of the e2e lane filter, was fixed and guarded (AUDIT_arch_2026 I-3, `check_lane_filter_copy.sh`). The gate stayed red for a second reason nobody had reached, and chasing it turned up something worse than the red run.

## The gate was reading the opening of every generation

imp-cli prints its `[tok=ID 'piece']` markers only for the first ten decode steps (`mode_oneshot.cpp`). `scripts/verify.sh`'s degeneration gate reads exactly that stream, and its own comment says it checks "the last 32 tokens".

| run | tokens generated | markers the gate saw |
|---|---|---|
| Qwen3-4B Q8_0, `--max-tokens 64` | 64 | 11 |
| Qwen3.5-4B MXFP4, `--max-tokens 96` | 96 | 11 |

So every threshold was being applied to the first eleven tokens. **A repetition loop starting at step 11 was invisible to the detector built to catch it.** That is the failure mode the gate exists for, and it could not see it.

`--token-trace` lifts the cap and verify.sh passes it: 64 markers on a 64-token run.

## The thresholds had never run on real data

With the instrument fixed, the first run that could see a whole generation failed **correct** output. Qwen3-4B continues "The capital of France is" with

```
 Paris, and the capital of Germany is Berlin. The capital of Spain is Madrid,
 and the capital of Italy is Rome. The capital of the United Kingdom is London, ...
```

"the capital of" recurs 4 times because the content is a list of capitals. The flat "no 3-gram more than 3 times" called that degeneration.

The obvious replacement, the share of the output covered by the top 3-gram, is worse: a 10-token phrase repeated six times spreads over ten different 3-grams, so its top one covers 30 % while the output is entirely a loop. That rule would have passed a loop and failed prose.

What separates them is the share of the output **made of** repeated 3-grams:

| stream | repeated-3-gram share | verdict |
|---|---|---|
| Qwen3.5-4B GDN, full 64-token run | 45 % | healthy |
| Qwen3-4B, list of capitals | 37 % | healthy |
| Qwen3.5-4B GDN, 49-token capture | 31 % | healthy |
| short correct answer | 0 % | healthy |
| `a b c` on a loop | 100 % | degenerate |
| stuck single token | 100 % | degenerate |
| two-token alternation | 100 % | degenerate |
| 10-token phrase on a loop | 100 % | degenerate |

Threshold 70 %, in the gap. 45 % is the worst healthy observation and is what sets the distance, not the 31 % the first calibration quoted; the real 64-token stream is pinned as a case so that number cannot drift out of the record. The distinct-token check also scales to the window that actually exists: a short correct answer has fewer than 8 distinct tokens and is not degenerate.

## Four rules, four cases, each carried by exactly one

The thresholds move to `scripts/degen_verdict.sh` so the CPU lane can exercise them without a GPU, and `guard_degen_thresholds` does. Removing any one rule turns its own case red:

| rule removed | case that goes red | why only that rule sees it |
|---|---|---|
| distinct tokens | `low-variety` | a de Bruijn sequence over 4 ids: every 3-gram occurs exactly once, run length 1 |
| repeated 3-grams | `phrase-loop` | 10 distinct tokens, run length 1 |
| run length | `own-run` | 16 distinct, repeat share 28 % |
| minimum length | `early-abort` | 3 tokens, all distinct, nothing repeats |

Two of those cases exist because a mutant went green and exposed a hole in the test set rather than in the code: the repeat rule and the distinct rule each had no case of their own until one was constructed for them.

## Gate

```
make dev-test                    100% tests passed, 0 tests failed out of 12
guard_degen_thresholds           13 streams + 3 reason checks, all verdicts hold
ci_static_gates.sh filesize lanes entrypoint alloc launchguards docs citations hygiene
                                 all selected gates passed
```

`make verify` full, on this tree, green:

```
=== verify full: OK ===   (23:28:49Z - 23:35:48Z)
PASS full gtest suite            PASS peak VRAM within 10% of baseline
PASS e2e unit/gpu lane split     PASS graphs ON delivers >= 1.3x decode speedup
PASS decode within 8% threshold  PASS Qwen3-4B Q8_0 (dense)
PASS prefill within 8% threshold      distinct=18/32, tokens=64, max-run=1, 3gram=4 repeat=37%
PASS long-ctx prefill (pp4096)   PASS Qwen3.5-4B MXFP4 (GDN)
                                      distinct=23/32, tokens=64, max-run=1, 3gram=2 repeat=45%
```

Both smoke lines now report 64 tokens where they used to report 11. That is the whole point: the gate is finally judging the generation instead of its opening.

`clang-format` is not applied to `args.cpp`: my two added help lines match the file's existing indentation, and running it would reflow 96 unrelated lines of the help text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSdBeR5CndT2AWdwSnNDhM
