### PR TITLE
ci: cut the workflow's critical path, and fix the change detection that had never run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.changes.outputs.code }}
+      cpp: ${{ steps.changes.outputs.cpp }}
 
     container:
       # Native CUDA devel image: nvcc $CUDA_VERSION is on PATH at /usr/local/cuda
@@ -92,15 +93,34 @@ jobs:
         run: |
           base="${{ github.event.pull_request.base.sha || github.event.before }}"
           code=true
+          # `cpp` gates the clang-tidy job, which lints changed src|tools *.cpp
+          # and nothing else. It used to start on every code PR and pay ~2.6 min
+          # (container pull + cache round trip) to print "nothing to lint" - and
+          # it does that on most PRs here, which are .cu, .py or .md. Same
+          # FAIL-OPEN rule as `code`: any uncertainty runs the job.
+          cpp=true
           if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
             files="$(git diff --name-only "$base" HEAD)"
             # code stays true unless EVERY changed file is markdown or under docs/.
             if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE '(\.md$|^docs/)'; then
               code=false
             fi
+            # `grep -c`, not `grep -q`, and no here-string. Two traps meet on
+            # this line. #1499: `grep -q` exits at the first match, the producer
+            # takes EPIPE and pipefail reports a non-zero pipeline for a
+            # SUCCESSFUL match. And the here-string the other lanes use to dodge
+            # that is a bashism - this job declares no `shell:`, so it gets
+            # whatever the CUDA image provides, and `Build` is the one required
+            # check (ruleset 14716423): a syntax error here fails every PR.
+            # `grep -c` reads all of stdin, so nothing ever takes EPIPE, and it
+            # is POSIX. `|| true` because grep exits 1 when the count is 0.
+            n_cpp="$(printf '%s\n' "$files" | grep -cE '^(src|tools)/.*\.cpp$' || true)"
+            [ "${n_cpp:-0}" -gt 0 ] || cpp=false
           fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          printf 'non-docs changes: code=%s\nchanged files:\n%s\n' "$code" "${files:-<none>}"
+          echo "cpp=$cpp" >> "$GITHUB_OUTPUT"
+          printf 'non-docs changes: code=%s (src|tools .cpp: %s)\nchanged files:\n%s\n' \
+            "$code" "$cpp" "${files:-<none>}"
 
       # The blocking static gates, FIRST, before the compile. Ruleset 14716423
       # requires exactly one context (`Build`), so a gate that runs only as its
@@ -264,7 +284,7 @@ jobs:
   tidy:
     name: clang-tidy
     needs: build
-    if: needs.build.outputs.code == 'true'
+    if: needs.build.outputs.cpp == 'true'
     runs-on: ubuntu-24.04
     container:
       image: nvidia/cuda:13.3.1-devel-ubuntu26.04@sha256:8cf42b8dc4c34d47fb42ffb0923f8a5e363469a7149181c094da336d311bb466
@@ -278,8 +298,13 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends cmake g++ git python3 clang-tidy
+      # cache/restore, not cache: this job only READS compile_commands.json and
+      # _deps. Plain `actions/cache` also runs a post-step that re-uploaded the
+      # ~476 MB build/ under a key the Build job had already written - 29 s on
+      # every run, and that much more of the repo's 10 GB cache quota spent
+      # evicting entries the next PR wants.
       - name: Restore build dir (compile_commands.json + _deps)
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build
           key: imp-build-${{ runner.os }}-cuda${{ env.CUDA_VERSION }}-${{ hashFiles('CMakeLists.txt', 'cmake/**') }}-${{ hashFiles('src/**', 'include/**', 'tools/**') }}-${{ hashFiles('tests/**') }}
@@ -679,6 +704,14 @@ jobs:
     runs-on: ubuntu-24.04
     container:
       image: nvidia/cuda:13.3.1-devel-ubuntu26.04@sha256:8cf42b8dc4c34d47fb42ffb0923f8a5e363469a7149181c094da336d311bb466
