### PR TITLE
perf(ssm): carry the verify's drafted conv row as one tap, not a window copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ set(IMP_COMPUTE_SOURCES
     src/compute/moe_routing.cu
     src/compute/reduce.cu
     src/compute/ssm.cu
+    src/compute/ssm_conv_tap.cu
     src/compute/gdn.cu
     src/compute/gdn_gated_norm.cu
     src/compute/hadamard.cu

--- a/docs/plans/2026-09-12-factored-verify-spare.md
+++ b/docs/plans/2026-09-12-factored-verify-spare.md
@@ -70,7 +70,7 @@ row from an earlier step cannot survive to be applied twice.
 | `GdnBatchedScanTest.FactoredSpareReproducesTheFullSpareAfterTheNextToken` | GREEN, bit-exact; red under a mutated delta column |
 | engine wiring: factor buffer, verify emits, accept/reject bookkeeping, next-step apply | not built |
 | drop the spare slots from `batch_verify_spare_slots` and the planner | not built |
-| conv window: carry the drafted tap instead of the full 4-tap window | not built, and a BLOCKER for dropping the slot, see below |
+| conv window: `ssm_conv_tap.cu`, stash + apply, `SsmConvTapTest` | built |
 | numerics: deterministic PPL, `DegenerationTest`, state diff against the full-spare arm | not built |
 
 The test is the gate on the algebra: it runs the real accept sequence both ways (full spare,
@@ -78,7 +78,7 @@ then factored) and compares the state **after the following token**, which is wh
 actually consumes. F32 state makes it exact, so it carries no tolerance - a tolerance there
 would hide a wrong `k` or `delta` index.
 
-## The conv window is a blocker, not an extra
+## The conv window is a blocker, not an extra (built 2026-09-12)
 
 First reading had the conv window as an optional follow-up. It is not. A slot is one
 contiguous block holding every GDN layer's conv window AND `h_state`
@@ -92,6 +92,20 @@ prefill commit race), so it gets its own stage and its own test.
 The alternative is to keep slot-shaped spares but give the spare region a different geometry,
 which means `SsmStateCache` stops having one uniform slot stride. That is the larger change of
 the two.
+
+`compute/ssm_conv_tap.cu` carries it: `ssm_conv_tap_stash` saves the drafted row's conv input
+per slot (channels halfs, 20 KiB per layer at 10240 channels against 160 for the window) and
+`ssm_conv_tap_apply` advances a slot's window by that tap, which is the single-row form of
+`ssm_conv1d_commit_kernel`. Its own translation unit because `ssm.cu` sits at 596 of the
+600-code-LOC kernel ceiling.
+
+The wiring does not need a "suppress the commit" flag: committing the conv at the SNAPSHOT
+length and stashing the tap for the drafted row is the same thing as committing at both
+lengths into two slots, because `d_real_n` bounds only the commit, never the conv output rows
+the scan consumes.
+
+Spare per slot with both halves factored: 2.3 MiB of recurrent factors plus 0.96 MiB of conv
+taps against 79.5 MiB, so 32 slots cost about 105 MiB against 2544.
 
 ## Bookkeeping the wiring stage has to get right
 

--- a/src/compute/ssm.h
+++ b/src/compute/ssm.h
@@ -134,4 +134,18 @@ void elementwise_mul(const Tensor& a, const Tensor& b, Tensor& out, cudaStream_t
 // Sigmoid multiply: out[i] = a[i] * sigmoid(b[i])
 void sigmoid_mul(const Tensor& a, const Tensor& b, Tensor& out, cudaStream_t stream);
 
+// Factored conv window for the batched speculative verify
+// (compute/ssm_conv_tap.cu, docs/plans/2026-09-12-factored-verify-spare.md).
+// The drafted row shifts the window by one, so what has to survive the step is
+// the single new tap rather than the whole window: channels halfs against
+// channels * kernel_size floats. Both pools are indexed by recurrent SLOT, so
+// a request keeps its row while it moves within the batch.
+// stash: x_in is [n_seq, n_tokens, channels] half, the row taken is real_n-1.
+// apply: advances slot's window by its stashed tap, the single-row form of
+// ssm_conv1d_commit_kernel.
+void ssm_conv_tap_stash(void* tap_pool, const void* x_in, int n_tokens, int channels, const int* d_real_n,
+                        const int* slots, int n_seq, cudaStream_t stream);
+void ssm_conv_tap_apply(void* conv_pool, int64_t slot_stride_floats, const void* tap_pool, int channels,
+                        int kernel_size, const int* slots, int n_seq, cudaStream_t stream);
+
 }  // namespace imp

