### PR TITLE
build(hooks): one docker build per tree, module-scoped pre-commit, paired A/B only on kernel diffs

### DIFF
--- a/.claude/skills/building-and-testing/SKILL.md
+++ b/.claude/skills/building-and-testing/SKILL.md
@@ -24,7 +24,7 @@ description: Use when building imp, running its test suite, checking CI status, 
 |---|---|---|
 | Incremental build (inner loop) | `make dev` | 2-14 s |
 | Incremental build + CI unit lane | `make dev-test` (= `ctest -L unit`) | ~3 s |
-| Full image (the gate; anything you measure or push) | `make build` -> `imp:test` | ~3.5 min regardless of diff |
+| Full image (the gate; anything you measure or push) | `make build` -> `imp:test` | ~3.5 min regardless of diff; 0 s when the image already carries the tree (`imp.tree` label) |
 | CPU unit binary | `make test-unit` (`imp-tests-unit`) | <5 s |
 | Full GPU suite | `make test-gpu` | 4-10 min |
 | E2E on real models | `make test-e2e` | Qwen3-4B-Instruct-2507-Q8_0, Qwen3.5-4B-mxfp4, gemma-4-26B-A4B Q4_K_M, `MOE_MODEL` (gpt-oss-20b-mxfp4), Qwen3-Coder-30B FP4, Nemotron-3-Nano NVFP4 (paths in `Makefile`) |
@@ -80,8 +80,9 @@ docker run --rm --gpus all -v $HOME/models:/models \
 Advisory jobs: `Lint`, `clang-tidy`, `Mock API contract`, `Real API contract (model-less)`, `Sanitizers`, `PTX fallback`.
 
 - Hooks: `make install-hooks` copies `scripts/pre-commit.hook` and `scripts/pre-push.hook`. Never edit `.git/hooks/*`: `guard_precommit_filter` in the CPU lane diffs them against the tracked files.
-- Pre-commit = static gates (~2 s) then `make test-gpu` (full suite, ~10 min) when staged `src/ include/ tools/ tests/ CMakeLists cmake/` files change; `.md .py .hook` skip. A 2-min timeout around `git commit` kills the suite and leaves files staged only. Alternative: `make test-gpu` by hand, read exit 0, then `git commit --no-verify`.
-- Pre-push = static gates, `require_free_gpu.sh`, then `make verify-fast`; the perf gate runs only when the diff matches `PERF_RE` (`src/{compute,exec,quant,runtime,model}/`, any `.cu/.cuh`, `cmake/`, `CMakeLists.txt`, `tests/perf_baseline*`). Skips: `IMP_VERIFY_SKIP_PERF/_VRAM/_GRAPHS=1`.
+- `make build` runs `scripts/build_image.sh`: skipped when `imp:test` already carries the tree fingerprint (label `imp.tree` = index tree + build args; only when the working tree equals the index, no unstaged or untracked files). `IMP_FORCE_BUILD=1` builds anyway. Saves 3.5 min per hook stage on one tree.
+- Pre-commit = static gates (~2 s), `make build`, then only the test modules the staged diff reaches (`modules_for` in `scripts/pre-commit.hook`: `src/memory|runtime` -> test-core test-kv test-e2e, `src/compute` -> test-compute test-attention test-quant test-kv test-moe-gdn, `src/exec` -> test-e2e test-moe-gdn test-compute test-attention, `src/model|quant` -> test-quant test-text test-e2e test-core, a `tests/` file -> its module); the full `make test-gpu` (224 tests, ~4 min) on `include/ src/core src/api CMakeLists cmake/` changes or with `IMP_PRECOMMIT_FULL=1`. `.md .py .hook` skip. A 2-min timeout around `git commit` still kills a long stage: run the stage by hand, read exit 0, then `git commit --no-verify`.
+- Pre-push = static gates, `require_free_gpu.sh`, then `make verify-fast`; the perf gate runs only when the diff matches `PERF_RE` (`src/{compute,exec,quant,runtime,model}/`, any `.cu/.cuh`, `cmake/`, `CMakeLists.txt`, `tests/perf_baseline*`). On `src/compute` or `src/exec` diffs the paired A/B (`make verify-ab`, 2 %, ~5 min) replaces the single-arm perf gate; `IMP_SKIP_AB=1` falls back to it. Skips: `IMP_VERIFY_SKIP_PERF/_VRAM/_GRAPHS=1`.
 - Hooks run `filesize lanes entrypoint alloc launchguards docs citations`; `hygiene` only in CI. Local hygiene check: `docker run --rm -v $PWD:/src -w /src -e HOME=/tmp imp:toolchain bash -c 'git config --global --add safe.directory /src; bash scripts/ci_static_gates.sh hygiene'`.
 - `docs_lint.py` regenerates `docs/audit/docs-rewrite/STALE.md` on every run; it blocks `git pull` until `git checkout -- docs/audit/docs-rewrite/STALE.md` or committed as an `.md`-only follow-up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ there instead of retelling it.
 ## [Unreleased]
 
 ### Changed
