### PR TITLE
perf(gdn): carry the verify's drafted row as (g, k, delta), not a second state slot

### DIFF
--- a/docs/plans/2026-09-12-factored-verify-spare.md
+++ b/docs/plans/2026-09-12-factored-verify-spare.md
@@ -1,0 +1,111 @@
+<!--
+layer: L2
+audience: kernel-devs
+verified: 2026-09-12
+commit: d28a5d48
+-->
+
+# Factored spare state for the batched speculative verify
+
+## The price being paid
+
+`speculative.batch_verify` reserves one spare recurrent slot per batch slot, held for a
+request's lifetime because accept swaps slots instead of copying
+(`engine_spec_batch_verify.cpp`). The spare is an exact duplicate of the state pool.
+Qwen3.8-27B-NVFP4-vllm at `runtime.max_batch_size=32`, measured 2026-09-12:
+
+| `speculative.batch_verify` | SSM/GDN state | KV pool | batch |
+|---|---:|---:|---:|
+| off | 2544 MiB (32 slots) | 2339 blocks, `max_model_len` 131 072 | 32 |
+| on | 5088 MiB (32 slots) | 1429 blocks, `max_model_len` 33 680 | clamped to 18 |
+
+79.5 MiB per slot, of which 72 MiB is the recurrent `h_state` and the rest the conv window.
+The clamp lands in the regime where the verify is already a loss (32 streams
+1966 -> 1159 tok/s, [2026-09-11-batched-mtp-verify.md](2026-09-11-batched-mtp-verify.md)).
+
+## Why a triple is enough
+
+The delta rule's per-token update in `gdn_scan_fused_kernel` is a scalar decay plus a rank-1
+outer product:
+
+    H_new[s][d] = g * H[s][d] + k[s] * delta[d]
+
+`g` is per head, `k` the L2-normalised key (`state_size`), `delta = (v - g * H^T k) * beta`
+(`head_dim`). So the state after the drafted row is fully determined by the state before it
+plus `(g, k, delta)`: `1 + state_size + head_dim` floats per head against
+`state_size * head_dim`. On this model (48 value heads, SS = HD = 128, 48 GDN layers) that is
+48 KiB per layer against 1.5 MiB, and 2.3 MiB per slot against 72 MiB.
+
+Same direction as TreeWY (arXiv 2608.20961) and Bole (arXiv 2608.01651), which report 82-99x
+lower transient state memory for tree verification on linear-attention models. The rank-1 form
+here is read off imp's own kernel, not ported.
+
+## Where the work lands
+
+`compute/gdn_factor.cuh` holds the layout and the two device helpers. Per (slot, head):
+
+    [0]                      g, and EXACTLY 0 is the "no pending row" sentinel - g is
+                             expf(fmaxf(A*dt, -20)) and cannot reach 0, so no side array
+    [1 .. 4)                 padding, keeps k 16-byte aligned
+    [4 + s]                  k[s], state_size of them
+    [4 + SS + d]             delta[d], head_dim of them
+
+`gdn_scan_fused_kernel` gained three optional parameters. `fac_out` receives the row for
+`real_n` **instead of** the full state copy `out_slots` used to take; `fac_in` carries a
+pending row applied to `H_reg` right after the state load, before any token is processed, so
+applying it costs no extra state traffic at all - the next step reads and writes the state
+regardless. Rows are indexed by the recurrent **slot**, not the batch position: a request keeps
+its slot across steps but moves within the batch.
+
+Invariant the kernel enforces: with `fac_out` set, the row is always defined. A row is written
+only when there is a drafted row past the snapshot (`snap_n >= 1 && real_n > snap_n`);
+otherwise the full state goes to `h_out` as before and `g` is set to the 0 sentinel, so a stale
+row from an earlier step cannot survive to be applied twice.
+
+## Status
+
+| stage | state |
+|---|---|
+| `gdn_factor.cuh`, kernel emit + apply, F32 and BF16 launchers | built |
+| `GdnBatchedScanTest.FactoredSpareReproducesTheFullSpareAfterTheNextToken` | GREEN, bit-exact; red under a mutated delta column |
+| engine wiring: factor buffer, verify emits, accept/reject bookkeeping, next-step apply | not built |
+| drop the spare slots from `batch_verify_spare_slots` and the planner | not built |
+| conv window: carry the drafted tap instead of the full 4-tap window | not built, and a BLOCKER for dropping the slot, see below |
+| numerics: deterministic PPL, `DegenerationTest`, state diff against the full-spare arm | not built |
+
+The test is the gate on the algebra: it runs the real accept sequence both ways (full spare,
+then factored) and compares the state **after the following token**, which is what the engine
+actually consumes. F32 state makes it exact, so it carries no tolerance - a tolerance there
+would hide a wrong `k` or `delta` index.
+
+## The conv window is a blocker, not an extra
+
+First reading had the conv window as an optional follow-up. It is not. A slot is one
+contiguous block holding every GDN layer's conv window AND `h_state`
+(`memory/ssm_state_size.h`, `ssm_bytes_per_slot`), and the spare exists because accept swaps
+whole slots. Factoring `h_state` alone leaves the drafted conv window with nowhere to live, so
+dropping the spare slot needs the conv factored too: the drafted row shifts the 4-tap window
+by one, so the carried form is the single new tap (40 KiB per layer against 160). That path
+has its own commit kernel (`ssm_conv1d_commit_kernel`) and its own race history (#1976, the
+prefill commit race), so it gets its own stage and its own test.
+
+The alternative is to keep slot-shaped spares but give the spare region a different geometry,
+which means `SsmStateCache` stops having one uniform slot stride. That is the larger change of
+the two.
+
+## Bookkeeping the wiring stage has to get right
+
+The scan self-clears in steady state: a verify step applies the row left by the previous one
+at the state load and writes a new row at the commit row, same launch. Explicit clears are
+needed exactly where that chain breaks, and each one is a way to advance a request's state by
+a token it never accepted:
+
+| event | why the row must be cleared |
+|---|---|
+| draft rejected | the next step would apply a row for a token that was not accepted |
+| request finished | same, for whatever request takes the slot next |
+| slot (re)assigned | a new request would inherit the previous tenant's row |
+| a non-verify step runs for that slot | nothing consumes the row, and it outlives its state |
+
+The 0 sentinel in `g` is what a clear writes, and the kernel already maintains "with `fac_out`
+set, the row is always defined" for the no-draft shape.