--- a/src/compute/ssm_conv_tap.cu
+++ b/src/compute/ssm_conv_tap.cu
@@ -1,0 +1,85 @@
+// Factored conv window for the batched speculative verify.
+//
+// Companion to compute/gdn_factor.cuh, which does the same for the recurrent
+// state. A slot is one contiguous block holding every GDN layer's conv window
+// AND h_state (memory/ssm_state_size.h), and the verify's spare slot exists
+// because accept swaps whole slots, so dropping the spare needs BOTH halves
+// carried compactly. docs/plans/2026-09-12-factored-verify-spare.md.
+//
+// The conv half is cheaper than the recurrent half: the drafted row shifts the
+// kernel_size window by exactly one, so the carried form is the single new tap
+// (channels halfs) rather than the whole window (channels * kernel_size
+// floats) - 20 KiB against 160 per layer at 10240 channels.
+//
+// Separate translation unit because ssm.cu sits at 596 of the 600-code-LOC
+// kernel ceiling.
+
+#include "compute/ssm.h"
+#include "core/logging.h"
+#include <cuda_fp16.h>
+
+namespace imp {
+
+namespace {
+
+// Stash the drafted row's conv input. Reads the row the commit kernel would
+// have folded into the spare window, indexed by SLOT so the row survives the
+// request moving within the batch.
+__global__ void ssm_conv_tap_stash_kernel(half* __restrict__ tap_pool, const half* __restrict__ x_in,
+                                          int n_tokens, int channels, const int* __restrict__ d_real_n,
+                                          const int* __restrict__ slots) {
+    const int ch = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ch >= channels)
+        return;
+    const int seq = blockIdx.y;
+    const int real_n = d_real_n ? min(n_tokens, __ldg(d_real_n)) : n_tokens;
+    if (real_n <= 0)
+        return;
+    const half* row = x_in + (static_cast<size_t>(seq) * n_tokens + (real_n - 1)) * channels;
+    tap_pool[static_cast<size_t>(slots[seq]) * channels + ch] = row[ch];
+}
+
+// Advance a window by the stashed tap: drop the oldest entry, append the tap.
+// Equivalent to ssm_conv1d_commit_kernel over a single row, which is what the
+// next step would have seen had the drafted row been committed at the time.
+__global__ void ssm_conv_tap_apply_kernel(float* __restrict__ conv_pool, int64_t slot_stride,
+                                          const half* __restrict__ tap_pool, int channels, int kernel_size,
+                                          const int* __restrict__ slots) {
+    const int ch = blockIdx.x * blockDim.x + threadIdx.x;
+    if (ch >= channels)
+        return;
+    const int slot = slots[blockIdx.y];
+    float* w = conv_pool + static_cast<size_t>(slot) * static_cast<size_t>(slot_stride) + ch * kernel_size;
+    for (int k = 0; k + 1 < kernel_size; k++)
+        w[k] = w[k + 1];
+    w[kernel_size - 1] = __half2float(tap_pool[static_cast<size_t>(slot) * channels + ch]);
+}
+
+constexpr int kTapThreads = 256;
+
+}  // namespace
+
+void ssm_conv_tap_stash(void* tap_pool, const void* x_in, int n_tokens, int channels, const int* d_real_n,
+                        const int* slots, int n_seq, cudaStream_t stream) {
+    if (!tap_pool || !x_in || !slots || n_seq <= 0 || channels <= 0 || n_tokens <= 0)
+        return;
+    dim3 grid((channels + kTapThreads - 1) / kTapThreads, n_seq);
+    ssm_conv_tap_stash_kernel<<<grid, kTapThreads, 0, stream>>>(static_cast<half*>(tap_pool),
+                                                                static_cast<const half*>(x_in), n_tokens,
+                                                                channels, d_real_n, slots);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+void ssm_conv_tap_apply(void* conv_pool, int64_t slot_stride_floats, const void* tap_pool, int channels,
+                        int kernel_size, const int* slots, int n_seq, cudaStream_t stream) {
+    if (!conv_pool || !tap_pool || !slots || n_seq <= 0 || channels <= 0 || kernel_size <= 0)
+        return;
+    dim3 grid((channels + kTapThreads - 1) / kTapThreads, n_seq);
+    ssm_conv_tap_apply_kernel<<<grid, kTapThreads, 0, stream>>>(static_cast<float*>(conv_pool),
+                                                                slot_stride_floats,
+                                                                static_cast<const half*>(tap_pool), channels,
+                                                                kernel_size, slots);
+    IMP_CUDA_CHECK_LAUNCH();
+}
+
+}  // namespace imp