+- Local gates run once per tree: `make build` skips when `imp:test` already carries the tree fingerprint (label `imp.tree`, `scripts/build_image.sh`, 3.5 min per skipped build), the pre-commit hook runs only the test modules the staged diff reaches (full suite on core/include/build changes or `IMP_PRECOMMIT_FULL=1`), and the pre-push hook runs the paired A/B instead of the single-arm perf gate on kernel diffs. Measured before: a commit cost ~7 min and a push ~10 min for one tree.
 - VRAM is committed on demand for the slot-shaped pools (`vram.lazy_commit`, default on): the SSM/GDN state slab reserves every slot at init and commits one per admitted sequence (scheduler admission gate), the engine arena commits as tenants take, so the Qwen3-VL tower lands on the first image instead of at load. The plan still charges every byte; the KV growth cap subtracts what lazy pools have charged but not committed (`vram_reserved_uncommitted_bytes`). Commits inside a reservation count as `planned_serving_commits()`, no longer as I2 violations. `kv_cache.growable_initial_pct` default 100 -> 25. Qwen3.8-27B-NVFP4 idle after warmup 30053 -> 25455 MiB, first image +0.9 s once, burst of 28 unchanged (`docs/internals/MEMORY.md` B0, lazy pools).
 
 ## [0.39.0] - 2026-09-10

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,12 @@ LABEL org.opencontainers.image.title="imp" \
       org.opencontainers.image.source="https://github.com/kekzl/imp" \
       org.opencontainers.image.licenses="MIT AND Apache-2.0"
 
+# Fingerprint of the tree + build args this image was built from (empty for a
+# dirty tree). scripts/build_image.sh reads it back to skip a rebuild of the
+# same tree.
+ARG IMP_TREE_ID=
+LABEL imp.tree="${IMP_TREE_ID}"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         jq \

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ check-deps:
 check-deps-online:
 	@bash scripts/check_dep_pins.sh --online
 
+# scripts/build_image.sh skips the build when $(DOCKER_IMG) already carries
+# this tree (label imp.tree); IMP_FORCE_BUILD=1 builds anyway.
 build: check-deps
-	docker build $(BUILD_ARGS) $(DEP_ARGS) -t $(DOCKER_IMG) .
+	@bash scripts/build_image.sh $(DOCKER_IMG) $(BUILD_ARGS) $(DEP_ARGS)
 
 # ---------------------------------------------------------------------------
 # Fast inner loop (`make dev`) — incremental compile, seconds not minutes.
@@ -509,7 +511,7 @@ install-hooks:
 	@cp scripts/pre-push.hook .git/hooks/pre-push
 	@chmod +x .git/hooks/pre-push
 	@echo "hooks installed:"
