### PR TITLE
perf(gdn): batched decode skips the residual save, copies by kernel, alpha+beta in one narrow FP16 launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ there instead of retelling it.
 
 ### Changed
 
+- Batched GDN decode drops three launches per layer: no residual save when the out-projection accumulates into
+  the hidden buffer, kernel copies instead of memcpy nodes, and alpha+beta as one split-K FP16 launch
+  (`gdn.alpha_beta_smallm`). Qwen3.8-27B-NVFP4 at 32 streams 1985.7 -> 2019.8 tok/s (+1.7 %, 3/3 pairs positive)
 - The two absolute perf bars in the GPU suite take the best of eight measurement windows: single
   windows on this box drop out by up to 4x (46.12 to 200.82 us in one run), which failed
   `SmallMDenseTest.BenchDecodeShape` on two of three runs of an unrelated tree (#1971)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/dispatch_paths.cpp
     src/compute/gemm.cu
     src/compute/gemm_capture_fp16_sm120.cu
+    src/compute/gemm_f16_narrow_smallm.cu
     src/compute/ffn_sparsity_probe.cu
     src/compute/ffn_sparsity_mask.cu
     src/compute/weight_dispatch.cu
@@ -430,6 +431,7 @@ set(IMP_EXEC_SOURCES
     src/quant/gpt_oss_mxfp4_convert.cu
     src/exec/executor_ffn.cu
     src/exec/executor_ssm_gdn.cu
+    src/exec/executor_gdn_alpha_beta.cu
     src/exec/executor_forward_moe.cu
     src/exec/executor_forward_moe_cutlass.cu
     src/exec/executor_forward_moe_batch.cu
@@ -964,6 +966,7 @@ if(IMP_BUILD_TESTS)
         tests/test_embedding.cu
         tests/test_gemm.cu
         tests/test_gemm_capture_fp16_sm120.cu
+        tests/test_gemm_f16_narrow_smallm.cu
         tests/test_gemm_dp4a.cu
         tests/test_gemm_kernel_registry.cu
         tests/test_fp8_gemm.cu

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -559,6 +559,9 @@ layout_override      = ""
 # aggregate at 32 streams on Qwen3.8-27B-NVFP4 for +0.21 % PPL, and the freed
 # bytes go to the KV pool. false = FP32 state.
 state_bf16           = true
+# Batched decode (2..32 rows): alpha and beta projections in one split-K FP16
+# tensor-core launch instead of two cuBLAS GEMMs (4 launches per GDN layer).
+alpha_beta_smallm    = true
 
 [gemm]
 # dp4a = INT8 4-element packed multiply-accumulate. mmvq = matrix*vec

--- a/src/compute/gemm_f16_narrow_smallm.cu
+++ b/src/compute/gemm_f16_narrow_smallm.cu
@@ -1,0 +1,218 @@
+// Narrow FP16 GEMM, up to two (W, C) pairs per launch (header: the contract).
+//
+// Grid (n16 tiles over both pairs) x kSplit. A CTA owns one 16-column tile and
+// one K range; its 8 warps take the k16 steps of that range round-robin and
+// each accumulates the whole 32x16 tile (2 m16 x 2 n8 mma.sync m16n8k16, FP32).
+// Reduce: warps -> smem -> one FP32 partial per CTA in ws[ks][m][col]; the
+// last CTA of a tile (atomic ticket) sums the kSplit partials in index order
+// and writes C. Fixed order = bitwise deterministic.
+//
+// Operand fragments come straight from global memory (u32 per lane, L2 hits:
+// the weight is 0.5 MiB per pair, the activation 320 KiB at M=32, K=5120).
+
+#include "compute/gemm_f16_narrow_smallm.h"
+#include "core/logging.h"
+#include "core/pdl.h"
+#include "core/pdl_device.cuh"
+
+#include <cstdint>
+
+namespace imp {
+namespace {
+
+constexpr int kMaxM = 32;
+constexpr int kNT = 16;
+constexpr int kWarps = 8;
+constexpr int kThreads = kWarps * 32;
+constexpr int kSplit = 8;
+constexpr int kKAlign = kSplit * 16;  // K % 128 == 0
+
+struct NarrowArgs {
+    const half* A;
+    int M;
+    int K;
+    const half* W[2];
+    half* C[2];
+    int N[2];
+    int tiles0;  // tiles [0, tiles0) belong to pair 0
+    float* ws;   // [kSplit][kMaxM][n_total]
+    int* tickets;
+    int n_total;
+};
+
+__device__ __forceinline__ uint32_t ld_u32(const half* p) {
+    return __ldg(reinterpret_cast<const unsigned int*>(p));
+}
+
+__device__ __forceinline__ void mma_f16_16x8x16(float* c, const uint32_t* a, const uint32_t* b) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, "
+        "{%0,%1,%2,%3};\n"
+        : "+f"(c[0]), "+f"(c[1]), "+f"(c[2]), "+f"(c[3])
+        : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]));
+}
+
+__global__ void __launch_bounds__(kThreads) gemm_f16_narrow_smallm_kernel(NarrowArgs args) {
+    __shared__ float s_red[kWarps][kMaxM][kNT];
+    __shared__ int s_last;
+
+    pdl_wait();
+
+    const int tile = blockIdx.x;
+    const int ks = blockIdx.y;
+    const int pair = (tile >= args.tiles0) ? 1 : 0;
+    const int tile_in_pair = tile - (pair ? args.tiles0 : 0);
+    const int K = args.K;
+    const int M = args.M;
+    const half* __restrict__ W = args.W[pair] + static_cast<size_t>(tile_in_pair) * kNT * K;
+
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int g = lane >> 2;
+    const int tg = lane & 3;
+
+    // A fragment rows g, g+8 (m-tile 0) and g+16, g+24 (m-tile 1); rows past M
+    // read zero (pointer clamped, value masked).
+    const half* Ar[4];
+    bool vr[4];
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        const int row = g + 8 * i;
+        vr[i] = row < M;
+        Ar[i] = args.A + static_cast<size_t>(vr[i] ? row : 0) * K + 2 * tg;
+    }
+    const half* Wg0 = W + static_cast<size_t>(g) * K + 2 * tg;
+    const half* Wg1 = Wg0 + static_cast<size_t>(8) * K;
+    const bool m1 = M > 16;
+
+    const int k_cta = K / kSplit;
+    const int k0 = ks * k_cta;
+    const int nsteps = k_cta >> 4;
+
+    float acc[2][2][4] = {};
+    for (int s = warp; s < nsteps; s += kWarps) {
+        const int k = k0 + s * 16;
+        uint32_t a[2][4];
+        a[0][0] = vr[0] ? ld_u32(Ar[0] + k) : 0u;
+        a[0][1] = vr[1] ? ld_u32(Ar[1] + k) : 0u;
+        a[0][2] = vr[0] ? ld_u32(Ar[0] + k + 8) : 0u;
+        a[0][3] = vr[1] ? ld_u32(Ar[1] + k + 8) : 0u;
+        if (m1) {
+            a[1][0] = vr[2] ? ld_u32(Ar[2] + k) : 0u;
+            a[1][1] = vr[3] ? ld_u32(Ar[3] + k) : 0u;
+            a[1][2] = vr[2] ? ld_u32(Ar[2] + k + 8) : 0u;
+            a[1][3] = vr[3] ? ld_u32(Ar[3] + k + 8) : 0u;
+        }
+        uint32_t b[2][2];
+        b[0][0] = ld_u32(Wg0 + k);
+        b[0][1] = ld_u32(Wg0 + k + 8);
+        b[1][0] = ld_u32(Wg1 + k);
+        b[1][1] = ld_u32(Wg1 + k + 8);
+        mma_f16_16x8x16(acc[0][0], a[0], b[0]);
+        mma_f16_16x8x16(acc[0][1], a[0], b[1]);
+        if (m1) {
+            mma_f16_16x8x16(acc[1][0], a[1], b[0]);
+            mma_f16_16x8x16(acc[1][1], a[1], b[1]);
+        }
+    }
+    pdl_trigger();
+
+    // C fragment: c0,c1 at (row g, cols 2tg, 2tg+1), c2,c3 at (row g+8, same cols).
+#pragma unroll
+    for (int i = 0; i < 2; ++i) {
+#pragma unroll
+        for (int j = 0; j < 2; ++j) {
+            const int col = 8 * j + 2 * tg;
+            s_red[warp][g + 16 * i][col] = acc[i][j][0];
+            s_red[warp][g + 16 * i][col + 1] = acc[i][j][1];
+            s_red[warp][g + 16 * i + 8][col] = acc[i][j][2];
+            s_red[warp][g + 16 * i + 8][col + 1] = acc[i][j][3];
+        }
+    }
+    __syncthreads();
+
+    const int col0 = tile * kNT;
+    float* ws = args.ws;
+    for (int o = threadIdx.x; o < kMaxM * kNT; o += kThreads) {
+        const int m = o / kNT;
+        const int c = o - m * kNT;
+        if (m >= M)
+            continue;
+        float sum = 0.0f;
+#pragma unroll
+        for (int w = 0; w < kWarps; ++w)
+            sum += s_red[w][m][c];
+        ws[(static_cast<size_t>(ks) * kMaxM + m) * args.n_total + col0 + c] = sum;
+    }
+    __threadfence();
+    __syncthreads();
+    if (threadIdx.x == 0)
+        s_last = (atomicAdd(&args.tickets[tile], 1) == kSplit - 1) ? 1 : 0;
+    __syncthreads();
+    if (!s_last)
+        return;
+    __threadfence();
+
+    half* __restrict__ C = args.C[pair];
+    const int N = args.N[pair];
+    for (int o = threadIdx.x; o < kMaxM * kNT; o += kThreads) {
+        const int m = o / kNT;
+        const int c = o - m * kNT;
+        if (m >= M)
+            continue;
+        float sum = 0.0f;
+#pragma unroll
+        for (int k2 = 0; k2 < kSplit; ++k2)
+            sum += __ldcg(&ws[(static_cast<size_t>(k2) * kMaxM + m) * args.n_total + col0 + c]);
+        C[static_cast<size_t>(m) * N + tile_in_pair * kNT + c] = __float2half_rn(sum);
+    }
+    if (threadIdx.x == 0)
+        args.tickets[tile] = 0;
+}
+
+size_t partials_bytes(int n_total) { return static_cast<size_t>(kSplit) * kMaxM * n_total * sizeof(float); }
+
+}  // namespace
+
+size_t gemm_f16_narrow_smallm_workspace_bytes(int n_total_max) {
+    const size_t p = (partials_bytes(n_total_max) + 255) & ~size_t(255);
+    return p + static_cast<size_t>(n_total_max / kNT + 1) * sizeof(int);
+}
+
+bool gemm_f16_narrow_smallm(const half* A, int M, int K, const half* W0, half* C0, int N0, const half* W1,
+                            half* C1, int N1, void* ws, size_t ws_bytes, cudaStream_t stream) {
+    if (!A || !W0 || !C0 || !ws || M < 1 || M > kMaxM || K < kKAlign || (K % kKAlign) != 0)
+        return false;
+    if (N0 <= 0 || (N0 % kNT) != 0 || N1 < 0 || (N1 % kNT) != 0 || (N1 > 0 && (!W1 || !C1)))
+        return false;
+    const int n_total = N0 + N1;
+    if (ws_bytes < gemm_f16_narrow_smallm_workspace_bytes(n_total))
+        return false;
+    if ((reinterpret_cast<uintptr_t>(A) & 3) || (reinterpret_cast<uintptr_t>(W0) & 3) ||
+        (W1 && (reinterpret_cast<uintptr_t>(W1) & 3)))
+        return false;
+
+    NarrowArgs args{};
+    args.A = A;
+    args.M = M;
+    args.K = K;
+    args.W[0] = W0;
+    args.W[1] = W1;
+    args.C[0] = C0;
+    args.C[1] = C1;
+    args.N[0] = N0;
+    args.N[1] = N1;
+    args.tiles0 = N0 / kNT;
+    args.ws = static_cast<float*>(ws);
+    args.tickets = reinterpret_cast<int*>(static_cast<char*>(ws) +
+                                          ((partials_bytes(n_total) + 255) & ~size_t(255)));
+    args.n_total = n_total;
+
+    const dim3 grid(n_total / kNT, kSplit);
+    pdl::enable_kernel(gemm_f16_narrow_smallm_kernel);
+    pdl::launch(gemm_f16_narrow_smallm_kernel, grid, dim3(kThreads), size_t(0), stream, args);
+    IMP_CUDA_CHECK_LAUNCH();
+    return true;
+}
+
+}  // namespace imp

