### PR TITLE
hooks: tools/ diffs run test-e2e only for batching_engine

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -83,7 +83,8 @@ modules_for() {
         src/exec/*) echo "test-e2e test-moe-gdn test-compute test-attention" ;;
         src/model/*|src/quant/*) echo "test-quant test-text test-e2e test-core" ;;
         src/vision/*|src/lora/*|src/sampling/*) echo "test-e2e test-compute" ;;
-        tools/*) echo "test-core test-e2e" ;;
+        tools/imp-server/batching_engine.*) echo "test-core test-e2e" ;;
+        tools/*) echo "test-core" ;;
         *) echo ALL ;;
     esac
 }


### PR DESCRIPTION
## What

`modules_for` in `scripts/pre-commit.hook`: `tools/*` mapped to `test-core test-e2e`. test-e2e links exactly one tools/ source (`tools/imp-server/batching_engine.cpp`, `CMakeLists.txt` test-e2e block); test-core links the rest (`tools/imp-server/*.cpp`, `tools/common/*`, `tools/imp-cli/args.cpp`, `tools/imp-quantize/*`).

New rule:

| Staged file | Modules |
|---|---|
| `tools/imp-server/batching_engine.*` | test-core test-e2e |
| other `tools/*` | test-core |

## Why

Pre-commit of the second #1990 commit (`tools/imp-server/utils.cpp` + `tests/test_sse_stream_utils.cpp`, 2026-09-11 18:46): test-e2e 316 s for a change no e2e test can observe.

## Checks

- `scripts/check_precommit_filter.sh`: 22 pre-commit cases, green
- `make install-hooks` done; no `.git/hooks` edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L8bf3qGhGMvruDSQZqjZb
