### PR TITLE
perf(memory): release the weight-file pages after upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ there instead of retelling it.
 
 ### Fixed
 
+- imp-server released the weight-file pages after upload instead of holding the whole checkpoint
+  resident for its lifetime. Qwen3.8-27B-NVFP4-vllm host RSS 21.53 -> 4.04 GiB (file-backed
+  18.48 -> 0.98 GiB); paired A/B against main: decode +0.04 %, prefill -0.50 % (#1934)
 - The degeneration gate in `scripts/verify.sh` judged eleven tokens of every run and called them
   "the last 32": imp-cli caps its `[tok=]` markers at ten decode steps. New `--token-trace` lifts
   the cap and the gate uses it, so a repetition loop starting at step 11 is now visible (#1933)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,6 +775,7 @@ if(IMP_BUILD_TESTS)
         tests/test_mla.cpp
         tests/test_weight_map_expert_gate.cpp
         tests/test_weight_map_modality_skips.cpp
+        tests/test_weight_page_release.cpp
         tests/test_checkpoint_limits.cpp
         tests/test_exit_codes.cpp
         # imp-quantize's tensor-selection rule. The tool is not otherwise

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -234,6 +234,15 @@ Size the deployment from the model plus the KV pool you intend to serve; pin
 `runtime.max_seq_len` rather than auto-fitting against a moving number. Tier
 model and invariants: [`internals/MEMORY.md`](internals/MEMORY.md).
 
+**Host RAM: read `RssAnon`, not `VmRSS`.** The loader maps the checkpoint and
+faults it in, and imp drops those pages again once the weights are on the GPU
+(#1934). Before that it held the whole file resident for the process lifetime:
+Qwen3.8-27B-NVFP4-vllm read 21.53 GiB of `VmRSS`, of which 18.48 GiB was the
+mapping and 1.01 GiB was actually anonymous. `docker stats` showed 3.2 GiB
+throughout, because the cgroup does not account a shared file mapping the way
+`ps` does, so the two disagree by design. Weights left on host by an offload
+placement refault on demand and are counted again while they are being read.
+
 ## Serving more than one model
 
 One GPU holds one model. `server.model_swap` (default on): a request naming a

--- a/src/model/model.cpp
+++ b/src/model/model.cpp
@@ -96,6 +96,28 @@ Model::~Model() {
 #endif
 }
 
+size_t Model::release_weight_pages() {
+#ifdef __linux__
+    size_t advised = 0;
+    auto drop = [&advised](void* p, size_t n) {
+        if (!p || n == 0)
+            return;
+        // Page-aligned by construction (mmap returns aligned addresses), and
+        // MADV_DONTNEED on a PROT_READ MAP_PRIVATE file mapping discards the
+        // resident pages only: a later read refaults from the page cache, so
+        // every pointer into the mapping stays valid and correct.
+        if (madvise(p, n, MADV_DONTNEED) == 0)
+            advised += n;
+    };
+    drop(mmap_base_, mmap_size_);
+    for (auto& [ptr, sz] : split_mmaps_)
+        drop(ptr, sz);
+    return advised;
+#else
+    return 0;
+#endif
+}
+
 void Model::release_gpu_allocation(void* ptr) {
     if (!ptr)
         return;

--- a/src/model/model.h
+++ b/src/model/model.h
@@ -160,6 +160,23 @@ public:
     // sidecars. Empty for GGUF and non-NVFP4 SafeTensors models.
     std::unordered_map<std::string, NvFP4PreQuantWeight> nvfp4_scratch_;
 
+    // Drop the resident pages of the weight-file mappings without unmapping
+    // them. The loaders map with MAP_POPULATE + MADV_WILLNEED, which is right
+    // for the load itself and pointless afterwards: once a tensor is uploaded
+    // its `data` is the device pointer (weight_upload.cu), so nothing reads
+    // those pages again unless the placement left weights on host, and then
+    // they refault from the page cache as minor faults.
+    //
+    // MADV_DONTNEED, not munmap: a host-resident expert or an offloaded layer
+    // still holds a pointer INTO the mapping, and there is no tensor iterator
+    // to prove otherwise field by field. Dropping pages keeps every pointer
+    // valid; unmapping would turn a missed field into a crash.
+    //
+    // Measured on Qwen3.8-27B-NVFP4-vllm: RssFile 18.48 GiB of a 21.53 GiB
+    // VmRSS before. Returns the bytes it advised away, 0 if there is nothing
+    // mapped.
+    size_t release_weight_pages();
+
     void* mmap_base_ = nullptr;
     size_t mmap_size_ = 0;
     std::vector<std::pair<void*, size_t>> split_mmaps_;  // additional shard mmaps

--- a/src/runtime/engine_weight_upload.cpp
+++ b/src/runtime/engine_weight_upload.cpp
@@ -403,6 +403,23 @@ bool Engine::init_weights() {
         }
     }
 
+    // Every phase that reads the checkpoint has run. The loaders faulted the
+    // whole weight file in (MAP_POPULATE + MADV_WILLNEED) and nothing dropped
+    // it again, so a serving process held the file resident for its whole life:
+    // measured 18.48 GiB of file-backed RSS out of 21.53 GiB total on
+    // Qwen3.8-27B-NVFP4-vllm, against 3.2 GiB in `docker stats`, which reports
+    // the cgroup and not this. It cost another session two OOM-killed
+    // background jobs.
+    //
+    // Pages only, not the mapping: host-resident experts and offloaded layers
+    // still point into it, and they refault from the page cache.
+    const size_t dropped = model_->release_weight_pages();
+    if (dropped > 0)
+        IMP_LOG_INFO(
+            "weight file pages released after upload: %.2f GiB advised away "
+            "(host-resident weights refault on demand)",
+            static_cast<double>(dropped) / (1024.0 * 1024.0 * 1024.0));
+
     return true;
 }
 

--- a/tests/test_weight_page_release.cpp
+++ b/tests/test_weight_page_release.cpp
@@ -1,0 +1,138 @@
+// Dropping the weight-file pages must not change what reads back.
+//
+// The loaders map the checkpoint with MAP_POPULATE + MADV_WILLNEED and nothing
+// dropped it again, so a serving process held the whole file resident for its
+// lifetime: measured 18.48 GiB of file-backed RSS out of 21.53 GiB total on
+// Qwen3.8-27B-NVFP4-vllm, while `docker stats` reported 3.2 GiB because the
+// cgroup does not account it. It cost another session two OOM-killed jobs.
+//
+// The release is MADV_DONTNEED, not munmap, and that choice is the whole safety
+// argument: a host-resident expert or an offloaded layer still holds a pointer
+// INTO the mapping (`executor_forward_moe_nvfp4_host.cu` passes `w.data` to the
+// expert cache), and there is no tensor iterator that could prove otherwise
+// field by field. Dropping pages keeps every such pointer valid and correct;
+// unmapping would turn one missed field into a use-after-free.
+//
+// This pins that property on a real mapping, with no GPU and no checkpoint.
+
+#include "model/model.h"
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace imp {
+namespace {
+
+// A file mapped exactly the way the loaders map a checkpoint.
+struct MappedFile {
+    std::string path;
+    void* base = nullptr;
+    size_t size = 0;
+
+    explicit MappedFile(size_t bytes) : size(bytes) {
+        char tmpl[] = "/tmp/imp_pagerelease_XXXXXX";
+        int fd = mkstemp(tmpl);
+        if (fd < 0)
+            return;
+        path = tmpl;
+        std::vector<uint8_t> pattern(size);
+        for (size_t i = 0; i < size; ++i)
+            pattern[i] = static_cast<uint8_t>((i * 31u + 7u) & 0xFF);
+        ssize_t w = write(fd, pattern.data(), pattern.size());
+        (void)w;
+        base = mmap(nullptr, size, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+        if (base == MAP_FAILED)
+            base = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
+        if (base == MAP_FAILED)
+            base = nullptr;
+        close(fd);
+    }
+    ~MappedFile() {
+        if (!path.empty())
+            ::remove(path.c_str());
+    }
+    static uint8_t expected(size_t i) { return static_cast<uint8_t>((i * 31u + 7u) & 0xFF); }
+};
+
+constexpr size_t kMapBytes = 2u * 1024u * 1024u;  // 2 MiB, several pages
+
+// The bytes must survive the release: MADV_DONTNEED on a read-only private file
+// mapping discards resident pages, and the next read refaults them from the
+// page cache. If this ever became munmap, this test segfaults, which is the
+// point.
+TEST(WeightPageRelease, DataStillReadsBackAfterRelease) {
+    MappedFile f(kMapBytes);
+    ASSERT_NE(f.base, nullptr) << "could not map the fixture file";
+
+    Model model;
+    model.mmap_base_ = f.base;
+    model.mmap_size_ = f.size;
+
+    const auto* bytes = static_cast<const uint8_t*>(f.base);
+    ASSERT_EQ(bytes[0], MappedFile::expected(0)) << "fixture did not map its own contents";
+
+    const size_t advised = model.release_weight_pages();
+    EXPECT_EQ(advised, f.size) << "the whole mapping should have been advised away";
+
+    // Every page, not just the first: a partial or misaligned advise would show
+    // up here and nowhere else.
+    for (size_t i = 0; i < f.size; i += 4096)
+        ASSERT_EQ(bytes[i], MappedFile::expected(i)) << "byte " << i << " changed across the release";
+    EXPECT_EQ(bytes[f.size - 1], MappedFile::expected(f.size - 1));
+
+    // The Model destructor owns the unmap; hand it over rather than double-free.
+}
+
+// Additional shard mappings are released too. The SafeTensors loader puts every
+// shard past the first into split_mmaps_, and on a sharded checkpoint that is
+// where nearly all of the bytes are.
+TEST(WeightPageRelease, SplitShardMappingsAreReleasedToo) {
+    MappedFile a(kMapBytes);
+    MappedFile b(kMapBytes);
+    ASSERT_NE(a.base, nullptr);
+    ASSERT_NE(b.base, nullptr);
+
+    Model model;
+    model.mmap_base_ = a.base;
+    model.mmap_size_ = a.size;
+    model.split_mmaps_.emplace_back(b.base, b.size);
+
+    EXPECT_EQ(model.release_weight_pages(), a.size + b.size);
+
+    const auto* bb = static_cast<const uint8_t*>(b.base);
+    for (size_t i = 0; i < b.size; i += 4096)
+        ASSERT_EQ(bb[i], MappedFile::expected(i)) << "shard byte " << i << " changed";
+}
+
+// A model that was never mapped (GGUF loaded from a warm cache, a stub model in
+// a test) must be a no-op rather than an madvise on a null pointer.
+TEST(WeightPageRelease, NoMappingIsANoOp) {
+    Model model;
+    EXPECT_EQ(model.release_weight_pages(), 0u);
+}
+
+// Calling it twice is harmless: the second call re-advises pages that may have
+// refaulted in between. Serving does not do this, but a future caller might.
+TEST(WeightPageRelease, ReleaseIsIdempotent) {
+    MappedFile f(kMapBytes);
+    ASSERT_NE(f.base, nullptr);
+    Model model;
+    model.mmap_base_ = f.base;
+    model.mmap_size_ = f.size;
+
+    EXPECT_EQ(model.release_weight_pages(), f.size);
+    EXPECT_EQ(model.release_weight_pages(), f.size);
+    const auto* bytes = static_cast<const uint8_t*>(f.base);
+    EXPECT_EQ(bytes[1234], MappedFile::expected(1234));
+}
+
+}  // namespace
+}  // namespace imp


### PR DESCRIPTION
imp-server held the whole checkpoint resident in host RAM for its process lifetime. The loaders map it with `MAP_POPULATE` + `MADV_WILLNEED`, which is right for the load itself, and nothing dropped it again.

Reported by another session on this host after it lost two background jobs to the OOM killer while an imp-server was running.

## Measured

Qwen3.8-27B-NVFP4-vllm, server up and having answered one request:

| | VmRSS | RssFile | RssAnon | `docker stats` |
|---|---|---|---|---|
| before | 21.53 GiB | 18.48 GiB | 1.01 GiB | 3.21 GiB |
| after | 4.04 GiB | 0.98 GiB | 1.01 GiB | 3.21 GiB |

`RssAnon` is unchanged, so nothing real was given up: the 17.5 GiB is the mapped checkpoint and nothing else. `docker stats` never saw it either way, because the cgroup does not account a shared file mapping the way `ps` does. That 6x disagreement is why this went unnoticed for so long, and it is now written down in `DEPLOYMENT.md` where an operator will look.

## Why MADV_DONTNEED and not munmap

A host-resident expert still holds a pointer **into** the mapping: `executor_forward_moe_nvfp4_host.cu:355` hands `w.data` to the expert cache, which `cudaMemcpyAsync`es from it during inference. `layer_offload.cu:35` does the same for offloaded layers. There is no tensor iterator in the tree, so proving "nothing points in here any more" would mean walking every tensor field of `Model` by hand, and one missed field is a use-after-free rather than a wasted page.

Dropping pages keeps every pointer valid. An uploaded tensor never comes back for them at all, because `weight_upload.cu:652` overwrites `weight.data` with the device pointer. A host-resident one refaults from the page cache as a minor fault.

`tests/test_weight_page_release.cpp` plants exactly that mutant, swapping the `madvise` for a `munmap`: the test binary segfaults mid-run instead of reporting a failure, which is the strongest form the red can take.

## The offload path, exercised

`moe.force_host_experts=8` on Qwen3.6-35B-A3B-NVFP4, so 8 of 40 MoE layers read from host during inference:

```
content   : The capital of France is Paris.
reasoning : Here's a thinking process: 1. Identify the User's Question ...
finish    : stop
RssFile   : 1.85 GiB idle -> 3.97 GiB while serving
```

Correct output, and the file-backed RSS climbs only by what is actually read. That is the mechanism working rather than being bypassed.

## Perf: neutral, and the single-arm number was noise

The single-arm `verify` run read decode +3.19 % against the pinned baseline. `scripts/verify_ab.sh`'s own header says this host moves 4-6 % on an unchanged tree between sessions, so that number means nothing on its own. Paired, 3 alternating pairs against `origin/main` in the same build:

```
paired decode  delta: mean  0.04%  (pairs -0.11  0.16  0.06)
paired prefill delta: mean -0.50%  (pairs -1.09 -0.35 -0.07)
PASS paired decode within 2%
PASS paired prefill within 2%
```

Neutral. No claim of a win.

## Gate

```
make dev-test                    100% tests passed, 0 tests failed out of 12
WeightPageRelease.*              4 tests passed
make verify (full)               === verify full: OK ===  (07:20:51Z - 07:27:47Z)
ci_static_gates.sh filesize lanes entrypoint alloc launchguards docs citations hygiene
                                 all selected gates passed
```

Not in here: any change to when the mapping is *unmapped*. That still happens in `~Model()`. This only stops the pages being pinned resident between upload and teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSdBeR5CndT2AWdwSnNDhM