--- a/src/compute/gemm_f16_narrow_smallm.h
+++ b/src/compute/gemm_f16_narrow_smallm.h
@@ -1,0 +1,29 @@
+#pragma once
+// Narrow FP16 GEMM for batched decode: up to two (W, C) pairs in one launch.
+//
+//   C_p[M, N_p] = A[M, K] @ W_p[N_p, K]^T     p = 0, 1
+//
+// FP16 operands, FP32 accumulate, FP16 out; M <= 32, N_p % 16 == 0, K % 128 == 0.
+// Built for the GDN alpha/beta projections (N = n_heads, 48 on Qwen3.8-27B):
+// at M = 32 they ran as two cuBLAS GEMMs of nvjet + splitKreduce each, 4
+// launches per GDN layer. Split-K across CTAs with a fixed-order final
+// reduce: bitwise deterministic per shape.
+//
+// Workspace (device, zero-initialised once): gemm_f16_narrow_smallm_workspace_bytes()
+// for the largest N_0 + N_1 the caller will pass. The tickets in it are reset
+// by the kernel itself, so one zeroing at allocation is enough.
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstddef>
+
+namespace imp {
+
+size_t gemm_f16_narrow_smallm_workspace_bytes(int n_total_max);
+
+// Returns false (nothing launched) when a shape or the workspace does not
+// fit; the caller keeps its previous path. N1 == 0 runs pair 0 only.
+bool gemm_f16_narrow_smallm(const half* A, int M, int K, const half* W0, half* C0, int N0, const half* W1,
+                            half* C1, int N1, void* ws, size_t ws_bytes, cudaStream_t stream);
+
+}  // namespace imp