+    # Own ccache namespace: these objects are RelWithDebInfo + ASan/UBSan host
+    # flags, so nothing here is shareable with the `Build` (Release) or
+    # `PTX fallback` stores and a shared dir would only evict theirs.
+    env:
+      CCACHE_DIR: /github/home/.ccache-asan
+      CCACHE_MAXSIZE: 2G
+      CCACHE_COMPILERCHECK: content
+      CCACHE_COMPRESS: "1"
     # This image ships no bash, so GitHub picks `sh -e {0}` and any bashism is a
     # syntax error at step start. The first version used a here-string and the
     # job died in 1m15s before building anything - with `Build` the only
@@ -691,7 +724,7 @@ jobs:
         shell: sh
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends bash git python3 cmake ninja-build ca-certificates
+          apt-get install -y --no-install-recommends bash git python3 cmake ninja-build ccache ca-certificates
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -719,6 +752,19 @@ jobs:
           fi
           echo "run=$run" >> "$GITHUB_OUTPUT"
           echo "sanitizer build: run=$run"
+
+      # This lane rebuilt every TU from scratch on every run: 19 min median over
+      # the last 8 PR runs, which WAS the wall clock of the whole workflow (the
+      # `Build` job's median is 6 min). It is the same store shape the
+      # `PTX fallback` lane already uses.
+      - name: Restore ccache
+        if: steps.scope.outputs.run == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /github/home/.ccache-asan
+          key: ${{ runner.os }}-cuda13.3-ccache-asan-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-cuda13.3-ccache-asan-
 
       - name: Fetch pinned deps
         if: steps.scope.outputs.run == 'true'
@@ -750,8 +796,21 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DIMP_SANITIZERS=ON \
             -DIMP_BUILD_TOOLS=OFF -DIMP_BUILD_BENCH=OFF -DIMP_BUILD_SERVER=OFF \
+            -DIMP_DISABLE_120F_FALLBACK=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=/deps/googletest
+          # IMP_DISABLE_120F_FALLBACK=ON: the option defaults OFF, so this lane
+          # was emitting the compute_120f PTX entry as well as the sm_120a SASS.
+          # The `Build` job measured the second gencode at +53.1% device-compile
+          # time, and this lane can use neither image - the runner has no GPU and
+          # CMakeLists.txt does not sanitize device code ("CUDA code is NOT
+          # sanitized"). The fatbin that ships is assembled and checked by the
+          # `PTX fallback` job, which deliberately leaves the option at OFF.
+          ccache -z
           cmake --build build-asan --target test-core test-text -j"$(nproc)"
+          ccache -s
 
       # A binary that contains none of the tests reports "PASSED 0 tests" and
       # exits 0. That is how the first version of this job would have gone green

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,25 @@ jobs:
         with:
           fetch-depth: 0  # full history so the base SHA is present for `git diff`
 