-	@echo "  pre-commit → Stage 1 'make test-gpu' (full GPU suite) on staged src/tests changes"
+	@echo "  pre-commit → Stage 1 GPU tests on staged src/tests changes (modules the diff reaches; full suite on core/include/build changes)"
 	@echo "  pre-push   → 'make verify-fast' on source changes (perf gate only for measured paths)"
 	@echo "  CI (Stage 2) runs 'ctest -L unit' — the CPU lane — automatically"
 

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# build_image.sh <tag> [docker build args...]
+#
+# `docker build` unless <tag> already carries this exact tree. The image is
+# labelled imp.tree=<fingerprint> at build time; the fingerprint is the index
+# tree (`git write-tree`) plus the build arguments, and it exists only when the
+# working tree IS the index: no unstaged change to a tracked file, no untracked
+# file that .gitignore does not cover. Anything else builds unconditionally,
+# because `COPY . .` would ship what the index does not describe.
+#
+# Measured cost of the rebuild this skips: 3.5 min per `make build`, which the
+# pre-commit hook (test-gpu), the pre-push hook (verify-fast) and verify-ab
+# each reached for the same tree.
+#
+# IMP_FORCE_BUILD=1 builds regardless.
+set -eu
+TAG="${1:?usage: build_image.sh <tag> [docker build args...]}"
+shift
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+fingerprint() {
+    git diff --quiet || return 0
+    [ -z "$(git ls-files --others --exclude-standard)" ] || return 0
+    local tree
+    tree="$(git write-tree)"
+    printf '%s\n%s\n' "$tree" "$*" | sha256sum | cut -c1-16
+}
+
+FP="$(fingerprint "$@")"
+if [ "${IMP_FORCE_BUILD:-0}" != "1" ] && [ -n "$FP" ]; then
+    HAVE="$(docker image inspect "$TAG" --format '{{index .Config.Labels "imp.tree"}}' 2>/dev/null || true)"
+    if [ "$HAVE" = "$FP" ]; then
+        echo "build: $TAG already carries this tree (imp.tree=$FP), skipping docker build (IMP_FORCE_BUILD=1 overrides)"
+        exit 0
+    fi
+fi
+if [ -z "$FP" ]; then
+    echo "build: working tree differs from the index (unstaged or untracked files), building without a fingerprint"
+fi
+exec docker build "$@" --build-arg "IMP_TREE_ID=${FP}" -t "$TAG" .

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -10,9 +10,11 @@
 # tests/, CMakeLists, *.cmake) — doc/config-only commits are not gated, and
 # neither are the .md and .py files that live inside those directories.
 #
-# Runs `make test-gpu` (Docker build + the full GTest suite via imp-tests; this
-# includes the CPU binaries too, so a commit that passes here has run everything).
-# Heavy by design. Skip a single commit with:  git commit --no-verify
+# Runs `make build` (skipped when imp:test already carries this tree, see
+# scripts/build_image.sh) and then the test modules the staged diff can reach
+# (modules_for below); the full suite (`make test-gpu`, imp-tests, ~4 min) when
+# the diff touches what every module links, or with IMP_PRECOMMIT_FULL=1.
+# Skip a single commit with:  git commit --no-verify
 set -uo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
@@ -65,5 +67,40 @@ if [ -x "$ROOT/scripts/require_free_gpu.sh" ]; then
     "$ROOT/scripts/require_free_gpu.sh" "pre-commit (Stage 1 / GPU)" || exit 1
 fi
 