--- a/src/core/config/gdn.h
+++ b/src/core/config/gdn.h
@@ -76,6 +76,12 @@ struct GDN {
     // FP32 on unsupported shapes. FP16 state stays refuted (subnormal
     // truncation). Opt out via gdn.state_bf16=false.
     bool state_bf16 = true;
+    // Batched decode (2 <= M <= 32): the alpha and beta projections run as one
+    // split-K FP16 tensor-core launch (compute/gemm_f16_narrow_smallm.cu)
+    // instead of two cuBLAS GEMMs (nvjet + splitKreduce each, 4 launches per
+    // GDN layer). FP16-resident alpha/beta weights only; other tiers keep the
+    // two-call path. false = the two cuBLAS calls.
+    bool alpha_beta_smallm = true;
     // Override gated-DeltaNet weight layout.
     std::string layout_override;
 };

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -679,6 +679,13 @@ private:
     void* gdn_chunkpar_ws_ = nullptr;
     size_t gdn_chunkpar_ws_bytes_ = 0;
 
+    // GDN alpha/beta narrow GEMM workspace (gdn.alpha_beta_smallm): split-K
+    // partials + per-tile tickets, ~100 KiB, zeroed once at allocation.
+    // nullptr keeps the two cuBLAS calls.
+    void* gdn_ab_ws_ = nullptr;
+    size_t gdn_ab_ws_bytes_ = 0;
+    bool gdn_ab_narrow_logged_ = false;
+
     // --- Separately allocated buffers (not part of unified workspace) ---
 
     // LRU cache for host-resident expert weights on GPU.
@@ -903,6 +910,12 @@ private:
     // two gemm_via_handle_ calls it would have issued anyway.
     bool try_smallm_pair_dispatch_(TensorID id_a, TensorID id_b, const Tensor& input,
                                    Tensor& out_a, Tensor& out_b, const GemmContext& ctx);
+    // Batched-decode GDN alpha + beta projections in one narrow FP16 launch
+    // (gdn.alpha_beta_smallm, executor_gdn_alpha_beta.cu). Returns false and
+    // launches nothing when a weight is not FP16-resident or a shape does not
+    // fit; the caller then issues its two gemm_via_handle_ calls.
+    bool try_gdn_alpha_beta_narrow_(TensorID alpha_id, TensorID beta_id, const Tensor& input, Tensor& alpha_out,
+                                    Tensor& beta_out, cudaStream_t stream);
     // General form: 2..3 weights on one input (attention q|k|v adds the
     // striped k/v shapes to q's single-stripe wave). Outputs must have row
     // stride N.

