### PR TITLE
docs(plans): index the batched verify and factored spare plans

### DIFF
--- a/docs/plans/2026-09-11-batched-mtp-verify.md
+++ b/docs/plans/2026-09-11-batched-mtp-verify.md
@@ -1,6 +1,8 @@
 # Batched MTP verify on the GDN hybrid (the concurrent-serving lever)
 
-Status (2026-09-11): in progress, branch `perf/batched-mtp-verify`. Stage
+Status (2026-09-13): stages 1-4 DONE, shipped opt-in as `speculative.batch_verify`
+(#1993, default off). The spare-slot price continues in
+[2026-09-12-factored-verify-spare](2026-09-12-factored-verify-spare.md). Stage
 table at the end carries the state of every stage.
 
 ## Why

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -24,3 +24,5 @@ is the other direction: text moved OUT of the roadmap.
 | [2026-08-31-mtp-multicandidate-hybrid](2026-08-31-mtp-multicandidate-hybrid.md) | CLOSED 2026-08-31, built and measured, gate not met | roadmap Closed, "speculation tree" |
 | [2026-08-31-roadmap-ledger-detail](2026-08-31-roadmap-ledger-detail.md) | record, moved out of the roadmap 2026-08-31 | - |
 | [2026-09-04-lever-ledger-detail](2026-09-04-lever-ledger-detail.md) | record, moved out of the roadmap 2026-09-04 | - |
+| [2026-09-11-batched-mtp-verify](2026-09-11-batched-mtp-verify.md) | **OPEN**: stages 1-4 shipped opt-in (#1993), default off | CHANGELOG `speculative.batch_verify` |
+| [2026-09-12-factored-verify-spare](2026-09-12-factored-verify-spare.md) | **OPEN**: shipped opt-in (#1996-#1998, #2002), default off | CHANGELOG `speculative.factored_spare` |


### PR DESCRIPTION
## Plan index

| file | before | after |
|---|---|---|
| `docs/plans/2026-09-11-batched-mtp-verify.md` | "in progress, branch `perf/batched-mtp-verify`" | stages 1-4 shipped opt-in (#1993), link to the factored-spare plan |
| `docs/plans/README.md` | no row for the 09-11 and 09-12 plans | both rows, **OPEN**, default off |

Not in here: no roadmap ledger row; both levers are default off and have no verdict yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyK5B3sNRjM2juTmm4UG3t