-echo "pre-commit (Stage 1 / GPU): staged source changes → make test-gpu"
-exec make -s test-gpu
+# Which test modules the staged diff can reach. The full suite (imp-tests, 224
+# tests, ~4 min after the build) runs when the diff touches what every module
+# links (core, include, the build itself) or when IMP_PRECOMMIT_FULL=1; a diff
+# confined to one subsystem runs that subsystem's modules (~30 s to 2 min).
+# A tests/ file maps to the module CMakeLists.txt lists it under. The push
+# hook still runs verify-fast on the whole tree.
+modules_for() {
+    case "$1" in
+        include/*|src/core/*|src/api/*|CMakeLists.txt|cmake/*|*.cmake) echo ALL ;;
+        tests/*) awk -v f="$1" '/imp_add_test_module\(/{m=$1; sub(/.*\(/,"",m)} index($0,f){print m; exit}' \
+                     "$ROOT/CMakeLists.txt" ;;
+        src/memory/*|src/runtime/*) echo "test-core test-kv test-e2e" ;;
+        src/compute/*) echo "test-compute test-attention test-quant test-kv test-moe-gdn" ;;
+        src/exec/*) echo "test-e2e test-moe-gdn test-compute test-attention" ;;
+        src/model/*|src/quant/*) echo "test-quant test-text test-e2e test-core" ;;
+        src/vision/*|src/lora/*|src/sampling/*) echo "test-e2e test-compute" ;;
+        tools/*) echo "test-core test-e2e" ;;
+        *) echo ALL ;;
+    esac
+}
+MODULES=""
+for f in $CHANGED; do
+    m="$(modules_for "$f")"
+    [ -z "$m" ] && m=ALL
+    MODULES="$MODULES $m"
+done
+MODULES="$(echo "$MODULES" | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')"
+if [ "${IMP_PRECOMMIT_FULL:-0}" = "1" ] || echo " $MODULES" | grep -q " ALL"; then
+    echo "pre-commit (Stage 1 / GPU): staged source changes → make test-gpu (full suite)"
+    exec make -s test-gpu
+fi
+echo "pre-commit (Stage 1 / GPU): staged source changes → make build + modules: $MODULES(IMP_PRECOMMIT_FULL=1 runs the full suite)"
+make -s build || exit 1
+for mod in $MODULES; do
+    echo "pre-commit: $mod"
+    docker run --rm --gpus all -v "$HOME/models:/models" imp:test "$mod" || exit 1
+done

--- a/scripts/pre-push.hook
+++ b/scripts/pre-push.hook
@@ -16,11 +16,16 @@
 #       gate that fires on a server-handler edit reports the box, not the change.
 #
 #   paired A/B (make verify-ab, AUDIT_arch_2026 H-3)
-#       runs after the perf gate on the same diffs. The single arm above cannot
-#       resolve a delta smaller than the host's own between-session movement
-#       (4-6 % on one tree, threshold 8 %); the paired arm alternates origin/main
-#       (imp:ab-<sha>, built once per sha) against imp:test in one session and
-#       judges the mean paired decode delta. IMP_SKIP_AB=1 skips it.
+#       replaces the single-arm perf gate on kernel diffs (src/compute, src/exec).
+#       The single arm cannot resolve a delta smaller than the host's own
+#       between-session movement (4-8 % on one tree, threshold 8 %); the paired
+#       arm alternates origin/main (imp:ab-<sha>, built once per sha) against
+#       imp:test in one session and judges the mean paired decode delta (2 %).
+#       IMP_SKIP_AB=1 falls back to the single-arm gate. Costs ~5 min, which is
+#       why the other measured paths keep the single arm.
+#
+#   docker build runs once per tree: `make build` skips when imp:test already
+#       carries the tree fingerprint (scripts/build_image.sh, label imp.tree).
 #
 #   roofline (tools/roofline/, per-kernel %-of-peak) has no automated arm: CI
 #       has no GPU runner and roofline.yml only re-parses committed history. A
@@ -138,14 +143,19 @@ if [ "$NEEDS_ROOFLINE" -eq 1 ] && [ -s "$ROOT/tools/roofline/history/index.jsonl
 fi
 
 if [ "$NEEDS_PERF" -eq 1 ]; then
-    echo "pre-push: source changes touch the measured paths → make verify-fast (with perf gate)"
-    make -s verify-fast || exit 1
-    if [ "${IMP_SKIP_AB:-0}" = "1" ]; then
-        echo "pre-push: paired A/B skipped (IMP_SKIP_AB=1)"
-        exit 0
+    # Kernel paths get the paired A/B (2 % against origin/main, ~5 min) and
+    # skip the single-arm perf gate, which cannot resolve below the host's own
+    # 4-8 % session drift (263 vs 286 tok/s on one tree, 2026-09-10). The
+    # other measured paths (runtime, model, quant, cmake) keep the single-arm
+    # gate: their changes move a number rarely, and the A/B would cost every
+    # push 5 min for it.
+    if [ "$NEEDS_ROOFLINE" -eq 1 ] && [ "${IMP_SKIP_AB:-0}" != "1" ]; then
+        echo "pre-push: kernel paths changed → make verify-fast (correctness) + paired A/B (make verify-ab)"
+        IMP_VERIFY_SKIP_PERF=1 make -s verify-fast || exit 1
+        exec make -s verify-ab
     fi
-    echo "pre-push: paired A/B against origin/main → make verify-ab"
-    exec make -s verify-ab
+    echo "pre-push: source changes touch the measured paths → make verify-fast (with perf gate)"
+    exec make -s verify-fast
 fi
 
 echo "pre-push: source changes outside the measured paths → make verify-fast (no perf gate)"

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,8 +66,11 @@ GPU correctness cannot run in CI (no GPU runner), so the suite is gated in
 stages — install the hooks with `make install-hooks`:
 
 - **Stage 1 — pre-commit (GPU), local.** `scripts/pre-commit.hook` runs
-  `make test-gpu` (the full GTest suite, which includes the CPU binaries too)
-  when staged changes touch `src/ include/ tools/ tests/ CMakeLists/ *.cmake`.
+  `make build` (skipped when `imp:test` already carries the tree) and the test
+  modules the staged diff reaches; the full `make test-gpu` (every binary) when
+  the diff touches `include/ src/core src/api CMakeLists *.cmake` or with
+  `IMP_PRECOMMIT_FULL=1`. It fires when staged changes touch
+  `src/ include/ tools/ tests/ CMakeLists/ *.cmake`.
   This is where the kernel oracles below are actually gated. (`pre-push` keeps
   the `make verify-fast` perf + peak-VRAM + smoke regression gate — the VRAM gate
   is the one that fails on a memory regression with flat throughput; it needs `jq`


### PR DESCRIPTION
## One docker build per tree

- `scripts/build_image.sh` labels `imp:test` with `imp.tree` (sha of the index tree plus the build args), only when the working tree equals the index (no unstaged change to a tracked file, no untracked non-ignored file); `make build` skips when the label matches, `IMP_FORCE_BUILD=1` builds anyway. A dirty tree builds unlabelled, as before.
- Every hook stage reaches `make build` (`test-gpu`, `verify-fast`, `verify-ab`); before this each of them rebuilt the same tree.

| `make build` on one tree | before | after |
|---|---|---|
| first call | 3.5 min | 5m21s (this run, with a label) |
| second call | 3.5 min | 0.3 s |

## Pre-commit runs the modules the diff reaches

- `modules_for` in `scripts/pre-commit.hook`: `src/memory|runtime` -> test-core test-kv test-e2e; `src/compute` -> test-compute test-attention test-quant test-kv test-moe-gdn; `src/exec` -> test-e2e test-moe-gdn test-compute test-attention; `src/model|quant` -> test-quant test-text test-e2e test-core; `src/vision|lora|sampling` -> test-e2e test-compute; `tools/` -> test-core test-e2e; a `tests/` file -> the module `CMakeLists.txt` lists it under (checked: `test_kv_cache_gpu.cpp` -> test-kv, `test_scheduler.cpp` -> test-e2e, `test_ssm.cu` -> test-moe-gdn).
- Full `make test-gpu` (224 tests, ~4 min after the build) on `include/ src/core src/api CMakeLists.txt cmake/` changes, on anything unmapped, or with `IMP_PRECOMMIT_FULL=1`.
- The KEEP/DROP filter lines are unchanged; `check_precommit_filter.sh` still parses them (22 pre-commit cases).

## Pre-push: paired A/B replaces the single-arm perf gate on kernel diffs

- `src/compute` or `src/exec` in the diff: `verify-fast` with `IMP_VERIFY_SKIP_PERF=1` (correctness, VRAM, graphs) then `make verify-ab` (2 % paired against `origin/main`). `IMP_SKIP_AB=1` falls back to the single arm.
- Other `PERF_RE` paths keep the single-arm gate. The single arm read 263.47 tok/s (-8.26 %, red) and 273.54 tok/s (-4.75 %) on one tree in one evening while the paired A/B read +0.63 % (#1981).

Measured before on one tree: a commit cost ~7 min (build + full suite), a push ~10 min (build + verify-fast + A/B).

## Gate

```
check_precommit_filter: 22 pre-commit case(s), 5 pre-push case(s), 7 scripts/*.sh case(s), installed hooks current
ctest -L unit: 100% tests passed, 0 tests failed out of 13
ci-static-gates (docs citations hygiene filesize lanes entrypoint): all selected gates passed
```

Not in here: a fingerprint for a dirty tree (it builds, as before); the module map is by directory, a cross-module effect that only a module outside the map catches is on `verify-fast` in the push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