--- a/src/exec/executor_gdn_alpha_beta.cu
+++ b/src/exec/executor_gdn_alpha_beta.cu
@@ -1,0 +1,79 @@
+// Batched-decode GDN alpha/beta projections: one launch for both.
+//
+// At 2 <= M <= 32 the two [n_heads, d_model] FP16 weights went through
+// gemm() as two cuBLAS GEMMs, nvjet + splitKreduce each: 4 launches per GDN
+// layer, none PDL-registered. gemm_f16_narrow_smallm runs both in one
+// split-K tensor-core launch. Output layout is the two-call one (alpha at
+// ssm_dt_buf_, beta at the 256-byte-aligned offset), so the scan is untouched.
+
+#include "compute/gemm_f16_narrow_smallm.h"
+#include "core/dispatch_policy.h"
+#include "core/logging.h"
+#include "exec/executor.h"
+
+namespace imp {
+
+namespace {
+
+// FP16 device pointer of an FP16-resident weight: the dequant cache entry when
+// the source was BF16/quantized, else the FP16 source itself (tier Undefined:
+// the Qwen3.8 alpha/beta are dequantized NVFP4 -> F16 at load and sit in no
+// cache, so gemm_via_handle_ ran them through the uncached fallback = gemm()).
+// nullptr = not resident as FP16, or a different shape than expected.
+const half* fp16_weight_ptr(const WeightCaches& wcache, const WeightHandle& h, int64_t N, int64_t K) {
+    if ((h.primary_tier != StorageTier::FP16 && h.primary_tier != StorageTier::Undefined) ||
+        h.shape[0] != N || h.shape[1] != K)
+        return nullptr;
+    auto it = wcache.fp16.find(h.source_data);
+    if (it != wcache.fp16.end() && it->second.qtype == QType::F16 && it->second.data)
+        return static_cast<const half*>(it->second.data);
+    if (h.source_qtype == QType::F16 && h.source_data)
+        return static_cast<const half*>(h.source_data);
+    return nullptr;
+}
+
+}  // namespace
+
+bool GraphExecutor::try_gdn_alpha_beta_narrow_(TensorID alpha_id, TensorID beta_id, const Tensor& input,
+                                               Tensor& alpha_out, Tensor& beta_out, cudaStream_t stream) {
+    if (!dispatch_policy().gdn.alpha_beta_smallm || gdn_ab_ws_ == nullptr)
+        return false;
+    if (alpha_id == kInvalidTensorID || beta_id == kInvalidTensorID)
+        return false;
+    if (cur_spec_verify_ || lora_ != nullptr || calib_)
+        return false;
+    const int M = static_cast<int>(input.shape[0]);
+    const int64_t K = input.shape[1];
+    if (M < 2 || M > 32 || input.qtype != QType::F16 || alpha_out.qtype != QType::F16 ||
+        beta_out.qtype != QType::F16 || input.stride[0] != K)
+        return false;
+    const int64_t N = alpha_out.shape[1];
+    if (beta_out.shape[1] != N)
+        return false;
+    const half* wa = fp16_weight_ptr(wcache_, registry_.handle(alpha_id), N, K);
+    const half* wb = fp16_weight_ptr(wcache_, registry_.handle(beta_id), N, K);
+    if (!wa || !wb) {
+        if (!gdn_ab_narrow_logged_) {
+            gdn_ab_narrow_logged_ = true;
+            const auto& h = registry_.handle(alpha_id);
+            IMP_LOG_INFO(
+                "gdn alpha/beta narrow GEMM declined: alpha tier=%d source_qtype=%d shape=[%lld,%lld] "
+                "expected [%lld,%lld] fp16_cache=%d (two-call route)",
+                static_cast<int>(h.primary_tier), static_cast<int>(h.source_qtype), (long long)h.shape[0],
+                (long long)h.shape[1], (long long)N, (long long)K, wcache_.fp16.count(h.source_data) ? 1 : 0);
+        }
+        return false;
+    }
+    const bool ok = gemm_f16_narrow_smallm(static_cast<const half*>(input.data), M, static_cast<int>(K), wa,
+                                           static_cast<half*>(alpha_out.data), static_cast<int>(N), wb,
+                                           static_cast<half*>(beta_out.data), static_cast<int>(N), gdn_ab_ws_,
+                                           gdn_ab_ws_bytes_, stream);
+    if (ok && !gdn_ab_narrow_logged_) {
+        gdn_ab_narrow_logged_ = true;
+        IMP_LOG_INFO("gdn alpha/beta narrow GEMM ACTIVE (M=%d, K=%lld, N=%lld x 2)", M, (long long)K,
+                     (long long)N);
+    }
+    return ok;
+}
+
+}  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -323,8 +323,15 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     Tensor r = view_tokens(residual_, n);
     Tensor no = view_tokens(norm_out_, n);
 
-    // 1. Save residual + RMSNorm
-    IMP_CUDA_CHECK_LOG(cudaMemcpyAsync(r.data, h.data, h.nbytes(), cudaMemcpyDeviceToDevice, stream));
+    // 1. Save residual + RMSNorm. The batched-decode beta=1 out-projection
+    // (residual_beta1_nvfp4_ok_, same gate as step 10 below) accumulates into
+    // h and never reads r: skip the save there, as the attention and FFN
+    // twins do. Kernel copy, not cudaMemcpyAsync: a memcpy node has no
+    // programmatic edge and cut the PDL chain once per layer.
+    const bool skip_residual_save = !dispatch_policy().gdn.fp32_out && !dump_hidden_dir() &&
+                                    residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h);
+    if (!skip_residual_save)
+        device_copy_async(r.data, h.data, h.nbytes(), stream);
     // Producer fusion: quantize into the small-M scratch inside the norm
     // kernel when ssm_in will take that route (batched decode, CUTLASS_NVFP4
     // tier); falls back to plain rmsnorm. The n==1 packed-input path is
@@ -421,10 +428,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
             // the per-group real row count; the snapshot (state after row 0)
             // comes from group 0 only - every group's row 0 is the same token
             // from the same committed state.
-            IMP_CUDA_CHECK_LOG(
-                cudaMemcpyAsync(xBC_out.data, xBC_in.data,
-                                static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_),
-                                cudaMemcpyDeviceToDevice, stream));
+            device_copy_async(xBC_out.data, xBC_in.data,
+                              static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_), stream);
             const int T = state.ssm_seq_tokens;
             void* conv_snap = (state.spec_snap_slab && state.ssm_state && ssm_idx >= 0)
                                   ? state.ssm_state->conv_state_in(state.spec_snap_slab, ssm_idx)
@@ -483,10 +488,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
             // reading stale buffer contents (measured as coherent output for
             // sequence 0 and garbage for the rest). n == 1 on the
             // single-sequence path, so this is the same copy it always was.
-            IMP_CUDA_CHECK_LOG(
-                cudaMemcpyAsync(xBC_out.data, xBC_in.data,
-                                static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_),
-                                cudaMemcpyDeviceToDevice, stream));
+            device_copy_async(xBC_out.data, xBC_in.data,
+                              static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_), stream);
             // Batched decode: ssm_n_seq sequences, one token each, each with
             // its own conv state. Falls through to the single-sequence call
             // when the step carries one sequence.
@@ -623,12 +626,18 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 gemm_via_handle_(ly.gdn_alpha_beta_packed_id, no, ab_packed_out, ctx);
             } else {
                 // 4-call fallback: ssm_dt_buf_ for alpha, +offset for beta.
+                // Batched decode runs both in one narrow FP16 launch first
+                // (gdn.alpha_beta_smallm); the two calls stay for every
+                // shape or tier it declines.
                 alpha_proj_out = Tensor(ssm_dt_buf_.data, compute_dtype_, 2, ab_shape, true);
                 char* beta_ptr = static_cast<char*>(ssm_dt_buf_.data) +
                                  ((static_cast<size_t>(n) * n_heads * es + 255) & ~size_t(255));
                 beta_proj_out = Tensor(beta_ptr, compute_dtype_, 2, ab_shape, true);
-                gemm_via_handle_(ly.gdn_alpha_id, no, alpha_proj_out, ctx);
-                gemm_via_handle_(ly.gdn_beta_id, no, beta_proj_out, ctx);
+                if (!try_gdn_alpha_beta_narrow_(ly.gdn_alpha_id, ly.gdn_beta_id, no, alpha_proj_out,
+                                                beta_proj_out, stream)) {
+                    gemm_via_handle_(ly.gdn_alpha_id, no, alpha_proj_out, ctx);
+                    gemm_via_handle_(ly.gdn_beta_id, no, beta_proj_out, ctx);
+                }
             }
             // Per-element dump: pre-softplus alpha and pre-sigmoid beta projections.
             // Compare to llama's `alpha-{layer}` and `beta-{layer}`.