+      # git refuses this checkout on ownership inside the container: the
+      # Actions runner owns /__w/imp/imp and the job's user does not. Without
+      # this, any gate that shells out to git dies - check-release.sh:55 got an
+      # empty `git rev-parse` and cd'd to nothing, which failed the required
+      # check for a reason that had nothing to do with the tree.
+      #
+      # This has to come BEFORE the detection step below, and did not: the step
+      # was the FIRST git caller in the job, its `git cat-file` died on exactly
+      # this ownership refusal with stderr suppressed, and the fail-open handed
+      # back code=true on every run. Proof from run 34412431017, whose diff is
+      # two files and neither is code:
+      #   non-docs changes: code=true (src|tools .cpp: true)
+      #   changed files:
+      # with nothing after "changed files:" - an empty `files`, so no `git diff`
+      # ever ran. The docs-only skip this step exists for had therefore never
+      # fired once, which is why a docs-only PR still paid a ~4 min Build.
+      - name: Trust the checkout (container UID differs from the runner's)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       # Docs-only changes (only **/*.md or docs/** touched) skip the expensive
       # CUDA build/test below but still report the required `Build` check as
       # success — every heavy step is gated on steps.changes.outputs.code, so the
@@ -99,6 +118,14 @@ jobs:
           # it does that on most PRs here, which are .cu, .py or .md. Same
           # FAIL-OPEN rule as `code`: any uncertainty runs the job.
           cpp=true
+          # Say so when the fail-open fires. Without this the step prints a
+          # perfectly normal-looking `code=true` and an empty file list, which
+          # is what let a permanently-open gate go unnoticed: it looks the same
+          # as a genuine code PR. A run that cannot resolve its base is a
+          # detection that is not running, and should read as one.
+          if [ -z "$base" ] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+            echo "::warning::change detection fell open (base '${base:-<unset>}' unresolvable) - every gated step runs"
+          fi
           if [ -n "$base" ] && git cat-file -e "${base}^{commit}" 2>/dev/null; then
             files="$(git diff --name-only "$base" HEAD)"
             # code stays true unless EVERY changed file is markdown or under docs/.
@@ -133,14 +160,6 @@ jobs:
       # so `which gate failed` keeps a check name and there is one list, not two.
       # Runs on docs-only PRs too: the docs and release-hygiene gates are exactly
       # the ones a docs-only change can break.
-      # git refuses this checkout on ownership inside the container: the
-      # Actions runner owns /__w/imp/imp and the job's user does not. Without
-      # this, any gate that shells out to git dies - check-release.sh:55 got an
-      # empty `git rev-parse` and cd'd to nothing, which failed the required
-      # check for a reason that had nothing to do with the tree.
-      - name: Trust the checkout (container UID differs from the runner's)
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
       - name: Static gates (blocking, before the build)
         run: bash scripts/ci_static_gates.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ there instead of retelling it.
 
 ### Fixed
 
+- CI change detection ran `git` before the step that marks the checkout a safe directory, so its
+  `git cat-file` died on the ownership refusal and the fail-open returned `code=true` every run:
+  the docs-only skip had never once fired, and a fall-open now says so with a `::warning::`
 - `speculative.batch_rr` no longer requires `speculative.ngram`, the key the measured MTP recipe sets
   to false, at either gate (the scheduler branch and the #1003 pipeline yield that reaches it):
   round-robin batched verify was off on every dense model running MTP alone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ there instead of retelling it.
 
 ### Changed
 
+- The `Sanitizers` lane keeps a ccache store of its own and drops the `compute_120f` PTX it cannot
+  use (no GPU, device code is not sanitized; +53.1 % device-compile time per `Build`). It rebuilt
+  every TU from scratch and was the workflow's critical path in 8 of 8 PR runs: 19 min median
+- `clang-tidy` starts only on a changed `src/`|`tools/` `.cpp` (new `cpp` output on `Build`,
+  fail-open like `code`) and restores the build cache read-only instead of re-uploading ~476 MB per
+  run; it was adding ~2.6 min after `Build` to lint zero files on every `.cu`- or docs-only PR
 - The NVFP4 loader enforces `quantization_config.ignore` instead of only parsing it: one inventory line reports the
   Linear slots and where the ignore entries landed (Qwen3.8-27B-NVFP4-vllm: 496 quantized, 0 unclassified; 170
   entries = 1 + 161 + 8), and an unclassified Linear or a missing `weight_global_scale` is refused ([quantization.md](docs/quantization.md))


### PR DESCRIPTION
## Summary

Measured first, per-job wall clock over the last 8 PR runs of `ci.yml`. `Sanitizers` was the run's wall clock in **8 of 8**, and total run time was 14-20.5 min.

**Measured on this branch, same workflow, end to end:**

| job | before (median) | after |
|---|---|---|
| **whole run** | **~19 min** | **5.8 min** |
| Sanitizers | 19.0 min | **2.6 min** |
| Build | 6.2 min | 3.9 min |
| clang-tidy (ran after Build) | 1.8 min | **skipped** |

Three changes, the third found only because the second one visibly failed to work.

### 1. `Sanitizers` gets a ccache, and stops building the PTX it cannot use

It had no compiler cache of any kind and rebuilt every TU, CUDA included, every run. It now keeps a store of its own (the shape `PTX fallback` already uses) and passes `IMP_DISABLE_120F_FALLBACK=ON`: the option defaults OFF, so the lane was also emitting the `compute_120f` PTX entry beside the `sm_120a` SASS. It can use neither image - no GPU on the runner, and `CMakeLists.txt` does not sanitize device code - and `Build` has the second gencode measured at **+53.1 % device-compile time**. The shipped fatbin is still assembled and checked by `PTX fallback`, which deliberately leaves the option at OFF.

Separating the two effects: cold ccache, single gencode was **13.7 min**; warm, **2.6-3.1 min**.

### 2. `clang-tidy` starts only when a `src/`|`tools/` `.cpp` changed

It required only `outputs.code`, so it started on every code PR and paid ~2.6 min of container pull and cache round trip on the `.cu`- and docs-only PRs that are most of them - onto the tail of the critical path, since it `needs: build`. `Build` now also publishes a `cpp` output (fail-open, like `code`). Its build cache also becomes `actions/cache/restore`: the job only reads `compile_commands.json` and `_deps`, but plain `actions/cache` re-uploaded ~476 MB per run under a key `Build` had already written - 29 s, and that much of the repo's 10 GB cache quota spent evicting entries the next PR wants.

### 3. The change detection had never run at all

The first CI run on this branch ran `clang-tidy` anyway. The reason, from the `Build` log on a two-file diff with no code in it:

```
non-docs changes: code=true (src|tools .cpp: true)
changed files:
```

Nothing after `changed files:` - an empty list, so no `git diff` ever ran. The detection step was the **first git caller in the job**, and the step running `git config --global --add safe.directory` sat 50 lines below it, so `git cat-file -e` died on the container ownership refusal with stderr suppressed and the fail-open returned `code=true` on every run.

So the docs-only skip this step exists for had **never once fired** - which is why a docs-only PR still paid a ~4 min `Build` - and the `cpp` gate from change 2 was inert for the same reason. The `safe.directory` step now runs immediately after checkout, and a fall-open prints a `::warning::` naming the base it could not resolve, because a silent `code=true` with an empty list reads exactly like a genuine code PR and is what let a permanently-open gate hide.

Confirmed on the current head:

```
non-docs changes: code=true (src|tools .cpp: false)
changed files:
.claude/skills/building-and-testing/SKILL.md
.claude/skills/shipping-prs/SKILL.md
.github/workflows/ci.yml
CHANGELOG.md
```

Populated list, `cpp: false`, no fall-open warning, and `clang-tidy` skipped.

Nothing here changes what CI *checks* - no gate, test or lane is dropped, and `Build` (the one required context, ruleset 14716423) keeps identical gating behaviour on code PRs. Docs-only PRs now genuinely skip the heavy steps, which is what the existing code always intended.

## Test plan

- [x] Green end to end on the current head; `clang-tidy` skipped, detection output verified in the job log (quoted above)
- [x] `scripts/ci_static_gates.sh` and `scripts/check_dep_pins.sh` green; the new `actions/cache/restore@<sha>` is 40-hex pinned
- [x] Detection logic exercised against a throwaway git repo under **both `dash` and `bash -eo pipefail`** - the CUDA image gives these steps `sh -e {0}`, confirmed in the job log. Resolvable base: docs-only -> `code=false cpp=false`; `+src/*.cpp` -> `true/true`; workflow-only -> `true/false`. Unresolvable base -> warning, `true/true`
- [ ] `make verify-fast` not run: no GPU in this session, and the diff is workflow + CHANGELOG only - no `src/`, `include/`, `tools/` or `tests/` file is touched, so it is outside `PERF_RE` and outside the pre-commit GPU trigger
- [ ] Not an engine perf change; no `tests/perf_baseline.json` refresh

## Known issue this PR does NOT fix

`clang-tidy`'s lint step exits 128 with `fatal: not a git repository`, and `continue-on-error: true` reports the job green regardless. **It is pre-existing** - byte-identical in run 2590 on `main`'s side, before this branch existed - and the step also uses `mapfile`/`${#arr[@]}` under `sh`, which would not survive even with git fixed. Same class as #1626 ("It had never linted a file").

Left alone deliberately: it is a correctness bug in an advisory lane, separate from this PR's subject, and it wants its own PR - one that should also decide whether `clang-tidy` keeps `continue-on-error`, since that flag is what let it hide. Change 3 above means it is at least no longer triggered on PRs that change no `.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HBb9gf2hacFVkWV9bn7Hk