--- a/tests/test_ssm.cu
+++ b/tests/test_ssm.cu
@@ -955,5 +955,77 @@ TEST(SSMConv1dTest, PrefillFirstRowsReadThePreviousWindowNotTheCommit) {
     cudaFree(d_out);
 }
 
+
+// The factored conv window (compute/ssm_conv_tap.cu). The verify's spare slot
+// carried the window after BOTH rows; the drafted row only shifts that window
+// by one, so what has to survive is the single new tap. The reference here is
+// the window definition itself, not the commit kernel, so a change to either
+// side has to agree with the contract rather than with the other side.
+TEST(SsmConvTapTest, StashedTapAdvancesTheWindowLikeTheTwoRowCommit) {
+    constexpr int channels = 320, kernel_size = 4, n_seq = 3, n_tokens = 2, n_slots = 5;
+    const std::vector<int> slots{3, 0, 4};
+    const size_t win = static_cast<size_t>(channels) * kernel_size;
+
+    std::vector<float> pool(static_cast<size_t>(n_slots) * win);
+    std::vector<half> x(static_cast<size_t>(n_seq) * n_tokens * channels);
+    for (size_t i = 0; i < pool.size(); i++) pool[i] = static_cast<float>((i * 37) % 211) * 0.25f - 20.0f;
+    for (size_t i = 0; i < x.size(); i++) x[i] = __float2half(static_cast<float>((i * 53) % 173) * 0.125f);
+
+    // Reference: the window the two-row commit leaves, and the one-row window
+    // the live slot keeps. Index k of a window at n rows reads x row n-K+k,
+    // falling back to the incoming window when that row is before the launch.
+    auto window_at = [&](int seq, int slot, int n) {
+        std::vector<float> w(channels * kernel_size);
+        for (int ch = 0; ch < channels; ch++)
+            for (int k = 0, t = n - kernel_size; k < kernel_size; k++, t++)
+                w[ch * kernel_size + k] =
+                    t >= 0 ? __half2float(x[(static_cast<size_t>(seq) * n_tokens + t) * channels + ch])
+                           : pool[static_cast<size_t>(slot) * win + ch * kernel_size + t + kernel_size];
+        return w;
+    };
+    // The live slot starts where the one-row commit left it.
+    std::vector<std::vector<float>> want(n_seq);
+    std::vector<float> start = pool;
+    for (int i = 0; i < n_seq; i++) {
+        want[i] = window_at(i, slots[i], 2);
+        const auto after1 = window_at(i, slots[i], 1);
+        std::copy(after1.begin(), after1.end(), start.begin() + static_cast<size_t>(slots[i]) * win);
+    }
+
+    float* d_pool = nullptr;
+    half *d_x = nullptr, *d_tap = nullptr;
+    int *d_slots = nullptr, *d_real = nullptr;
+    const int real_n = n_tokens;
+    auto up = [](auto** d, const void* src, size_t bytes) {
+        ASSERT_EQ(cudaMalloc(d, bytes), cudaSuccess);
+        if (src) cudaMemcpy(*d, src, bytes, cudaMemcpyHostToDevice); else cudaMemset(*d, 0, bytes);
+    };
+    up(&d_pool, start.data(), start.size() * sizeof(float));
+    up(&d_x, x.data(), x.size() * sizeof(half));
+    up(&d_tap, nullptr, static_cast<size_t>(n_slots) * channels * sizeof(half));
+    up(&d_slots, slots.data(), slots.size() * sizeof(int));
+    up(&d_real, &real_n, sizeof(int));
+
+    ssm_conv_tap_stash(d_tap, d_x, n_tokens, channels, d_real, d_slots, n_seq, nullptr);
+    ssm_conv_tap_apply(d_pool, static_cast<int64_t>(win), d_tap, channels, kernel_size, d_slots, n_seq,
+                       nullptr);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    std::vector<float> got(start.size());
+    cudaMemcpy(got.data(), d_pool, got.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    // Named slots must match the two-row window; unnamed ones must be untouched,
+    // because the apply addresses by slot id and not by batch position.
+    for (int sl = 0; sl < n_slots; sl++) {
+        const auto it = std::find(slots.begin(), slots.end(), sl);
+        const bool named = it != slots.end();
+        const std::vector<float>& ref = named ? want[it - slots.begin()] : start;
+        const size_t off = named ? 0 : static_cast<size_t>(sl) * win;
+        for (size_t e = 0; e < win; e++)
+            ASSERT_EQ(got[static_cast<size_t>(sl) * win + e], ref[off + e]) << "slot " << sl << " elem " << e;
+    }
+
+    cudaFree(d_pool); cudaFree(d_x); cudaFree(d_tap); cudaFree(d_slots); cudaFree(d_real);
+}
+
 }  // namespace
 }  // namespace imp