--- a/src/compute/gdn.cu
+++ b/src/compute/gdn.cu
@@ -1,4 +1,5 @@
 #include "compute/gdn_internal.cuh"
+#include "compute/gdn_factor.cuh"
 #include "core/logging.h"
 
 #include <cuda_bf16.h>
@@ -82,7 +83,14 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
     // snapshot in place (snap_slots[seq] == seq_slots[seq]): this CTA is the
     // only reader and writer of its column, and the read precedes the write.
     const int* __restrict__ out_slots = nullptr,
-    const int* __restrict__ snap_slots = nullptr) {
+    const int* __restrict__ snap_slots = nullptr,
+    // Factored spare (compute/gdn_factor.cuh): fac_in carries a pending
+    // rank-1 row applied right after the state load, fac_out receives the row
+    // for real_n instead of a second full state copy. Both [n_seq, n_heads,
+    // fac_stride]; nullptr keeps the full-state contract above.
+    float* __restrict__ fac_out = nullptr,
+    const float* __restrict__ fac_in = nullptr,
+    int fac_stride = 0) {
     const int h = blockIdx.x;
     if (h >= n_heads)
         return;
@@ -155,6 +163,12 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
         for (int s = 0; s < SS_PER; s++)
             H_reg[s] = static_cast<float>(H_col[(s_base + s) * HD]);
     }
+    // Factor rows are indexed by the recurrent SLOT, not by the batch
+    // position: a request keeps its slot across steps but moves within the
+    // batch, so indexing by seq would hand the next step another request's row.
+    const size_t fac_row = (static_cast<size_t>(seq_slots ? seq_slots[seq] : seq) * n_heads + h) *
+                           static_cast<size_t>(fac_stride);
+    gdn_factor_apply<SS_PER>(H_reg, fac_in ? fac_in + fac_row : nullptr, SS, s_base, d);
 
     // Shared memory: K_norm[SS] + Q_norm[SS] + reduce_buf[HD]
     extern __shared__ float smem[];
