### PR TITLE
fix(server): cached_tokens present on a miss, /tokenize takes prompt as an alias of content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ there instead of retelling it.
 - Local gates run once per tree: `make build` skips when `imp:test` already carries the tree fingerprint (label `imp.tree`, `scripts/build_image.sh`, 3.5 min per skipped build), the pre-commit hook runs only the test modules the staged diff reaches (full suite on core/include/build changes or `IMP_PRECOMMIT_FULL=1`), and the pre-push hook runs the paired A/B instead of the single-arm perf gate on kernel diffs. Measured before: a commit cost ~7 min and a push ~10 min for one tree.
 - VRAM is committed on demand for the slot-shaped pools (`vram.lazy_commit`, default on): the SSM/GDN state slab reserves every slot at init and commits one per admitted sequence (scheduler admission gate), the engine arena commits as tenants take, so the Qwen3-VL tower lands on the first image instead of at load. The plan still charges every byte; the KV growth cap subtracts what lazy pools have charged but not committed (`vram_reserved_uncommitted_bytes`). Commits inside a reservation count as `planned_serving_commits()`, no longer as I2 violations. `kv_cache.growable_initial_pct` default 100 -> 25. Qwen3.8-27B-NVFP4 idle after warmup 30053 -> 25455 MiB, first image +0.9 s once, burst of 28 unchanged (`docs/internals/MEMORY.md` B0, lazy pools).
 
+### Fixed
+- `usage.prompt_tokens_details.cached_tokens` is present on a prefix-cache miss too (0, the OpenAI shape) on `/v1/chat/completions` and `/v1/completions`: a client probing once at startup read the absent field as "not reported" (#1980). `/tokenize` takes `prompt` (vLLM) as an alias of `content` (llama.cpp) instead of a 400 that made clients fall back to length estimates (#1980).
+
 ## [0.39.0] - 2026-09-10
 
 ### Added

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,7 +27,7 @@ all of them at once.
 | `POST /v1/responses` | ✅ | OpenAI Responses, the dialect Codex and the Agents SDK speak by default |
 | `POST /v1/embeddings` | ✅ | needs an embedding model loaded |
 | `POST /v1/rerank`, `POST /rerank` | ✅ | Cohere/Jina/vLLM shape |
-| `POST /tokenize`, `POST /detokenize` | ✅ | |
+| `POST /tokenize`, `POST /detokenize` | ✅ | `/tokenize` takes `content` (llama.cpp) or `prompt` (vLLM) |
 | `GET /v1/models` | ✅ | loaded model plus the rest of the directory, each with `loaded: true|false` |
 | `GET /health`, `/metrics`, `/props`, `/info` | ✅ | `/props` is the llama.cpp shape, `/info` the TGI one |
 | `POST /admin/suspend`, `/admin/resume` | ✅ | see [`DEPLOYMENT.md`](DEPLOYMENT.md) |

--- a/tests/api/mock_server.py
+++ b/tests/api/mock_server.py
@@ -467,6 +467,8 @@ class MockHandler(BaseHTTPRequestHandler):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": completion_tokens * n_choices,
                 "total_tokens": prompt_tokens + completion_tokens * n_choices,
+                # Mirrors the server: cached_tokens is present on a miss (0), #1980.
+                "prompt_tokens_details": {"cached_tokens": 0},
             }
             if reasoning_tokens:
                 usage["completion_tokens_details"] = {
@@ -565,6 +567,7 @@ class MockHandler(BaseHTTPRequestHandler):
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,
                     "total_tokens": prompt_tokens + completion_tokens,
+                    "prompt_tokens_details": {"cached_tokens": 0},
                 },
             }
             if reasoning_tokens:
@@ -651,6 +654,7 @@ class MockHandler(BaseHTTPRequestHandler):
                 "prompt_tokens": prompt_tokens,
                 "completion_tokens": len(tokens),
                 "total_tokens": prompt_tokens + len(tokens),
+                "prompt_tokens_details": {"cached_tokens": 0},
             },
         })
 
@@ -658,7 +662,11 @@ class MockHandler(BaseHTTPRequestHandler):
         body = self._parse_json_body(raw)
         if body is None:
             return