@@ -973,8 +982,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         // Compare to llama's `linear_attn_out-{layer}` from eval-callback.
         dump_tensor_npy("gdn_linear_attn_out", out_buf, stream, layer, cur_decode_step_);
         elementwise_add(out_buf, r, stream);
-        IMP_CUDA_CHECK_LOG(
-            cudaMemcpyAsync(h.data, out_buf.data, h.nbytes(), cudaMemcpyDeviceToDevice, stream));
+        device_copy_async(h.data, out_buf.data, h.nbytes(), stream);
     }
 }
 

--- a/src/exec/executor_workspace_buffers.cu
+++ b/src/exec/executor_workspace_buffers.cu
@@ -12,6 +12,7 @@
 #include "exec/gemm_scratch.h"  // prewarm_mmvq_scratch
 #include "exec/nvfp4_expert_offload.h"
 #include "compute/gdn.h"        // gdn_scan_chunkpar_workspace_bytes
+#include "compute/gemm_f16_narrow_smallm.h"  // gemm_f16_narrow_smallm_workspace_bytes
 #include "compute/gemm.h"       // kGemmCublasWorkspaceBytes, block_q8_1
 #include "compute/gemm_cutlass_sm120.h"
 #include "compute/gemm_cutlass_mxfp4_sm120.h"
@@ -1063,6 +1064,21 @@ void GraphExecutor::allocate_auxiliary_buffers(bool skip_batch_dequant) {
         }
     }
 
