### PR TITLE
fix(gbnf): a repetition bound past INT_MAX is refused, not thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ there instead of retelling it.
 
 ### Fixed
 
+- A GBNF grammar whose repetition bound is past `INT_MAX` aborted the process: `std::stoi` threw
+  `std::out_of_range` before the `kMaxRepeat` check ran, and grammars arrive on the request path.
+  Found by the first nightly libFuzzer run that built, after 3.3M/269k/272k executions (#1972)
+
 - NVFP4 checkpoints with both a `recipe.yaml` and a `quantization_config` read their ignore list
   from the recipe's patterns instead of the expanded names in `config.json` (4 vs 222 on
   Gemma-4-26B-A4B-it-NVFP4): the 30 routers arrived unclassified and the load was refused (#1970)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,9 +127,9 @@ there instead of retelling it.
 
 ### Fixed
 
-- A GBNF grammar whose repetition bound is past `INT_MAX` aborted the process: `std::stoi` threw
-  `std::out_of_range` before the `kMaxRepeat` check ran, and grammars arrive on the request path.
-  Found by the first nightly libFuzzer run that built, after 3.3M/269k/272k executions (#1972)
+- A GBNF grammar whose repetition bound is past `INT_MAX` answered 500 `{"message":"stoi"}` instead
+  of a 400: `std::stoi` threw before the `kMaxRepeat` check ran. Now 400 "repetition bound over 1024
+  (at offset 31)". Found by the first nightly libFuzzer run that built (#1972)
 
 - NVFP4 checkpoints with both a `recipe.yaml` and a `quantization_config` read their ignore list
   from the recipe's patterns instead of the expanded names in `config.json` (4 vs 222 on

--- a/src/compute/gbnf_parser.cpp
+++ b/src/compute/gbnf_parser.cpp
@@ -22,6 +22,20 @@ constexpr int kMaxRepeat = 1024;
 // nests anywhere near this.
 constexpr int kMaxGroupDepth = 64;
 
+// Digits to a repetition bound without std::stoi's throw. An empty string is 0
+// (`{,4}` means "up to 4"); anything that cannot be under kMaxRepeat is false,
+// which the caller turns into the same refusal an in-range but too-large bound
+// gets. Five digits is already past kMaxRepeat, so the accumulator cannot run
+// away.
+inline bool bound_from_digits(const std::string& s, int& out) {
+    if (s.size() > 5)
+        return false;
+    out = 0;
+    for (char c : s)
+        out = out * 10 + (c - '0');
+    return true;
+}
+
 bool is_word_char(char c) {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
 }
@@ -253,8 +267,17 @@ struct Parser {
         pos++;
         if (a.empty() && b.empty())
             return fail("empty { } repetition");
-        lo = a.empty() ? 0 : std::stoi(a);
-        hi = has_comma ? (b.empty() ? -1 : std::stoi(b)) : lo;
+        // The bound check below is the gate, and std::stoi used to throw
+        // std::out_of_range before it ever ran: `1 ::= x{24444444044444444}`
+        // aborted the process, and parse_gbnf reads request-supplied grammars
+        // (tools/imp-server/constraint_validation.cpp). Found by fuzz_gbnf on
+        // the first nightly run that built, 2026-09-10.
+        if (!bound_from_digits(a, lo) || (has_comma && !b.empty() && !bound_from_digits(b, hi)))
+            return fail("repetition bound over " + std::to_string(kMaxRepeat));
+        if (!has_comma)
+            hi = lo;
+        else if (b.empty())
+            hi = -1;
         if (lo > kMaxRepeat || hi > kMaxRepeat)
             return fail("repetition bound over " + std::to_string(kMaxRepeat));
         if (hi >= 0 && hi < lo)

--- a/src/compute/gbnf_parser.cpp
+++ b/src/compute/gbnf_parser.cpp
@@ -268,10 +268,11 @@ struct Parser {
         if (a.empty() && b.empty())
             return fail("empty { } repetition");
         // The bound check below is the gate, and std::stoi used to throw
-        // std::out_of_range before it ever ran: `1 ::= x{24444444044444444}`
-        // aborted the process, and parse_gbnf reads request-supplied grammars
-        // (tools/imp-server/constraint_validation.cpp). Found by fuzz_gbnf on
-        // the first nightly run that built, 2026-09-10.
+        // std::out_of_range before it ever ran. Measured on the server, same
+        // request: 500 {"message":"stoi","type":"server_error"} before, 400
+        // "repetition bound over 1024 (at offset 31)" after. httplib's
+        // exception handler is what kept that a 500 rather than an abort; the
+        // fuzz harness has none and died. Found by fuzz_gbnf, 2026-09-10.
         if (!bound_from_digits(a, lo) || (has_comma && !b.empty() && !bound_from_digits(b, hi)))
             return fail("repetition bound over " + std::to_string(kMaxRepeat));
         if (!has_comma)

--- a/tests/test_fuzz_corpus.cpp
+++ b/tests/test_fuzz_corpus.cpp
@@ -176,6 +176,9 @@ std::vector<std::string> gbnf_corpus() {
         "root ::= obj\nobj ::= \"{\" pair (\",\" pair)* \"}\"\npair ::= \"x\"",
         "root ::= \"a\"{1,1024}",
         "root ::= \"a\"{0,100000}",
+        // std::out_of_range out of std::stoi, before the bound check (2026-09-10)
+        "root ::= \"a\"{24444444044444444}",
+        "1::=--_1k{24444444044444444}4444444444444)4444,44",
         "root ::= " + std::string(20000, '(') + "\"a\"" + std::string(20000, ')'),
         "root ::= root",
         "root ::=",

--- a/tests/test_gbnf_grammar.cpp
+++ b/tests/test_gbnf_grammar.cpp
@@ -111,10 +111,10 @@ TEST(GbnfGrammar, RefusesAbsurdRepetitionBounds) {
     EXPECT_TRUE(compile_error("root ::= \"a\"{0,8}").empty());
 }
 
-// A bound past INT_MAX reached std::stoi before the check above ran, and its
-// std::out_of_range aborted the process. parse_gbnf reads request-supplied
-// grammars, so that was a one-request kill. Found by fuzz_gbnf on the first
-// nightly run that built (2026-09-10), reduced from
+// A bound past INT_MAX reached std::stoi before the check above ran. On the
+// server that surfaced as 500 {"message":"stoi"} instead of a 400; anywhere
+// without an exception handler (the fuzz harness) it aborted. Found by
+// fuzz_gbnf on the first nightly run that built (2026-09-10), reduced from
 // `1::=--_1k{24444444044444444}...`.
 TEST(GbnfGrammar, ARepetitionBoundPastIntMaxIsRefusedNotThrown) {
     for (const char* g : {"root ::= \"a\"{24444444044444444}",

--- a/tests/test_gbnf_grammar.cpp
+++ b/tests/test_gbnf_grammar.cpp
@@ -111,6 +111,26 @@ TEST(GbnfGrammar, RefusesAbsurdRepetitionBounds) {
     EXPECT_TRUE(compile_error("root ::= \"a\"{0,8}").empty());
 }
 
+// A bound past INT_MAX reached std::stoi before the check above ran, and its
+// std::out_of_range aborted the process. parse_gbnf reads request-supplied
+// grammars, so that was a one-request kill. Found by fuzz_gbnf on the first
+// nightly run that built (2026-09-10), reduced from
+// `1::=--_1k{24444444044444444}...`.
+TEST(GbnfGrammar, ARepetitionBoundPastIntMaxIsRefusedNotThrown) {
+    for (const char* g : {"root ::= \"a\"{24444444044444444}",
+                          "root ::= \"a\"{0,24444444044444444}",
+                          "root ::= \"a\"{99999999999999999999999999,2}",
+                          "root ::= \"a\"{2147483648}"}) {
+        std::string err;
+        std::vector<imp::GbnfRule> rules;
+        int32_t root = -1;
+        EXPECT_FALSE(imp::parse_gbnf(g, rules, root, &err)) << g;
+        EXPECT_FALSE(err.empty()) << g;
+    }
+    // Still parses on the useful side of the bound.
+    EXPECT_TRUE(compile_error("root ::= \"a\"{1,1024}").empty());
+}
+
 // -----------------------------------------------------------------------------
 // Core language semantics
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## The first fuzz run that ever built found a crash in 71 seconds

#1969 made the nightly libFuzzer job build. Dispatched against `main` right
after it landed, `fuzz_gbnf` died:

```
1::=--_1k{24444444044444444}4444444444444)4444,44
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoi
```

| target | executions in 600 s | result |
|---|---|---|
| `fuzz_json_schema` | 3300998 | clean |
| `fuzz_regex` | 268906 | clean |
| `fuzz_gbnf` | crashed after 71 s | `std::out_of_range` |

`kMaxRepeat` (1024) is the gate, and `std::stoi` ran before it. A repetition
bound wider than `int` threw where nothing catches it.

## What it actually cost, measured

The first commit here called it a one-request kill. It is not, and the
correction is the second commit. `imp-server` installs an httplib exception
handler (`main.cpp:438`), so the grammar arrives as a server error rather than
an abort. Both readings from `build-dev/imp-server` started model-less on
`127.0.0.1:18080` with `root ::= "a"{24444444044444444}`:

| | status | body |
|---|---|---|
| before | 500 | `{"message":"stoi","type":"server_error"}` |
| after | 400 | `{"message":"the GBNF grammar cannot be enforced as a constraint: repetition bound over 1024 (at offset 31)","type":"invalid_request_error"}` |

The abort is real wherever no handler sits above the call, which is where
`fuzz_gbnf` met it.

## The fix

`bound_from_digits()` converts the digit run without throwing. Over five digits
is already past `kMaxRepeat`, so it returns false and the caller emits the same
refusal an in-range but too-large bound gets. At five digits the accumulator
cannot overflow. `{1,1024}` still parses, `{0,100000}` is still refused with the
same message.

A throwing conversion on request data is a class, not one instance, so the other
`std::sto*` calls on request-driven input were checked: `logit_bias` keys
(`handlers_chat_params.cpp:293`, `handlers_chat.cpp:738`) sit in try/catch,
traceparent flags (`tracing.cpp:63`) are two validated hex digits, tool-call
numbers (`tool_call.cpp:274`, `tool_call_gemma.cpp:178`) sit in try/catch.

## Gate

`GbnfGrammar.ARepetitionBoundPastIntMaxIsRefusedNotThrown` covers `{n}`,
`{0,n}`, a 26-digit bound and `INT_MAX+1`, and asserts `{1,1024}` still parses.
The crasher and its reduction join the committed fuzz corpus, so the CPU lane
replays them on every PR.

Mutation-validated. Restoring the two `std::stoi` calls:

```
[  FAILED  ] GbnfGrammar.ARepetitionBoundPastIntMaxIsRefusedNotThrown
[  FAILED  ] FuzzCorpus.Gbnf
```

Restored: 33/33 across `GbnfGrammar`, `GbnfDepthCap` and `FuzzCorpus`. The
pre-commit GPU suite ran clean; the push gate read tg128 within its bound and
paired decode +5.00% (8.55 / 3.06 / 3.38), which is this box's window noise on a
parser-only change, not a speedup.

Not in here: `kMaxRepeat` does not move. `chat_template.cpp:747` has no
try/catch anywhere in its file and parses a tool's `parameters` JSON from the
request body through `std::stoll`; it sits behind the same httplib handler and
is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
