### PR TITLE
fix(server): /v1/models, /props, /info advertise a growable KV pool's ceiling, not its commit; pre-commit hook runs modules by absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ there instead of retelling it.
 
 ## [Unreleased]
 
+### Fixed
+- `/v1/models` (`max_model_len`, `meta.n_ctx_train`), `/props` and `/info` advertise a growable KV pool's ceiling instead of its current commit. Since `kv_cache.growable_initial_pct` defaulted to 25 (v0.40.0) Qwen3.8-27B-NVFP4 came up at 875 of 13264 blocks and advertised 14000 tokens (v0.39.0: 56976) while a 16860-token prompt was served after one growth; now 131072, the resolver's `max_seq_len`. `/health` `kv_capacity_tokens` still reports the commit, `kv_ceiling_blocks` the ceiling.
+- `scripts/pre-commit.hook` runs a test module by absolute path: since #1982 it exec'd a bare `test-e2e`, and the gtest threadsafe death test `DeviceFaultSignalTest` re-execs argv[0] with `execv` (no PATH search) and failed every pre-commit that reached it.
+
 ## [0.40.1] - 2026-09-11
 
 ### Changed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -347,7 +347,12 @@ llama.cpp's `n_ctx` (top-level and under `default_generation_settings`),
 report what the KV pool can actually hold: the resolver's `max_seq_len` is a
 plan, the pool is clamped after it, and on a tight card the two differ (97204
 against 52256 on Qwen3.8-27B-NVFP4). The probes report the smaller of the two
-since #1542; `/health`'s `kv_capacity_tokens` was always the real number.
+since #1542. A growable pool (`kv_cache.growable`, default on) counts by its
+ceiling, not by what it has committed so far: at start it holds
+`kv_cache.growable_initial_pct` (25 %) of the plan and grows at admission
+(Qwen3.8-27B-NVFP4: 875 of 13264 blocks committed, 131072 advertised).
+`/health` reports both, `kv_capacity_tokens` for the commit and
+`kv_ceiling_blocks` for the ceiling.
 
 Server-only flags (not on `imp-cli`):
 

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -102,5 +102,7 @@ echo "pre-commit (Stage 1 / GPU): staged source changes → make build + modules
 make -s build || exit 1
 for mod in $MODULES; do
     echo "pre-commit: $mod"
-    docker run --rm --gpus all -v "$HOME/models:/models" imp:test "$mod" || exit 1
+    # Absolute path: gtest threadsafe death tests re-exec argv[0] with execv
+    # (no PATH search); a bare "test-e2e" fails DeviceFaultSignalTest.
+    docker run --rm --gpus all -v "$HOME/models:/models" imp:test "/usr/local/bin/$mod" || exit 1
 done

--- a/tests/test_server_request_limits.cpp
+++ b/tests/test_server_request_limits.cpp
@@ -271,6 +271,24 @@ TEST(ServableContext, UnknownCapacityLeavesThePlanAlone) {
     EXPECT_EQ(servable_context_tokens(8192, 0), 8192);
 }
 
+// A growable pool advertises its ceiling, not the 25 % it committed at start:
+// Qwen3.8-27B-NVFP4 on v0.40.0 came up at 875 of 13264 blocks and /v1/models
+// said 14000 tokens while a 16860-token prompt was served after one growth.
+TEST(ServableContext, GrowablePoolAdvertisesItsCeiling) {
+    EXPECT_EQ(kv_capacity_ceiling_tokens(875, 13264, 16), 13264LL * 16);
+    EXPECT_EQ(servable_context_tokens(131072, kv_capacity_ceiling_tokens(875, 13264, 16)), 131072);
+}
+
+// A fixed pool has ceiling == total; a rescue-floor pool that cannot grow keeps
+// reporting the floor (#1542 still holds there).
+TEST(ServableContext, FixedPoolAdvertisesWhatItHolds) {
+    EXPECT_EQ(kv_capacity_ceiling_tokens(3266, 3266, 16), 3266LL * 16);
+    EXPECT_EQ(kv_capacity_ceiling_tokens(16, 16, 32), 512);
+    EXPECT_EQ(servable_context_tokens(131072, kv_capacity_ceiling_tokens(16, 16, 32)), 512);
+    // ceiling below total never happens; the larger of the two is what it holds.
+    EXPECT_EQ(kv_capacity_ceiling_tokens(100, 0, 16), 1600);
+}
+
 // ---------------------------------------------------------------------------
 // Latency histogram ladders (#1577)
 // ---------------------------------------------------------------------------

--- a/tools/imp-server/handlers.cpp
+++ b/tools/imp-server/handlers.cpp
@@ -251,6 +251,8 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
     // differ by a lot - 97204 against 52256 on Qwen3.8-27B-NVFP4, so a prompt
     // between them was advertised as servable and was not (#1542). /health has
     // reported the real number all along; /v1/models reported the plan.
