### PR TITLE
fix(template): a tool parameter past INT64_MAX renders instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ there instead of retelling it.
 
 ### Fixed
 
+- A tool whose `parameters` schema carries a JSON number between `INT64_MAX` and `UINT64_MAX`
+  (`9223372036854775808` survives the request roundtrip as an integer) made the template renderer
+  throw `std::out_of_range` out of `std::stoll`; it now renders as a double (#1973)
+
 - A GBNF grammar whose repetition bound is past `INT_MAX` answered 500 `{"message":"stoi"}` instead
   of a 400: `std::stoi` threw before the `kMaxRepeat` check ran. Now 400 "repetition bound over 1024
   (at offset 31)". Found by the first nightly libFuzzer run that built (#1972)

--- a/src/model/chat_template.cpp
+++ b/src/model/chat_template.cpp
@@ -2,6 +2,7 @@
 #include "core/logging.h"
 #include "core/process_diag.h"
 
+#include <stdexcept>
 #include <algorithm>
 #include <functional>
 
@@ -743,9 +744,21 @@ static jinja::Value json_string_to_value(const std::string& json_str) {
         std::string num_str = json_str.substr(start, pos - start);
         if (num_str.empty())
             return jinja::Value();
-        if (is_float)
+        // A JSON number between INT64_MAX and UINT64_MAX survives the request
+        // roundtrip as an integer (9223372036854775808 dumps unchanged; only
+        // past ~1e19 does nlohmann turn it into 1e+26), and std::stoll throws
+        // out_of_range on it. This file has no other catch, so that reached the
+        // request path as a 500. Fall back to the double the value already is.
+        try {
+            if (!is_float)
+                return jinja::Value(static_cast<int64_t>(std::stoll(num_str)));
+        } catch (const std::out_of_range&) {
+        }
+        try {
             return jinja::Value(std::stod(num_str));
-        return jinja::Value(static_cast<int64_t>(std::stoll(num_str)));
+        } catch (const std::out_of_range&) {
+            return jinja::Value();
+        }
     };
 
     return parse_value();

--- a/tests/test_chat_template.cpp
+++ b/tests/test_chat_template.cpp
@@ -961,5 +961,35 @@ TEST_F(HFChatTemplateTest, MissingField) {
     EXPECT_TRUE(result.empty());
 }
 
+
+// A tool's `parameters` schema comes off the request body, and a JSON number
+// between INT64_MAX and UINT64_MAX reaches the template renderer as an integer
+// string: nlohmann keeps 9223372036854775808 verbatim and only normalises past
+// ~1e19. std::stoll threw std::out_of_range on it, in a file with no other
+// catch, and the request answered 500. Same class as the GBNF bound (#1972).
+TEST(ChatTemplateTools, AToolParameterPastInt64MaxRendersInsteadOfThrowing) {
+    Tokenizer tok = make_chat_tokenizer();
+    ChatTemplate tpl;
+    ASSERT_TRUE(tpl.init(ChatTemplateFamily::CHATML, tok,
+                         "{% for t in tools %}{{ t.function.parameters.properties.x.maximum }}"
+                         "{% endfor %}{% for m in messages %}{{ m.content }}{% endfor %}"));
+    std::vector<ChatMessage> msgs = {{"user", "hi"}};
+    for (const char* schema : {R"({"type":"object","properties":{"x":{"maximum":9223372036854775808}}})",
+                               R"({"type":"object","properties":{"x":{"maximum":18446744073709551615}}})",
+                               R"({"type":"object","properties":{"x":{"maximum":-9223372036854775809}}})"}) {
+        std::vector<ToolFunction> tools = {{"f", "d", schema}};
+        EXPECT_NO_THROW({
+            auto ids = tpl.apply_with_tools(tok, msgs, tools);
+            (void)ids;
+        }) << schema;
+    }
+    // The ordinary side still renders.
+    std::vector<ToolFunction> ok = {{"f", "d", R"({"type":"object","properties":{"x":{"maximum":42}}})"}};
+    EXPECT_NO_THROW({
+        auto ids = tpl.apply_with_tools(tok, msgs, ok);
+        (void)ids;
+    });
+}
+
 }  // namespace
 }  // namespace imp


### PR DESCRIPTION
## The second throwing conversion on request data

#1972 fixed a `std::stoi` that threw before its own bound check. Checking
whether it was the only one turned up `src/model/chat_template.cpp`, which has
no `catch` anywhere in the file and runs `std::stoll` over a tool's
`parameters` schema. That schema arrives verbatim from the request body
(`handlers_chat_core.cpp:291` dumps `t["function"]["parameters"]`).

Reachability depends entirely on what nlohmann does to a wide integer, so it was
measured, not assumed:

| request value | dump | kind |
|---|---|---|
| `99999999999999999999999999` | `1e+26` | float |
| `9223372036854775808` (INT64_MAX+1) | `9223372036854775808` | integer |
| `9223372036854775807` (INT64_MAX) | `9223372036854775807` | integer |

Only past roughly 1e19 does the value become a float. The window between
`INT64_MAX` and `UINT64_MAX` reaches the renderer as an integer string that
`std::stoll` cannot hold, so it threw where nothing catches and the request
answered 500.

## The fix

The number falls back to the double it already is, which is what a wider integer
means to a template. A value `std::stod` cannot hold either becomes an undefined
Jinja value rather than an exception.

## Gate

`ChatTemplateTools.AToolParameterPastInt64MaxRendersInsteadOfThrowing` covers
`INT64_MAX+1`, `UINT64_MAX` and `INT64_MIN-1`, and asserts an ordinary `42`
still renders.

Mutation-validated. Restoring the bare `std::stoll`:

```
[  FAILED  ] ChatTemplateTools.AToolParameterPastInt64MaxRendersInsteadOfThrowing
```

Restored: `test-text` 238/238, `test-core` 1526/1526.

The pre-commit GPU suite did not run: the card is held by a non-container tenant
(8021-8226 MiB, 21-25 % util, `docker ps` empty), and this change is host-only
C++ in the template renderer, with no kernel and nothing the perf gate can move.
`ci_static_gates.sh` is green except `kernel-resources`, which needs docker
inside the container it runs in. CI has no GPU either, so its Build job checks
the same surface this was checked against.

Not in here: no audit of `std::sto*` outside the request path. The loader and
GGUF sites read files, not request bodies, and the four request-driven sites
checked in #1972 are already guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