+    // GDN alpha/beta narrow GEMM workspace (gdn.alpha_beta_smallm): split-K
+    // partials + tickets for N = 2 x n_heads. The kernel resets its tickets,
+    // so one zeroing here is the whole initialisation. nullptr keeps the two
+    // cuBLAS calls.
+    if (has_gdn_ && dispatch_policy().gdn.alpha_beta_smallm && cfg.ssm_dt_rank > 0) {
+        gdn_ab_ws_bytes_ = gemm_f16_narrow_smallm_workspace_bytes(2 * cfg.ssm_dt_rank);
+        gdn_ab_ws_ = vram_alloc(vram_alloc_, gdn_ab_ws_bytes_, "gdn_ab_ws");
+        if (gdn_ab_ws_) {
+            IMP_CUDA_CHECK_LOG(cudaMemset(gdn_ab_ws_, 0, gdn_ab_ws_bytes_));
+        } else {
+            IMP_LOG_WARN("gdn alpha/beta workspace unavailable (%zu B) - two-call route", gdn_ab_ws_bytes_);
+            gdn_ab_ws_bytes_ = 0;
+        }
+    }
+
     // FP8 activation scratch buffers (for FP8 prefill weight cache)
     if (wcache_.use_fp8) {
         int max_dim = cfg.d_model;
@@ -1496,6 +1512,8 @@ void GraphExecutor::free_buffers() {
 
     vfree(gdn_chunkpar_ws_);
     gdn_chunkpar_ws_bytes_ = 0;
+    vfree(gdn_ab_ws_);
+    gdn_ab_ws_bytes_ = 0;
 
     // Free LongRoPE frequency tables
     if (longrope_short_freqs_) {

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -277,6 +277,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     B("gdn.chunkpar_scan", cfg.gdn.chunkpar_scan);
     I("gdn.chunkpar_strip", cfg.gdn.chunkpar_strip);
     B("gdn.state_bf16", cfg.gdn.state_bf16);
+    B("gdn.alpha_beta_smallm", cfg.gdn.alpha_beta_smallm);
 
     // [gemm]
     B("gemm.no_dp4a_gemv", cfg.gemm.no_dp4a_gemv);

--- a/tests/test_gemm_f16_narrow_smallm.cu
+++ b/tests/test_gemm_f16_narrow_smallm.cu
@@ -1,0 +1,278 @@
+// gemm_f16_narrow_smallm: the one-launch alpha/beta projection of batched GDN
+// decode. Checks against a double CPU reference at the Qwen3.8-27B shape
+// (K = 5120, N = 48 per pair) for M = 1, 5, 16, 17, 32, the single-pair form,
+// bitwise determinism across launches (split-K reduce in fixed order), and
+// that unsupported shapes are refused rather than computed wrong.
+
+#include <gtest/gtest.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include "compute/gemm.h"
+#include "compute/gemm_f16_narrow_smallm.h"
+#include "core/tensor.h"
+
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+using namespace imp;
+
+namespace {
+
+struct DevBuf {
+    void* p = nullptr;
+    explicit DevBuf(size_t bytes) { cudaMalloc(&p, bytes); }
+    ~DevBuf() {
+        if (p)
+            cudaFree(p);
+    }
+    DevBuf(const DevBuf&) = delete;
+    DevBuf& operator=(const DevBuf&) = delete;
+};
+
+std::vector<__half> to_half(const std::vector<float>& v) {
+    std::vector<__half> h(v.size());
+    for (size_t i = 0; i < v.size(); ++i)
+        h[i] = __float2half(v[i]);
+    return h;
+}
+
+// Reference over the FP16-rounded inputs, double accumulate.
+void ref_gemm(const std::vector<__half>& A, const std::vector<__half>& W, std::vector<double>& C, int M,
+              int N, int K) {
+    C.assign(static_cast<size_t>(M) * N, 0.0);
+    for (int m = 0; m < M; ++m)
+        for (int n = 0; n < N; ++n) {
+            double s = 0.0;
+            for (int k = 0; k < K; ++k)
+                s += static_cast<double>(__half2float(A[static_cast<size_t>(m) * K + k])) *
+                     static_cast<double>(__half2float(W[static_cast<size_t>(n) * K + k]));
+            C[static_cast<size_t>(m) * N + n] = s;
+        }
+}
+
+struct Case {
+    int M, N0, N1, K;
+    std::vector<__half> A, W0, W1;
+    DevBuf dA, dW0, dW1, dC0, dC1, ws;
+    size_t ws_bytes;
+
+    Case(int m, int n0, int n1, int k, uint32_t seed)
+        : M(m),
+          N0(n0),
+          N1(n1),
+          K(k),
+          dA(static_cast<size_t>(m) * k * 2),
+          dW0(static_cast<size_t>(n0) * k * 2),
+          dW1(static_cast<size_t>(n1 > 0 ? n1 : 1) * k * 2),
+          dC0(static_cast<size_t>(m) * n0 * 2),
+          dC1(static_cast<size_t>(m) * (n1 > 0 ? n1 : 1) * 2),
+          ws(gemm_f16_narrow_smallm_workspace_bytes(n0 + n1)),
+          ws_bytes(gemm_f16_narrow_smallm_workspace_bytes(n0 + n1)) {
+        std::mt19937 rng(seed);
+        std::normal_distribution<float> na(0.0f, 1.0f), nw(0.0f, 0.05f);
+        std::vector<float> a(static_cast<size_t>(m) * k), w0(static_cast<size_t>(n0) * k),
+            w1(static_cast<size_t>(n1) * k);
+        for (auto& x : a)
+            x = na(rng);
+        for (auto& x : w0)
+            x = nw(rng);
+        for (auto& x : w1)
+            x = nw(rng);
+        A = to_half(a);
+        W0 = to_half(w0);
+        W1 = to_half(w1);
+        cudaMemcpy(dA.p, A.data(), A.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemcpy(dW0.p, W0.data(), W0.size() * 2, cudaMemcpyHostToDevice);
+        if (n1 > 0)
+            cudaMemcpy(dW1.p, W1.data(), W1.size() * 2, cudaMemcpyHostToDevice);
+        cudaMemset(ws.p, 0, ws_bytes);
+    }
+
+    bool run(cudaStream_t s = nullptr) {
+        return gemm_f16_narrow_smallm(static_cast<const half*>(dA.p), M, K, static_cast<const half*>(dW0.p),
+                                      static_cast<half*>(dC0.p), N0,
+                                      N1 > 0 ? static_cast<const half*>(dW1.p) : nullptr,
+                                      N1 > 0 ? static_cast<half*>(dC1.p) : nullptr, N1, ws.p, ws_bytes, s);
+    }
+
+    std::vector<__half> out(int pair) const {
+        const int n = pair == 0 ? N0 : N1;
+        std::vector<__half> h(static_cast<size_t>(M) * n);
+        cudaMemcpy(h.data(), pair == 0 ? dC0.p : dC1.p, h.size() * 2, cudaMemcpyDeviceToHost);
+        return h;
+    }
+};
+
+void expect_close(const std::vector<__half>& got, const std::vector<double>& ref, const char* tag) {
+    ASSERT_EQ(got.size(), ref.size()) << tag;
+    double max_err = 0.0;
+    for (size_t i = 0; i < got.size(); ++i) {
+        const double g = __half2float(got[i]);
+        const double tol = 4e-3 + 4e-3 * std::fabs(ref[i]);  // FP16 output rounding + FP32 accumulate
+        max_err = std::max(max_err, std::fabs(g - ref[i]));
+        ASSERT_NEAR(g, ref[i], tol) << tag << " at " << i;
+    }
+    printf("  %s: max |err| %.3e over %zu outputs\n", tag, max_err, got.size());
+}
+
+}  // namespace
+
+TEST(GemmF16NarrowSmallM, MatchesReferenceAtQwen38Shape) {
+    const int K = 5120, N = 48;
+    for (int M : {1, 5, 16, 17, 32}) {
+        Case c(M, N, N, K, 1234u + static_cast<uint32_t>(M));
+        ASSERT_TRUE(c.run()) << "M=" << M;
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        std::vector<double> r0, r1;
+        ref_gemm(c.A, c.W0, r0, M, N, K);
+        ref_gemm(c.A, c.W1, r1, M, N, K);
+        char tag0[32], tag1[32];
+        snprintf(tag0, sizeof tag0, "M=%d alpha", M);
+        snprintf(tag1, sizeof tag1, "M=%d beta", M);
+        expect_close(c.out(0), r0, tag0);
+        expect_close(c.out(1), r1, tag1);
+    }
+}
+
+TEST(GemmF16NarrowSmallM, SinglePairAndWiderN) {
+    const int K = 4096;
+    for (int N : {16, 64, 128}) {
+        Case c(32, N, 0, K, 77u + static_cast<uint32_t>(N));
+        ASSERT_TRUE(c.run());
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        std::vector<double> r0;
+        ref_gemm(c.A, c.W0, r0, 32, N, K);
+        char tag[32];
+        snprintf(tag, sizeof tag, "N=%d single", N);
+        expect_close(c.out(0), r0, tag);
+    }
+}
+
+TEST(GemmF16NarrowSmallM, DeterministicAcrossLaunches) {
+    Case c(32, 48, 48, 5120, 99u);
+    ASSERT_TRUE(c.run());
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const auto a0 = c.out(0), b0 = c.out(1);
+    for (int i = 0; i < 50; ++i)
+        ASSERT_TRUE(c.run());
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    const auto a1 = c.out(0), b1 = c.out(1);
+    for (size_t i = 0; i < a0.size(); ++i) {
+        ASSERT_EQ(__half_as_ushort(a0[i]), __half_as_ushort(a1[i])) << "alpha " << i;
+        ASSERT_EQ(__half_as_ushort(b0[i]), __half_as_ushort(b1[i])) << "beta " << i;
+    }
+}
+
+TEST(GemmF16NarrowSmallM, RefusesUnsupportedShapes) {
+    Case c(32, 48, 48, 5120, 5u);
+    const half* A = static_cast<const half*>(c.dA.p);
+    const half* W = static_cast<const half*>(c.dW0.p);
+    half* C = static_cast<half*>(c.dC0.p);
+    EXPECT_FALSE(
+        gemm_f16_narrow_smallm(A, 33, 5120, W, C, 48, nullptr, nullptr, 0, c.ws.p, c.ws_bytes, nullptr));
+    EXPECT_FALSE(
+        gemm_f16_narrow_smallm(A, 32, 5000, W, C, 48, nullptr, nullptr, 0, c.ws.p, c.ws_bytes, nullptr));
+    EXPECT_FALSE(
+        gemm_f16_narrow_smallm(A, 32, 5120, W, C, 40, nullptr, nullptr, 0, c.ws.p, c.ws_bytes, nullptr));
+    EXPECT_FALSE(gemm_f16_narrow_smallm(A, 32, 5120, W, C, 48, nullptr, nullptr, 0, c.ws.p, 64, nullptr));
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}
+
+// Informational: per-launch wall inside a replayed CUDA graph (the regime the
+// kernel runs in: batched-decode graphs), narrow kernel vs the two cuBLAS
+// gemm() calls it replaces. No threshold (timing anchors flake in the full
+// suite); read the numbers. WSL2 host launch cost would dominate an eager loop.
+TEST(GemmF16NarrowSmallM, BenchQwen38Shape) {
+    Case c(32, 48, 48, 5120, 11u);
+    cudaStream_t s;
+    ASSERT_EQ(cudaStreamCreate(&s), cudaSuccess);
+    const int64_t a_shape[2] = {32, 5120}, w_shape[2] = {48, 5120}, c_shape[2] = {32, 48};
+    Tensor tA(c.dA.p, QType::F16, 2, a_shape, true), tW0(c.dW0.p, QType::F16, 2, w_shape, true),
+        tW1(c.dW1.p, QType::F16, 2, w_shape, true), tC0(c.dC0.p, QType::F16, 2, c_shape, true),
+        tC1(c.dC1.p, QType::F16, 2, c_shape, true);
+    auto cublas_pair = [&]() {
+        gemm(tA, tW0, tC0, 1.0f, 0.0f, s);
+        gemm(tA, tW1, tC1, 1.0f, 0.0f, s);
+    };
+    // Warm both paths past the idle downclock (>1 s of work).
+    cudaEvent_t w0, w1;
+    cudaEventCreate(&w0);
+    cudaEventCreate(&w1);
+    cudaEventRecord(w0, s);
+    for (int i = 0; i < 20000; ++i) {
+        ASSERT_TRUE(c.run(s));
+        if ((i % 10) == 0)
+            cublas_pair();
+    }
+    cudaEventRecord(w1, s);
+    ASSERT_EQ(cudaEventSynchronize(w1), cudaSuccess);
+    float warm_ms = 0.0f;
+    cudaEventElapsedTime(&warm_ms, w0, w1);
+    printf("  warmup: %.0f ms\n", warm_ms);
+
+    constexpr int kPerGraph = 64;
+    auto time_graph = [&](const char* tag, auto&& body) {
+        cudaGraph_t g;
+        cudaGraphExec_t ge;
+        ASSERT_EQ(cudaStreamBeginCapture(s, cudaStreamCaptureModeThreadLocal), cudaSuccess);
+        for (int i = 0; i < kPerGraph; ++i)
+            body();
+        ASSERT_EQ(cudaStreamEndCapture(s, &g), cudaSuccess);
+        ASSERT_EQ(cudaGraphInstantiate(&ge, g, 0), cudaSuccess);
+        for (int i = 0; i < 20; ++i)
+            ASSERT_EQ(cudaGraphLaunch(ge, s), cudaSuccess);
+        cudaEvent_t e0, e1;
+        cudaEventCreate(&e0);
+        cudaEventCreate(&e1);
+        const int reps = 50;
+        cudaEventRecord(e0, s);
+        for (int i = 0; i < reps; ++i)
+            cudaGraphLaunch(ge, s);
+        cudaEventRecord(e1, s);
+        ASSERT_EQ(cudaEventSynchronize(e1), cudaSuccess);
+        float ms = 0.0f;
+        cudaEventElapsedTime(&ms, e0, e1);
+        printf("  %s: %.2f us per launch in graph (%d launches x %d replays, L2-resident)\n", tag,
+               ms * 1000.0f / (reps * kPerGraph), kPerGraph, reps);
+        cudaEventDestroy(e0);
+        cudaEventDestroy(e1);
+        cudaGraphExecDestroy(ge);
+        cudaGraphDestroy(g);
+    };
+    time_graph("narrow kernel (alpha+beta)", [&]() { c.run(s); });
+    gemm_set_lt_capture_allowed(true);
+    time_graph("cuBLAS gemm() x2 (alpha, beta)", cublas_pair);
+    gemm_set_lt_capture_allowed(false);
+
+    // Numerics against the path it replaces: both accumulate in FP32 and round
+    // once to FP16, in different summation orders. Report how many outputs
+    // differ and by how much (1 FP16 ulp is the expected class).
+    cublas_pair();
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    const auto ref0 = c.out(0), ref1 = c.out(1);
+    ASSERT_TRUE(c.run(s));
+    ASSERT_EQ(cudaStreamSynchronize(s), cudaSuccess);
+    const auto got0 = c.out(0), got1 = c.out(1);
+    size_t n_diff = 0;
+    double max_abs = 0.0, max_rel = 0.0;
+    for (size_t i = 0; i < ref0.size(); ++i) {
+        for (int p = 0; p < 2; ++p) {
+            const float r = __half2float(p ? ref1[i] : ref0[i]);
+            const float g = __half2float(p ? got1[i] : got0[i]);
+            if (r != g) {
+                ++n_diff;
+                max_abs = std::max(max_abs, static_cast<double>(std::fabs(r - g)));
+                max_rel = std::max(max_rel,
+                                   static_cast<double>(std::fabs(r - g) / std::max(std::fabs(r), 1e-3f)));
+            }
+            EXPECT_NEAR(g, r, 1e-2 + 4e-3 * std::fabs(r)) << "pair " << p << " at " << i;
+        }
+    }
+    printf("  vs cuBLAS: %zu of %zu outputs differ, max |diff| %.3e, max rel %.3e\n", n_diff, 2 * ref0.size(),
+           max_abs, max_rel);
+    cudaStreamDestroy(s);
+    EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+}

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -245,7 +245,9 @@ def main():
     # norm fold through the quantizer. The fold's algebra stays in the CPU lane (AwqNormFold x6).
     # 1093 -> 1094: PrefillFirstRowsReadThePreviousWindowNotTheCommit (test-moe-gdn, GPU, no model):
     # rows 0..K-2 of the conv1d prefill against the CPU form over 300 launches.
-    PINNED = 1094
+    # 1094 -> 1099: GemmF16NarrowSmallM x5 (test-compute, GPU, no model): the one-launch
+    # alpha/beta projection of batched GDN decode against a double CPU reference.
+    PINNED = 1099
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
## Batched GDN decode: three launches fewer per layer

- `run_gdn` skips the residual save when the out-projection accumulates into `h` (`residual_beta1_nvfp4_ok_`, the rule attention and FFN already applied); the conv-input and residual copies are `device_copy_async` kernels (PDL edge) instead of memcpy nodes. `src/exec/executor_ssm_gdn.cu`
- The alpha and beta projections (`[48, 5120]` FP16 each on Qwen3.8-27B) run as one split-K FP16 tensor-core launch: `src/compute/gemm_f16_narrow_smallm.cu`, M <= 32, N % 16 == 0, K % 128 == 0, two (W, C) pairs per launch, KSPLIT 8 with a fixed-order last-CTA reduce (bitwise deterministic). Gate `gdn.alpha_beta_smallm` (default on); any other shape or tier keeps the two `gemm_via_handle_` calls. `src/exec/executor_gdn_alpha_beta.cu`
- The alpha/beta handles are tier `Undefined` on the NVFP4 checkpoint (phase 0 dequantizes them to a fresh F16 buffer that sits in no cache), so the resolver accepts `Undefined` with an F16 source; the first arm logs `gdn alpha/beta narrow GEMM ACTIVE`.

| Qwen3.8-27B-NVFP4-vllm, 32 streams, tok/s | trial 1 | trial 2 | trial 3 |
|---|---|---|---|
| main `2468e064` (imp:ab-2468e064) | 1980.9 | 1982.4 | 1993.9 |
| this branch | 2012.8 | 2027.3 | 2019.4 |
| this branch, `gdn.alpha_beta_smallm=false` | 1994.4 | 1984.6 | 2008.0 |
| this branch, `gdn.alpha_beta_smallm=true` | 1998.6 | 2038.5 | 2032.9 |

Two-image rows: alternating pairs, fresh server per arm, `tools/analysis/conc_client.py 8094 32 3`, pins `runtime.max_batch_size=32 runtime.max_seq_len=4096 kv_cache.max_blocks=2387`. All three pairs positive in both A/Bs; +1.7 % mean on the two-image A/B.

| kernel, M=32 K=5120 N=48 x 2 | per launch |
|---|---|
| narrow kernel, in a replayed graph | 4.00 us |
| cuBLAS `gemm()` x2, in a replayed graph | 18.58 us |

Numerics: 10 of 3072 outputs differ from cuBLAS by 1 FP16 ulp (max abs 9.8e-4); deterministic PPL over `tools/analysis/ppl_corpus_45k.txt` at `--prefill-chunk-size 32` (routes the corpus through the M=32 path): 4.6449 on vs 4.6456 off. Batched greedy outputs on 4 concurrent prompts stay coherent; off/off byte-identical, on/off part at near-ties (summation-order class, SETTLED D-2).

Tests: `tests/test_gemm_f16_narrow_smallm.cu` (test-compute, GPU): double reference at M = 1/5/16/17/32, single pair and N up to 128, bitwise determinism over 50 launches, refused shapes, the in-graph bench. `tools/check_test_lanes.py` PINNED 1094 -> 1099.

`tests/perf_baseline.json` is untouched: the gate measures batch-1 spec-off decode on Qwen3-8B Q8_0, which runs none of the changed paths.

Not in here: the M=1 decode path (alpha/beta already fused there), Mamba2 `run_ssm`, prefill n > 32, the host-tail class.

## Gate

```
PASS fast gtest filter
  decode  tg128 =  298.03 tok/s  (baseline  287.19, delta 3.77%)
  prefill pp512 = 12663.41 tok/s  (baseline 12406.87, delta 2.07%)
PASS decode within 8% threshold
PASS prefill within 8% threshold
  prefill pp4096 = 15691.07 tok/s  (baseline 15324.70, delta 2.39%, FA2)
PASS long-ctx prefill (pp4096/FA2) within 8% threshold
== peak VRAM vs baseline ==
  own peak VRAM = 20844 MiB  (baseline 20716, delta 0.62%)
PASS peak VRAM within 10% of baseline
== graphs ON vs OFF decode gate ==
  graphs OFF tg256 =  179.31 tok/s
  graphs ON  tg256 =  474.99 tok/s   (2.65x, threshold 1.3x)
PASS graphs ON delivers ≥1.3x decode speedup
PASS Qwen3-4B Q8_0 (dense) (distinct=18/32 need 8, tokens=64, max-run=1, 3gram=4 repeat=37%, contains 'Paris')
== paired A/B: A=imp:ab-2468e064  B=imp:test  pairs=3  model=Qwen3-8B-Q8_0.gguf  threshold=-2% ==
  pair 1  arm A  tg128   298.62  pp512  12592.03  (imp:ab-2468e064)
  pair 1  arm B  tg128   298.01  pp512  12679.36  (imp:test)
  pair 1  delta B/A: decode -0.20%  prefill 0.69%
  pair 2  arm B  tg128   298.68  pp512  12387.77  (imp:test)
  pair 2  arm A  tg128   298.34  pp512  12662.39  (imp:ab-2468e064)
  pair 2  delta B/A: decode 0.11%  prefill -2.17%
  pair 3  arm A  tg128   297.99  pp512  12553.27  (imp:ab-2468e064)
  pair 3  arm B  tg128   298.30  pp512  12603.34  (imp:test)
  pair 3  delta B/A: decode 0.10%  prefill 0.40%
  paired decode  delta: mean 0.00%  (pairs -0.20 0.11 0.10; min -0.20% max 0.11%; 1 of 3 negative)
  paired prefill delta: mean -0.36%  (pairs 0.69 -2.17 0.40)
PASS paired decode within 2% (mean 0.00%)
PASS paired prefill within 2% (mean -0.36%)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