--- a/tools/check_test_lanes.py
+++ b/tools/check_test_lanes.py
@@ -258,7 +258,9 @@ def main():
     # 1110 -> 1111: FactoredSpareReproducesTheFullSpareAfterTheNextToken (test-moe-gdn, GPU, no model):
     # the batched verify's drafted row carried as (g, k, delta) must leave the state after the FOLLOWING
     # token bit-identical to the full spare slot.
-    PINNED = 1111
+    # 1111 -> 1112: StashedTapAdvancesTheWindowLikeTheTwoRowCommit (test-compute, GPU, no model): the
+    # conv half of the same spare, tap stash plus window advance against the window definition.
+    PINNED = 1112
 
     text = CMAKE.read_text()
     mods = module_sources(text)


### PR DESCRIPTION
Second half of the factored verify spare, after #1996. Plan and measured price in `docs/plans/2026-09-12-factored-verify-spare.md`.

#1996 carried the drafted row's recurrent state as `(g, k, delta)`. A slot also holds every GDN layer's conv window, and the spare exists because accept swaps **whole slots**, so factoring the recurrent half alone leaves the drafted conv window with nowhere to live. The conv half had to follow before the slot can be dropped at all. That correction is why this is a second PR rather than a follow-up.

## The conv half is the cheaper one

The drafted row shifts the `kernel_size` window by exactly one, so what has to survive the step is the single new tap: `channels` halfs against `channels * kernel_size` floats, 20 KiB against 160 per layer at 10240 channels.

`ssm_conv_tap_stash` saves that row per **slot** (a request keeps its slot while it moves within the batch); `ssm_conv_tap_apply` advances a slot's window by it, which is the single-row form of `ssm_conv1d_commit_kernel`. Its own translation unit because `ssm.cu` sits at 596 of the 600-code-LOC kernel ceiling.

The wiring will not need a "suppress the commit" flag: committing the conv at the **snapshot** length and stashing the tap for the drafted row is the same thing as committing at both lengths into two slots, because `d_real_n` bounds only the commit and never the conv output rows the scan consumes.

With both halves factored a spare costs 2.3 MiB of recurrent factors plus 0.96 MiB of conv taps per slot against 79.5 MiB, so 32 slots come to about 105 MiB against 2544. That is what clears the `max_batch_size` 32 -> 18 clamp and the KV pool 2339 -> 1429 blocks measured in #1995.

Nothing calls either function yet, so serving behaviour is unchanged. `make verify-fast` OK; push-hook paired A/B against main, three pairs: decode mean -0.06%, prefill mean -0.34%.

## Test

`SsmConvTapTest.StashedTapAdvancesTheWindowLikeTheTwoRowCommit` checks stash plus apply against the **window definition**, not against the commit kernel, so a change to either side has to agree with the contract rather than merely with the other side. It also pins that unnamed slots stay untouched, since the apply addresses by slot id. Red under a mutation that appends the tap without shifting the window (960 prints from the binary under test). `test-moe-gdn` 179/179 green. GPU test count 1111 -> 1112.

## What is left

Engine wiring (factor and tap buffers, verify emits, accept/reject bookkeeping, next-step apply), then `batch_verify_spare_slots` to 0 and the planner. The plan doc records the four events where the row must be cleared explicitly, since the scan self-clears only in steady state: reject, request finished, slot reassigned, and any non-verify step for that slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyK5B3sNRjM2juTmm4UG3t