-        text = body.get("content", body.get("text", ""))
+        # `content` (llama.cpp) or `prompt` (vLLM), as the server takes them (#1980).
+        text = body.get("content") or body.get("prompt") or ""
+        if not isinstance(text, str) or not text:
+            self._send_error(400, "\"content\" (or its alias \"prompt\") is required")
+            return
         # Mock: 1 token per 4 chars
         n_tokens = max(1, len(text) // 4)
         tokens = list(range(100, 100 + n_tokens))

--- a/tests/api/test_chat.py
+++ b/tests/api/test_chat.py
@@ -31,6 +31,9 @@ def test_basic_response_shape(client, model):
     assert body["usage"]["total_tokens"] == (
         body["usage"]["prompt_tokens"] + body["usage"]["completion_tokens"]
     )
+    # #1980: present on a miss too (0), the OpenAI shape a startup probe reads.
+    cached = body["usage"]["prompt_tokens_details"]["cached_tokens"]
+    assert isinstance(cached, int) and 0 <= cached <= body["usage"]["prompt_tokens"]
 
 
 def test_system_message(client, model):
@@ -260,3 +263,14 @@ class TestSpeculativeDecoding:
             f"  off: {off_text[:160]!r}\n"
             f"  on : {on_text[:160]!r}"
         )
+
+
+def test_tokenize_takes_content_or_prompt(client, model):
+    """/tokenize: `content` (llama.cpp) and `prompt` (vLLM) are the same field (#1980)."""
+    a = client.post("/tokenize", json={"model": model, "content": "hallo welt"})
+    b = client.post("/tokenize", json={"model": model, "prompt": "hallo welt"})
+    assert a.status_code == 200 and b.status_code == 200
+    assert a.json()["tokens"] == b.json()["tokens"]
+    assert len(a.json()["tokens"]) > 0
+    r = client.post("/tokenize", json={"model": model})
+    assert r.status_code == 400

--- a/tests/test_server_robustness.py
+++ b/tests/test_server_robustness.py
@@ -274,6 +274,7 @@ def main():
     check_valid("/v1/completions valid", "/v1/completions", {"model": M, "prompt": "Say PONG", "max_tokens": 8})
     check_valid("/v1/embeddings valid", "/v1/embeddings", {"model": M, "input": "hello"})
     check_valid("/tokenize valid", "/tokenize", {"model": M, "content": "hello world"})
+    check_valid("/tokenize valid (prompt alias)", "/tokenize", {"model": M, "prompt": "hello world"})
     check_valid("/detokenize valid", "/detokenize", {"model": M, "tokens": [9707, 1879]})
 
     print()

--- a/tools/imp-server/handlers_chat.cpp
+++ b/tools/imp-server/handlers_chat.cpp
@@ -428,6 +428,9 @@ void stream_completion_response_(httplib::Response& res, ServerState& state, con
                                    {{"prompt_tokens", n_prompt_tokens},
                                     {"completion_tokens", n_output_tokens},
                                     {"total_tokens", n_prompt_tokens + n_output_tokens}}}};
+                if (json details = prompt_tokens_details_(server_req->request, n_prompt_tokens);
+                    !details.is_null())
+                    usage_obj["usage"]["prompt_tokens_details"] = std::move(details);
                 add_spec_usage_(usage_obj["usage"], server_req->request);
                 std::string usage_chunk = "data: " + dump_safe(usage_obj) + "\n\n";
                 sink.write(usage_chunk.data(), usage_chunk.size());
@@ -602,6 +605,8 @@ void nonstream_completion_response_(httplib::Response& res, ServerState& state, 
                       {{"prompt_tokens", n_prompt_tokens},
                        {"completion_tokens", n_output_tokens},
                        {"total_tokens", n_prompt_tokens + n_output_tokens}}}};
+    if (json details = prompt_tokens_details_(active_req, n_prompt_tokens); !details.is_null())
+        response["usage"]["prompt_tokens_details"] = std::move(details);
     add_spec_usage_(response["usage"], active_req);
 
     res.set_content(dump_safe(response), "application/json");