+    // A growable pool holds its ceiling, not its current commit: the scheduler
+    // grows it at admission (kv_capacity_ceiling_tokens).
     long long kv_capacity_tokens = -1;
     {
         std::unique_lock<std::timed_mutex> lock(state.mtx, kObservabilityLockTimeout);
@@ -260,7 +262,8 @@ void handle_models(const httplib::Request& /*req*/, httplib::Response& res, Serv
             max_seq_len = state.max_seq_len;
             if (state.ctx && state.ctx->engine) {
                 if (const auto* kv = state.ctx->engine->kv_cache())
-                    kv_capacity_tokens = static_cast<long long>(kv->total_blocks()) * kv->block_size();
+                    kv_capacity_tokens = kv_capacity_ceiling_tokens(kv->total_blocks(), kv->ceiling_blocks(),
+                                                                    kv->block_size());
             }
         } else {
             ServerState::ObsStatus snap = state.model_status_snapshot();
@@ -392,7 +395,8 @@ static void snapshot_ctx(ServerState& state, bool& loaded, std::string& model_na
         model_name = state.model_name;
         if (state.ctx && state.ctx->engine) {
             if (const auto* kv = state.ctx->engine->kv_cache())
-                kv_capacity_tokens = static_cast<long long>(kv->total_blocks()) * kv->block_size();
+                kv_capacity_tokens = kv_capacity_ceiling_tokens(kv->total_blocks(), kv->ceiling_blocks(),
+                                                                kv->block_size());
         }
     } else {
         ServerState::ObsStatus snap = state.model_status_snapshot();

--- a/tools/imp-server/utils.cpp
+++ b/tools/imp-server/utils.cpp
@@ -179,6 +179,10 @@ int servable_context_tokens(int planned_max_seq_len, long long kv_capacity_token
     return static_cast<int>(kv_capacity_tokens);
 }
 
+long long kv_capacity_ceiling_tokens(int total_blocks, int ceiling_blocks, int block_size) {
+    return static_cast<long long>(std::max(total_blocks, ceiling_blocks)) * block_size;
+}
+
 bool is_anthropic_path(const std::string& path) { return path.rfind("/v1/messages", 0) == 0; }
 
 void send_anthropic_error(httplib::Response& res, int status, const char* type, const std::string& message,

--- a/tools/imp-server/utils.h
+++ b/tools/imp-server/utils.h
@@ -130,6 +130,13 @@ bool prompt_within_input_budget(httplib::Response& res, size_t bytes, int max_in
 // kv_capacity_tokens <= 0 means "unknown", and the plan stands.
 int servable_context_tokens(int planned_max_seq_len, long long kv_capacity_tokens);
 
+// The capacity a growable pool may reach, in tokens: the ceiling, not what is
+// committed right now. Since kv_cache.growable_initial_pct defaulted to 25 the
+// committed count is a moving floor (875 of a 13264-block ceiling on
+// Qwen3.8-27B-NVFP4, 14000 tokens advertised for a pool that served a
+// 16860-token prompt after one growth). A fixed pool has ceiling == total.
+long long kv_capacity_ceiling_tokens(int total_blocks, int ceiling_blocks, int block_size);
+
 // True for the endpoints that speak the Anthropic dialect, whose errors have a
 // different envelope: `{"type":"error","error":{...}}` rather than
 // `{"error":{...}}`. Four call sites in main.cpp used to spell this test out


### PR DESCRIPTION
## /v1/models, /props, /info advertise the KV ceiling

- Since `kv_cache.growable_initial_pct` defaulted to 25 (v0.40.0) a growable pool starts at a quarter of the plan and grows at admission; the three endpoints multiplied `total_blocks()` by `block_size()` and advertised the commit.
- New `kv_capacity_ceiling_tokens(total, ceiling, block_size)` = `max(total, ceiling) * block_size` in `tools/imp-server/utils.cpp`; a fixed or rescue-floor pool has `ceiling == total` and keeps reporting what it holds (#1542 still holds there).
- `/health` unchanged: `kv_capacity_tokens` is the commit, `kv_ceiling_blocks` the ceiling.
- Tests: `ServableContext.GrowablePoolAdvertisesItsCeiling`, `ServableContext.FixedPoolAdvertisesWhatItHolds` in `tests/test_server_request_limits.cpp`. Docs: `docs/usage.md`, CHANGELOG.

| Qwen3.8-27B-NVFP4, v0.40.x defaults | before | after |
|---|---|---|
| committed / ceiling blocks at start | 875 / 13264 | 875 / 13264 |
| `/v1/models` `max_model_len` | 14000 | 131072 |
| 16860-token prompt | served after one growth | served after one growth |

## pre-commit hook: test module by absolute path

- Since #1982 the hook ran `imp:test "$mod"`; the entrypoint execs a bare `test-e2e`, argv[0] has no directory, and the gtest threadsafe death test `DeviceFaultSignalTest.FaultInsideAStepCancelsFaultsAndRefusesLaterRequests` re-execs argv[0] with `execv` (no PATH search): `execv(test-e2e, ...) in /home/imp failed: No such file or directory`, signal 6.
- `imp-tests` (what `make test-e2e` runs) calls `$DIR/$bin`, which is why the Makefile lane was green. The hook now runs `/usr/local/bin/$mod`; this PR's own pre-commit run is the check.

## Gate

`git push` pre-push hook, `make verify-fast` (perf gate skipped: no measured path touched):

```
PASS fast gtest filter
== perf vs baseline ==
  pin: 2026-07-26T01:48:33Z (47 days old), model Qwen3-8B-Q8_0.gguf
SKIP perf gate (IMP_VERIFY_SKIP_PERF=1)
== peak VRAM vs baseline ==
  own peak VRAM = 20706 MiB  (baseline 20716, delta -0.05%)
PASS peak VRAM within 10% of baseline
== graphs ON vs OFF decode gate ==
  graphs OFF tg256 =  210.26 tok/s
  graphs ON  tg256 =  467.27 tok/s   (2.22x, threshold 1.3x)
PASS graphs ON delivers ≥1.3x decode speedup
== smoke prompts (degeneration check) ==
PASS Qwen3-4B Q8_0 (dense) (distinct=18/32 need 8, tokens=64, max-run=1, 3gram=4 repeat=37%, contains 'Paris')
```

Not in here: no change to pool growth, admission or `/health`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZdQMdA51ndDvwXH2Wo8RN