@@ -292,10 +306,21 @@ __global__ void __launch_bounds__(HD * SPLIT, 1) gdn_scan_fused_kernel(
         // no barrier needed). For the unpadded case real_n == n_tokens and
         // this is the single end-of-scan store the kernel always did.
         if (t + 1 == real_n) {
-            StateT* H_col = h_out + static_cast<size_t>(h) * SS * HD + d;
+            // Factored only when there IS a drafted row past the snapshot.
+            // Otherwise the row would describe the transition into the state
+            // the snapshot already holds and the next step would apply it a
+            // second time; the 0 sentinel below keeps the buffer defined so a
+            // stale row from an earlier step cannot survive either.
+            if (fac_out && snap_n >= 1 && real_n > snap_n) {
+                gdn_factor_store<SS_PER>(fac_out + fac_row, s_k, SS, s_base, d, part, g_t, delta_d);
+            } else {
+                if (fac_out && d == 0 && part == 0)
+                    fac_out[fac_row] = 0.0f;
+                StateT* H_col = h_out + static_cast<size_t>(h) * SS * HD + d;
 #pragma unroll
-            for (int s = 0; s < SS_PER; s++)
-                H_col[(s_base + s) * HD] = static_cast<StateT>(H_reg[s]);
+                for (int s = 0; s < SS_PER; s++)
+                    H_col[(s_base + s) * HD] = static_cast<StateT>(H_reg[s]);
+            }
         }
         if (t + 1 == snap_n) {
             StateT* S_col = h_snap_dst + static_cast<size_t>(h) * SS * HD + d;
@@ -383,7 +408,8 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
                                 half* y, int n_seq, int n_tokens, int n_heads, int head_dim_ssm,
                                 int state_size, int n_groups, cudaStream_t stream, int grouped_layout,
                                 const int* d_real_n, const int* seq_row_offsets, float* h_snap,
-                                const int* d_snap_n, const int* out_slots, const int* snap_slots) {
+                                const int* d_snap_n, const int* out_slots, const int* snap_slots,
+                                float* fac_out, const float* fac_in, int fac_stride) {
     if (n_seq <= 0)
         return;
     if (seq_row_offsets && d_real_n)
@@ -419,7 +445,7 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
         pdl::launch(gdn_scan_fused_kernel<128, 128, half, SPLIT>, dim3(grid), dim3(128 * SPLIT), size_t(smem), stream,
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
             conv_channels, grouped_layout, d_real_n, h_snap, d_snap_n, seq_slots, h_state_seq_stride,
-            seq_row_offsets, out_slots, snap_slots);
+            seq_row_offsets, out_slots, snap_slots, fac_out, fac_in, fac_stride);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         const size_t smem = (2 * 64 + 64) * sizeof(float);
@@ -427,7 +453,7 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
         pdl::launch(gdn_scan_fused_kernel<64, 64, half>, dim3(grid), dim3(64), size_t(smem), stream,
             conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups,
             conv_channels, grouped_layout, d_real_n, h_snap, d_snap_n, seq_slots, h_state_seq_stride,
-            seq_row_offsets, out_slots, snap_slots);
+            seq_row_offsets, out_slots, snap_slots, fac_out, fac_in, fac_stride);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         IMP_LOG_ERROR("gdn_scan_fused_f32_batched: unsupported head_dim=%d state_size=%d", head_dim_ssm,
@@ -445,7 +471,8 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
                                  int head_dim_ssm, int state_size, int n_groups, cudaStream_t stream,
                                  int grouped_layout, const int* d_real_n, const int* seq_row_offsets,
                                  __nv_bfloat16* h_snap, const int* d_snap_n, const int* out_slots,
-                                 const int* snap_slots) {
+                                 const int* snap_slots, float* fac_out, const float* fac_in,
+                                 int fac_stride) {
     if (n_seq <= 0)
         return;
     if (seq_row_offsets && d_real_n)
@@ -464,7 +491,7 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
         pdl::launch(gdn_scan_fused_kernel<128, 128, half, SPLIT, __nv_bfloat16>, dim3(grid), dim3(128 * SPLIT), size_t(smem), stream,
         conv_f32, alpha, beta, A_log, dt_bias, h_state_pool, y, n_tokens, n_heads, n_groups, conv_channels,
         grouped_layout, d_real_n, h_snap, d_snap_n, seq_slots, h_state_seq_stride, seq_row_offsets, out_slots,
-        snap_slots);
+        snap_slots, fac_out, fac_in, fac_stride);
     IMP_CUDA_CHECK_LAUNCH();
 }
 
@@ -493,13 +520,13 @@ void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* al
                     dim3(128 * kScanSplit128), size_t(kScanSmem128), stream, conv_f32, alpha, beta, A_log,
                     dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
                     static_cast<float*>(nullptr), nullptr, static_cast<const int*>(nullptr), int64_t(0),
-                    static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                    static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         pdl::enable_kernel(gdn_scan_fused_kernel<64, 64, half>);
         pdl::launch(gdn_scan_fused_kernel<64, 64, half>, dim3(n_heads), dim3(64), size_t(smem), stream, conv_f32, alpha, beta, A_log, dt_bias, h_state, y, n_tokens,
                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
-                                            static_cast<float*>(nullptr), nullptr, static_cast<const int*>(nullptr), int64_t(0), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                                            static_cast<float*>(nullptr), nullptr, static_cast<const int*>(nullptr), int64_t(0), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Fallback: per-token loop (for unsupported HD/SS sizes). The host
@@ -536,7 +563,7 @@ void gdn_scan_fused_bf16(const float* conv_f32, int conv_channels, const half* a
                 dim3(128 * kScanSplit128), size_t(kScanSmem128), stream, conv_f32, alpha, beta, A_log,
                 dt_bias, h_state, y, n_tokens, n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
                 static_cast<__nv_bfloat16*>(nullptr), nullptr, static_cast<const int*>(nullptr), int64_t(0),
-                static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
     IMP_CUDA_CHECK_LAUNCH();
 }
 
@@ -554,13 +581,13 @@ void gdn_scan_fused_fp32out(const float* conv_f32, int conv_channels, const half
                     dim3(128 * kScanSplit128), size_t(kScanSmem128), stream, conv_f32, alpha, beta, A_log,
                     dt_bias, h_state, y_fp32, n_tokens, n_heads, n_groups, conv_channels, grouped_layout,
                     d_real_n, h_snap, d_snap_n, static_cast<const int*>(nullptr), int64_t(0),
-                    static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                    static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
         IMP_CUDA_CHECK_LAUNCH();
     } else if (head_dim_ssm == 64 && state_size == 64) {
         pdl::enable_kernel(gdn_scan_fused_kernel<64, 64, float>);
         pdl::launch(gdn_scan_fused_kernel<64, 64, float>, dim3(n_heads), dim3(64), size_t(smem), stream, conv_f32, alpha, beta, A_log, dt_bias, h_state, y_fp32, n_tokens,
                                             n_heads, n_groups, conv_channels, grouped_layout, d_real_n,
-                                            h_snap, d_snap_n, static_cast<const int*>(nullptr), int64_t(0), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                                            h_snap, d_snap_n, static_cast<const int*>(nullptr), int64_t(0), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
         IMP_CUDA_CHECK_LAUNCH();
     } else {
         // Refuse, do not approximate. This branch used to run the FP16 decode
@@ -602,7 +629,7 @@ void gdn_scan_fused_fp32out_bf16(const float* conv_f32, int conv_channels, const
                 dim3(128 * kScanSplit128), size_t(kScanSmem128), stream, conv_f32, alpha, beta, A_log,
                 dt_bias, h_state, y_fp32, n_tokens, n_heads, n_groups, conv_channels, grouped_layout,
                 d_real_n, h_snap, d_snap_n, static_cast<const int*>(nullptr), int64_t(0),
-                static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr));
+                static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<const int*>(nullptr), static_cast<float*>(nullptr), static_cast<const float*>(nullptr), 0);
     IMP_CUDA_CHECK_LAUNCH();
 }
 