--- a/tools/imp-server/handlers_internal.h
+++ b/tools/imp-server/handlers_internal.h
@@ -18,6 +18,7 @@
 #include "runtime/spec_request.h"
 #include "memory/kv_cache.h"
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -325,17 +326,16 @@ inline SpecFieldParse parse_spec_field_(const nlohmann::json& body, int armed_mt
 inline nlohmann::json prompt_tokens_details_(const std::shared_ptr<imp::Request>& req, int n_prompt_tokens) {
     if (!req)
         return nlohmann::json();
-    nlohmann::json details = nlohmann::json::object();
+    // cached_tokens is always present, 0 on a miss: OpenAI sends the field with
+    // 0 and a client probing once at startup reads "absent" as "unsupported" (#1980).
+    nlohmann::json details = {{"cached_tokens", std::max(0, req->cached_tokens)}};
     if (req->cached_tokens > 0 || req->pin_kv_prefix) {
-        details["cached_tokens"] = req->cached_tokens;
         const int creation = cache_creation_tokens_(req, n_prompt_tokens);
         if (creation > 0)
             details["cache_creation_tokens"] = creation;
     }
     if (req->evicted_kv_tokens > 0)
         details["evicted_tokens"] = req->evicted_kv_tokens;
-    if (details.empty())
-        return nlohmann::json();
     return details;
 }
 

--- a/tools/imp-server/handlers_misc.cpp
+++ b/tools/imp-server/handlers_misc.cpp
@@ -39,10 +39,16 @@ void handle_tokenize(const httplib::Request& req, httplib::Response& res, Server
         return;
     }
 
+    // `content` is the llama.cpp spelling, `prompt` the vLLM one; a client written
+    // against either gets the exact count instead of a 400 and a length estimate (#1980).
     std::string content = body.value("content", "");
+    if (content.empty())
+        content = body.value("prompt", "");
     if (content.empty()) {
         res.status = 400;
-        json err = {{"error", {{"message", "\"content\" is required"}, {"type", "invalid_request_error"}}}};
+        json err = {{"error",
+                     {{"message", "\"content\" (or its alias \"prompt\") is required"},
+                      {"type", "invalid_request_error"}}}};
         res.set_content(dump_safe(err), "application/json");
         return;
     }


### PR DESCRIPTION
Closes #1980.

## `usage.prompt_tokens_details.cached_tokens` on a miss

- `prompt_tokens_details_` (`tools/imp-server/handlers_internal.h`) always emits `cached_tokens` (0 on a miss); `cache_creation_tokens` and `evicted_tokens` stay conditional.
- `/v1/completions` (non-stream and the usage chunk) now carries the object too; it never did.
- Anthropic and Responses shims already read `.value("cached_tokens", 0)`: no change downstream.
- Mock server mirrors the shape on all three OpenAI usage sites; `tests/api/test_chat.py` asserts the field on a cold request.

| route | before (miss) | after (miss) |
|---|---|---|
| `/v1/chat/completions` | field absent | `{"cached_tokens":0}` |
| `/v1/chat/completions` stream usage chunk | field absent | `{"cached_tokens":0}` |
| `/v1/completions` | field absent, also on a hit | `{"cached_tokens":0}` |

## `/tokenize` takes `prompt`

- `content` (llama.cpp) or `prompt` (vLLM); the 400 names both. Wrong type stays a 400 through the exception handler.
- `tests/api/test_chat.py::test_tokenize_takes_content_or_prompt` (mock + real lanes), `tests/test_server_robustness.py` valid-control row.
- `docs/API.md` endpoint row.

## Gate

Dev binary, Qwen3-4B-Instruct-2507-Q8_0.gguf, `server.prefix_cache=true`, RTX 5090:

```
== chat 1 (miss)
{"completion_tokens":4,"prompt_tokens":609,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":613}
== chat 2 (hit)
{"completion_tokens":4,"prompt_tokens":609,"prompt_tokens_details":{"cached_tokens":608},"total_tokens":613}
== stream usage
"usage":{"completion_tokens":4,"prompt_tokens":609,"prompt_tokens_details":{"cached_tokens":608},"total_tokens":613}
== completions
{"completion_tokens":2,"prompt_tokens":3,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":5}
== messages
{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":11,"output_tokens":2}
== tokenize content
{"tokens":[11866,385,77748]}
== tokenize prompt
{"tokens":[11866,385,77748]}
== tokenize none
{"error":{"message":"\"content\" (or its alias \"prompt\") is required","type":"invalid_request_error"}} [400]
== tokenize wrong type
{"error":{"message":"[json.exception.type_error.302] type must be string, but is number","type":"invalid_request_error"}} [400]
```

Mock battery: `126 passed, 89 skipped, 9 deselected`.

Not in here: `/v1/tokenize` (vLLM has none either, the route is `/tokenize`), `messages` on `/tokenize` (would render the chat template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
