### PR TITLE
perf(m1): GDN input projections in one launch, out-projection with the residual, q|k|v fused on gated attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ there instead of retelling it.
 
 ### Changed
 
+- Single-stream decode on native-NVFP4 hybrids drops 6 launches per GDN layer and 2 per attention layer
+  (`gdn.m1_fused`: in_proj|gate|alpha|beta one launch, out-projection with the residual, conv in place, q|k|v
+  one launch). Qwen3.8-27B-NVFP4 batch=1 spec-off 94.4 -> 99.5 tok/s (+5.1..6.0 %, 5/5) ([roadmap.md](docs/roadmap.md))
 - Batched GDN decode drops three launches per layer: no residual save when the out-projection accumulates into
   the hidden buffer, kernel copies instead of memcpy nodes, and alpha+beta as one split-K FP16 launch
   (`gdn.alpha_beta_smallm`). Qwen3.8-27B-NVFP4 at 32 streams 1985.7 -> 2019.8 tok/s (+1.7 %, 3/3 pairs positive)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ set(IMP_QUANT_SOURCES
     src/quant/nvfp4_gemm_smallm.cu
     src/quant/nvfp4_gemm_smallm_v2.cu
     src/quant/nvfp4_gemv_fused.cu
+    src/quant/nvfp4_gemv_gdn_input.cu
     src/quant/nvfp4_gemv_moe.cu
     src/quant/mxfp4_gemm.cu
     # src/quant/turboquant.cu removed (TurboQuant retired Phase 5, 2026-05-17)
@@ -1013,6 +1014,7 @@ if(IMP_BUILD_TESTS)
         tests/test_nvfp4_gemv_kpar_loop.cu
         tests/test_nvfp4_gemm_batched.cu
         tests/test_nvfp4_gemv_gemma3_dims.cu
+        tests/test_nvfp4_gemv_gdn_input.cu
         tests/test_nvfp4_gemm_graph_capture.cu
         # tests/test_turboquant.cu removed (TurboQuant retired Phase 5, 2026-05-17)
         tests/test_cutlass_grouped_3x_nvfp4.cu

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,7 +33,7 @@ Detail records: [`plans/2026-09-04-lever-ledger-detail.md`](plans/2026-09-04-lev
 |---|---|
 | GDN hybrid @32 vs vLLM | AHEAD. Qwen3.8-27B 1807.9 vs 1447.8 tok/s (+24.9%, vLLM 0.27.1), 1833.8 vs 1410.7 (+30.0%, 0.28.0), @8 573.0 vs 495.8 (+15.6%), @32 x 1082-token prompts 873.4 vs 497.8 (+75.5%), 3/3 each |
 | dense NVFP4 @32 vs vLLM | PARITY OR AHEAD (2026-09-08). Qwen3-14B 38-token prompts 3948.9 vs 3817.6 (+3.4%, 2026-09-03); 982-token prompts 2491.2/2515.5/2482.6 vs 2485.9/2490.9/2497.7 (+0.2/+1.0/-0.6%, 2 of 3; was 1845.0 vs 2478.0 = 0.75x before the grouped FP8 decode attention, #1953) |
-| batch=1 | 87.4 tok/s spec-off = 78% of the ~112 tok/s roofline (14.5 GB/token at 1628 GB/s resident); past it only through the MTP verify |
+| batch=1 | 99.5 tok/s spec-off (2026-09-10, `gdn.m1_fused`) = 89% of the ~112 tok/s roofline (14.5 GB/token at 1628 GB/s resident), was 87.4 = 78% on 2026-08-27; past it only through the MTP verify |
 | raw-speed half of [`GOAL.md`](GOAL.md) | MET: batch=1 decode +13-48% vs llama.cpp on every hero (2026-07-12 re-sweep), MoE prefill leads vLLM single-seq, cross-engine PPL parity measured. Everything open below is the agentic half |
 | admission at fan-out | `auto` resolves 28 vs a pinned 32 (630 vs 936): admission, not rotation, and 28 sustain full rate under continuous arrival |
 | next engine-side post | the dense decode step at 32 streams after the grouped FP8 attention and the small-M launch work (ledger 2026-09-08, second row): the small-M GEMM class re-priced at 83% of resident bandwidth by launch durations (5.49 vs 4.56 ms floor per Qwen3-14B step BEFORE the PDL weight prefetch + q\|k\|v launch, which took ~0.3 ms of that), and the prefill forward at 80% of the FP4 peak (Open 2) |
@@ -296,6 +296,17 @@ mixed, default off.
        model=Qwen3.8-27B-NVFP4 cuda=13.3 path=nsys server window 778 steps
        cmd=`nsys profile ... imp-server` + chat 1024-tok]
 ```
+
+Launch chain at M=1 (2026-09-10, nsys graph-node trace on 0b095c4d): a GDN
+layer ran 17 kernels for 155 us, 138 us of them the five big GEMVs at
+1550-1650 GB/s; the rest was in_proj / gate / alpha / beta as four launches
+(20.2 + 12.6 + 4.1 + 3.9 us; the two FP16 alpha/beta GEMVs read 0.5 MB each,
+pure latency), residual save + add + copy-back (2.7 us) and the xBC copy before
+the conv (1.8 us). An attention layer ran k and v as two 4 us launches after q.
+
+| lever | verdict | evidence | ref |
+|---|---|---|---|
+| `gdn.m1_fused`: in_proj + gate + alpha + beta in one multi-row GEMV grid (NVFP4 rows and FP16 rows in the same launch), out-projection with the residual in its epilogue, conv reads proj in place, gated attention q\|k\|v in one launch | SHIPPED default-on | `imp-cli --bench` tg256 spec-off, same binary, flag off/on alternating: 94.03/94.34/94.40 -> 99.22/99.17/100.06 tok/s (+5.5/+5.1/+6.0 %, 3/3). GDN input segments bit-identical to the kernels they replace (in_proj multirow, gate K-par, alpha/beta gemv_fp16; test-quant `NvFP4GemvGdnInput`); the residual epilogue rounds once instead of twice and k/v move to the multirow order, so greedy 200-token completions under `runtime.deterministic=true` diverge from the flag-off arm at a near-tie after 400-800 characters (SETTLED D-2 class; flag-on with and without CUDA graphs byte-equal); chunk-1 PPL on the 45k corpus (every token through the M=1 path, deterministic) 4.5641 -> 4.5646; degen_suite 50/50; final binary re-measured 94.65/94.42 -> 99.55/99.54 tok/s | 2026-09-10 |
 
 ### The MTP verify on a GDN hybrid (2026-08-17 .. 08-19)
 

--- a/imp.conf.example
+++ b/imp.conf.example
@@ -562,6 +562,11 @@ state_bf16           = true
 # Batched decode (2..32 rows): alpha and beta projections in one split-K FP16
 # tensor-core launch instead of two cuBLAS GEMMs (4 launches per GDN layer).
 alpha_beta_smallm    = true
+# Single-stream decode (M=1) on native-NVFP4 hybrids: in_proj, gate, alpha and
+# beta in one GEMV launch, out-projection with the residual in its epilogue,
+# gated attention q|k|v in one launch (6 launches per GDN layer and 2 per
+# attention layer fewer). false = the per-projection launches.
+m1_fused             = true
 
 [gemm]
 # dp4a = INT8 4-element packed multiply-accumulate. mmvq = matrix*vec

--- a/src/core/config/gdn.h
+++ b/src/core/config/gdn.h
@@ -82,6 +82,13 @@ struct GDN {
     // GDN layer). FP16-resident alpha/beta weights only; other tiers keep the
     // two-call path. false = the two cuBLAS calls.
     bool alpha_beta_smallm = true;
+    // Single-stream decode (M=1) on native-NVFP4 hybrids: in_proj, gate,
+    // alpha and beta in one GEMV launch (quant/nvfp4_gemv_gdn_input.cu), the
+    // out-projection adds the residual in its epilogue (no residual save,
+    // add or copy-back), and gated attention runs q|k|v as one launch. 6
+    // launches per GDN layer and 2 per attention layer fewer. false = the
+    // per-projection launches.
+    bool m1_fused = true;
     // Override gated-DeltaNet weight layout.
     std::string layout_override;
 };

--- a/src/exec/executor.h
+++ b/src/exec/executor.h
@@ -685,6 +685,9 @@ private:
     void* gdn_ab_ws_ = nullptr;
     size_t gdn_ab_ws_bytes_ = 0;
     bool gdn_ab_narrow_logged_ = false;
+    bool gdn_m1_input_logged_ = false;
+    bool gdn_m1_out_logged_ = false;
+    bool attn_m1_qkv_logged_ = false;
 
     // --- Separately allocated buffers (not part of unified workspace) ---
 
@@ -916,6 +919,24 @@ private:
     // fit; the caller then issues its two gemm_via_handle_ calls.
     bool try_gdn_alpha_beta_narrow_(TensorID alpha_id, TensorID beta_id, const Tensor& input, Tensor& alpha_out,
                                     Tensor& beta_out, cudaStream_t stream);
+    // The NVFP4 view gemm_via_handle_ would hand the M=1 decode GEMV for this
+    // weight (decode tier NVFP4 in wcache_.nvfp4, or native CUTLASS_NVFP4 via
+    // its source bytes). false = that dispatch would not take the GEMV.
+    bool nvfp4_decode_weight_(TensorID id, NvFP4QuantResult& out) const;
+    // M=1 GDN launch fusion (gdn.m1_fused, executor_gdn_alpha_beta.cu):
+    // in_proj + gate + alpha + beta in one GEMV launch; the out-projection
+    // adds the residual in its epilogue. Each returns false and launches
+    // nothing when a weight or shape does not fit; the caller keeps its path.
+    // alpha/beta go to ssm_dt_buf_ in the 4-call layout (alpha at 0, beta at
+    // the 256-byte-aligned offset) that the scan reads.
+    bool try_gdn_input_fused_m1_(const TransformerLayer& ly, const Tensor& input, Tensor& proj, Tensor& gate_out,
+                                 int n_heads, cudaStream_t stream);
+    bool gdn_out_residual_m1_ok_(const TransformerLayer& ly, int n, const Tensor& h) const;
+    void gdn_out_residual_m1_(const TransformerLayer& ly, const Tensor& y, Tensor& h, cudaStream_t stream);
+    // M=1 attention q|k|v in one NVFP4 GEMV launch on gated-attention models
+    // (the ungated nvfp4_qkv path already does this). Same decline contract.
+    bool try_attn_qkv_fused_m1_(const TransformerLayer& ly, const Tensor& input, Tensor& q_out, Tensor& k_out,
+                                Tensor& v_out, cudaStream_t stream);
     // General form: 2..3 weights on one input (attention q|k|v adds the
     // striped k/v shapes to q's single-stripe wave). Outputs must have row
     // stride N.

--- a/src/exec/executor_attention_qkv.cu
+++ b/src/exec/executor_attention_qkv.cu
@@ -323,6 +323,11 @@
                         Tensor* qkv_outs[3] = {&q_target, &kk, &vv};
                         qkv_multi = try_smallm_multi_dispatch_(qkv_ids, qkv_outs, 3, no, ctx);
                     }
+                    // Single-stream decode on gated attention (the ungated
+                    // nvfp4_qkv path above already fuses): q|k|v in one
+                    // NVFP4 GEMV launch instead of three.
+                    if (!qkv_multi && n == 1 && ly.wv.data != nullptr)
+                        qkv_multi = try_attn_qkv_fused_m1_(ly, no, q_target, kk, vv, stream);
                     if (!qkv_multi) {
                         gemm_via_handle_(ly.wq_id, no, q_target, ctx);
                         gemm_via_handle_(ly.wk_id, no, kk, kv_ctx);

--- a/src/exec/executor_gdn_alpha_beta.cu
+++ b/src/exec/executor_gdn_alpha_beta.cu
@@ -10,6 +10,8 @@
 #include "core/dispatch_policy.h"
 #include "core/logging.h"
 #include "exec/executor.h"
+#include "quant/nvfp4_gemm.h"
+#include <stdexcept>
 
 namespace imp {
 
@@ -74,6 +76,121 @@ bool GraphExecutor::try_gdn_alpha_beta_narrow_(TensorID alpha_id, TensorID beta_
                      (long long)N);
     }
     return ok;
+}
+
+// Mirrors the M=1, beta=0 NVFP4 cases of gemm_via_handle_ (executor_gemm_dispatch.cu).
+bool GraphExecutor::nvfp4_decode_weight_(TensorID id, NvFP4QuantResult& out) const {
+    if (id == kInvalidTensorID)
+        return false;
+    const WeightHandle& h = registry_.handle(id);
+    const StorageTier decode = (h.decode_tier == StorageTier::Undefined) ? h.primary_tier : h.decode_tier;
+    if (decode == StorageTier::NVFP4) {
+        auto it = wcache_.nvfp4.find(h.source_data);
+        if (it == wcache_.nvfp4.end())
+            return false;
+        out = it->second;
+        out.owned = false;
+        return true;
+    }
+    if (decode == StorageTier::CUTLASS_NVFP4 && h.source_data && h.source_scales) {
+        out.packed_data = const_cast<void*>(h.source_data);
+        out.micro_scales = const_cast<void*>(h.source_scales);
+        out.tensor_scale = h.source_tensor_scale;
+        out.N = h.shape[0];
+        out.K = h.shape[1] * 2;
+        out.owned = false;
+        return true;
+    }
+    return false;
+}
+
+bool GraphExecutor::try_gdn_input_fused_m1_(const TransformerLayer& ly, const Tensor& input, Tensor& proj,
+                                            Tensor& gate_out, int n_heads, cudaStream_t stream) {
+    if (!dispatch_policy().gdn.m1_fused || cur_spec_verify_ || calib_ || n_heads <= 0)
+        return false;
+    if (input.shape[0] != 1 || input.qtype != QType::F16 || proj.qtype != QType::F16 ||
+        gate_out.qtype != QType::F16 || compute_dtype_ != QType::F16 || ssm_dt_buf_.data == nullptr)
+        return false;
+    // The packed alpha|beta weight (F16 checkpoints) owns that layout.
+    if (ly.gdn_alpha_id == kInvalidTensorID || ly.gdn_beta_id == kInvalidTensorID ||
+        ly.gdn_alpha_beta_packed.data != nullptr)
+        return false;
+    const int64_t K = input.shape[1];
+    NvFP4QuantResult w_in, w_gate;
+    if (!nvfp4_decode_weight_(ly.ssm_in_id, w_in) || !nvfp4_decode_weight_(ly.gdn_gate_id, w_gate))
+        return false;
+    if (w_in.K != K || w_gate.K != K || w_in.N != proj.shape[1] || w_gate.N != gate_out.shape[1])
+        return false;
+    const int64_t N = n_heads;
+    const half* wa = fp16_weight_ptr(wcache_, registry_.handle(ly.gdn_alpha_id), N, K);
+    const half* wb = fp16_weight_ptr(wcache_, registry_.handle(ly.gdn_beta_id), N, K);
+    if (!wa || !wb)
+        return false;
+    half* alpha_out = static_cast<half*>(ssm_dt_buf_.data);
+    half* beta_out = reinterpret_cast<half*>(static_cast<char*>(ssm_dt_buf_.data) +
+                                             ((static_cast<size_t>(N) * sizeof(half) + 255) & ~size_t(255)));
+    const bool ok = gemv_nvfp4_gdn_input_fused(w_in, w_gate, wa, wb, static_cast<int>(N),
+                                               static_cast<const half*>(input.data), static_cast<half*>(proj.data),
+                                               static_cast<half*>(gate_out.data), alpha_out, beta_out,
+                                               static_cast<int>(K), stream);
+    if (ok && !gdn_m1_input_logged_) {
+        gdn_m1_input_logged_ = true;
+        IMP_LOG_INFO("gdn M=1 fused input GEMV ACTIVE (K=%lld, rows %lld + %lld + 2 x %lld)", (long long)K,
+                     (long long)w_in.N, (long long)w_gate.N, (long long)N);
+    }
+    return ok;
+}
+
+bool GraphExecutor::gdn_out_residual_m1_ok_(const TransformerLayer& ly, int n, const Tensor& h) const {
+    if (!dispatch_policy().gdn.m1_fused || n != 1 || h.qtype != QType::F16)
+        return false;
+    if (cur_spec_verify_ || calib_ || lora_ != nullptr)
+        return false;
+    NvFP4QuantResult w;
+    return nvfp4_decode_weight_(ly.ssm_out_id, w) && w.N == h.shape[1];
+}
+
+void GraphExecutor::gdn_out_residual_m1_(const TransformerLayer& ly, const Tensor& y, Tensor& h,
+                                         cudaStream_t stream) {
+    NvFP4QuantResult w;
+    if (!nvfp4_decode_weight_(ly.ssm_out_id, w) || w.K != y.shape[1] || w.N != h.shape[1] ||
+        y.qtype != QType::F16)
+        throw std::runtime_error("gdn_out_residual_m1_: out-projection shape/tier changed after the gate");
+    // One thread owns each output row: it reads residual[row] before it
+    // writes y[row], so h may be both.
+    gemv_nvfp4_residual(w, static_cast<const half*>(y.data), static_cast<half*>(h.data),
+                        static_cast<const half*>(h.data), static_cast<int>(w.N), static_cast<int>(w.K), stream);
+    if (!gdn_m1_out_logged_) {
+        gdn_m1_out_logged_ = true;
+        IMP_LOG_INFO("gdn M=1 out-projection with residual epilogue ACTIVE (N=%lld, K=%lld)", (long long)w.N,
+                     (long long)w.K);
+    }
+}
+
+bool GraphExecutor::try_attn_qkv_fused_m1_(const TransformerLayer& ly, const Tensor& input, Tensor& q_out,
+                                           Tensor& k_out, Tensor& v_out, cudaStream_t stream) {
+    if (!dispatch_policy().gdn.m1_fused || cur_spec_verify_ || calib_)
+        return false;
+    if (input.shape[0] != 1 || input.qtype != QType::F16 || q_out.qtype != QType::F16 ||
+        k_out.qtype != QType::F16 || v_out.qtype != QType::F16)
+        return false;
+    const int64_t K = input.shape[1];
+    NvFP4QuantResult wq, wk, wv;
+    if (!nvfp4_decode_weight_(ly.wq_id, wq) || !nvfp4_decode_weight_(ly.wk_id, wk) ||
+        !nvfp4_decode_weight_(ly.wv_id, wv))
+        return false;
+    if (wq.K != K || wk.K != K || wv.K != K || wq.N != q_out.shape[1] || wk.N != k_out.shape[1] ||
+        wv.N != v_out.shape[1])
+        return false;
+    gemv_nvfp4_qkv_fused(wq, wk, wv, static_cast<const half*>(input.data), static_cast<half*>(q_out.data),
+                         static_cast<half*>(k_out.data), static_cast<half*>(v_out.data), static_cast<int>(wq.N),
+                         static_cast<int>(wk.N), static_cast<int>(wv.N), static_cast<int>(K), stream);
+    if (!attn_m1_qkv_logged_) {
+        attn_m1_qkv_logged_ = true;
+        IMP_LOG_INFO("attention M=1 fused q|k|v NVFP4 GEMV ACTIVE (K=%lld, rows %lld + %lld + %lld)",
+                     (long long)K, (long long)wq.N, (long long)wk.N, (long long)wv.N);
+    }
+    return true;
 }
 
 }  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -2,6 +2,7 @@
 #include "exec/executor.h"
 #include "exec/executor_kernels.h"
 #include "exec/executor_debug.h"
+#include "exec/executor_helpers.h"
 #include "exec/gemm_context.h"
 #include "compute/layernorm.h"
 #include "compute/activation.h"
@@ -328,8 +329,9 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     // h and never reads r: skip the save there, as the attention and FFN
     // twins do. Kernel copy, not cudaMemcpyAsync: a memcpy node has no
     // programmatic edge and cut the PDL chain once per layer.
-    const bool skip_residual_save = !dispatch_policy().gdn.fp32_out && !dump_hidden_dir() &&
-                                    residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h);
+    const bool skip_residual_save =
+        !dispatch_policy().gdn.fp32_out && !dump_hidden_dir() &&
+        (residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h) || gdn_out_residual_m1_ok_(ly, n, h));
     if (!skip_residual_save)
         device_copy_async(r.data, h.data, h.nbytes(), stream);
     // Producer fusion: quantize into the small-M scratch inside the norm
@@ -354,6 +356,7 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     int64_t proj_shape[2] = {static_cast<int64_t>(n), static_cast<int64_t>(conv_channels)};
     Tensor proj;
     bool gate_paired = false;
+    bool m1_fused_input = false;
     if (fused_input) {
         // One GEMV produces [proj | gate | alpha | beta] contiguously in
         // gdn_fused_proj_buf_; the views below take offset slices.
@@ -372,7 +375,11 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
         // reorder. One smallm v2 launch for both when both route there.
         int64_t gate_shape_early[2] = {static_cast<int64_t>(n), static_cast<int64_t>(inner)};
         Tensor gate_early(ssm_z_buf_.data, compute_dtype_, 2, gate_shape_early, true);
-        gate_paired = try_smallm_pair_dispatch_(ly.ssm_in_id, ly.gdn_gate_id, no, proj, gate_early, ctx);
+        // M=1 (gdn.m1_fused): in_proj, gate, alpha and beta in one GEMV
+        // launch; alpha/beta land in the 4-call layout of step 4 below.
+        m1_fused_input = try_gdn_input_fused_m1_(ly, no, proj, gate_early, n_heads, stream);
+        gate_paired = m1_fused_input ||
+                      try_smallm_pair_dispatch_(ly.ssm_in_id, ly.gdn_gate_id, no, proj, gate_early, ctx);
         if (!gate_paired)
             gemm_via_handle_(ly.ssm_in_id, no, proj, ctx);
     }
@@ -387,8 +394,14 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
     void* conv_st = (state.ssm_state && ssm_idx >= 0) ? state.ssm_state->conv_state(state.ssm_seq_id, ssm_idx)
                                                       : nullptr;
 
-    // conv_f32 destination for FP32 pipeline (conv+SiLU output)
+    // conv_f32 destination for FP32 pipeline (conv+SiLU output). At n == 1 it
+    // sits past the FP16 input row, so the decode conv reads proj in place
+    // (no xBC copy); every tail scratch below is relative to conv_f32.
     float* conv_f32 = static_cast<float*>(ssm_proj_buf_.data);
+    if (n == 1)
+        conv_f32 = reinterpret_cast<float*>(static_cast<char*>(ssm_proj_buf_.data) +
+                                            align256(static_cast<size_t>(conv_channels) *
+                                                     dtype_size(compute_dtype_)));
 
     if (conv_st) {
         if (state.ragged_prefill()) {
@@ -488,8 +501,11 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
             // reading stale buffer contents (measured as coherent output for
             // sequence 0 and garbage for the rest). n == 1 on the
             // single-sequence path, so this is the same copy it always was.
-            device_copy_async(xBC_out.data, xBC_in.data,
-                              static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_), stream);
+            // At n == 1 conv_f32 sits past the input row (see above): the
+            // conv reads proj in place, no copy.
+            if (n > 1)
+                device_copy_async(xBC_out.data, xBC_in.data,
+                                  static_cast<size_t>(n) * conv_channels * dtype_size(compute_dtype_), stream);
             // Batched decode: ssm_n_seq sequences, one token each, each with
             // its own conv state. Falls through to the single-sequence call
             // when the step carries one sequence.
@@ -500,8 +516,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                     static_cast<const half*>(xBC_out.data), ly.ssm_conv1d_w, ly.ssm_conv1d_b, conv_f32,
                     state.ssm_n_seq, conv_channels, conv_kernel, stream);
             } else {
-                ssm_conv1d_decode_f32_silu(conv_st, xBC_out, ly.ssm_conv1d_w, ly.ssm_conv1d_b, conv_f32,
-                                           conv_kernel, stream);
+                ssm_conv1d_decode_f32_silu(conv_st, n == 1 ? xBC_in : xBC_out, ly.ssm_conv1d_w, ly.ssm_conv1d_b,
+                                           conv_f32, conv_kernel, stream);
             }
         }
     } else {
@@ -633,8 +649,9 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 char* beta_ptr = static_cast<char*>(ssm_dt_buf_.data) +
                                  ((static_cast<size_t>(n) * n_heads * es + 255) & ~size_t(255));
                 beta_proj_out = Tensor(beta_ptr, compute_dtype_, 2, ab_shape, true);
-                if (!try_gdn_alpha_beta_narrow_(ly.gdn_alpha_id, ly.gdn_beta_id, no, alpha_proj_out,
-                                                beta_proj_out, stream)) {
+                // m1_fused_input: step 2 already wrote both into this layout.
+                if (!m1_fused_input && !try_gdn_alpha_beta_narrow_(ly.gdn_alpha_id, ly.gdn_beta_id, no,
+                                                                   alpha_proj_out, beta_proj_out, stream)) {
                     gemm_via_handle_(ly.gdn_alpha_id, no, alpha_proj_out, ctx);
                     gemm_via_handle_(ly.gdn_beta_id, no, beta_proj_out, ctx);
                 }
@@ -970,6 +987,10 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                                                                static_cast<__half*>(h.data), total);
         IMP_CUDA_CHECK_LAUNCH();
         IMP_CUDA_CHECK_LOG(cudaFreeAsync(fp32_out, stream));
+    } else if (gdn_out_residual_m1_ok_(ly, n, h) && !dump_hidden_dir()) {
+        // M=1 (gdn.m1_fused): h = out_proj(y) + h in the GEMV epilogue; the
+        // residual save above was skipped under the same gate.
+        gdn_out_residual_m1_(ly, y_buf, h, stream);
     } else if (residual_beta1_nvfp4_ok_(ly.ssm_out_id, n, h) && !dump_hidden_dir()) {
         // Batched-decode NVFP4: h += out_proj(y) via the smallm accumulate
         // path (h still holds the residual — see run_ssm's twin). The

--- a/src/quant/nvfp4_gemm.cu
+++ b/src/quant/nvfp4_gemm.cu
@@ -316,6 +316,7 @@ void nvfp4_gemv_pdl_register() {
     NVFP4_REGISTER(gemv_nvfp4_swiglu_residual_mr_kernel<NR>);
     NVFP4_REGISTER(gemv_nvfp4_geglu_residual_kernel);
     NVFP4_REGISTER(gemv_nvfp4_geglu_residual_mr_kernel<NR>);
+    nvfp4_gdn_input_pdl_register();
     // MoE GEMV kernels
     // MoE decode GEMVs are not instrumented (no pdl_wait) and stay
     // unregistered: registration is the promise that the kernel waits.

--- a/src/quant/nvfp4_gemm.h
+++ b/src/quant/nvfp4_gemm.h
@@ -106,6 +106,15 @@ void gemv_nvfp4_qkv_fused(const NvFP4QuantResult& wq, const NvFP4QuantResult& wk
 void gemv_nvfp4_gate_up_fused(const NvFP4QuantResult& wg, const NvFP4QuantResult& wu, const half* x, half* yg,
                               half* yu, int rows, int K, cudaStream_t stream);
 
+// M=1 GDN input projections in one launch: in_proj + gate (NVFP4) and alpha +
+// beta (FP16 [ab_rows, K] each) on one x. Returns false (nothing launched)
+// when K % 16 != 0, K > 8192 or a weight's K differs; the caller keeps its
+// four-call path. Registered for PDL by nvfp4_gemv_pdl_register().
+bool gemv_nvfp4_gdn_input_fused(const NvFP4QuantResult& w_in, const NvFP4QuantResult& w_gate, const half* w_alpha,
+                                const half* w_beta, int ab_rows, const half* x, half* y_in, half* y_gate,
+                                half* y_alpha, half* y_beta, int K, cudaStream_t stream);
+void nvfp4_gdn_input_pdl_register();
+
 // GEMV with residual add: y[M] = A_nvfp4[M,K] @ x[K] + residual[M]
 void gemv_nvfp4_residual(const NvFP4QuantResult& A, const half* x, half* y, const half* residual, int M,
                          int K, cudaStream_t stream);

--- a/src/quant/nvfp4_gemv_gdn_input.cu
+++ b/src/quant/nvfp4_gemv_gdn_input.cu
@@ -1,0 +1,185 @@
+// M=1 GDN input projections in one launch: in_proj and gate (NVFP4 rows) plus
+// alpha and beta (FP16 rows, the loader dequantizes them) share one grid.
+// Replaces four launches per GDN layer at batch=1 on native-NVFP4 hybrids (the
+// F16 gdn_input_packed path only covers F16/BF16 checkpoints). Per-row math and
+// reduction order are those of the kernel each segment replaces (multirow
+// warp_k_loop, K-par gemv_nvfp4_row + reduce_kpar, gemv_fp16_kernel), so every
+// output is bit-identical to the four-launch path.
+
+#include "quant/nvfp4_gemm.h"
+#include "quant/nvfp4_gemm_internal.cuh"
+#include "quant/nvfp4_quant.h"
+#include "core/pdl.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdint>
+#include "core/pdl_device.cuh"
+
+namespace imp {
+
+namespace {
+
+struct GdnInputArgs {
+    const uint8_t* packed_in;
+    const uint8_t* ms_in;
+    float ts_in;
+    half* y_in;
+    int in_rows;
+    const uint8_t* packed_gate;
+    const uint8_t* ms_gate;
+    float ts_gate;
+    half* y_gate;
+    int gate_rows;
+    const half* w_alpha;
+    half* y_alpha;
+    const half* w_beta;
+    half* y_beta;
+    int ab_rows;
+    const half* x;
+    int K;
+};
+
+// Same loads and accumulation order as gemv_fp16_kernel (compute/gemm_gemv_dtype.cu):
+// 16 halves per lane per iteration, half2 products summed in fp32. K % 16 == 0.
+__device__ __forceinline__ float warp_dot_fp16(const half* __restrict__ row, const half* __restrict__ x,
+                                               int K, int lane) {
+    const int K_vec16 = K / 16;
+    const float4* row_v = reinterpret_cast<const float4*>(row);
+    const float4* x_v = reinterpret_cast<const float4*>(x);
+    float sum = 0.0f;
+    for (int i = lane; i < K_vec16; i += 32) {
+        float4 a0 = row_v[2 * i];
+        float4 a1 = row_v[2 * i + 1];
+        float4 x0 = x_v[2 * i];
+        float4 x1 = x_v[2 * i + 1];
+        const half2* a_h2_0 = reinterpret_cast<const half2*>(&a0);
+        const half2* x_h2_0 = reinterpret_cast<const half2*>(&x0);
+        const half2* a_h2_1 = reinterpret_cast<const half2*>(&a1);
+        const half2* x_h2_1 = reinterpret_cast<const half2*>(&x1);
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            half2 prod = __hmul2(a_h2_0[j], x_h2_0[j]);
+            sum += __half2float(prod.x) + __half2float(prod.y);
+        }
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            half2 prod = __hmul2(a_h2_1[j], x_h2_1[j]);
+            sum += __half2float(prod.x) + __half2float(prod.y);
+        }
+    }
+    return sum;
+}
+
+constexpr int kGdnInputNR = 8;  // warp-per-row rows per block (in_proj, alpha, beta)
+constexpr int kGdnGateRowsPerBlock = kMRThreads / kKparThreads;  // 2: K-par rows per block
+
+// Block ranges: [0, in_blocks) in_proj rows warp-per-row (the multirow kernel's
+// order), then gate rows at kKparThreads per row with reduce_kpar's order (the
+// gate takes gemv_nvfp4_kpar_kernel in the executor, not the multirow form, so
+// this keeps it bit-identical too), then alpha/beta rows warp-per-row.
+__global__ void __launch_bounds__(kMRThreads) gemv_nvfp4_gdn_input_kernel(GdnInputArgs a) {
+    const int warp_id = threadIdx.x / 32;
+    const int lane = threadIdx.x & 31;
+    const int K_half = a.K / 2;
+    const int n_mb = a.K / kMicroBlockSize;
+    const int in_blocks = (a.in_rows + kGdnInputNR - 1) / kGdnInputNR;
+    const int gate_blocks = (a.gate_rows + kGdnGateRowsPerBlock - 1) / kGdnGateRowsPerBlock;
+
+    if (blockIdx.x >= in_blocks && blockIdx.x < in_blocks + gate_blocks) {
+        // Gate: two rows per block, kKparThreads (128) threads each, the
+        // K-par kernel's loop stride and cross-warp reduction order.
+        __shared__ float warp_sums[kGdnGateRowsPerBlock][kKparWarps];
+        const int half_id = threadIdx.x / kKparThreads;
+        const int tid = threadIdx.x % kKparThreads;
+        const int row = (blockIdx.x - in_blocks) * kGdnGateRowsPerBlock + half_id;
+        const bool live = row < a.gate_rows;
+        pdl_wait();
+        float acc = 0.0f;
+        if (live)
+            acc = gemv_nvfp4_row(a.packed_gate + (int64_t)row * K_half, a.ms_gate + (int64_t)row * n_mb,
+                                 a.ts_gate, a.x, n_mb, tid);
+        pdl_trigger();
+        acc = warp_reduce(acc);
+        if ((tid & 31) == 0)
+            warp_sums[half_id][tid / 32] = acc;
+        __syncthreads();
+        if (live && tid == 0) {
+            float total = warp_sums[half_id][0];
+#pragma unroll
+            for (int w = 1; w < kKparWarps; w++)
+                total += warp_sums[half_id][w];
+            a.y_gate[row] = __float2half(total);
+        }
+        return;
+    }
+
+    // Warp-per-row segments: row is 0-based inside its own segment.
+    const bool in_seg = blockIdx.x < in_blocks;
+    const int row = (in_seg ? blockIdx.x : blockIdx.x - in_blocks - gate_blocks) * kGdnInputNR + warp_id;
+    if (in_seg ? row >= a.in_rows : row >= 2 * a.ab_rows)
+        return;
+    pdl_wait();
+    float acc;
+    half* out;
+    int local_row;
+    if (in_seg) {
+        local_row = row;
+        out = a.y_in;
+        acc = warp_k_loop(a.packed_in + (int64_t)row * K_half, a.ms_in + (int64_t)row * n_mb, a.ts_in, n_mb,
+                          lane, [&] __device__(const uint8_t* pb, int off) {
+                              return dot_micro_block(pb, a.x, off);
+                          });
+    } else {
+        const bool is_alpha = row < a.ab_rows;
+        local_row = is_alpha ? row : row - a.ab_rows;
+        const half* w = is_alpha ? a.w_alpha : a.w_beta;
+        out = is_alpha ? a.y_alpha : a.y_beta;
+        acc = warp_dot_fp16(w + (int64_t)local_row * a.K, a.x, a.K, lane);
+    }
+    pdl_trigger();
+    acc = warp_reduce(acc);
+    if (lane == 0)
+        out[local_row] = __float2half(acc);
+}
+
+}  // namespace
+
+bool gemv_nvfp4_gdn_input_fused(const NvFP4QuantResult& w_in, const NvFP4QuantResult& w_gate,
+                                const half* w_alpha, const half* w_beta, int ab_rows, const half* x,
+                                half* y_in, half* y_gate, half* y_alpha, half* y_beta, int K,
+                                cudaStream_t stream) {
+    const int n_mb = K / kMicroBlockSize;
+    if (K % 16 != 0 || n_mb > 512 || w_in.K != K || w_gate.K != K || ab_rows <= 0)
+        return false;
+    GdnInputArgs a;
+    a.packed_in = reinterpret_cast<const uint8_t*>(w_in.packed_data);
+    a.ms_in = reinterpret_cast<const uint8_t*>(w_in.micro_scales);
+    a.ts_in = w_in.tensor_scale;
+    a.y_in = y_in;
+    a.in_rows = static_cast<int>(w_in.N);
+    a.packed_gate = reinterpret_cast<const uint8_t*>(w_gate.packed_data);
+    a.ms_gate = reinterpret_cast<const uint8_t*>(w_gate.micro_scales);
+    a.ts_gate = w_gate.tensor_scale;
+    a.y_gate = y_gate;
+    a.gate_rows = static_cast<int>(w_gate.N);
+    a.w_alpha = w_alpha;
+    a.y_alpha = y_alpha;
+    a.w_beta = w_beta;
+    a.y_beta = y_beta;
+    a.ab_rows = ab_rows;
+    a.x = x;
+    a.K = K;
+    const int blocks = (a.in_rows + kGdnInputNR - 1) / kGdnInputNR +
+                       (a.gate_rows + kGdnGateRowsPerBlock - 1) / kGdnGateRowsPerBlock +
+                       (2 * ab_rows + kGdnInputNR - 1) / kGdnInputNR;
+    pdl::launch(gemv_nvfp4_gdn_input_kernel, dim3(blocks), dim3(kMRThreads), size_t(0), stream, a);
+    return true;
+}
+
+void nvfp4_gdn_input_pdl_register() {
+    pdl::enable_kernel(gemv_nvfp4_gdn_input_kernel);
+    cudaFuncSetAttribute(gemv_nvfp4_gdn_input_kernel, cudaFuncAttributePreferredSharedMemoryCarveout,
+                         cudaSharedmemCarveoutMaxL1);
+}
+
+}  // namespace imp

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -278,6 +278,7 @@ bool apply_one(RuntimeConfig& cfg, const std::string& dotted_key, const std::str
     I("gdn.chunkpar_strip", cfg.gdn.chunkpar_strip);
     B("gdn.state_bf16", cfg.gdn.state_bf16);
     B("gdn.alpha_beta_smallm", cfg.gdn.alpha_beta_smallm);
+    B("gdn.m1_fused", cfg.gdn.m1_fused);
 
     // [gemm]
     B("gemm.no_dp4a_gemv", cfg.gemm.no_dp4a_gemv);

--- a/tests/test_nvfp4_gemv_gdn_input.cu
+++ b/tests/test_nvfp4_gemv_gdn_input.cu
@@ -1,0 +1,220 @@
+// The M=1 GDN fused input GEMV (quant/nvfp4_gemv_gdn_input.cu) against the
+// four launches it replaces at Qwen3.8-27B dims (K=5120: in_proj 10240 rows,
+// gate 6144, alpha/beta 48 each). in_proj takes the multirow kernel at these
+// rows, the gate the 128-thread K-par kernel, alpha/beta the gemv_fp16 sum:
+// all four reproduced bit-for-bit. Plus an fp32 host reference for every
+// segment and the K-shape declines.
+
+#include "quant/nvfp4_quant.h"
+#include "quant/nvfp4_gemm.h"
+#include "compute/gemm.h"
+#include "core/tensor.h"
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace imp {
+namespace {
+
+constexpr int kK = 5120;
+constexpr int kInRows = 10240;
+constexpr int kGateRows = 6144;
+constexpr int kAbRows = 48;
+
+class NvFP4GemvGdnInput : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (cudaSetDevice(0) != cudaSuccess)
+            GTEST_SKIP() << "No CUDA device";
+        cudaStreamCreate(&stream_);
+    }
+    void TearDown() override {
+        for (void* p : allocs_)
+            cudaFree(p);
+        if (stream_)
+            cudaStreamDestroy(stream_);
+    }
+
+    std::vector<half> host_weight(int N, int K, int seed) {
+        std::vector<half> h(static_cast<size_t>(N) * K);
+        for (size_t i = 0; i < h.size(); ++i)
+            h[i] = __float2half(((static_cast<int>(i * 17u + seed) % 31) - 15) * 0.01f);
+        return h;
+    }
+
+    half* upload(const std::vector<half>& h) {
+        half* d = nullptr;
+        EXPECT_EQ(cudaMalloc(&d, h.size() * sizeof(half)), cudaSuccess);
+        EXPECT_EQ(cudaMemcpy(d, h.data(), h.size() * sizeof(half), cudaMemcpyHostToDevice), cudaSuccess);
+        allocs_.push_back(d);
+        return d;
+    }
+
+    half* device_out(int n) {
+        half* d = nullptr;
+        EXPECT_EQ(cudaMalloc(&d, static_cast<size_t>(n) * sizeof(half)), cudaSuccess);
+        cudaMemset(d, 0, static_cast<size_t>(n) * sizeof(half));
+        allocs_.push_back(d);
+        return d;
+    }
+
+    void quantize(half* d_w, int N, int K, NvFP4QuantResult& qr) {
+        int64_t wshape[2] = {N, K};
+        Tensor w_t(d_w, QType::F16, 2, wshape, true);
+        quantize_fp16_to_nvfp4(w_t, qr, stream_);
+        ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+    }
+
+    std::vector<half> download(const half* d, int n) {
+        EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+        std::vector<half> h(static_cast<size_t>(n));
+        EXPECT_EQ(cudaMemcpy(h.data(), d, h.size() * sizeof(half), cudaMemcpyDeviceToHost), cudaSuccess);
+        return h;
+    }
+
+    static int count_diff_bits(const std::vector<half>& a, const std::vector<half>& b) {
+        int n = 0;
+        for (size_t i = 0; i < a.size(); ++i)
+            if (__half_as_ushort(a[i]) != __half_as_ushort(b[i]))
+                ++n;
+        return n;
+    }
+
+    // fp32 dot of the DEQUANTIZED weight row (what the NVFP4 kernels compute)
+    // or of the FP16 row, against the host x.
+    static void expect_close(const char* what, const std::vector<half>& got, const std::vector<float>& ref,
+                             float tol) {
+        ASSERT_EQ(got.size(), ref.size());
+        int bad = 0;
+        for (size_t i = 0; i < got.size(); ++i) {
+            const float g = __half2float(got[i]);
+            if (std::isnan(g) || std::fabs(g - ref[i]) > tol + 0.02f * std::fabs(ref[i]))
+                ++bad;
+        }
+        EXPECT_EQ(bad, 0) << what << ": " << bad << " of " << got.size() << " outputs off the reference";
+    }
+
+    cudaStream_t stream_ = nullptr;
+    std::vector<void*> allocs_;
+};
+
+TEST_F(NvFP4GemvGdnInput, MatchesTheFourLaunchesAtQwen38Dims) {
+    auto h_in = host_weight(kInRows, kK, 1);
+    auto h_gate = host_weight(kGateRows, kK, 2);
+    auto h_a = host_weight(kAbRows, kK, 3);
+    auto h_b = host_weight(kAbRows, kK, 4);
+    std::vector<half> h_x(kK);
+    for (int i = 0; i < kK; ++i)
+        h_x[i] = __float2half(((i * 23) % 29 - 14) * 0.02f);
+
+    half* d_in = upload(h_in);
+    half* d_gate = upload(h_gate);
+    half* d_a = upload(h_a);
+    half* d_b = upload(h_b);
+    half* d_x = upload(h_x);
+    NvFP4QuantResult q_in, q_gate;
+    quantize(d_in, kInRows, kK, q_in);
+    quantize(d_gate, kGateRows, kK, q_gate);
+
+    // Reference launches: the kernels the executor dispatched before.
+    half* r_in = device_out(kInRows);
+    half* r_gate = device_out(kGateRows);
+    half* r_a = device_out(kAbRows);
+    half* r_b = device_out(kAbRows);
+    gemv_nvfp4_kpar(q_in, d_x, r_in, kInRows, kK, stream_);
+    gemv_nvfp4_kpar(q_gate, d_x, r_gate, kGateRows, kK, stream_);
+    {
+        int64_t ab_shape[2] = {kAbRows, kK};
+        int64_t x_shape[1] = {kK};
+        int64_t y_shape[1] = {kAbRows};
+        Tensor wa(d_a, QType::F16, 2, ab_shape, true), wb(d_b, QType::F16, 2, ab_shape, true);
+        Tensor x_t(d_x, QType::F16, 1, x_shape, true);
+        Tensor ya(r_a, QType::F16, 1, y_shape, true), yb(r_b, QType::F16, 1, y_shape, true);
+        gemv(wa, x_t, ya, stream_);
+        gemv(wb, x_t, yb, stream_);
+    }
+
+    half* f_in = device_out(kInRows);
+    half* f_gate = device_out(kGateRows);
+    half* f_a = device_out(kAbRows);
+    half* f_b = device_out(kAbRows);
+    ASSERT_TRUE(gemv_nvfp4_gdn_input_fused(q_in, q_gate, d_a, d_b, kAbRows, d_x, f_in, f_gate, f_a, f_b, kK,
+                                           stream_));
+
+    auto g_in = download(f_in, kInRows), e_in = download(r_in, kInRows);
+    auto g_gate = download(f_gate, kGateRows), e_gate = download(r_gate, kGateRows);
+    auto g_a = download(f_a, kAbRows), e_a = download(r_a, kAbRows);
+    auto g_b = download(f_b, kAbRows), e_b = download(r_b, kAbRows);
+    // in_proj rows >= 6 x SMs x 8 take the multirow kernel: same warp_k_loop order.
+    EXPECT_EQ(count_diff_bits(g_in, e_in), 0) << "in_proj is not bit-identical to gemv_nvfp4_kpar (multirow)";
+    EXPECT_EQ(count_diff_bits(g_a, e_a), 0) << "alpha is not bit-identical to gemv_fp16_kernel";
+    EXPECT_EQ(count_diff_bits(g_b, e_b), 0) << "beta is not bit-identical to gemv_fp16_kernel";
+    // 6144 gate rows take the 128-thread K-par kernel in gemv_nvfp4_kpar; the
+    // fused kernel reproduces its loop stride and reduction order.
+    EXPECT_EQ(count_diff_bits(g_gate, e_gate), 0) << "gate is not bit-identical to gemv_nvfp4_kpar (K-par)";
+
+    // fp32 host references (dequantized NVFP4 rows for in_proj / gate).
+    auto ref_nvfp4 = [&](const NvFP4QuantResult& q, int N) {
+        std::vector<half> deq(static_cast<size_t>(N) * kK);
+        half* d_deq = nullptr;
+        EXPECT_EQ(cudaMalloc(&d_deq, deq.size() * sizeof(half)), cudaSuccess);
+        allocs_.push_back(d_deq);
+        dequantize_nvfp4_to_fp16(q, d_deq, stream_);
+        deq = download(d_deq, N * kK);
+        std::vector<float> ref(N, 0.0f);
+        for (int r = 0; r < N; ++r) {
+            double s = 0.0;
+            for (int k = 0; k < kK; ++k)
+                s += static_cast<double>(__half2float(deq[static_cast<size_t>(r) * kK + k])) *
+                     __half2float(h_x[k]);
+            ref[r] = static_cast<float>(s);
+        }
+        return ref;
+    };
+    auto ref_fp16 = [&](const std::vector<half>& w, int N) {
+        std::vector<float> ref(N, 0.0f);
+        for (int r = 0; r < N; ++r) {
+            double s = 0.0;
+            for (int k = 0; k < kK; ++k)
+                s += static_cast<double>(__half2float(w[static_cast<size_t>(r) * kK + k])) *
+                     __half2float(h_x[k]);
+            ref[r] = static_cast<float>(s);
+        }
+        return ref;
+    };
+    expect_close("in_proj", g_in, ref_nvfp4(q_in, kInRows), 0.05f);
+    expect_close("gate", g_gate, ref_nvfp4(q_gate, kGateRows), 0.05f);
+    expect_close("alpha", g_a, ref_fp16(h_a, kAbRows), 0.05f);
+    expect_close("beta", g_b, ref_fp16(h_b, kAbRows), 0.05f);
+
+    free_nvfp4_result(q_in);
+    free_nvfp4_result(q_gate);
+}
+
+TEST_F(NvFP4GemvGdnInput, DeclinesShapesTheKernelCannotServe) {
+    NvFP4QuantResult q_in, q_gate;
+    q_in.K = kK;
+    q_gate.K = kK;
+    half* dummy = device_out(16);
+    // K mismatch between the input and a weight.
+    EXPECT_FALSE(gemv_nvfp4_gdn_input_fused(q_in, q_gate, dummy, dummy, 1, dummy, dummy, dummy, dummy, dummy,
+                                            kK + 16, stream_));
+    // K > 8192 (n_mb > 512): the multirow form declines.
+    q_in.K = 16384;
+    q_gate.K = 16384;
+    EXPECT_FALSE(gemv_nvfp4_gdn_input_fused(q_in, q_gate, dummy, dummy, 1, dummy, dummy, dummy, dummy, dummy,
+                                            16384, stream_));
+    // K % 16 != 0.
+    q_in.K = 5128;
+    q_gate.K = 5128;
+    EXPECT_FALSE(gemv_nvfp4_gdn_input_fused(q_in, q_gate, dummy, dummy, 1, dummy, dummy, dummy, dummy, dummy,
+                                            5128, stream_));
+    EXPECT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+}
+
+}  // namespace
+}  // namespace imp

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -247,7 +247,7 @@ def main():
     # rows 0..K-2 of the conv1d prefill against the CPU form over 300 launches.
     # 1094 -> 1099: GemmF16NarrowSmallM x5 (test-compute, GPU, no model): the one-launch
     # alpha/beta projection of batched GDN decode against a double CPU reference.
-    PINNED = 1099
+    PINNED = 1101
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
## What

Single-stream (M=1) decode on native-NVFP4 hybrids ran the GDN input projections as four launches per layer (in_proj multirow 20.2 us, gate K-par 12.6, alpha 4.1, beta 3.9: the two FP16 alpha/beta GEMVs read 0.5 MB each and are pure launch latency), then residual save + add + copy-back (2.7 us) around the out-projection and an xBC copy before the conv (1.8 us); gated attention ran k and v as two 4 us launches after q. The F16 `gdn_input_packed` fusion never applied here (F16/BF16 checkpoints only).

`gdn.m1_fused` (default on):

- `quant/nvfp4_gemv_gdn_input.cu`: in_proj + gate (NVFP4 rows) + alpha + beta (FP16 rows) in one grid. Each segment keeps the loop and reduction order of the kernel it replaces (multirow `warp_k_loop`, K-par `gemv_nvfp4_row` + `reduce_kpar`, `gemv_fp16_kernel`), so every output is bit-identical.
- GDN out-projection: `gemv_nvfp4_residual` with `h` as both residual and output; no residual save, add or copy-back.
- The decode conv reads `proj` in place: `conv_f32` sits past the FP16 input row at n == 1.
- Gated attention: q|k|v in one `gemv_nvfp4_qkv_fused` launch (the ungated path already did this).

6 launches per GDN layer and 2 per attention layer fewer.

## Measured

Qwen3.8-27B-NVFP4-vllm, `imp-cli --bench --bench-pp 512 --bench-reps 5 --max-tokens 256 --set speculative.ngram=false`, same binary, flag off/on alternating:

| round | off | on |
|---|---|---|
| 1 | 94.03 | 99.22 |
| 2 | 94.34 | 99.17 |
| 3 | 94.40 | 100.06 |
| 4 (final kernel) | 94.65 | 99.55 |
| 5 (final kernel) | 94.42 | 99.54 |

+5.5 / +5.1 / +6.0 / +5.2 / +5.4 %, 5/5 (rounds 1-3 on the first kernel revision with the gate in warp order, 4-5 on the shipped one). All three `M=1 ... ACTIVE` lines in every on arm, none in the off arms. Batch=1 spec-off now 89 % of the ~112 tok/s roofline (was 78 % on 2026-08-27, 84 % on this tree before the change).

## Numerics

- test-quant `NvFP4GemvGdnInput`: in_proj, gate, alpha, beta bit-identical to `gemv_nvfp4_kpar` / `gemv()` at the Qwen3.8 shapes, fp32 host reference for every segment, K-shape declines.
- Two numerics changes remain, both the summation-order / rounding class of SETTLED D-2: the residual epilogue rounds once (`fp16(dot + h)`) where the old path rounded the GEMV output first and added in a second kernel, and k/v (1024 rows each) move from the 128-thread K-par order to the multirow order inside q's launch, as the ungated `nvfp4_qkv` path always had.
- Greedy 200-token completions (server JSON, `runtime.deterministic=true`, prefix cache off): flag-off twice byte-equal; flag-on diverges from flag-off at a near-tie after 805 / 415 / 411 characters on three prompts; flag-on with and without CUDA graphs byte-equal.
- Chunk-1 PPL on the 45k corpus (13 811 tokens, every token through the M=1 path, `runtime.deterministic=true`): 4.5641 off -> 4.5646 on (an earlier build with the gate in warp order read 4.5608: the judge scatters +-0.07 % across summation orders).
- `tools/analysis/degen_suite.py` against `imp-server` on the branch binary: 50 checks, 0 FAIL, 0 skipped; server log clean of the stderr pattern.

## Gate

Pre-push hook on the pushed tree (Qwen3-8B-Q8_0, the gate model, does not take any of these paths):

```
PASS fast gtest filter
  decode  tg128 =  296.42 tok/s  (baseline  287.19, delta 3.21%)
  prefill pp512 = 12593.62 tok/s  (baseline 12406.87, delta 1.51%)
PASS decode within 8% threshold
PASS prefill within 8% threshold
  prefill pp4096 = 15639.60 tok/s  (baseline 15324.70, delta 2.05%, FA2)
PASS long-ctx prefill (pp4096/FA2) within 8% threshold
PASS peak VRAM within 10% of baseline
PASS graphs ON delivers >=1.3x decode speedup
PASS Qwen3-4B Q8_0 (dense) (distinct=18/32 need 8, tokens=64, max-run=1, 3gram=4 repeat=37%, contains 'Paris')
== paired A/B: A=imp:ab-0b095c4d  B=imp:test  pairs=3  model=Qwen3-8B-Q8_0.gguf  threshold=-2% ==
  paired decode  delta: mean 0.11%  (pairs 0.26 0.02 0.05; min 0.02% max 0.26%; 0 of 3 negative)
  paired prefill delta: mean 0.45%  (pairs 0.43 0.74 0.19)
PASS paired decode within 2% (mean 0.11%)
PASS paired prefill within 2% (mean 0.45%)
```

Not in here: batched decode (n > 1) numbers. The n > 1 conv copy, `residual_beta1_nvfp4_ok_` and the smallm pair dispatch keep their paths; `tools/check_test_lanes.py` PINNED 1099 -> 1101 for the two new GPU-lane tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