--- a/src/compute/gdn.h
+++ b/src/compute/gdn.h
@@ -43,7 +43,13 @@ void gdn_scan_fused_f32_batched(const float* conv_f32, int conv_channels, const 
                                 int grouped_layout = 0, const int* d_real_n = nullptr,
                                 const int* seq_row_offsets = nullptr, float* h_snap = nullptr,
                                 const int* d_snap_n = nullptr, const int* out_slots = nullptr,
-                                const int* snap_slots = nullptr);
+                                const int* snap_slots = nullptr,
+                                // Factored spare, compute/gdn_factor.cuh. fac_out receives the
+                                // rank-1 row for real_n INSTEAD of a full state copy (out_slots is
+                                // then unused); fac_in carries a pending row applied after the
+                                // state load. Both [n_seq, n_heads, fac_stride] floats.
+                                float* fac_out = nullptr, const float* fac_in = nullptr,
+                                int fac_stride = 0);
 
 void gdn_scan_fused_f32(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                         const float* A_log, const float* dt_bias, float* h_state, half* y, int n_tokens,
@@ -64,7 +70,8 @@ void gdn_scan_fused_bf16_batched(const float* conv_f32, int conv_channels, const
                                  int grouped_layout = 0, const int* d_real_n = nullptr,
                                  const int* seq_row_offsets = nullptr, __nv_bfloat16* h_snap = nullptr,
                                  const int* d_snap_n = nullptr, const int* out_slots = nullptr,
-                                 const int* snap_slots = nullptr);
+                                 const int* snap_slots = nullptr, float* fac_out = nullptr,
+                                 const float* fac_in = nullptr, int fac_stride = 0);
 void gdn_scan_fused_bf16(const float* conv_f32, int conv_channels, const half* alpha, const half* beta,
                          const float* A_log, const float* dt_bias, __nv_bfloat16* h_state, half* y,
                          int n_tokens, int n_heads, int head_dim_ssm, int state_size, int n_groups,

--- a/src/compute/gdn_factor.cuh
+++ b/src/compute/gdn_factor.cuh
@@ -1,0 +1,84 @@
+#pragma once
+
+// Factored spare state for the batched speculative verify.
+//
+// The gated delta rule's per-token state update is a scalar decay plus a
+// rank-1 outer product (gdn.cu, "Delta rule scan"):
+//
+//     H_new[s][d] = g * H[s][d] + k[s] * delta[d]
+//
+// so the state after the drafted row is fully determined by the state before
+// it plus (g, k, delta). The batched verify used to carry the drafted row as a
+// SECOND full state slot per batch slot - an exact duplicate of the pool,
+// 79.5 MiB per slot on Qwen3.8-27B, which took max_batch 32 -> 18 and the KV
+// pool 2339 -> 1429 blocks (docs/plans/2026-09-11-batched-mtp-verify.md).
+// The triple is (1 + state_size + head_dim) floats per head instead of
+// state_size * head_dim: 48 KiB against 1.5 MiB per layer on that model.
+//
+// Layout per (sequence, head), `gdn_factor_floats_per_head` floats:
+//   [0]                      g, the decay scalar. EXACTLY 0 means "no pending
+//                            update": g is expf(fmaxf(A*dt, -20)) and cannot
+//                            reach 0, so the sentinel needs no side array.
+//   [1 .. kGdnFactorPad)     padding, keeps k 16-byte aligned
+//   [kGdnFactorPad + s]      k[s], the L2-normalised key, state_size of them
+//   [kGdnFactorPad + SS + d] delta[d], head_dim of them
+
+#include <cuda_runtime.h>
+
+namespace imp {
+
+inline constexpr int kGdnFactorPad = 4;
+
+// Floats per (sequence, head) row of a factor buffer.
+inline constexpr int gdn_factor_floats_per_head(int state_size, int head_dim) {
+    return kGdnFactorPad + state_size + head_dim;
+}
+
+#ifdef __CUDACC__
+
+// Apply a pending factored row to the state column this thread owns, in
+// registers, right after the state load and before any token is processed.
+// A no-op when `fac` is null or carries the 0 sentinel, so the caller does not
+// have to know which sequences have a pending row.
+// H_reg holds SS_PER rows starting at s_base of column d; k is indexed by the
+// absolute row, delta by the column.
+template <int SS_PER>
+__device__ __forceinline__ void gdn_factor_apply(float (&H_reg)[SS_PER], const float* __restrict__ fac,
+                                                 int state_size, int s_base, int d) {
+    if (fac == nullptr)
+        return;
+    const float g = fac[0];
+    if (g == 0.0f)
+        return;
+    const float* __restrict__ k = fac + kGdnFactorPad;
+    const float delta_d = k[state_size + d];
+#pragma unroll
+    for (int s = 0; s < SS_PER; s++)
+        H_reg[s] = g * H_reg[s] + k[s_base + s] * delta_d;
+}
+
+// Write the factored row for the token just processed. Mirrors the ownership
+// the scan already has: every thread owns column d and rows
+// [s_base, s_base + SS_PER), and k is block-wide in shared memory, so the
+// d == 0 threads cover the whole of k between them and one thread writes g.
+template <int SS_PER>
+__device__ __forceinline__ void gdn_factor_store(float* __restrict__ fac, const float* __restrict__ k_smem,
+                                                 int state_size, int s_base, int d, int part, float g,
+                                                 float delta_d) {
+    if (fac == nullptr)
+        return;
+    float* __restrict__ k_out = fac + kGdnFactorPad;
+    if (part == 0)
+        k_out[state_size + d] = delta_d;
+    if (d == 0) {
+#pragma unroll
+        for (int s = 0; s < SS_PER; s++)
+            k_out[s_base + s] = k_smem[s_base + s];
+        if (part == 0)
+            fac[0] = g;
+    }
+}
+
+#endif  // __CUDACC__
+
+}  // namespace imp

--- a/src/exec/executor_ssm_gdn.cu
+++ b/src/exec/executor_ssm_gdn.cu
@@ -779,6 +779,13 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                 throw std::runtime_error("run_gdn: ragged prefill without device seq_offsets");
             const int scan_n_tokens = grouped ? state.ssm_seq_tokens : 1;  // ignored when row_offs != nullptr
             const int* real_n = grouped ? state.d_chunk_len : nullptr;
+            // Factored spare: this layer's slice of the [layer][slot][head]
+            // buffer. fac_out only on a grouped verify chunk (it replaces the
+            // full-state commit there); fac_in on any shape, because the row a
+            // verify left is applied by whatever runs next.
+            const int64_t fac_off = state.ssm_fac_layer_stride * static_cast<int64_t>(ssm_idx);
+            float* const fac_out = (grouped && state.ssm_fac_out) ? state.ssm_fac_out + fac_off : nullptr;
+            const float* const fac_in = state.ssm_fac_in ? state.ssm_fac_in + fac_off : nullptr;
             // Batched verify: per-group snapshot slots (ssm_snap_slots) replace
             // the group-0 slab; d_snap_n still names the row.
             const bool per_group_snap = grouped && state.ssm_out_slots && state.ssm_snap_slots;
@@ -862,7 +869,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                     static_cast<int64_t>(state.ssm_state->slot_stride_bytes() / sizeof(__nv_bfloat16)),
                     static_cast<half*>(y_buf.data), state.ssm_n_seq, scan_n_tokens, n_heads, head_dim_ssm,
                     ssize, n_groups, stream, gl, real_n, row_offs, static_cast<__nv_bfloat16*>(snap), snap_n,
-                    grouped ? state.ssm_out_slots : nullptr, grouped ? state.ssm_snap_slots : nullptr);
+                    grouped ? state.ssm_out_slots : nullptr, grouped ? state.ssm_snap_slots : nullptr,
+                    fac_out, fac_in, state.ssm_fac_stride);
             } else {
                 gdn_scan_fused_f32_batched(
                     conv_f32, conv_channels, static_cast<const half*>(alpha_proj_out.data),
@@ -872,7 +880,8 @@ void GraphExecutor::run_gdn(int layer, const InferenceState& state, cudaStream_t
                     static_cast<int64_t>(state.ssm_state->slot_stride_bytes() / sizeof(float)),
                     static_cast<half*>(y_buf.data), state.ssm_n_seq, scan_n_tokens, n_heads, head_dim_ssm,
                     ssize, n_groups, stream, gl, real_n, row_offs, static_cast<float*>(snap), snap_n,
-                    grouped ? state.ssm_out_slots : nullptr, grouped ? state.ssm_snap_slots : nullptr);
+                    grouped ? state.ssm_out_slots : nullptr, grouped ? state.ssm_snap_slots : nullptr,
+                    fac_out, fac_in, state.ssm_fac_stride);
             }
         } else {
             const int gl = cfg.gdn_grouped_head_layout ? 1 : 0;

--- a/src/exec/inference_state.h
+++ b/src/exec/inference_state.h
@@ -81,6 +81,17 @@ struct InferenceState {
     // above (in-place commit, group-0 snapshot into spec_snap_slab).
     const int* ssm_out_slots = nullptr;
     const int* ssm_snap_slots = nullptr;
+    // Factored spare (compute/gdn_factor.cuh, docs/plans/2026-09-12-factored-verify-spare.md).
+    // ssm_fac_out replaces ssm_out_slots: the drafted row is carried as
+    // (g, k, delta) per head instead of a second full state slot. ssm_fac_in
+    // carries the row a previous verify left for an ACCEPTED request; the scan
+    // applies it to the state it just loaded, so it costs no state traffic.
+    // Both are the base of a [n_ssm_layers][slot][head][ssm_fac_stride] float
+    // buffer; the per-layer stride is ssm_fac_layer_stride floats.
+    float* ssm_fac_out = nullptr;
+    const float* ssm_fac_in = nullptr;
+    int ssm_fac_stride = 0;
+    int64_t ssm_fac_layer_stride = 0;
 
     // BitDecoding Phase 3 residual KV cache.
     //

--- a/tests/test_gdn_batched.cu
+++ b/tests/test_gdn_batched.cu
@@ -33,6 +33,7 @@
 
 #include <gtest/gtest.h>
 #include <cuda_runtime.h>
+#include "compute/gdn_factor.cuh"
 #include <cuda_fp16.h>
 #include "compute/gdn.h"
 #include "compute/ssm.h"
@@ -851,6 +852,137 @@ TEST_F(GdnBatchedScanTest, VerifyGroupsConvCommitsToSpareAndSnapshotsInPlace) {
 
     cudaFree(d_pool); cudaFree(d_out); cudaFree(d_w); cudaFree(d_b); cudaFree(d_x);
     cudaFree(d_live); cudaFree(d_spare); cudaFree(d_lens);
+}
+
+
+// The factored spare (compute/gdn_factor.cuh). The verify carried the drafted
+// row as a second FULL state slot per batch slot - an exact duplicate of the
+// pool. The delta rule's per-token update is g*H + k (x) delta, so the row is
+// a (g, k, delta) triple instead: 48 KiB against 1.5 MiB per layer on
+// Qwen3.8-27B. What must hold is that the next step cannot tell the two apart,
+// so this runs the real accept sequence both ways and compares the state AFTER
+// the following token, not the factors themselves.
+TEST_F(GdnBatchedScanTest, FactoredSpareReproducesTheFullSpareAfterTheNextToken) {
+    const ScanShape s{/*n_seq=*/3, /*n_tokens=*/2};
+    const std::vector<int> live{4, 0, 2};
+    const std::vector<int> spare{1, 5, 3};
+    const int conv_channels = 2 * s.n_groups * s.state_size + s.n_heads * s.head_dim;
+    const int inner = s.n_heads * s.head_dim;
+    const size_t rows = static_cast<size_t>(s.n_seq) * s.n_tokens;
+    const size_t state_elems = static_cast<size_t>(s.n_heads) * s.state_size * s.head_dim;
+    const int n_slots = 6;
+    const size_t pool_elems = static_cast<size_t>(n_slots) * state_elems;
+    const int fac_stride = imp::gdn_factor_floats_per_head(s.state_size, s.head_dim);
+    // Rows are indexed by SLOT, like the state pool, so the buffer spans slots.
+    const size_t fac_elems = static_cast<size_t>(n_slots) * s.n_heads * fac_stride;
+
+    std::vector<float> h_conv(rows * conv_channels), h_alpha_f(rows * s.n_heads), h_beta_f(rows * s.n_heads);
+    std::vector<float> h_Alog(s.n_heads), h_dtb(s.n_heads), h_pool_init(pool_elems);
+    // A third token per sequence: the step that follows the accept.
+    std::vector<float> h_conv3(static_cast<size_t>(s.n_seq) * conv_channels);
+    std::vector<float> h_alpha3_f(static_cast<size_t>(s.n_seq) * s.n_heads);
+    std::vector<float> h_beta3_f(static_cast<size_t>(s.n_seq) * s.n_heads);
+    fill(h_conv, 2281);
+    fill(h_alpha_f, 4409, -2.0f, 2.0f);
+    fill(h_beta_f, 1123, -2.0f, 2.0f);
+    fill(h_Alog, 6653, -4.0f, -0.5f);
+    fill(h_dtb, 331, -1.0f, 1.0f);
+    fill(h_pool_init, 8819, -0.5f, 0.5f);
+    fill(h_conv3, 5501);
+    fill(h_alpha3_f, 7717, -2.0f, 2.0f);
+    fill(h_beta3_f, 9931, -2.0f, 2.0f);
+    auto to_half = [](const std::vector<float>& f) {
+        std::vector<half> h(f.size());
+        for (size_t i = 0; i < f.size(); i++) h[i] = __float2half(f[i]);
+        return h;
+    };
+    const std::vector<half> h_alpha = to_half(h_alpha_f), h_beta = to_half(h_beta_f);
+    const std::vector<half> h_alpha3 = to_half(h_alpha3_f), h_beta3 = to_half(h_beta3_f);
+
+    float *d_conv = nullptr, *d_conv3 = nullptr, *d_Alog = nullptr, *d_dtb = nullptr, *d_pool = nullptr;
+    float* d_fac = nullptr;
+    half *d_alpha = nullptr, *d_beta = nullptr, *d_alpha3 = nullptr, *d_beta3 = nullptr, *d_y = nullptr;
+    int *d_live = nullptr, *d_spare = nullptr, *d_lens = nullptr;
+    auto dev = [](auto** p, size_t bytes) { ASSERT_EQ(cudaMalloc(p, bytes), cudaSuccess); };
+    dev(&d_conv, h_conv.size() * sizeof(float));
+    dev(&d_conv3, h_conv3.size() * sizeof(float));
+    dev(&d_alpha, h_alpha.size() * sizeof(half));
+    dev(&d_beta, h_beta.size() * sizeof(half));
+    dev(&d_alpha3, h_alpha3.size() * sizeof(half));
+    dev(&d_beta3, h_beta3.size() * sizeof(half));
+    dev(&d_Alog, h_Alog.size() * sizeof(float));
+    dev(&d_dtb, h_dtb.size() * sizeof(float));
+    dev(&d_pool, pool_elems * sizeof(float));
+    dev(&d_fac, fac_elems * sizeof(float));
+    dev(&d_y, rows * inner * sizeof(half));
+    dev(&d_live, live.size() * sizeof(int));
+    dev(&d_spare, spare.size() * sizeof(int));
+    dev(&d_lens, 2 * sizeof(int));
+    auto up = [](void* d, const auto& v) {
+        cudaMemcpy(d, v.data(), v.size() * sizeof(v[0]), cudaMemcpyHostToDevice);
+    };
+    up(d_conv, h_conv); up(d_conv3, h_conv3); up(d_alpha, h_alpha); up(d_beta, h_beta);
+    up(d_alpha3, h_alpha3); up(d_beta3, h_beta3); up(d_Alog, h_Alog); up(d_dtb, h_dtb);
+    up(d_live, live); up(d_spare, spare);
+    const int lens[2] = {2, 1};
+    cudaMemcpy(d_lens, lens, sizeof(lens), cudaMemcpyHostToDevice);
+
+    // Arm A, today's contract: the verify commits the drafted row into the
+    // spare slot, accept makes the spare live, the next token runs from it.
+    cudaMemcpy(d_pool, h_pool_init.data(), pool_elems * sizeof(float), cudaMemcpyHostToDevice);
+    gdn_scan_fused_f32_batched(d_conv, conv_channels, d_alpha, d_beta, d_Alog, d_dtb, d_pool, d_live,
+                               static_cast<int64_t>(state_elems), d_y, s.n_seq, s.n_tokens, s.n_heads,
+                               s.head_dim, s.state_size, s.n_groups, nullptr, /*grouped_layout=*/1,
+                               d_lens, nullptr, nullptr, d_lens + 1, /*out_slots=*/d_spare,
+                               /*snap_slots=*/d_live);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    gdn_scan_fused_f32_batched(d_conv3, conv_channels, d_alpha3, d_beta3, d_Alog, d_dtb, d_pool, d_spare,
+                               static_cast<int64_t>(state_elems), d_y, s.n_seq, /*n_tokens=*/1, s.n_heads,
+                               s.head_dim, s.state_size, s.n_groups, nullptr, /*grouped_layout=*/1);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<float> want(pool_elems);
+    cudaMemcpy(want.data(), d_pool, pool_elems * sizeof(float), cudaMemcpyDeviceToHost);
+
+    // Arm B, factored: no spare slot. The verify emits (g, k, delta) for the
+    // drafted row and snapshots the accepted row in place; the next token runs
+    // from the live slot with the row applied at the state load.
+    cudaMemcpy(d_pool, h_pool_init.data(), pool_elems * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemset(d_fac, 0, fac_elems * sizeof(float));
+    gdn_scan_fused_f32_batched(d_conv, conv_channels, d_alpha, d_beta, d_Alog, d_dtb, d_pool, d_live,
+                               static_cast<int64_t>(state_elems), d_y, s.n_seq, s.n_tokens, s.n_heads,
+                               s.head_dim, s.state_size, s.n_groups, nullptr, /*grouped_layout=*/1,
+                               d_lens, nullptr, nullptr, d_lens + 1, /*out_slots=*/nullptr,
+                               /*snap_slots=*/d_live, /*fac_out=*/d_fac, /*fac_in=*/nullptr, fac_stride);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    // The sentinel has to be live: every head must carry a non-zero decay.
+    std::vector<float> fac(fac_elems);
+    cudaMemcpy(fac.data(), d_fac, fac_elems * sizeof(float), cudaMemcpyDeviceToHost);
+    for (int i = 0; i < s.n_seq; i++)
+        for (int h = 0; h < s.n_heads; h++)
+            ASSERT_GT(fac[(static_cast<size_t>(live[i]) * s.n_heads + h) * fac_stride], 0.0f)
+                << "seq " << i << " head " << h << ": g is the 'no pending row' sentinel";
+    gdn_scan_fused_f32_batched(d_conv3, conv_channels, d_alpha3, d_beta3, d_Alog, d_dtb, d_pool, d_live,
+                               static_cast<int64_t>(state_elems), d_y, s.n_seq, /*n_tokens=*/1, s.n_heads,
+                               s.head_dim, s.state_size, s.n_groups, nullptr, /*grouped_layout=*/1,
+                               nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                               /*fac_out=*/nullptr, /*fac_in=*/d_fac, fac_stride);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    std::vector<float> got(pool_elems);
+    cudaMemcpy(got.data(), d_pool, pool_elems * sizeof(float), cudaMemcpyDeviceToHost);
+
+    // Same arithmetic in the same order on both arms, so F32 state makes this
+    // exact. A tolerance here would hide a wrong k or delta index.
+    for (int i = 0; i < s.n_seq; i++) {
+        const size_t a = static_cast<size_t>(spare[i]) * state_elems;
+        const size_t b = static_cast<size_t>(live[i]) * state_elems;
+        for (size_t e = 0; e < state_elems; e++)
+            ASSERT_EQ(want[a + e], got[b + e]) << "seq " << i << " elem " << e;
+    }
+
+    for (void* p : {(void*)d_conv, (void*)d_conv3, (void*)d_alpha, (void*)d_beta, (void*)d_alpha3,
+                    (void*)d_beta3, (void*)d_Alog, (void*)d_dtb, (void*)d_pool, (void*)d_fac,
+                    (void*)d_y, (void*)d_live, (void*)d_spare, (void*)d_lens})
+        cudaFree(p);
 }
 
 }  // namespace

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -255,7 +255,10 @@ def main():
     # 1108 -> 1110: MeanStdMergesAcrossSpanAndDecodeSteps and
     # OutlierPageLosesTheBudgetSlotToTheConsistentPage (test-attention, GPU, no model): the sparse page
     # score's mean/std merge against a double CPU reference, and the ranking the corner bound gets wrong.
-    PINNED = 1110
+    # 1110 -> 1111: FactoredSpareReproducesTheFullSpareAfterTheNextToken (test-moe-gdn, GPU, no model):
+    # the batched verify's drafted row carried as (g, k, delta) must leave the state after the FOLLOWING
+    # token bit-identical to the full spare slot.
+    PINNED = 1111
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
Stage 1 of the factored verify spare: the algebra and the kernel support, measured price and plan in `docs/plans/2026-09-12-factored-verify-spare.md`. Follows #1995, which sized the problem.

## What it costs today

`speculative.batch_verify` reserves one spare recurrent slot per batch slot, held for a request's lifetime because accept swaps slots instead of copying. The spare is an exact duplicate of the state pool. Qwen3.8-27B-NVFP4-vllm at `runtime.max_batch_size=32`:

| `speculative.batch_verify` | SSM/GDN state | KV pool | batch |
|---|---:|---:|---:|
| off | 2544 MiB (32 slots) | 2339 blocks, `max_model_len` 131 072 | 32 |
| on | 5088 MiB (32 slots) | 1429 blocks, `max_model_len` 33 680 | clamped to 18 |

## Why a triple is enough

The delta rule's per-token update in `gdn_scan_fused_kernel` is a scalar decay plus a rank-1 outer product:

    H_new[s][d] = g * H[s][d] + k[s] * delta[d]

So the state after the drafted row is fully determined by the state before it plus `(g, k, delta)`: `1 + state_size + head_dim` floats per head against `state_size * head_dim`. On this model 48 KiB per layer against 1.5 MiB, 2.3 MiB per slot against 72 MiB. Same direction as TreeWY (arXiv 2608.20961) and Bole (arXiv 2608.01651); the rank-1 form here is read off imp's own kernel rather than ported.

## What this PR contains

`compute/gdn_factor.cuh` (layout plus two device helpers) and three optional kernel parameters. `fac_out` receives the row for `real_n` instead of the full copy `out_slots` took. `fac_in` carries a pending row applied to `H_reg` right after the state load, which is why this design costs no extra state traffic: the next step reads and writes the state regardless, so the apply rides along.

Rows are indexed by the recurrent **slot**, not the batch position, because a request keeps its slot across steps but moves within the batch. Invariant: with `fac_out` set the row is always defined. A row is written only when a drafted row exists past the snapshot, otherwise the full state goes to `h_out` as before and `g` takes the 0 sentinel, so a stale row cannot survive to be applied twice.

**Nothing in the engine passes either pointer yet**, so serving behaviour is unchanged. Push-hook paired A/B against main, three pairs: decode mean 0.00%, prefill mean -0.44%, both inside 2%. `make verify-fast` OK, peak VRAM -0.05%.

## Test

`GdnBatchedScanTest.FactoredSpareReproducesTheFullSpareAfterTheNextToken` runs the real accept sequence both ways (full spare slot, then factored) and compares the state **after the following token**, which is what the engine actually consumes, rather than comparing the factors themselves. F32 state makes it exact, so it carries no tolerance; a tolerance there would hide a wrong `k` or `delta` index. Red under a mutation that shifts the delta column by one. GPU test count 1110 -> 1111.

## What is left, and one correction

The conv window turned out to be a **blocker, not a follow-up**: a slot is one contiguous block holding every layer's conv window and `h_state`, and the spare exists because accept swaps whole slots, so factoring `h_state` alone leaves the drafted conv window with nowhere to live. Dropping the spare slot needs the conv factored too (the drafted row shifts the 4-tap window by one, so the carried form is the single new tap). That path has its own commit kernel and its own race history (#1976), so it gets its own stage and its own test.

The plan doc also records the four events where the row must be explicitly cleared, since the scan self-clears only in steady state: reject, request finished, slot reassigned, and any non-verify step for that slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L8bf3qGhGMvruDSQZqjZb